### PR TITLE
style: apply consistent formatting across all languages

### DIFF
--- a/app/biome.json
+++ b/app/biome.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 120
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noUnusedVariables": "off",
+        "noUnusedFunctionParameters": "off",
+        "noUnusedPrivateClassMembers": "off"
+      },
+      "suspicious": {
+        "noImplicitAnyLet": "off"
+      },
+      "style": {
+        "useNodejsImportProtocol": "off",
+        "noNonNullAssertion": "off"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "always",
+      "trailingCommas": "all"
+    }
+  }
+}

--- a/app/src-rust/rustfmt.toml
+++ b/app/src-rust/rustfmt.toml
@@ -1,7 +1,4 @@
 edition = "2021"
 max_width = 120
 use_small_heuristics = "Max"
-fn_single_line = false
 match_block_trailing_comma = true
-imports_granularity = "Crate"
-group_imports = "StdExternalCrate"

--- a/app/src-rust/src/installer.rs
+++ b/app/src-rust/src/installer.rs
@@ -8,10 +8,7 @@ use std::time::Duration;
 static INSTALLING: AtomicBool = AtomicBool::new(false);
 
 fn progress_path() -> PathBuf {
-    dirs::home_dir()
-        .unwrap_or_default()
-        .join(".metalsharp")
-        .join("install_progress.json")
+    dirs::home_dir().unwrap_or_default().join(".metalsharp").join("install_progress.json")
 }
 
 fn write_progress(step: usize, total: usize, name: &str, status: &str, log_line: &str, error: Option<&str>) {
@@ -73,7 +70,7 @@ fn run_install_all() {
         None => {
             write_progress(0, 0, "", "error", "no home directory", Some("no home directory"));
             return;
-        }
+        },
     };
 
     let steps: Vec<(&str, Box<dyn Fn(&PathBuf) -> Result<bool, String>>)> = vec![
@@ -95,10 +92,10 @@ fn run_install_all() {
         match installer(&home) {
             Ok(false) => {
                 write_progress(step_num, total, name, "done", &format!("{} already installed — skipping", name), None);
-            }
+            },
             Ok(true) => {
                 write_progress(step_num, total, name, "done", &format!("{} installed!", name), None);
-            }
+            },
             Err(e) => {
                 let is_required = i < 7;
                 if is_required {
@@ -107,7 +104,7 @@ fn run_install_all() {
                 } else {
                     write_progress(step_num, total, name, "skipped", &format!("{} skipped: {}", name, e), None);
                 }
-            }
+            },
         }
 
         std::thread::sleep(Duration::from_millis(200));
@@ -121,11 +118,7 @@ fn install_rosetta() -> Result<bool, String> {
     if plist.exists() {
         return Ok(false);
     }
-    let running = Command::new("pgrep")
-        .args(["-q", "oahd"])
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false);
+    let running = Command::new("pgrep").args(["-q", "oahd"]).status().map(|s| s.success()).unwrap_or(false);
     if running {
         return Ok(false);
     }
@@ -191,11 +184,7 @@ fn install_metalsharp_bundle(home: &PathBuf) -> Result<bool, String> {
         let _ = fs::create_dir_all(&wine_dir);
 
         let extracted_wine115 = tmp_extract.join("wine-11.5");
-        let source = if extracted_wine115.exists() {
-            extracted_wine115
-        } else {
-            tmp_extract.join("wine")
-        };
+        let source = if extracted_wine115.exists() { extracted_wine115 } else { tmp_extract.join("wine") };
 
         if source.exists() {
             if let Ok(entries) = fs::read_dir(&source) {
@@ -308,9 +297,7 @@ fn install_metalsharp_wine(home: &PathBuf) -> Result<bool, String> {
 }
 
 fn install_gptk(_home: &PathBuf) -> Result<bool, String> {
-    let gptk_wine = PathBuf::from(
-        "/Applications/Game Porting Toolkit.app/Contents/Resources/wine/bin/wine64"
-    );
+    let gptk_wine = PathBuf::from("/Applications/Game Porting Toolkit.app/Contents/Resources/wine/bin/wine64");
     if gptk_wine.exists() {
         return Ok(false);
     }
@@ -430,7 +417,8 @@ fn install_dxvk(home: &PathBuf) -> Result<bool, String> {
 }
 
 fn install_windows_steam(home: &PathBuf) -> Result<bool, String> {
-    let steam_exe = home.join(".metalsharp")
+    let steam_exe = home
+        .join(".metalsharp")
         .join("prefix-steam")
         .join("drive_c")
         .join("Program Files (x86)")
@@ -499,22 +487,16 @@ fn install_windows_steam(home: &PathBuf) -> Result<bool, String> {
     for _ in 0..90 {
         std::thread::sleep(Duration::from_secs(2));
         if steam_exe.exists() {
-            let steam_dir = home.join(".metalsharp")
-                .join("prefix-steam")
-                .join("drive_c")
-                .join("Program Files (x86)")
-                .join("Steam");
+            let steam_dir =
+                home.join(".metalsharp").join("prefix-steam").join("drive_c").join("Program Files (x86)").join("Steam");
             let _ = crate::steam::deploy_steamwebhelper_wrapper(&steam_dir);
             return Ok(true);
         }
     }
 
     if steam_exe.exists() {
-        let steam_dir = home.join(".metalsharp")
-            .join("prefix-steam")
-            .join("drive_c")
-            .join("Program Files (x86)")
-            .join("Steam");
+        let steam_dir =
+            home.join(".metalsharp").join("prefix-steam").join("drive_c").join("Program Files (x86)").join("Steam");
         let _ = crate::steam::deploy_steamwebhelper_wrapper(&steam_dir);
         Ok(true)
     } else {
@@ -533,11 +515,7 @@ fn check_command(cmd: &str) -> bool {
             return true;
         }
     }
-    Command::new("/usr/bin/which")
-        .arg(cmd)
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
+    Command::new("/usr/bin/which").arg(cmd).output().map(|o| o.status.success()).unwrap_or(false)
 }
 
 fn install_mono_arm64() -> Result<bool, String> {
@@ -602,19 +580,13 @@ fn install_moltenvk() -> Result<bool, String> {
 }
 
 fn find_brew() -> Result<PathBuf, String> {
-    let candidates = [
-        PathBuf::from("/opt/homebrew/bin/brew"),
-        PathBuf::from("/usr/local/bin/brew"),
-    ];
+    let candidates = [PathBuf::from("/opt/homebrew/bin/brew"), PathBuf::from("/usr/local/bin/brew")];
     for c in &candidates {
         if c.exists() {
             return Ok(c.clone());
         }
     }
-    let output = Command::new("which")
-        .arg("brew")
-        .output()
-        .ok();
+    let output = Command::new("which").arg("brew").output().ok();
     if let Some(o) = output {
         if o.status.success() {
             let path = String::from_utf8_lossy(&o.stdout).trim().to_string();
@@ -628,16 +600,9 @@ fn find_brew() -> Result<PathBuf, String> {
 
 fn brew_install(package: &str) -> Result<bool, String> {
     let brew = find_brew()?;
-    let output = Command::new(&brew)
-        .args(["install", package])
-        .output()
-        .map_err(|e| format!("brew failed: {}", e))?;
+    let output = Command::new(&brew).args(["install", package]).output().map_err(|e| format!("brew failed: {}", e))?;
 
-    let combined = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
+    let combined = format!("{}{}", String::from_utf8_lossy(&output.stdout), String::from_utf8_lossy(&output.stderr));
 
     if output.status.success() || combined.contains("already installed") {
         Ok(true)
@@ -675,7 +640,10 @@ fn brew_cask_install(package: &str) -> Result<bool, String> {
         String::from_utf8_lossy(&reinstall_output.stderr)
     );
 
-    if reinstall_output.status.success() || reinstall_combined.contains("already installed") || reinstall_combined.contains("It seems there is already an app") {
+    if reinstall_output.status.success()
+        || reinstall_combined.contains("already installed")
+        || reinstall_combined.contains("It seems there is already an app")
+    {
         Ok(true)
     } else {
         let combined = format!("{}\n{}", install_combined, reinstall_combined);
@@ -684,10 +652,7 @@ fn brew_cask_install(package: &str) -> Result<bool, String> {
 }
 
 fn find_bundled_archive(name: &str) -> Option<PathBuf> {
-    let candidates = [
-        find_in_resources(name),
-        find_in_dev_path(name),
-    ];
+    let candidates = [find_in_resources(name), find_in_dev_path(name)];
 
     if let Some(found) = candidates.into_iter().find(|c| c.is_some()).flatten() {
         return Some(found);
@@ -725,17 +690,9 @@ fn download_from_github_release(filename: &str) -> Option<PathBuf> {
         }
     }
 
-    let url = format!(
-        "https://github.com/aaf2tbz/metalsharp/releases/download/bundles/{}",
-        filename
-    );
+    let url = format!("https://github.com/aaf2tbz/metalsharp/releases/download/bundles/{}", filename);
 
-    let output = Command::new("curl")
-        .args(["-sL", "--progress-bar", "-o"])
-        .arg(&cached)
-        .arg(&url)
-        .output()
-        .ok()?;
+    let output = Command::new("curl").args(["-sL", "--progress-bar", "-o"]).arg(&cached).arg(&url).output().ok()?;
 
     if output.status.success() && cached.exists() {
         let size = fs::metadata(&cached).ok().map(|m| m.len()).unwrap_or(0);
@@ -839,11 +796,9 @@ fn copy_dir_recursive(src: &PathBuf, dst: &PathBuf) {
 fn extract_zst(archive: &PathBuf, dest: &PathBuf, name: &str) -> Result<(), String> {
     let _ = fs::create_dir_all(dest);
 
-    let file = fs::File::open(archive)
-        .map_err(|e| format!("cannot open archive: {}", e))?;
+    let file = fs::File::open(archive).map_err(|e| format!("cannot open archive: {}", e))?;
 
-    let mut decoder = zstd::Decoder::new(file)
-        .map_err(|e| format!("zstd decode error: {}", e))?;
+    let mut decoder = zstd::Decoder::new(file).map_err(|e| format!("zstd decode error: {}", e))?;
 
     let mut tar_cmd = Command::new("tar")
         .args(["-xf", "-"])
@@ -856,13 +811,11 @@ fn extract_zst(archive: &PathBuf, dest: &PathBuf, name: &str) -> Result<(), Stri
         .map_err(|e| format!("tar spawn failed: {}", e))?;
 
     if let Some(mut stdin) = tar_cmd.stdin.take() {
-        std::io::copy(&mut decoder, &mut stdin)
-            .map_err(|e| format!("zstd decompression failed: {}", e))?;
+        std::io::copy(&mut decoder, &mut stdin).map_err(|e| format!("zstd decompression failed: {}", e))?;
         drop(stdin);
     }
 
-    let status = tar_cmd.wait()
-        .map_err(|e| format!("tar wait failed: {}", e))?;
+    let status = tar_cmd.wait().map_err(|e| format!("tar wait failed: {}", e))?;
 
     if !status.success() {
         return Err(format!("tar extraction failed for {}", name));

--- a/app/src-rust/src/launch.rs
+++ b/app/src-rust/src/launch.rs
@@ -43,11 +43,11 @@ fn engine_method(engine: Engine) -> &'static str {
 
 fn get_engine_for_appid(appid: u32) -> Engine {
     match appid {
-         105600 => Engine::FnaArm64,
-         504230 => Engine::SteamD3DMetalPerf,
-         265930 => Engine::SteamD3DMetalPerf,
-         312520 | 375520 | 848450 => Engine::DxmtMetal,
-         535520 | 391540 => Engine::Wined3d32,
+        105600 => Engine::FnaArm64,
+        504230 => Engine::SteamD3DMetalPerf,
+        265930 => Engine::SteamD3DMetalPerf,
+        312520 | 375520 | 848450 => Engine::DxmtMetal,
+        535520 | 391540 => Engine::Wined3d32,
 
         2050650 | 1583230 => Engine::SteamD3DMetalPerf,
         3164500 => Engine::DxmtMetal,
@@ -58,21 +58,19 @@ fn get_engine_for_appid(appid: u32) -> Engine {
 
         814380 | 1593500 => Engine::SteamMetalfx,
 
-        397540 | 298110 | 552520 | 1091500 | 1868140 | 1551360 | 1716740 |
-        1203620 | 1282100 | 750920 | 1172380 | 870780 | 1196590 |
-        1236300 | 1888160 | 976310 | 2767030 | 292030 | 990080 |
-        1172470 | 2290180 | 620 => Engine::SteamD3DMetalPerf,
+        397540 | 298110 | 552520 | 1091500 | 1868140 | 1551360 | 1716740 | 1203620 | 1282100 | 750920 | 1172380
+        | 870780 | 1196590 | 1236300 | 1888160 | 976310 | 2767030 | 292030 | 990080 | 1172470 | 2290180 | 620 => {
+            Engine::SteamD3DMetalPerf
+        },
 
-        548430 | 892970 | 1313140 | 1623730 | 553850 | 367520 | 413150 |
-        1145360 | 588650 | 1637320 | 1562430 | 1092790 | 1229490 |
-        1971650 | 1809540 | 1237320 | 1326470 | 275850 | 1643320 |
-        379720 | 782330 | 289070 | 1147560 | 1222680 | 252950 |
-        230410 | 252490 | 730 => Engine::SteamD3DMetalPerf,
+        548430 | 892970 | 1313140 | 1623730 | 553850 | 367520 | 413150 | 1145360 | 588650 | 1637320 | 1562430
+        | 1092790 | 1229490 | 1971650 | 1809540 | 1237320 | 1326470 | 275850 | 1643320 | 379720 | 782330 | 289070
+        | 1147560 | 1222680 | 252950 | 230410 | 252490 | 730 => Engine::SteamD3DMetalPerf,
 
         _ => {
             let game_dir = crate::setup::resolve_game_dir(appid);
             detect_engine_from_dir(&game_dir)
-        }
+        },
     }
 }
 
@@ -167,76 +165,80 @@ pub fn launch_auto(appid: u32) -> Result<(u32, &'static str), Box<dyn std::error
             let exe = dir.join("TerrariaLauncher.exe");
             let pid = launch_fna_arm64(&exe.to_string_lossy(), dir)?;
             Ok((pid, "xna_fna_arm64"))
-        }
+        },
         Engine::FnaX86 => {
             let dir = game_dir.as_ref().unwrap_or(&local_dir);
             let exe = dir.join("Celeste.exe");
             let pid = launch_fna_x86(&exe.to_string_lossy(), dir)?;
             Ok((pid, "xna_fna_x86"))
-        }
+        },
         Engine::DxmtMetal => {
             let dir = game_dir.as_ref().unwrap_or(&local_dir);
             let exe = resolve_game_exe_fallback(dir);
             let pid = launch_dxmt_metal(&exe, dir)?;
             Ok((pid, "dxmt_metal"))
-        }
+        },
         Engine::DxmtMetal12 => {
             let dir = game_dir.as_ref().unwrap_or(&local_dir);
             let exe = resolve_game_exe_fallback(dir);
             let pid = launch_dxmt_metal12(&exe, dir)?;
             Ok((pid, "dxmt_metal12"))
-        }
+        },
         Engine::Wined3d32 => {
             let dir = game_dir.as_ref().unwrap_or(&local_dir);
             let exe = resolve_game_exe_fallback(dir);
             let pid = launch_wined3d_32(&exe, dir)?;
             Ok((pid, "wined3d_32"))
-        }
+        },
         Engine::MetalsharpWine => {
             let dir = game_dir.as_ref().unwrap_or(&local_dir);
             let exe = resolve_game_exe_fallback(dir);
             let pid = launch_metalsharp_wine(&exe, dir)?;
             Ok((pid, "metalsharp_wine"))
-        }
+        },
         Engine::SteamBare => {
             let pid = launch_via_steam(appid)?;
             Ok((pid, "steam"))
-        }
+        },
         Engine::SteamMetalfx => {
-            let pid = launch_via_steam_with_env(appid, &[
-                ("D3DM_ENABLE_METALFX", "1"),
-                ("D3DM_ENABLE_ASYNC_COMMIT", "1"),
-                ("D3DM_MULTITHREADED_INTERFACE_ENABLE", "1"),
-                ("D3DM_IGNORE_D3D11_RENDER_BARRIERS", "1"),
-                ("D3DM_SAMPLE_NAN_TO_ZERO", "1"),
-                ("D3DM_FLUSH_POS_INF_TO_NAN", "1"),
-                ("MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE", "1"),
-                ("MVK_ALLOW_METAL_FENCES", "1"),
-            ])?;
+            let pid = launch_via_steam_with_env(
+                appid,
+                &[
+                    ("D3DM_ENABLE_METALFX", "1"),
+                    ("D3DM_ENABLE_ASYNC_COMMIT", "1"),
+                    ("D3DM_MULTITHREADED_INTERFACE_ENABLE", "1"),
+                    ("D3DM_IGNORE_D3D11_RENDER_BARRIERS", "1"),
+                    ("D3DM_SAMPLE_NAN_TO_ZERO", "1"),
+                    ("D3DM_FLUSH_POS_INF_TO_NAN", "1"),
+                    ("MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE", "1"),
+                    ("MVK_ALLOW_METAL_FENCES", "1"),
+                ],
+            )?;
             Ok((pid, "steam_metalfx"))
-        }
-         Engine::SteamD3DMetalPerf => {
-             let gptk_dll = "/Applications/Game Porting Toolkit.app/Contents/Resources/wine/lib/wine/x86_64-windows";
-             let gptk_dyld = "/Applications/Game Porting Toolkit.app/Contents/Resources/wine/lib/wine/x86_64-unix";
-             let ms_root = dirs::home_dir().ok_or("no home dir")?.join(".metalsharp").join("runtime").join("wine");
-             let ms_dyld = ms_root.join("lib").join("wine").join("x86_64-unix").to_string_lossy().to_string();
-             let dyld = format!("{}:{}", gptk_dyld, ms_dyld);
-             let wine_dll_path = format!("{}:{}",
-                 gptk_dll,
-                 ms_root.join("lib").join("wine").join("x86_64-windows").to_string_lossy()
-             );
-             let pid = launch_via_steam_with_env(appid, &[
-                 ("WINEDLLPATH", &wine_dll_path),
-                 ("DYLD_FALLBACK_LIBRARY_PATH", &dyld),
-                 ("D3DM_ENABLE_ASYNC_COMMIT", "1"),
-                 ("D3DM_MULTITHREADED_INTERFACE_ENABLE", "1"),
-                 ("D3DM_IGNORE_D3D11_RENDER_BARRIERS", "1"),
-                 ("D3DM_SAMPLE_NAN_TO_ZERO", "1"),
-                 ("D3DM_FLUSH_POS_INF_TO_NAN", "1"),
-             ])?;
-             Ok((pid, "steam_d3dmetal_perf"))
-         }
-     }
+        },
+        Engine::SteamD3DMetalPerf => {
+            let gptk_dll = "/Applications/Game Porting Toolkit.app/Contents/Resources/wine/lib/wine/x86_64-windows";
+            let gptk_dyld = "/Applications/Game Porting Toolkit.app/Contents/Resources/wine/lib/wine/x86_64-unix";
+            let ms_root = dirs::home_dir().ok_or("no home dir")?.join(".metalsharp").join("runtime").join("wine");
+            let ms_dyld = ms_root.join("lib").join("wine").join("x86_64-unix").to_string_lossy().to_string();
+            let dyld = format!("{}:{}", gptk_dyld, ms_dyld);
+            let wine_dll_path =
+                format!("{}:{}", gptk_dll, ms_root.join("lib").join("wine").join("x86_64-windows").to_string_lossy());
+            let pid = launch_via_steam_with_env(
+                appid,
+                &[
+                    ("WINEDLLPATH", &wine_dll_path),
+                    ("DYLD_FALLBACK_LIBRARY_PATH", &dyld),
+                    ("D3DM_ENABLE_ASYNC_COMMIT", "1"),
+                    ("D3DM_MULTITHREADED_INTERFACE_ENABLE", "1"),
+                    ("D3DM_IGNORE_D3D11_RENDER_BARRIERS", "1"),
+                    ("D3DM_SAMPLE_NAN_TO_ZERO", "1"),
+                    ("D3DM_FLUSH_POS_INF_TO_NAN", "1"),
+                ],
+            )?;
+            Ok((pid, "steam_d3dmetal_perf"))
+        },
+    }
 }
 
 pub fn launch_with_method(appid: u32, method: &str) -> Result<(u32, &'static str), Box<dyn std::error::Error>> {
@@ -251,47 +253,56 @@ pub fn launch_with_method(appid: u32, method: &str) -> Result<(u32, &'static str
 
     match method {
         "native_metalfx_low" => {
-            let pid = launch_via_steam_with_env(appid, &[
-                ("D3DM_ENABLE_METALFX", "1"),
-                ("D3DM_METALFX_QUALITY", "low"),
-                ("D3DM_ENABLE_ASYNC_COMMIT", "1"),
-                ("D3DM_MULTITHREADED_INTERFACE_ENABLE", "1"),
-                ("D3DM_IGNORE_D3D11_RENDER_BARRIERS", "1"),
-                ("D3DM_SAMPLE_NAN_TO_ZERO", "1"),
-                ("D3DM_FLUSH_POS_INF_TO_NAN", "1"),
-                ("MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE", "1"),
-                ("MVK_ALLOW_METAL_FENCES", "1"),
-            ])?;
+            let pid = launch_via_steam_with_env(
+                appid,
+                &[
+                    ("D3DM_ENABLE_METALFX", "1"),
+                    ("D3DM_METALFX_QUALITY", "low"),
+                    ("D3DM_ENABLE_ASYNC_COMMIT", "1"),
+                    ("D3DM_MULTITHREADED_INTERFACE_ENABLE", "1"),
+                    ("D3DM_IGNORE_D3D11_RENDER_BARRIERS", "1"),
+                    ("D3DM_SAMPLE_NAN_TO_ZERO", "1"),
+                    ("D3DM_FLUSH_POS_INF_TO_NAN", "1"),
+                    ("MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE", "1"),
+                    ("MVK_ALLOW_METAL_FENCES", "1"),
+                ],
+            )?;
             Ok((pid, "native_metalfx_low"))
-        }
+        },
         "native_metalfx_medium" => {
-            let pid = launch_via_steam_with_env(appid, &[
-                ("D3DM_ENABLE_METALFX", "1"),
-                ("D3DM_METALFX_QUALITY", "medium"),
-                ("D3DM_ENABLE_ASYNC_COMMIT", "1"),
-                ("D3DM_MULTITHREADED_INTERFACE_ENABLE", "1"),
-                ("D3DM_IGNORE_D3D11_RENDER_BARRIERS", "1"),
-                ("D3DM_SAMPLE_NAN_TO_ZERO", "1"),
-                ("D3DM_FLUSH_POS_INF_TO_NAN", "1"),
-                ("MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE", "1"),
-                ("MVK_ALLOW_METAL_FENCES", "1"),
-            ])?;
+            let pid = launch_via_steam_with_env(
+                appid,
+                &[
+                    ("D3DM_ENABLE_METALFX", "1"),
+                    ("D3DM_METALFX_QUALITY", "medium"),
+                    ("D3DM_ENABLE_ASYNC_COMMIT", "1"),
+                    ("D3DM_MULTITHREADED_INTERFACE_ENABLE", "1"),
+                    ("D3DM_IGNORE_D3D11_RENDER_BARRIERS", "1"),
+                    ("D3DM_SAMPLE_NAN_TO_ZERO", "1"),
+                    ("D3DM_FLUSH_POS_INF_TO_NAN", "1"),
+                    ("MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE", "1"),
+                    ("MVK_ALLOW_METAL_FENCES", "1"),
+                ],
+            )?;
             Ok((pid, "native_metalfx_medium"))
-        }
+        },
         "native_metalfx_high" => {
-            let pid = launch_via_steam_with_env(appid, &[
-                ("D3DM_ENABLE_METALFX", "1"),
-                ("D3DM_METALFX_QUALITY", "high"),
-                ("D3DM_ENABLE_ASYNC_COMMIT", "1"),
-                ("D3DM_MULTITHREADED_INTERFACE_ENABLE", "1"),
-                ("D3DM_IGNORE_D3D11_RENDER_BARRIERS", "1"),
-                ("D3DM_SAMPLE_NAN_TO_ZERO", "1"),
-                ("D3DM_FLUSH_POS_INF_TO_NAN", "1"),
-                ("MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE", "1"),
-                ("MVK_ALLOW_METAL_FENCES", "1"),
-            ])?;
+            let pid = launch_via_steam_with_env(
+                appid,
+                &[
+                    ("D3DM_ENABLE_METALFX", "1"),
+                    ("D3DM_METALFX_QUALITY", "high"),
+                    ("D3DM_ENABLE_ASYNC_COMMIT", "1"),
+                    ("D3DM_MULTITHREADED_INTERFACE_ENABLE", "1"),
+                    ("D3DM_IGNORE_D3D11_RENDER_BARRIERS", "1"),
+                    ("D3DM_SAMPLE_NAN_TO_ZERO", "1"),
+                    ("D3DM_FLUSH_POS_INF_TO_NAN", "1"),
+                    ("MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE", "1"),
+                    ("MVK_ALLOW_METAL_FENCES", "1"),
+                ],
+            )?;
             Ok((pid, "native_metalfx_high"))
-        }
+        },
         _ => Err(format!("Unknown launch method: {}", method).into()),
     }
 }
@@ -338,7 +349,9 @@ pub fn launch_via_steam_with_env(appid: u32, extra_env: &[(&str, &str)]) -> Resu
         crate::steam::launch_wine_steam()?;
         for _ in 0..30 {
             std::thread::sleep(std::time::Duration::from_secs(2));
-            if crate::steam::is_wine_steam_running() { break; }
+            if crate::steam::is_wine_steam_running() {
+                break;
+            }
         }
         std::thread::sleep(std::time::Duration::from_secs(5));
     }
@@ -346,18 +359,14 @@ pub fn launch_via_steam_with_env(appid: u32, extra_env: &[(&str, &str)]) -> Resu
     let url = format!("steam://run/{}", appid);
 
     let mut cmd = Command::new(&wine);
-    cmd.env("WINEPREFIX", &prefix_str)
-        .env("WINEDEBUG", "-all");
+    cmd.env("WINEPREFIX", &prefix_str).env("WINEDEBUG", "-all");
 
     for (key, val) in extra_env {
         cmd.env(key, val);
     }
 
-    let child = cmd
-        .args(["start", &url])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()?;
+    let child =
+        cmd.args(["start", &url]).stdout(std::process::Stdio::null()).stderr(std::process::Stdio::null()).spawn()?;
 
     Ok(child.id())
 }
@@ -396,10 +405,7 @@ fn launch_fna_x86(exe_path: &str, game_dir: &PathBuf) -> Result<u32, Box<dyn std
 
 fn launch_fna_arm64(exe_path: &str, game_dir: &PathBuf) -> Result<u32, Box<dyn std::error::Error>> {
     let mono_config = find_config("terraria-mono.config");
-    let dyld = format!(
-        "{}:/opt/homebrew/lib",
-        game_dir.to_string_lossy()
-    );
+    let dyld = format!("{}:/opt/homebrew/lib", game_dir.to_string_lossy());
 
     let child = Command::new("mono")
         .current_dir(game_dir)
@@ -423,11 +429,7 @@ fn launch_dxmt_metal(exe_path: &str, game_dir: &PathBuf) -> Result<u32, Box<dyn 
 
     let prefix = home.join(".metalsharp").join("prefix-steam");
     let prefix_str = prefix.to_string_lossy().to_string();
-    let exe_name = std::path::Path::new(exe_path)
-        .file_name()
-        .unwrap_or_default()
-        .to_string_lossy()
-        .to_string();
+    let exe_name = std::path::Path::new(exe_path).file_name().unwrap_or_default().to_string_lossy().to_string();
 
     let dyld_wine = ms_root.join("lib").join("wine").join("x86_64-unix").to_string_lossy().to_string();
     let dyld_dxmt = ms_root.join("lib").join("dxmt").join("x86_64-unix").to_string_lossy().to_string();
@@ -472,11 +474,7 @@ fn launch_dxmt_metal12(exe_path: &str, game_dir: &PathBuf) -> Result<u32, Box<dy
 
     let prefix = home.join(".metalsharp").join("prefix-steam");
     let prefix_str = prefix.to_string_lossy().to_string();
-    let exe_name = std::path::Path::new(exe_path)
-        .file_name()
-        .unwrap_or_default()
-        .to_string_lossy()
-        .to_string();
+    let exe_name = std::path::Path::new(exe_path).file_name().unwrap_or_default().to_string_lossy().to_string();
 
     let dyld_wine = ms_root.join("lib").join("wine").join("x86_64-unix").to_string_lossy().to_string();
     let dyld_dxmt = ms_root.join("lib").join("dxmt").join("x86_64-unix").to_string_lossy().to_string();
@@ -522,18 +520,17 @@ fn launch_wined3d_32(exe_path: &str, game_dir: &PathBuf) -> Result<u32, Box<dyn 
 
     let prefix = home.join(".metalsharp").join("prefix-steam");
     let prefix_str = prefix.to_string_lossy().to_string();
-    let exe_name = std::path::Path::new(exe_path)
-        .file_name()
-        .unwrap_or_default()
-        .to_string_lossy()
-        .to_string();
+    let exe_name = std::path::Path::new(exe_path).file_name().unwrap_or_default().to_string_lossy().to_string();
 
     let child = Command::new(&wine)
         .current_dir(game_dir)
         .env("WINEPREFIX", &prefix_str)
         .env("WINEDEBUG", "-all")
         .env("WINEDLLOVERRIDES", "dxgi,d3d11=b;gameoverlayrenderer,gameoverlayrenderer64=d")
-        .env("DYLD_FALLBACK_LIBRARY_PATH", ms_root.join("lib").join("wine").join("x86_64-unix").to_string_lossy().to_string())
+        .env(
+            "DYLD_FALLBACK_LIBRARY_PATH",
+            ms_root.join("lib").join("wine").join("x86_64-unix").to_string_lossy().to_string(),
+        )
         .arg(&exe_name)
         .spawn()?;
 
@@ -551,17 +548,16 @@ fn launch_metalsharp_wine(exe_path: &str, game_dir: &PathBuf) -> Result<u32, Box
 
     let prefix = home.join(".metalsharp").join("prefix-steam");
     let prefix_str = prefix.to_string_lossy().to_string();
-    let exe_name = std::path::Path::new(exe_path)
-        .file_name()
-        .unwrap_or_default()
-        .to_string_lossy()
-        .to_string();
+    let exe_name = std::path::Path::new(exe_path).file_name().unwrap_or_default().to_string_lossy().to_string();
 
     let child = Command::new(&wine)
         .current_dir(game_dir)
         .env("WINEPREFIX", &prefix_str)
         .env("WINEDEBUG", "-all")
-        .env("DYLD_FALLBACK_LIBRARY_PATH", ms_root.join("lib").join("wine").join("x86_64-unix").to_string_lossy().to_string())
+        .env(
+            "DYLD_FALLBACK_LIBRARY_PATH",
+            ms_root.join("lib").join("wine").join("x86_64-unix").to_string_lossy().to_string(),
+        )
         .arg(&exe_name)
         .spawn()?;
 
@@ -617,24 +613,16 @@ pub fn kill_game(appid: u32) -> Result<(), Box<dyn std::error::Error>> {
 
     let resolved = crate::setup::resolve_game_dir(appid);
 
-    let dirs_to_check = if let Some(ref rd) = resolved {
-        vec![rd.clone(), game_dir.clone()]
-    } else {
-        vec![game_dir.clone()]
-    };
+    let dirs_to_check =
+        if let Some(ref rd) = resolved { vec![rd.clone(), game_dir.clone()] } else { vec![game_dir.clone()] };
 
     for dir in &dirs_to_check {
         if dir.exists() {
-            if let Ok(output) = Command::new("pgrep")
-                .args(["-a", "-f", &dir.to_string_lossy()])
-                .output()
-            {
+            if let Ok(output) = Command::new("pgrep").args(["-a", "-f", &dir.to_string_lossy()]).output() {
                 for line in String::from_utf8_lossy(&output.stdout).lines() {
                     if let Some(pid_str) = line.split_whitespace().next() {
                         if let Ok(pid) = pid_str.parse::<i32>() {
-                            let _ = Command::new("kill")
-                                .args(["-9", &pid.to_string()])
-                                .status();
+                            let _ = Command::new("kill").args(["-9", &pid.to_string()]).status();
                         }
                     }
                 }
@@ -642,9 +630,7 @@ pub fn kill_game(appid: u32) -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    let _ = Command::new("pkill")
-        .args(["-9", "-f", "UnityCrashHandler"])
-        .status();
+    let _ = Command::new("pkill").args(["-9", "-f", "UnityCrashHandler"]).status();
 
     Ok(())
 }
@@ -682,10 +668,7 @@ fn find_metalsharp_native() -> Result<String, Box<dyn std::error::Error>> {
 
 fn find_scripts_dir() -> Option<PathBuf> {
     let home = dirs::home_dir().unwrap_or_default();
-    let candidates = vec![
-        home.join("metalsharp").join("scripts"),
-        home.join(".metalsharp").join("scripts"),
-    ];
+    let candidates = vec![home.join("metalsharp").join("scripts"), home.join(".metalsharp").join("scripts")];
     candidates.into_iter().find(|p| p.exists())
 }
 
@@ -733,10 +716,7 @@ pub fn run_game_setup_script(appid: u32) -> Result<(), Box<dyn std::error::Error
 }
 
 fn find_mono() -> Result<String, Box<dyn std::error::Error>> {
-    let candidates = vec![
-        PathBuf::from("/opt/homebrew/bin/mono"),
-        PathBuf::from("/usr/local/bin/mono"),
-    ];
+    let candidates = vec![PathBuf::from("/opt/homebrew/bin/mono"), PathBuf::from("/usr/local/bin/mono")];
 
     for c in candidates {
         if c.exists() {
@@ -771,10 +751,8 @@ fn find_wine() -> Result<String, Box<dyn std::error::Error>> {
 
 fn find_config(name: &str) -> String {
     let home = dirs::home_dir().unwrap_or_default();
-    let candidates = vec![
-        home.join("metalsharp").join("configs").join(name),
-        home.join(".metalsharp").join("configs").join(name),
-    ];
+    let candidates =
+        vec![home.join("metalsharp").join("configs").join(name), home.join(".metalsharp").join("configs").join(name)];
     for c in candidates {
         if c.exists() {
             return c.to_string_lossy().to_string();
@@ -785,10 +763,8 @@ fn find_config(name: &str) -> String {
 
 fn find_shims_dir() -> String {
     let home = dirs::home_dir().unwrap_or_default();
-    let candidates = vec![
-        home.join(".metalsharp").join("runtime").join("shims"),
-        home.join(".metalsharp").join("shims"),
-    ];
+    let candidates =
+        vec![home.join(".metalsharp").join("runtime").join("shims"), home.join(".metalsharp").join("shims")];
     for c in candidates {
         if c.exists() {
             return c.to_string_lossy().to_string();
@@ -831,10 +807,7 @@ fn launch_via_wine(exe_path: &str) -> Result<u32, Box<dyn std::error::Error>> {
 
     ensure_wine_prefix(&prefix)?;
 
-    let child = Command::new(&wine)
-        .env("WINEPREFIX", &prefix_str)
-        .arg(exe_path)
-        .spawn()?;
+    let child = Command::new(&wine).env("WINEPREFIX", &prefix_str).arg(exe_path).spawn()?;
 
     Ok(child.id())
 }

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -1,8 +1,8 @@
 mod installer;
+mod launch;
 mod scan;
 mod setup;
 mod steam;
-mod launch;
 
 use serde_json::json;
 use std::sync::Arc;
@@ -44,17 +44,23 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
     match (method, url.as_str()) {
         (Method::Get, "/status") => {
             app_log("Backend status checked");
-            resp(200, json!({
+            resp(
+                200,
+                json!({
+                    "ok": true,
+                    "version": "0.1.0"
+                }),
+            )
+        },
+        (Method::Get, "/update/check") => resp(
+            200,
+            json!({
                 "ok": true,
-                "version": "0.1.0"
-            }))
-        }
-        (Method::Get, "/update/check") => resp(200, json!({
-            "ok": true,
-            "current": "0.1.0",
-            "latest": "0.1.0",
-            "updateAvailable": false
-        })),
+                "current": "0.1.0",
+                "latest": "0.1.0",
+                "updateAvailable": false
+            }),
+        ),
         (Method::Get, "/setup/state") => resp(200, setup::state()),
         (Method::Post, "/setup/save") => {
             let body = read_body(req);
@@ -62,11 +68,14 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
                 Ok(v) => resp(200, v),
                 Err(e) => resp(500, json!({"ok": false, "error": e.to_string()})),
             }
-        }
-        (Method::Get, "/setup/device-name") => resp(200, json!({
-            "ok": true,
-            "name": setup::generate_device_name(),
-        })),
+        },
+        (Method::Get, "/setup/device-name") => resp(
+            200,
+            json!({
+                "ok": true,
+                "name": setup::generate_device_name(),
+            }),
+        ),
         (Method::Get, "/setup/dependencies") => resp(200, setup::dependencies()),
         (Method::Post, "/setup/install-deps") => {
             let body = read_body(req);
@@ -74,19 +83,13 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
                 Ok(v) => resp(200, v),
                 Err(e) => resp(500, json!({"ok": false, "error": e.to_string()})),
             }
-        }
-        (Method::Post, "/setup/install-all") => {
-            match installer::start_install_all() {
-                Ok(v) => resp(200, v),
-                Err(e) => resp(500, json!({"ok": false, "error": e.to_string()})),
-            }
-        }
-        (Method::Get, "/setup/install-progress") => {
-            resp(200, installer::read_progress())
-        }
-        (Method::Get, "/setup/installing") => {
-            resp(200, json!({"installing": installer::is_installing()}))
-        }
+        },
+        (Method::Post, "/setup/install-all") => match installer::start_install_all() {
+            Ok(v) => resp(200, v),
+            Err(e) => resp(500, json!({"ok": false, "error": e.to_string()})),
+        },
+        (Method::Get, "/setup/install-progress") => resp(200, installer::read_progress()),
+        (Method::Get, "/setup/installing") => resp(200, json!({"installing": installer::is_installing()})),
         (Method::Post, "/game/prepare") => {
             let body = read_body(req);
             let appid = body.get("appid").and_then(|v| v.as_u64());
@@ -97,24 +100,24 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
                         Ok(v) => resp(200, v),
                         Err(e) => resp(500, json!({"ok": false, "error": e.to_string()})),
                     }
-                }
+                },
                 None => resp(400, json!({"ok": false, "error": "appid required"})),
             }
-        }
+        },
         (Method::Get, "/scan") => {
             app_log("Scanning for installed games...");
             match scan::scan_all() {
                 Ok(result) => resp(200, result),
                 Err(e) => resp(500, json!({"ok": false, "error": e.to_string()})),
             }
-        }
+        },
         (Method::Get, "/steam/status") => resp(200, steam::status()),
         (Method::Get, "/steam/library") => {
             app_log("Loading Steam library...");
             let result = steam::library();
             app_log(&format!("Loaded {} games", result.get("total").and_then(|t| t.as_u64()).unwrap_or(0)));
             resp(200, result)
-        }
+        },
         (Method::Get, "/steam/api-key") => resp(200, steam::get_api_key()),
         (Method::Post, "/steam/save-api-key") => {
             let body = read_body(req);
@@ -124,7 +127,7 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
                 Ok(_) => resp(200, json!({"ok": true})),
                 Err(e) => resp(500, json!({"ok": false, "error": e.to_string()})),
             }
-        }
+        },
         (Method::Post, "/steam/install") => match steam::install_steam() {
             Ok(p) => resp(200, json!({"ok": true, "path": p})),
             Err(e) => resp(500, json!({"ok": false, "error": e.to_string()})),
@@ -135,23 +138,19 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
                 Ok(v) => resp(200, v),
                 Err(e) => resp(500, json!({"ok": false, "error": e.to_string()})),
             }
-        }
+        },
         (Method::Post, "/steam/stop") => {
             app_log("Stopping Wine Steam...");
             match steam::stop_wine_steam() {
                 Ok(v) => resp(200, v),
                 Err(e) => resp(500, json!({"ok": false, "error": e.to_string()})),
             }
-        }
-        (Method::Get, "/steam/is-running") => {
-            resp(200, json!({"ok": true, "running": steam::is_wine_steam_running()}))
-        }
-        (Method::Get, "/steam/watch-steamapps") => {
-            match steam::watch_steamapps() {
-                Some(new_ids) => resp(200, json!({"ok": true, "new_appids": new_ids})),
-                None => resp(200, json!({"ok": true, "new_appids": []})),
-            }
-        }
+        },
+        (Method::Get, "/steam/is-running") => resp(200, json!({"ok": true, "running": steam::is_wine_steam_running()})),
+        (Method::Get, "/steam/watch-steamapps") => match steam::watch_steamapps() {
+            Some(new_ids) => resp(200, json!({"ok": true, "new_appids": new_ids})),
+            None => resp(200, json!({"ok": true, "new_appids": []})),
+        },
         (Method::Post, "/steam/install-game") => {
             let body = read_body(req);
             let appid = body.get("appid").and_then(|v| v.as_u64());
@@ -162,10 +161,10 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
                         Ok(v) => resp(200, v),
                         Err(e) => resp(500, json!({"ok": false, "error": e.to_string()})),
                     }
-                }
+                },
                 None => resp(400, json!({"ok": false, "error": "appid required"})),
             }
-        }
+        },
         (Method::Post, "/steam/launch-game") => {
             let body = read_body(req);
             let appid = body.get("appid").and_then(|v| v.as_u64());
@@ -176,10 +175,10 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
                         Ok(v) => resp(200, v),
                         Err(e) => resp(500, json!({"ok": false, "error": e.to_string()})),
                     }
-                }
+                },
                 None => resp(400, json!({"ok": false, "error": "appid required"})),
             }
-        }
+        },
         (Method::Post, "/steam/view-game") => {
             let body = read_body(req);
             let appid = body.get("appid").and_then(|v| v.as_u64());
@@ -190,10 +189,10 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
                         Ok(v) => resp(200, v),
                         Err(e) => resp(500, json!({"ok": false, "error": e.to_string()})),
                     }
-                }
+                },
                 None => resp(400, json!({"ok": false, "error": "appid required"})),
             }
-        }
+        },
         (Method::Get, "/logs") => {
             let home = dirs::home_dir().unwrap_or_default();
             let log_path = home.join(".metalsharp").join("logs");
@@ -220,7 +219,7 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
                 }));
             }
             resp(200, json!({"ok": true, "logs": entries}))
-        }
+        },
         (Method::Get, "/config") => resp(200, launch::get_config()),
         (Method::Post, "/config") => {
             let body = read_body(req);
@@ -229,7 +228,7 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
                 Ok(cfg) => resp(200, cfg),
                 Err(e) => resp(500, json!({"ok": false, "error": e.to_string()})),
             }
-        }
+        },
         (Method::Post, "/launch") => {
             let body = read_body(req);
             let exe = body.get("exePath").and_then(|v| v.as_str()).unwrap_or("");
@@ -244,8 +243,10 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
             let mut game_type = "native";
             if steam_app_id.is_some() {
                 let home = dirs::home_dir().unwrap_or_default();
-                let marker = home.join(".metalsharp")
-                    .join("games").join(steam_app_id.unwrap().to_string())
+                let marker = home
+                    .join(".metalsharp")
+                    .join("games")
+                    .join(steam_app_id.unwrap().to_string())
                     .join(".metalsharp_prepared");
                 if let Ok(content) = std::fs::read_to_string(&marker) {
                     if content.contains("is_dotnet=true") {
@@ -256,33 +257,37 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
             }
 
             match launch::launch(&resolved, game_type) {
-                Ok(pid) => { app_log(&format!("Process started: pid {}", pid)); resp(200, json!({"ok": true, "pid": pid})) }
-                Err(e) => { app_log(&format!("Launch failed: {}", e)); resp(500, json!({"ok": false, "error": e.to_string()})) }
+                Ok(pid) => {
+                    app_log(&format!("Process started: pid {}", pid));
+                    resp(200, json!({"ok": true, "pid": pid}))
+                },
+                Err(e) => {
+                    app_log(&format!("Launch failed: {}", e));
+                    resp(500, json!({"ok": false, "error": e.to_string()}))
+                },
             }
-        }
+        },
         (Method::Post, "/game/launch-auto") => {
             let body = read_body(req);
             let appid = body.get("appid").and_then(|v| v.as_u64());
             match appid {
                 Some(id) => {
-                    let launch_method = body.get("launchMethod")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("auto");
+                    let launch_method = body.get("launchMethod").and_then(|v| v.as_str()).unwrap_or("auto");
                     app_log(&format!("Auto-launching game: appid {} method {}", id, launch_method));
                     match launch::launch_with_method(id as u32, launch_method) {
                         Ok((pid, game_type)) => {
                             app_log(&format!("Launched appid {} as {} (pid {})", id, game_type, pid));
                             resp(200, json!({"ok": true, "pid": pid, "gameType": game_type, "appid": id}))
-                        }
+                        },
                         Err(e) => {
                             app_log(&format!("Auto-launch failed: {}", e));
                             resp(500, json!({"ok": false, "error": e.to_string()}))
-                        }
+                        },
                     }
-                }
+                },
                 None => resp(400, json!({"ok": false, "error": "appid required"})),
             }
-        }
+        },
         (Method::Post, "/kill") => {
             let body = read_body(req);
             let pid = body.get("pid").and_then(|v| v.as_u64()).unwrap_or(0) as i32;
@@ -299,7 +304,7 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
                     Err(e) => resp(500, json!({"ok": false, "error": e.to_string()})),
                 }
             }
-        }
+        },
         (Method::Post, "/steam/uninstall-game") => {
             let body = read_body(req);
             match body.get("appid").and_then(|v| v.as_u64()).map(|v| v as u32) {
@@ -309,10 +314,10 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
                         Ok(r) => resp(200, r),
                         Err(e) => resp(500, json!({"ok": false, "error": e.to_string()})),
                     }
-                }
+                },
                 None => resp(400, json!({"ok": false, "error": "appid required"})),
             }
-        }
+        },
         _ => resp(404, json!({"ok": false, "error": "not found"})),
     }
 }
@@ -328,14 +333,15 @@ fn app_log(msg: &str) {
     let now = chrono_now();
     let line = format!("[{}] {}\n", now, msg);
     let log_path = log_dir.join(format!("{}.log", chrono_date()));
-    let _ = std::fs::OpenOptions::new().create(true).append(true).open(&log_path)
+    let _ = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
         .and_then(|mut f| std::io::Write::write_all(&mut f, line.as_bytes()));
 }
 
 fn chrono_now() -> String {
-    let d = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default();
+    let d = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap_or_default();
     let secs = d.as_secs();
     let h = (secs / 3600) % 24;
     let m = (secs / 60) % 60;
@@ -344,17 +350,18 @@ fn chrono_now() -> String {
 }
 
 fn chrono_date() -> String {
-    let d = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default();
+    let d = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap_or_default();
     let secs = d.as_secs();
     let days = secs / 86400;
     let y = 1970 + (days * 400 + 146096) / 146097;
     let mut remaining = days - (((y - 1) * 365) + ((y - 1) / 4) - ((y - 1) / 100) + ((y - 1) / 400));
-    let ml = [31,28,31,30,31,30,31,31,30,31,30,31];
+    let ml = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
     let mut mo = 1;
     for (i, &md) in ml.iter().enumerate() {
-        if remaining < md { mo = i + 1; break; }
+        if remaining < md {
+            mo = i + 1;
+            break;
+        }
         remaining -= md;
     }
     format!("{:04}-{:02}-{:02}", y, mo, remaining + 1)
@@ -371,7 +378,13 @@ fn resolve_game_exe(appid: u32) -> String {
                 let name_lower = name.to_lowercase();
                 if name_lower.starts_with("terraria") && !name_lower.contains("server")
                     || name_lower.starts_with("hl2") && !name_lower.contains("launcher")
-                    || !name_lower.contains("setup") && !name_lower.contains("redist") && !name_lower.contains("dotnet") && !name_lower.contains("installer") && !name_lower.contains("uninstall") && !name_lower.contains("vcredist") && !name_lower.contains("crashhandler")
+                    || !name_lower.contains("setup")
+                        && !name_lower.contains("redist")
+                        && !name_lower.contains("dotnet")
+                        && !name_lower.contains("installer")
+                        && !name_lower.contains("uninstall")
+                        && !name_lower.contains("vcredist")
+                        && !name_lower.contains("crashhandler")
                 {
                     return entry.path().to_string_lossy().to_string();
                 }
@@ -383,9 +396,15 @@ fn resolve_game_exe(appid: u32) -> String {
         if let Some(ext) = entry.path().extension() {
             if ext == "exe" {
                 let name = entry.file_name().to_string_lossy().to_lowercase();
-                if !name.contains("setup") && !name.contains("redist") && !name.contains("dotnet")
-                    && !name.contains("installer") && !name.contains("uninstall") && !name.contains("vcredist")
-                    && !name.contains("server") && !name.contains("crashhandler") {
+                if !name.contains("setup")
+                    && !name.contains("redist")
+                    && !name.contains("dotnet")
+                    && !name.contains("installer")
+                    && !name.contains("uninstall")
+                    && !name.contains("vcredist")
+                    && !name.contains("server")
+                    && !name.contains("crashhandler")
+                {
                     return entry.path().to_string_lossy().to_string();
                 }
             }
@@ -398,6 +417,5 @@ fn resolve_game_exe(appid: u32) -> String {
 fn read_body(req: &mut tiny_http::Request) -> serde_json::Map<String, serde_json::Value> {
     let mut buf = Vec::new();
     let _ = req.as_reader().read_to_end(&mut buf);
-    serde_json::from_slice::<serde_json::Map<String, serde_json::Value>>(&buf)
-        .unwrap_or_default()
+    serde_json::from_slice::<serde_json::Map<String, serde_json::Value>>(&buf).unwrap_or_default()
 }

--- a/app/src-rust/src/scan.rs
+++ b/app/src-rust/src/scan.rs
@@ -172,7 +172,7 @@ fn parse_acf(contents: &str) -> Option<(u32, String, String)> {
                 "appid" => appid = v.parse().ok(),
                 "name" => name = Some(v.to_string()),
                 "installdir" => install_dir = Some(v.to_string()),
-                _ => {}
+                _ => {},
             }
         }
     }
@@ -250,7 +250,10 @@ fn find_exe_in_dir(dir: &PathBuf) -> Option<String> {
                     continue;
                 }
                 let lower = name.to_lowercase();
-                let matches_name = lower.starts_with("rain") || lower.starts_with("terraria") || lower.starts_with("hl2") || lower == "game.exe";
+                let matches_name = lower.starts_with("rain")
+                    || lower.starts_with("terraria")
+                    || lower.starts_with("hl2")
+                    || lower == "game.exe";
                 if matches_name {
                     return Some(entry.path().to_string_lossy().to_string());
                 }

--- a/app/src-rust/src/setup.rs
+++ b/app/src-rust/src/setup.rs
@@ -36,10 +36,7 @@ pub fn save_step(body: &Map<String, Value>) -> Result<Value, Box<dyn std::error:
     let config_path = config_dir.join("setup.json");
 
     let mut cfg: Map<String, Value> = if config_path.exists() {
-        std::fs::read_to_string(&config_path)
-            .ok()
-            .and_then(|s| serde_json::from_str(&s).ok())
-            .unwrap_or_default()
+        std::fs::read_to_string(&config_path).ok().and_then(|s| serde_json::from_str(&s).ok()).unwrap_or_default()
     } else {
         Map::new()
     };
@@ -63,16 +60,12 @@ pub fn save_step(body: &Map<String, Value>) -> Result<Value, Box<dyn std::error:
 
 pub fn generate_device_name() -> String {
     let adjectives = [
-        "Swift", "Crimson", "Silent", "Bright", "Shadow",
-        "Frost", "Ember", "Storm", "Lunar", "Solar",
-        "Nova", "Pixel", "Cyber", "Iron", "Neon",
-        "Blaze", "Drift", "Pulse", "Glitch", "Volt",
+        "Swift", "Crimson", "Silent", "Bright", "Shadow", "Frost", "Ember", "Storm", "Lunar", "Solar", "Nova", "Pixel",
+        "Cyber", "Iron", "Neon", "Blaze", "Drift", "Pulse", "Glitch", "Volt",
     ];
     let nouns = [
-        "Wolf", "Falcon", "Tiger", "Raven", "Phoenix",
-        "Cobra", "Panther", "Hawk", "Lynx", "Viper",
-        "Fox", "Bear", "Eagle", "Shark", "Dragon",
-        "Knight", "Blade", "Spark", "Forge", "Core",
+        "Wolf", "Falcon", "Tiger", "Raven", "Phoenix", "Cobra", "Panther", "Hawk", "Lynx", "Viper", "Fox", "Bear",
+        "Eagle", "Shark", "Dragon", "Knight", "Blade", "Spark", "Forge", "Core",
     ];
 
     let mut buf: [u8; 4] = [0; 4];
@@ -80,11 +73,7 @@ pub fn generate_device_name() -> String {
         use std::io::Read;
         let _ = f.read_exact(&mut buf);
     } else {
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos()
-            .to_ne_bytes();
+        let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_nanos().to_ne_bytes();
         for (i, b) in nanos.iter().take(4).enumerate() {
             buf[i] = *b;
         }
@@ -101,9 +90,7 @@ pub fn dependencies() -> Value {
     let mono = check_command("mono") || check_path(&PathBuf::from("/opt/homebrew/bin/mono"));
     let mono_x86 = check_path(&home.join(".metalsharp/runtime/mono-x86/bin/mono"));
     let rosetta = check_rosetta();
-    let gptk = check_path(&PathBuf::from(
-        "/Applications/Game Porting Toolkit.app/Contents/Resources/wine/bin/wine64"
-    ));
+    let gptk = check_path(&PathBuf::from("/Applications/Game Porting Toolkit.app/Contents/Resources/wine/bin/wine64"));
     let xcode_cli = check_command("clang") || check_command("xcodebuild");
     let steam = check_path(&home.join("Library/Application Support/Steam/Steam.app/Contents/MacOS/steam_osx"))
         || check_path(&PathBuf::from("/Applications/Steam.app/Contents/MacOS/steam_osx"));
@@ -210,7 +197,7 @@ pub fn install_dependencies(body: &Map<String, Value>) -> Result<Value, Box<dyn 
             "sdl3" => run_brew_install("sdl3"),
             _ => {
                 json!({"id": id, "ok": false, "error": "unknown dependency"})
-            }
+            },
         };
         results.push(result);
     }
@@ -242,7 +229,7 @@ fn run_brew_install(package: &str) -> Value {
             } else {
                 json!({"id": package, "ok": false, "error": combined.lines().last().unwrap_or("unknown error")})
             }
-        }
+        },
         Err(e) => json!({"id": package, "ok": false, "error": e.to_string()}),
     }
 }
@@ -293,8 +280,7 @@ pub fn resolve_game_dir(appid: u32) -> Option<PathBuf> {
 
 pub fn prepare_game(appid: u32) -> Result<Value, Box<dyn std::error::Error>> {
     let home = dirs::home_dir().ok_or("no home dir")?;
-    let game_dir = resolve_game_dir(appid)
-        .ok_or_else(|| format!("game directory not found for appid {}", appid))?;
+    let game_dir = resolve_game_dir(appid).ok_or_else(|| format!("game directory not found for appid {}", appid))?;
 
     let marker = game_dir.join(".metalsharp_prepared");
 
@@ -307,7 +293,13 @@ pub fn prepare_game(appid: u32) -> Result<Value, Box<dyn std::error::Error>> {
         535520 => "wined3d_32",
         945360 | 1139900 => "metalsharp_wine",
         620 => "wine_devel",
-        _ => if is_dotnet { "xna_fna" } else { "steam_d3dmetal_perf" },
+        _ => {
+            if is_dotnet {
+                "xna_fna"
+            } else {
+                "steam_d3dmetal_perf"
+            }
+        },
     };
 
     if !marker.exists() {
@@ -326,7 +318,7 @@ pub fn prepare_game(appid: u32) -> Result<Value, Box<dyn std::error::Error>> {
             if is_dotnet {
                 setup_fna_runtime(&game_dir, &home)?;
             }
-        }
+        },
     }
 
     std::fs::write(&marker, format!("prepared: game_type={}", game_type))?;
@@ -340,7 +332,8 @@ pub fn prepare_game(appid: u32) -> Result<Value, Box<dyn std::error::Error>> {
 }
 
 fn prepare_terrarria(game_dir: &PathBuf, home: &PathBuf) -> Result<(), Box<dyn std::error::Error>> {
-    let mac_libs = home.join("Library/Application Support/Steam/steamapps/common/Terraria/Terraria.app/Contents/MacOS/osx");
+    let mac_libs =
+        home.join("Library/Application Support/Steam/steamapps/common/Terraria/Terraria.app/Contents/MacOS/osx");
 
     if mac_libs.exists() {
         for lib in &["libsteam_api.dylib", "libSDL3.0.dylib", "libFAudio.0.dylib", "libFNA3D.0.dylib", "libnfd.dylib"] {
@@ -436,9 +429,7 @@ fn prepare_celeste(game_dir: &PathBuf, home: &PathBuf) -> Result<(), Box<dyn std
         let alias_file = repo.join("src/fna/shims/csteamworks_aliases.txt");
         if shim_src.exists() {
             let mut cmd = std::process::Command::new("clang");
-            cmd.args(["-shared", "-arch", "x86_64"])
-                .arg("-o").arg(&csteamworks)
-                .arg(&shim_src);
+            cmd.args(["-shared", "-arch", "x86_64"]).arg("-o").arg(&csteamworks).arg(&shim_src);
 
             if alias_file.exists() {
                 if let Ok(aliases) = std::fs::read_to_string(&alias_file) {
@@ -459,7 +450,8 @@ fn prepare_celeste(game_dir: &PathBuf, home: &PathBuf) -> Result<(), Box<dyn std
             if result.is_err() || !result.unwrap().success() {
                 let _ = std::process::Command::new("clang")
                     .args(["-shared", "-arch", "x86_64"])
-                    .arg("-o").arg(&csteamworks)
+                    .arg("-o")
+                    .arg(&csteamworks)
                     .arg(&shim_src)
                     .args(["-undefined", "dynamic_lookup", "-install_name", "@loader_path/libCSteamworks.dylib"])
                     .stdout(std::process::Stdio::null())
@@ -480,7 +472,8 @@ fn prepare_celeste(game_dir: &PathBuf, home: &PathBuf) -> Result<(), Box<dyn std
             if stub_src.exists() {
                 let _ = std::process::Command::new("clang")
                     .args(["-shared", "-arch", "x86_64"])
-                    .arg("-o").arg(&dst)
+                    .arg("-o")
+                    .arg(&dst)
                     .arg(&stub_src)
                     .args(["-undefined", "dynamic_lookup", "-install_name", &format!("@loader_path/{}", fmod)])
                     .stdout(std::process::Stdio::null())
@@ -530,7 +523,10 @@ fn prepare_metalsharp_game(game_dir: &PathBuf, home: &PathBuf, appid: u32) -> Re
         if wine.exists() {
             let _ = std::process::Command::new(&wine)
                 .env("WINEPREFIX", &prefix_str)
-                .env("DYLD_FALLBACK_LIBRARY_PATH", ms_root.join("lib").join("wine").join("x86_64-unix").to_string_lossy().to_string())
+                .env(
+                    "DYLD_FALLBACK_LIBRARY_PATH",
+                    ms_root.join("lib").join("wine").join("x86_64-unix").to_string_lossy().to_string(),
+                )
                 .arg("wineboot")
                 .arg("--init")
                 .stdout(std::process::Stdio::null())
@@ -638,9 +634,7 @@ fn has_native_windows_dlls(game_dir: &PathBuf) -> bool {
                         || name_lower.contains("fmod")
                         || managed_extensions.iter().any(|e| name_lower.ends_with(e));
                     if !is_managed_wrapper {
-                        let output = std::process::Command::new("file")
-                            .arg(&path)
-                            .output();
+                        let output = std::process::Command::new("file").arg(&path).output();
                         if let Ok(o) = output {
                             let desc = String::from_utf8_lossy(&o.stdout);
                             if desc.contains("PE32") && !desc.contains(".Net") && !desc.contains("Mono/.Net") {
@@ -710,10 +704,8 @@ fn setup_fna_runtime(game_dir: &PathBuf, home: &PathBuf) -> Result<(), Box<dyn s
         }
     }
 
-    let sdl3_candidates = [
-        PathBuf::from("/opt/homebrew/lib/libSDL3.0.dylib"),
-        PathBuf::from("/usr/local/lib/libSDL3.0.dylib"),
-    ];
+    let sdl3_candidates =
+        [PathBuf::from("/opt/homebrew/lib/libSDL3.0.dylib"), PathBuf::from("/usr/local/lib/libSDL3.0.dylib")];
     for sdl3 in &sdl3_candidates {
         if sdl3.exists() {
             let dst = game_dir.join("libSDL3.0.dylib");
@@ -774,27 +766,22 @@ fn build_shim(src: &PathBuf, game_dir: &PathBuf) {
     let output = game_dir.join(output_name);
     let result = std::process::Command::new("clang")
         .args(["-shared", "-arch", "arm64"])
-        .arg("-o").arg(&output)
+        .arg("-o")
+        .arg(&output)
         .arg(src)
-        .arg("-install_name").arg(install_name)
+        .arg("-install_name")
+        .arg(install_name)
         .output();
 
     if let Ok(o) = result {
         if o.status.success() {
-            let _ = std::process::Command::new("codesign")
-                .args(["--force", "-s", "-"])
-                .arg(&output)
-                .output();
+            let _ = std::process::Command::new("codesign").args(["--force", "-s", "-"]).arg(&output).output();
         }
     }
 }
 
 fn check_command(cmd: &str) -> bool {
-    std::process::Command::new("which")
-        .arg(cmd)
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
+    std::process::Command::new("which").arg(cmd).output().map(|o| o.status.success()).unwrap_or(false)
 }
 
 fn check_path(path: &PathBuf) -> bool {
@@ -826,10 +813,5 @@ fn check_brew(formula: &str) -> bool {
 
 fn check_rosetta() -> bool {
     PathBuf::from("/Library/Apple/System/Library/LaunchDaemons/com.apple.oahd.plist").exists()
-        || std::process::Command::new("pgrep")
-            .arg("-q")
-            .arg("oahd")
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false)
+        || std::process::Command::new("pgrep").arg("-q").arg("oahd").status().map(|s| s.success()).unwrap_or(false)
 }

--- a/app/src-rust/src/steam.rs
+++ b/app/src-rust/src/steam.rs
@@ -13,34 +13,20 @@ fn ms_wine() -> PathBuf {
 }
 
 fn steam_prefix() -> PathBuf {
-    dirs::home_dir()
-        .unwrap_or_default()
-        .join(".metalsharp")
-        .join("prefix-steam")
+    dirs::home_dir().unwrap_or_default().join(".metalsharp").join("prefix-steam")
 }
 
 fn steam_exe_path() -> PathBuf {
-    steam_prefix()
-        .join("drive_c")
-        .join("Program Files (x86)")
-        .join("Steam")
-        .join("Steam.exe")
+    steam_prefix().join("drive_c").join("Program Files (x86)").join("Steam").join("Steam.exe")
 }
 
 pub fn status() -> Value {
     let home = dirs::home_dir().unwrap_or_default();
 
-    let wine_steam_dir = steam_prefix()
-        .join("drive_c")
-        .join("Program Files (x86)")
-        .join("Steam");
+    let wine_steam_dir = steam_prefix().join("drive_c").join("Program Files (x86)").join("Steam");
     let wine_steam_exe = wine_steam_dir.join("Steam.exe");
     let windows_installed = wine_steam_exe.exists();
-    let windows_path = if windows_installed {
-        Some(wine_steam_dir.to_string_lossy().to_string())
-    } else {
-        None
-    };
+    let windows_path = if windows_installed { Some(wine_steam_dir.to_string_lossy().to_string()) } else { None };
 
     let login_state = detect_login_state();
 
@@ -65,16 +51,8 @@ pub fn status() -> Value {
 }
 
 pub fn is_wine_steam_running() -> bool {
-    Command::new("pgrep")
-        .args(["-f", "Steam.exe"])
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
-        || Command::new("pgrep")
-            .args(["-f", "steam.exe"])
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
+    Command::new("pgrep").args(["-f", "Steam.exe"]).output().map(|o| o.status.success()).unwrap_or(false)
+        || Command::new("pgrep").args(["-f", "steam.exe"]).output().map(|o| o.status.success()).unwrap_or(false)
 }
 
 pub fn launch_wine_steam() -> Result<Value, Box<dyn std::error::Error>> {
@@ -84,10 +62,7 @@ pub fn launch_wine_steam() -> Result<Value, Box<dyn std::error::Error>> {
     }
 
     let exe = steam_exe_path();
-    let steam_dir = steam_prefix()
-        .join("drive_c")
-        .join("Program Files (x86)")
-        .join("Steam");
+    let steam_dir = steam_prefix().join("drive_c").join("Program Files (x86)").join("Steam");
 
     if !exe.exists() || !steam_dir.join("steamui.dll").exists() {
         return Err("Steam is not installed — use the setup wizard to install it first".into());
@@ -97,11 +72,7 @@ pub fn launch_wine_steam() -> Result<Value, Box<dyn std::error::Error>> {
         return Ok(json!({"ok": true, "message": "Steam already running"}));
     }
 
-    let ms_root = dirs::home_dir()
-        .unwrap_or_default()
-        .join(".metalsharp")
-        .join("runtime")
-        .join("wine");
+    let ms_root = dirs::home_dir().unwrap_or_default().join(".metalsharp").join("runtime").join("wine");
     let dyld = format!(
         "{}:{}",
         ms_root.join("lib").to_string_lossy(),
@@ -117,7 +88,10 @@ pub fn launch_wine_steam() -> Result<Value, Box<dyn std::error::Error>> {
         .env("STEAM_RUNTIME", "0")
         .env("MS_FWD_COMPAT_GL_CTX", "1")
         .env("DYLD_FALLBACK_LIBRARY_PATH", &dyld)
-        .env("WINEDLLOVERRIDES", "dxgi,d3d11,d3d10core=n,b;bcrypt=b;ncrypt=b;gameoverlayrenderer,gameoverlayrenderer64=d")
+        .env(
+            "WINEDLLOVERRIDES",
+            "dxgi,d3d11,d3d10core=n,b;bcrypt=b;ncrypt=b;gameoverlayrenderer,gameoverlayrenderer64=d",
+        )
         .arg(&exe)
         .args(["-no-cef-sandbox", "-cef-single-process", "-noverifyfiles", "-no-dwrite"])
         .stdout(std::process::Stdio::null())
@@ -128,10 +102,7 @@ pub fn launch_wine_steam() -> Result<Value, Box<dyn std::error::Error>> {
 }
 
 pub fn stop_wine_steam() -> Result<Value, Box<dyn std::error::Error>> {
-    let targets = [
-        "Steam.exe", "steam.exe", "steamservice.exe",
-        "steamwebhelper.exe", "winedevice.exe",
-    ];
+    let targets = ["Steam.exe", "steam.exe", "steamservice.exe", "steamwebhelper.exe", "winedevice.exe"];
 
     for target in &targets {
         let _ = Command::new("pkill")
@@ -157,11 +128,8 @@ pub fn stop_wine_steam() -> Result<Value, Box<dyn std::error::Error>> {
 
     std::thread::sleep(std::time::Duration::from_secs(2));
 
-    let still_running = Command::new("pgrep")
-        .args(["-f", "Steam.exe"])
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false);
+    let still_running =
+        Command::new("pgrep").args(["-f", "Steam.exe"]).output().map(|o| o.status.success()).unwrap_or(false);
 
     if still_running {
         for target in &targets {
@@ -205,11 +173,7 @@ pub fn launch_game_via_steam(appid: u32) -> Result<Value, Box<dyn std::error::Er
     let prefix_str = steam_prefix().to_string_lossy().to_string();
     let url = format!("steam://run/{}", appid);
 
-    let ms_root = dirs::home_dir()
-        .unwrap_or_default()
-        .join(".metalsharp")
-        .join("runtime")
-        .join("wine");
+    let ms_root = dirs::home_dir().unwrap_or_default().join(".metalsharp").join("runtime").join("wine");
     let dyld = format!(
         "{}:{}",
         ms_root.join("lib").to_string_lossy(),
@@ -240,11 +204,7 @@ pub fn view_game_in_steam(appid: u32) -> Result<Value, Box<dyn std::error::Error
     let prefix_str = steam_prefix().to_string_lossy().to_string();
     let url = format!("steam://nav/games/details/{}", appid);
 
-    let ms_root = dirs::home_dir()
-        .unwrap_or_default()
-        .join(".metalsharp")
-        .join("runtime")
-        .join("wine");
+    let ms_root = dirs::home_dir().unwrap_or_default().join(".metalsharp").join("runtime").join("wine");
     let dyld = format!(
         "{}:{}",
         ms_root.join("lib").to_string_lossy(),
@@ -271,10 +231,7 @@ pub fn get_wine_steam_installed_games() -> Vec<u32> {
             for entry in entries.flatten() {
                 let name = entry.file_name().to_string_lossy().to_string();
                 if name.starts_with("appmanifest_") && name.ends_with(".acf") {
-                    if let Some(id_str) = name
-                        .strip_prefix("appmanifest_")
-                        .and_then(|s| s.strip_suffix(".acf"))
-                    {
+                    if let Some(id_str) = name.strip_prefix("appmanifest_").and_then(|s| s.strip_suffix(".acf")) {
                         if let Ok(id) = id_str.parse::<u32>() {
                             if !appids.contains(&id) {
                                 appids.push(id);
@@ -350,12 +307,7 @@ fn find_bundled_steamwebhelper_wrapper() -> Option<PathBuf> {
     }
 
     let url = "https://github.com/aaf2tbz/metalsharp/releases/download/bundles/steamwebhelper.exe";
-    let output = Command::new("curl")
-        .args(["-sL", "-o"])
-        .arg(&cached)
-        .arg(url)
-        .output()
-        .ok()?;
+    let output = Command::new("curl").args(["-sL", "-o"]).arg(&cached).arg(url).output().ok()?;
 
     if output.status.success() && cached.exists() {
         let size = std::fs::metadata(&cached).map(|m| m.len()).unwrap_or(0);
@@ -398,13 +350,10 @@ pub fn uninstall_game(appid: u32) -> Result<Value, Box<dyn std::error::Error>> {
         let manifest_path = steamapps.join(&manifest_name);
         if manifest_path.exists() {
             let contents = std::fs::read_to_string(&manifest_path).unwrap_or_default();
-            let install_dir = contents
-                .lines()
-                .find(|l| l.contains("\"installdir\""))
-                .and_then(|l| {
-                    let parts: Vec<&str> = l.splitn(2, |c: char| c == '\t' || c == ' ').collect();
-                    parts.last().map(|s| s.trim().trim_matches('"').to_string())
-                });
+            let install_dir = contents.lines().find(|l| l.contains("\"installdir\"")).and_then(|l| {
+                let parts: Vec<&str> = l.splitn(2, |c: char| c == '\t' || c == ' ').collect();
+                parts.last().map(|s| s.trim().trim_matches('"').to_string())
+            });
 
             if let Some(dir_name) = install_dir {
                 let game_dir = steamapps.join("common").join(&dir_name);
@@ -417,10 +366,7 @@ pub fn uninstall_game(appid: u32) -> Result<Value, Box<dyn std::error::Error>> {
         }
     }
 
-    let local_dir = home
-        .join(".metalsharp")
-        .join("games")
-        .join(appid.to_string());
+    let local_dir = home.join(".metalsharp").join("games").join(appid.to_string());
     if local_dir.exists() {
         let _ = std::fs::remove_dir_all(&local_dir);
     }
@@ -492,8 +438,7 @@ pub fn library() -> Value {
         _ => {
             let mut fallback: Vec<(u32, String)> = Vec::new();
             for &appid in &wine_steam_appids {
-                let name =
-                    get_game_name_from_manifest(appid).unwrap_or_else(|| format!("Game {}", appid));
+                let name = get_game_name_from_manifest(appid).unwrap_or_else(|| format!("Game {}", appid));
                 fallback.push((appid, name));
             }
             for &appid in &downloaded_appids {
@@ -502,7 +447,7 @@ pub fn library() -> Value {
                 }
             }
             fallback
-        }
+        },
     };
 
     let owned_appids: Vec<u32> = owned.iter().map(|(id, _)| *id).collect();
@@ -562,12 +507,7 @@ fn get_downloaded_appids() -> Vec<u32> {
                         .max_depth(3)
                         .into_iter()
                         .flatten()
-                        .any(|e| {
-                            e.path()
-                                .extension()
-                                .map(|ext| ext == "exe")
-                                .unwrap_or(false)
-                        });
+                        .any(|e| e.path().extension().map(|ext| ext == "exe").unwrap_or(false));
                     if has_exe {
                         appids.push(id);
                     }
@@ -584,23 +524,15 @@ fn read_steam_config() -> (Option<String>, Option<String>) {
     let config_path = home.join(".metalsharp/cache/steam_config.json");
     if let Ok(contents) = std::fs::read_to_string(&config_path) {
         if let Ok(cfg) = serde_json::from_str::<serde_json::Map<String, Value>>(&contents) {
-            let key = cfg
-                .get("steam_api_key")
-                .and_then(|v| v.as_str())
-                .map(String::from);
-            let sid = cfg
-                .get("steam_id")
-                .and_then(|v| v.as_str())
-                .map(String::from);
+            let key = cfg.get("steam_api_key").and_then(|v| v.as_str()).map(String::from);
+            let sid = cfg.get("steam_id").and_then(|v| v.as_str()).map(String::from);
             return (key, sid);
         }
     }
     (None, get_steam_id())
 }
 
-fn fetch_owned_games(
-    _steam_id: Option<&str>,
-) -> Result<Vec<(u32, String)>, Box<dyn std::error::Error>> {
+fn fetch_owned_games(_steam_id: Option<&str>) -> Result<Vec<(u32, String)>, Box<dyn std::error::Error>> {
     let (api_key, steam_id) = read_steam_config();
     let key = api_key.as_deref().unwrap_or("");
     let sid = steam_id.as_deref().or(_steam_id).unwrap_or("");
@@ -609,9 +541,7 @@ fn fetch_owned_games(
         return Ok(vec![]);
     }
 
-    let cache_path = dirs::home_dir()
-        .map(|h| h.join(".metalsharp/cache/owned_games.json"))
-        .unwrap_or_default();
+    let cache_path = dirs::home_dir().map(|h| h.join(".metalsharp/cache/owned_games.json")).unwrap_or_default();
 
     if cache_path.exists() {
         if let Ok(contents) = std::fs::read_to_string(&cache_path) {
@@ -643,9 +573,7 @@ fn fetch_owned_games(
         key, sid
     );
 
-    let output = Command::new("curl")
-        .args(["-sL", "-m", "15", &url])
-        .output()?;
+    let output = Command::new("curl").args(["-sL", "-m", "15", &url]).output()?;
 
     if !output.status.success() {
         return Err("curl failed".into());
@@ -653,10 +581,7 @@ fn fetch_owned_games(
 
     let body: Value = serde_json::from_slice(&output.stdout)?;
 
-    let games_arr = body
-        .get("response")
-        .and_then(|r| r.get("games"))
-        .and_then(|g| g.as_array());
+    let games_arr = body.get("response").and_then(|r| r.get("games")).and_then(|g| g.as_array());
 
     let result: Vec<(u32, String)> = match games_arr {
         Some(arr) => arr
@@ -679,18 +604,9 @@ fn save_cache(path: &PathBuf, games: &[(u32, String)]) -> Result<(), Box<dyn std
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let arr: Vec<Value> = games
-        .iter()
-        .map(|(id, name)| json!({"appid": id, "name": name}))
-        .collect();
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    std::fs::write(
-        path,
-        serde_json::to_string_pretty(&json!({"timestamp": now, "games": arr}))?,
-    )?;
+    let arr: Vec<Value> = games.iter().map(|(id, name)| json!({"appid": id, "name": name})).collect();
+    let now = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_secs();
+    std::fs::write(path, serde_json::to_string_pretty(&json!({"timestamp": now, "games": arr}))?)?;
     Ok(())
 }
 
@@ -712,10 +628,7 @@ fn get_installed_appids() -> Vec<u32> {
             for entry in entries.flatten() {
                 let name = entry.file_name().to_string_lossy().to_string();
                 if name.starts_with("appmanifest_") && name.ends_with(".acf") {
-                    if let Some(id_str) = name
-                        .strip_prefix("appmanifest_")
-                        .and_then(|s| s.strip_suffix(".acf"))
-                    {
+                    if let Some(id_str) = name.strip_prefix("appmanifest_").and_then(|s| s.strip_suffix(".acf")) {
                         if let Ok(id) = id_str.parse::<u32>() {
                             if !appids.contains(&id) {
                                 appids.push(id);
@@ -733,12 +646,10 @@ fn get_installed_appids() -> Vec<u32> {
 fn detect_login_state() -> Value {
     let home = dirs::home_dir().unwrap_or_default();
     let mac_path = home.join("Library/Application Support/Steam/config/loginusers.vdf");
-    let wine_path =
-        home.join(".metalsharp/prefix-steam/drive_c/Program Files (x86)/Steam/config/loginusers.vdf");
+    let wine_path = home.join(".metalsharp/prefix-steam/drive_c/Program Files (x86)/Steam/config/loginusers.vdf");
 
-    let contents = std::fs::read_to_string(&mac_path)
-        .or_else(|_| std::fs::read_to_string(&wine_path))
-        .unwrap_or_default();
+    let contents =
+        std::fs::read_to_string(&mac_path).or_else(|_| std::fs::read_to_string(&wine_path)).unwrap_or_default();
 
     if contents.is_empty() {
         return json!({"state": "unknown", "account": null});
@@ -749,9 +660,7 @@ fn detect_login_state() -> Value {
     for line in contents.lines() {
         let trimmed = line.trim();
         if let Some(name) = parse_vdf_value(trimmed, "PersonaName") {
-            let remembered = contents
-                .lines()
-                .any(|l| l.contains("RememberPassword") && l.contains("1"));
+            let remembered = contents.lines().any(|l| l.contains("RememberPassword") && l.contains("1"));
             accounts.push(json!({
                 "name": name,
                 "remembered": remembered,
@@ -781,10 +690,7 @@ pub fn install_steam() -> Result<String, Box<dyn std::error::Error>> {
     let metalsharp_dir = home.join(".metalsharp");
     std::fs::create_dir_all(&metalsharp_dir)?;
 
-    let steam_dir = steam_prefix()
-        .join("drive_c")
-        .join("Program Files (x86)")
-        .join("Steam");
+    let steam_dir = steam_prefix().join("drive_c").join("Program Files (x86)").join("Steam");
 
     if steam_dir.join("steamui.dll").exists() && steam_exe_path().exists() {
         return Ok("Steam already installed".into());
@@ -796,9 +702,7 @@ pub fn install_steam() -> Result<String, Box<dyn std::error::Error>> {
     let _ = std::fs::remove_file(&installer);
 
     let url = "https://steamcdn-a.akamaihd.net/client/installer/SteamSetup.exe";
-    let output = Command::new("curl")
-        .args(["-sL", "-o", &installer.to_string_lossy(), url])
-        .status()?;
+    let output = Command::new("curl").args(["-sL", "-o", &installer.to_string_lossy(), url]).status()?;
     if !output.success() {
         let mut found = false;
         if let Ok(exe) = std::env::current_exe() {
@@ -831,11 +735,7 @@ pub fn install_steam() -> Result<String, Box<dyn std::error::Error>> {
 
     let prefix_str = prefix.to_string_lossy().to_string();
 
-    let ms_root = dirs::home_dir()
-        .unwrap_or_default()
-        .join(".metalsharp")
-        .join("runtime")
-        .join("wine");
+    let ms_root = dirs::home_dir().unwrap_or_default().join(".metalsharp").join("runtime").join("wine");
     let dyld = format!(
         "{}:{}",
         ms_root.join("lib").to_string_lossy(),
@@ -868,11 +768,7 @@ pub fn install_steam() -> Result<String, Box<dyn std::error::Error>> {
 }
 
 pub fn watch_steamapps() -> Option<String> {
-    let steamapps = steam_prefix()
-        .join("drive_c")
-        .join("Program Files (x86)")
-        .join("Steam")
-        .join("steamapps");
+    let steamapps = steam_prefix().join("drive_c").join("Program Files (x86)").join("Steam").join("steamapps");
 
     if !steamapps.exists() {
         return None;
@@ -897,10 +793,7 @@ pub fn watch_steamapps() -> Option<String> {
         }
     }
 
-    let _ = std::fs::write(
-        &cached_path,
-        current.iter().map(|id| id.to_string()).collect::<Vec<_>>().join("\n"),
-    );
+    let _ = std::fs::write(&cached_path, current.iter().map(|id| id.to_string()).collect::<Vec<_>>().join("\n"));
 
     if new_appids.is_empty() {
         None

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -1,6 +1,6 @@
-import { app, BrowserWindow, ipcMain, dialog, shell } from "electron";
-import * as path from "path";
+import { app, BrowserWindow, dialog, ipcMain, shell } from "electron";
 import * as fs from "fs";
+import * as path from "path";
 import { RustBridge } from "./rust-bridge";
 
 let shellPath: string | undefined;
@@ -78,7 +78,7 @@ function startSteamappsWatcher() {
     "drive_c",
     "Program Files (x86)",
     "Steam",
-    "steamapps"
+    "steamapps",
   );
 
   if (!fs.existsSync(steamappsDir)) return;
@@ -135,9 +135,12 @@ app.on("before-quit", () => {
 });
 
 function registerIpc() {
-  ipcMain.handle("backend:request", async (_e, method: string, url: string, body?: Record<string, unknown>, timeoutMs?: number) => {
-    return bridge.request(method, url, body, timeoutMs);
-  });
+  ipcMain.handle(
+    "backend:request",
+    async (_e, method: string, url: string, body?: Record<string, unknown>, timeoutMs?: number) => {
+      return bridge.request(method, url, body, timeoutMs);
+    },
+  );
 
   ipcMain.handle("app:is-first-launch", () => {
     return isFirstLaunch();
@@ -181,13 +184,21 @@ function registerIpc() {
       const { spawn } = require("child_process");
       const env = { ...process.env, PATH: ensureShellPath() };
       const brewPath = ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"].find((p) => {
-        try { fs.accessSync(p); return true; } catch { return false; }
+        try {
+          fs.accessSync(p);
+          return true;
+        } catch {
+          return false;
+        }
       });
 
       let proc;
       if (command.startsWith("brew ")) {
         if (!brewPath) {
-          resolve({ ok: false, error: "Homebrew is not installed. Install it from https://brew.sh first." });
+          resolve({
+            ok: false,
+            error: "Homebrew is not installed. Install it from https://brew.sh first.",
+          });
           return;
         }
         const args = command.split(/\s+/).slice(1);
@@ -214,19 +225,31 @@ function registerIpc() {
       let stderr = "";
       let settled = false;
 
-      const timer = setTimeout(() => {
-        if (!settled) {
-          settled = true;
-          proc.kill();
-          resolve({ ok: false, error: "Installation timed out after 10 minutes." });
-        }
-      }, 10 * 60 * 1000);
+      const timer = setTimeout(
+        () => {
+          if (!settled) {
+            settled = true;
+            proc.kill();
+            resolve({
+              ok: false,
+              error: "Installation timed out after 10 minutes.",
+            });
+          }
+        },
+        10 * 60 * 1000,
+      );
 
       proc.stdout.on("data", (d: Buffer) => (stdout += d.toString()));
       proc.stderr.on("data", (d: Buffer) => (stderr += d.toString()));
       proc.on("error", (err: Error) => {
-        if (!settled) { settled = true; clearTimeout(timer); }
-        resolve({ ok: false, error: `Failed to run "${command}": ${err.message}` });
+        if (!settled) {
+          settled = true;
+          clearTimeout(timer);
+        }
+        resolve({
+          ok: false,
+          error: `Failed to run "${command}": ${err.message}`,
+        });
       });
       proc.on("close", (code: number) => {
         if (settled) return;
@@ -234,7 +257,10 @@ function registerIpc() {
         clearTimeout(timer);
         const combined = `${stdout}${stderr}`;
         const ok = code === 0 || combined.includes("already installed");
-        resolve({ ok, error: ok ? null : combined.split("\n").filter(Boolean).pop() ?? `exit code ${code}` });
+        resolve({
+          ok,
+          error: ok ? null : (combined.split("\n").filter(Boolean).pop() ?? `exit code ${code}`),
+        });
       });
     });
   });
@@ -243,13 +269,22 @@ function registerIpc() {
     const { exec } = require("child_process");
     return new Promise((resolve) => {
       const script = `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`;
-      exec(`osascript -e 'tell application "Terminal" to do script "${script.replace(/"/g, '\\\\"')}"'`, (err: Error | null) => {
-        if (err) {
-          resolve({ ok: false, error: "Failed to open Terminal for Homebrew install" });
-        } else {
-          resolve({ ok: true, message: "Terminal opened — complete the Homebrew install there" });
-        }
-      });
+      exec(
+        `osascript -e 'tell application "Terminal" to do script "${script.replace(/"/g, '\\\\"')}"'`,
+        (err: Error | null) => {
+          if (err) {
+            resolve({
+              ok: false,
+              error: "Failed to open Terminal for Homebrew install",
+            });
+          } else {
+            resolve({
+              ok: true,
+              message: "Terminal opened — complete the Homebrew install there",
+            });
+          }
+        },
+      );
     });
   });
 }

--- a/app/src/main/preload.ts
+++ b/app/src/main/preload.ts
@@ -3,14 +3,9 @@ import { contextBridge, ipcRenderer } from "electron";
 contextBridge.exposeInMainWorld("metalsharp", {
   request: (method: string, url: string, body?: Record<string, unknown>, timeoutMs?: number) =>
     ipcRenderer.invoke("backend:request", method, url, body, timeoutMs),
-  isFirstLaunch: () =>
-    ipcRenderer.invoke("app:is-first-launch"),
-  ejectDmg: () =>
-    ipcRenderer.invoke("app:eject-dmg"),
-  installDeps: (command: string) =>
-    ipcRenderer.invoke("app:install-deps", command),
-  installHomebrew: () =>
-    ipcRenderer.invoke("app:install-homebrew"),
-  onSteamappsChanged: (callback: () => void) =>
-    ipcRenderer.on("steamapps:changed", callback),
+  isFirstLaunch: () => ipcRenderer.invoke("app:is-first-launch"),
+  ejectDmg: () => ipcRenderer.invoke("app:eject-dmg"),
+  installDeps: (command: string) => ipcRenderer.invoke("app:install-deps", command),
+  installHomebrew: () => ipcRenderer.invoke("app:install-homebrew"),
+  onSteamappsChanged: (callback: () => void) => ipcRenderer.on("steamapps:changed", callback),
 });

--- a/app/src/main/rust-bridge.ts
+++ b/app/src/main/rust-bridge.ts
@@ -1,6 +1,6 @@
-import { ChildProcess, spawn } from "child_process";
-import * as path from "path";
+import { type ChildProcess, spawn } from "child_process";
 import * as http from "http";
+import * as path from "path";
 
 function getShellPath(): string {
   const home = process.env.HOME || "";
@@ -38,7 +38,11 @@ export class RustBridge {
     }
 
     this.proc = spawn(binPath, [], {
-      env: { ...process.env, PATH: shellPath, METALSHARP_PORT: String(this.port) },
+      env: {
+        ...process.env,
+        PATH: shellPath,
+        METALSHARP_PORT: String(this.port),
+      },
       stdio: ["ignore", "pipe", "pipe"],
     });
 

--- a/app/src/renderer/api-types.ts
+++ b/app/src/renderer/api-types.ts
@@ -76,7 +76,12 @@ interface DependenciesResponse {
 }
 
 type MetalsharpAPI = {
-  request: (method: string, url: string, body?: Record<string, unknown>, timeoutMs?: number) => Promise<BackendResponse>;
+  request: (
+    method: string,
+    url: string,
+    body?: Record<string, unknown>,
+    timeoutMs?: number,
+  ) => Promise<BackendResponse>;
   isFirstLaunch: () => Promise<boolean>;
   ejectDmg: () => Promise<void>;
   installDeps: (command: string) => Promise<{ ok: boolean; error?: string }>;

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -1,37 +1,40 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; font-src 'self'; img-src 'self' https://steamcdn-a.akamaihd.net https://cdn.akamai.steamstatic.com https://store.steampowered.com; style-src 'self' 'unsafe-inline'; script-src 'self';" />
-  <title>MetalSharp</title>
-  <link rel="stylesheet" href="styles.css" />
-</head>
-<body>
-  <div id="app">
-    <div class="drag-bar"></div>
-    <nav class="sidebar">
-      <div class="logo">
-        <img src="icon.png" class="logo-icon" alt="MetalSharp" />
-        <span class="logo-text">MetalSharp</span>
-      </div>
-      <div class="nav-items">
-        <button class="nav-item active" data-view="library">Library</button>
-        <button class="nav-item" data-view="logs">Logs</button>
-        <button class="theme-toggle-sidebar" id="btn-theme" title="Toggle light mode">Light Mode</button>
-        <button class="nav-item" data-view="settings">Settings</button>
-      </div>
-      <div class="sidebar-footer">
-        <div class="status-dot" id="backend-status"></div>
-        <span class="status-text" id="backend-status-text">Connecting...</span>
-      </div>
-    </nav>
-    <main class="content" id="main-content">
-      <div class="view" id="view-library"></div>
-       <div class="view hidden" id="view-logs"></div>
-      <div class="view hidden" id="view-settings"></div>
-    </main>
-  </div>
-  <script src="index.js"></script>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; font-src 'self'; img-src 'self' https://steamcdn-a.akamaihd.net https://cdn.akamai.steamstatic.com https://store.steampowered.com; style-src 'self' 'unsafe-inline'; script-src 'self';"
+    />
+    <title>MetalSharp</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div id="app">
+      <div class="drag-bar"></div>
+      <nav class="sidebar">
+        <div class="logo">
+          <img src="icon.png" class="logo-icon" alt="MetalSharp" />
+          <span class="logo-text">MetalSharp</span>
+        </div>
+        <div class="nav-items">
+          <button type="button" class="nav-item active" data-view="library">Library</button>
+          <button type="button" class="nav-item" data-view="logs">Logs</button>
+          <button type="button" class="theme-toggle-sidebar" id="btn-theme" title="Toggle light mode">Light Mode</button>
+          <button type="button" class="nav-item" data-view="settings">Settings</button>
+        </div>
+        <div class="sidebar-footer">
+          <div class="status-dot" id="backend-status"></div>
+          <span class="status-text" id="backend-status-text">Connecting...</span>
+        </div>
+      </nav>
+      <main class="content" id="main-content">
+        <div class="view" id="view-library"></div>
+        <div class="view hidden" id="view-logs"></div>
+        <div class="view hidden" id="view-settings"></div>
+      </main>
+    </div>
+    <script src="index.js"></script>
+  </body>
 </html>

--- a/app/src/renderer/index.ts
+++ b/app/src/renderer/index.ts
@@ -99,16 +99,25 @@ class App {
 
   private switchView(view: string) {
     this.currentView = view;
-    document.querySelectorAll(".nav-item").forEach((b) => b.classList.remove("active"));
+    document.querySelectorAll(".nav-item").forEach((b) => {
+      b.classList.remove("active");
+    });
     document.querySelector(`[data-view="${view}"]`)?.classList.add("active");
-    document.querySelectorAll(".view").forEach((v) => v.classList.add("hidden"));
+    document.querySelectorAll(".view").forEach((v) => {
+      v.classList.add("hidden");
+    });
     document.getElementById(`view-${view}`)?.classList.remove("hidden");
 
     if (view === "settings") this.renderSettings();
     if (view === "logs") this.renderLogs();
   }
 
-  private async api<T = unknown>(method: string, url: string, body?: Record<string, unknown>, timeoutMs?: number): Promise<T | null> {
+  private async api<T = unknown>(
+    method: string,
+    url: string,
+    body?: Record<string, unknown>,
+    timeoutMs?: number,
+  ): Promise<T | null> {
     try {
       const res = await getAPI().request(method, url, body, timeoutMs);
       if (!res.ok && res.error) this.toast(res.error, "error");
@@ -151,7 +160,11 @@ class App {
     const scan = await this.api<{ steam: SteamStatus }>("GET", "/scan");
     if (scan) this.steam = scan.steam ?? { installed: false, running: false };
 
-    const steamStatus = await this.api<{ installed: boolean; running: boolean; metalsharp_wine_available: boolean }>("GET", "/steam/status");
+    const steamStatus = await this.api<{
+      installed: boolean;
+      running: boolean;
+      metalsharp_wine_available: boolean;
+    }>("GET", "/steam/status");
     this.wineSteamInstalled = steamStatus?.installed ?? false;
     this.wineSteamRunning = steamStatus?.running ?? false;
     this.metalsharpWineAvailable = steamStatus?.metalsharp_wine_available ?? false;
@@ -190,10 +203,18 @@ class App {
     overlay.appendChild(wizard);
 
     switch (step) {
-      case 0: this.renderSetupWelcome(wizard); break;
-      case 1: this.renderSetupInstall(wizard); break;
-      case 2: this.renderSetupSteam(wizard); break;
-      case 3: this.renderSetupComplete(wizard); break;
+      case 0:
+        this.renderSetupWelcome(wizard);
+        break;
+      case 1:
+        this.renderSetupInstall(wizard);
+        break;
+      case 2:
+        this.renderSetupSteam(wizard);
+        break;
+      case 3:
+        this.renderSetupComplete(wizard);
+        break;
     }
   }
 
@@ -333,7 +354,8 @@ class App {
         (brewBtn as HTMLButtonElement).disabled = true;
         const result = await getAPI().installHomebrew();
         if (result.ok) {
-          brewBtn.innerHTML = '<span class="setup-install-btn-label">Homebrew — Terminal Opened</span><span class="setup-install-btn-desc">Complete the install in Terminal, then click below</span>';
+          brewBtn.innerHTML =
+            '<span class="setup-install-btn-label">Homebrew — Terminal Opened</span><span class="setup-install-btn-desc">Complete the install in Terminal, then click below</span>';
           brewBtn.classList.remove("btn-primary");
           brewBtn.classList.add("btn-secondary");
           depBtn.style.opacity = "1";
@@ -346,7 +368,9 @@ class App {
         }
       });
 
-      depBtn.addEventListener("click", () => this.startDepInstall(logContainer, logDiv, progressBar, progressLabel, nextBtn));
+      depBtn.addEventListener("click", () =>
+        this.startDepInstall(logContainer, logDiv, progressBar, progressLabel, nextBtn),
+      );
     } else {
       const depBtn = document.createElement("button");
       depBtn.className = "btn btn-primary btn-lg setup-install-btn";
@@ -354,19 +378,22 @@ class App {
       depBtn.innerHTML = `<span class="setup-install-btn-label">Install Dependencies</span><span class="setup-install-btn-desc">MetalSharp Wine, GPTK, Mono, DXVK, Wine, and more</span>`;
       buttonsDiv.appendChild(depBtn);
 
-      depBtn.addEventListener("click", () => this.startDepInstall(logContainer, logDiv, progressBar, progressLabel, nextBtn));
+      depBtn.addEventListener("click", () =>
+        this.startDepInstall(logContainer, logDiv, progressBar, progressLabel, nextBtn),
+      );
     }
 
     body.querySelector("#setup-back")?.addEventListener("click", () => this.renderSetupStep(0));
 
-    nextBtn.addEventListener("click", () => this.renderSetupStep(2));  }
+    nextBtn.addEventListener("click", () => this.renderSetupStep(2));
+  }
 
   private async startDepInstall(
     logContainer: HTMLElement,
     logDiv: HTMLElement,
     progressBar: HTMLElement,
     progressLabel: HTMLElement,
-    nextBtn: HTMLElement
+    nextBtn: HTMLElement,
   ) {
     const depBtn = document.getElementById("btn-install-deps") as HTMLButtonElement;
     if (depBtn) {
@@ -380,7 +407,10 @@ class App {
     const started = await this.api<{ ok: boolean; error?: string }>("POST", "/setup/install-all");
     if (!started?.ok) {
       this.toast(started?.error ?? "Failed to start installation", "error");
-      if (depBtn) { depBtn.disabled = false; depBtn.style.opacity = "1"; }
+      if (depBtn) {
+        depBtn.disabled = false;
+        depBtn.style.opacity = "1";
+      }
       return;
     }
 
@@ -395,7 +425,14 @@ class App {
     addLog("Starting installation...", "info");
 
     const pollInterval = setInterval(async () => {
-      const progress = await this.api<{ step: number; total: number; current: string; status: string; log: string; error: string | null }>("GET", "/setup/install-progress");
+      const progress = await this.api<{
+        step: number;
+        total: number;
+        current: string;
+        status: string;
+        log: string;
+        error: string | null;
+      }>("GET", "/setup/install-progress");
       if (!progress) return;
 
       const pct = progress.total > 0 ? Math.round((progress.step / progress.total) * 100) : 0;
@@ -420,7 +457,11 @@ class App {
           logDiv.appendChild(marker);
         }
         clearInterval(pollInterval);
-        if (depBtn) { depBtn.disabled = false; depBtn.style.opacity = "1"; depBtn.textContent = "Retry"; }
+        if (depBtn) {
+          depBtn.disabled = false;
+          depBtn.style.opacity = "1";
+          depBtn.textContent = "Retry";
+        }
         return;
       } else if (progress.status === "installing") {
         const existing = logDiv.querySelector(`[data-step="${progress.step}"]`);
@@ -483,11 +524,13 @@ class App {
 
     const initialStatus = await checkSteamStatus();
     if (initialStatus?.running) {
-      statusDiv.innerHTML = '<span class="badge badge-ok" style="font-size:14px;padding:12px 24px;">Steam is running</span>';
+      statusDiv.innerHTML =
+        '<span class="badge badge-ok" style="font-size:14px;padding:12px 24px;">Steam is running</span>';
       installBtn.style.display = "none";
       nextBtn.style.display = "inline-flex";
     } else if (initialStatus?.installed) {
-      statusDiv.innerHTML = '<span class="badge badge-ok" style="font-size:14px;padding:12px 24px;">Steam is installed</span>';
+      statusDiv.innerHTML =
+        '<span class="badge badge-ok" style="font-size:14px;padding:12px 24px;">Steam is installed</span>';
       installBtn.textContent = "Launch Steam";
     }
 
@@ -498,15 +541,22 @@ class App {
       const steamStatus = await checkSteamStatus();
 
       if (steamStatus?.running) {
-        statusDiv.innerHTML = '<span class="badge badge-ok" style="font-size:14px;padding:12px 24px;">Steam is running</span>';
+        statusDiv.innerHTML =
+          '<span class="badge badge-ok" style="font-size:14px;padding:12px 24px;">Steam is running</span>';
         installBtn.style.display = "none";
         nextBtn.style.display = "inline-flex";
         return;
       }
 
       if (!steamStatus?.installed) {
-        statusDiv.innerHTML = '<div class="spinner"></div> <span style="color:var(--text-dim);font-size:13px;">Downloading Steam installer... Complete setup in the Steam window.</span>';
-        const installResult = await this.api<{ ok: boolean; path?: string; error?: string; message?: string }>("POST", "/steam/install");
+        statusDiv.innerHTML =
+          '<div class="spinner"></div> <span style="color:var(--text-dim);font-size:13px;">Downloading Steam installer... Complete setup in the Steam window.</span>';
+        const installResult = await this.api<{
+          ok: boolean;
+          path?: string;
+          error?: string;
+          message?: string;
+        }>("POST", "/steam/install");
         if (!installResult?.ok) {
           statusDiv.innerHTML = `<span style="color:var(--error)">${installResult?.error ?? "Failed to install Steam"}</span>`;
           installBtn.textContent = "Retry Install";
@@ -514,31 +564,41 @@ class App {
           return;
         }
 
-        statusDiv.innerHTML = '<div class="spinner"></div> <span style="color:var(--text-dim);font-size:13px;">Steam setup running — complete the installer in the Steam window...</span>';
+        statusDiv.innerHTML =
+          '<div class="spinner"></div> <span style="color:var(--text-dim);font-size:13px;">Steam setup running — complete the installer in the Steam window...</span>';
 
         const pollInstall = setInterval(async () => {
           const s = await checkSteamStatus();
           if (s?.installed || s?.running) {
             clearInterval(pollInstall);
             this.wineSteamInstalled = true;
-            statusDiv.innerHTML = '<span class="badge badge-ok" style="font-size:14px;padding:12px 24px;">Steam installed</span>';
+            statusDiv.innerHTML =
+              '<span class="badge badge-ok" style="font-size:14px;padding:12px 24px;">Steam installed</span>';
             installBtn.textContent = "Launch Steam";
             (installBtn as HTMLButtonElement).disabled = false;
           }
         }, 3000);
-        setTimeout(() => { clearInterval(pollInstall); }, 300000);
+        setTimeout(() => {
+          clearInterval(pollInstall);
+        }, 300000);
         return;
       }
 
-      statusDiv.innerHTML = '<div class="spinner"></div> <span style="color:var(--text-dim);font-size:13px;">Launching Steam — log in through the Steam window...</span>';
-      const launchResult = await this.api<{ ok: boolean; pid?: number; error?: string }>("POST", "/steam/launch");
+      statusDiv.innerHTML =
+        '<div class="spinner"></div> <span style="color:var(--text-dim);font-size:13px;">Launching Steam — log in through the Steam window...</span>';
+      const launchResult = await this.api<{
+        ok: boolean;
+        pid?: number;
+        error?: string;
+      }>("POST", "/steam/launch");
       if (launchResult?.ok) {
         this.wineSteamRunning = true;
         const pollSteam = setInterval(async () => {
           const s = await checkSteamStatus();
           if (s?.running) {
             clearInterval(pollSteam);
-            statusDiv.innerHTML = '<span class="badge badge-ok" style="font-size:14px;padding:12px 24px;">Steam is running</span>';
+            statusDiv.innerHTML =
+              '<span class="badge badge-ok" style="font-size:14px;padding:12px 24px;">Steam is running</span>';
             installBtn.style.display = "none";
             nextBtn.style.display = "inline-flex";
           }
@@ -612,7 +672,11 @@ class App {
       const key = keyInput?.value?.trim();
 
       this.setupDeviceName = name;
-      await this.api("POST", "/setup/save", { step: 3, deviceName: name, completed: true });
+      await this.api("POST", "/setup/save", {
+        step: 3,
+        deviceName: name,
+        completed: true,
+      });
 
       if (key) {
         await this.api("POST", "/steam/save-api-key", { key });
@@ -636,8 +700,8 @@ class App {
       const steamStatusBadge = this.wineSteamRunning
         ? '<span class="badge badge-ok" style="margin-left:8px">Steam Running</span>'
         : this.wineSteamInstalled
-        ? '<span class="badge badge-warn" style="margin-left:8px">Steam Offline</span>'
-        : '';
+          ? '<span class="badge badge-warn" style="margin-left:8px">Steam Offline</span>'
+          : "";
 
       el.innerHTML = `
         <div class="library-header">
@@ -646,7 +710,7 @@ class App {
             <p class="subtitle">No games yet ${steamStatusBadge}</p>
           </div>
           <div class="header-actions">
-            <button class="btn btn-secondary" id="btn-steam-launch" title="${this.wineSteamRunning ? 'Stop Wine Steam' : 'Start Wine Steam'}">${this.wineSteamRunning ? 'Stop Steam' : 'Start Steam'}</button>
+            <button class="btn btn-secondary" id="btn-steam-launch" title="${this.wineSteamRunning ? "Stop Wine Steam" : "Start Wine Steam"}">${this.wineSteamRunning ? "Stop Steam" : "Start Steam"}</button>
             <input class="control-input" type="text" id="library-search" placeholder="Search games..." />
             <button class="btn btn-secondary" id="btn-scan">Refresh</button>
           </div>
@@ -662,14 +726,14 @@ class App {
       return;
     }
 
-    const installedGames = lib.games.filter(g => g.installed);
-    const notInstalled = lib.games.filter(g => !g.installed);
+    const installedGames = lib.games.filter((g) => g.installed);
+    const notInstalled = lib.games.filter((g) => !g.installed);
 
     const steamStatusBadge = this.wineSteamRunning
       ? '<span class="badge badge-ok" style="margin-left:8px">Steam Running</span>'
       : this.wineSteamInstalled
-      ? '<span class="badge badge-warn" style="margin-left:8px">Steam Offline</span>'
-      : '';
+        ? '<span class="badge badge-warn" style="margin-left:8px">Steam Offline</span>'
+        : "";
 
     el.innerHTML = `
       <div class="library-header">
@@ -678,7 +742,7 @@ class App {
           <p class="subtitle">${lib.total} games &middot; ${installedGames.length} installed ${steamStatusBadge}</p>
         </div>
         <div class="header-actions">
-          <button class="btn btn-secondary" id="btn-steam-launch" title="${this.wineSteamRunning ? 'Stop Wine Steam' : 'Start Wine Steam'}">${this.wineSteamRunning ? 'Stop Steam' : 'Start Steam'}</button>
+          <button class="btn btn-secondary" id="btn-steam-launch" title="${this.wineSteamRunning ? "Stop Wine Steam" : "Start Wine Steam"}">${this.wineSteamRunning ? "Stop Steam" : "Start Steam"}</button>
           <input class="control-input" type="text" id="library-search" placeholder="Search games..." />
           <select class="control-input control-select" id="library-filter">
             <option value="all">All Games</option>
@@ -712,9 +776,9 @@ class App {
     this.libraryFilter = filter;
 
     let games = this.library.games;
-    if (filter === "installed") games = games.filter(g => g.installed);
-    if (filter === "not_installed") games = games.filter(g => !g.installed);
-    if (search) games = games.filter(g => g.name.toLowerCase().includes(search));
+    if (filter === "installed") games = games.filter((g) => g.installed);
+    if (filter === "not_installed") games = games.filter((g) => !g.installed);
+    if (search) games = games.filter((g) => g.name.toLowerCase().includes(search));
 
     this.renderGameGrid(games);
   }
@@ -746,7 +810,8 @@ class App {
 
     let actionHtml: string;
     if (isDownloading) {
-      const statusText = this.downloadProgress >= 95 ? "Installing..." : `Downloading ${Math.round(this.downloadProgress)}%`;
+      const statusText =
+        this.downloadProgress >= 95 ? "Installing..." : `Downloading ${Math.round(this.downloadProgress)}%`;
       actionHtml = `
         <div class="download-bar">
           <div class="download-progress" style="width:${this.downloadProgress}%"></div>
@@ -866,7 +931,7 @@ class App {
     if (!this.wineSteamRunning) {
       this.toast("Starting Steam...", "success");
       await this.api("POST", "/steam/launch");
-      await new Promise(r => setTimeout(r, 10000));
+      await new Promise((r) => setTimeout(r, 10000));
       this.wineSteamRunning = true;
     }
 
@@ -879,7 +944,10 @@ class App {
       if (lib?.games) {
         const installed = lib.games.find((g: SteamGame) => g.appid === game.appid && g.installed);
         if (installed) {
-          if (this.progressInterval) { clearInterval(this.progressInterval); this.progressInterval = null; }
+          if (this.progressInterval) {
+            clearInterval(this.progressInterval);
+            this.progressInterval = null;
+          }
           this.pollingForInstall = null;
           this.toast(`${game.name} installed!`, "success");
           await this.loadLibrary();
@@ -898,7 +966,7 @@ class App {
     if (!isFna && this.wineSteamInstalled && !this.wineSteamRunning) {
       this.toast("Starting Steam...", "success");
       await this.api("POST", "/steam/launch");
-      await new Promise(r => setTimeout(r, 10000));
+      await new Promise((r) => setTimeout(r, 10000));
       this.wineSteamRunning = true;
     }
 
@@ -906,8 +974,15 @@ class App {
     await this.api("POST", "/game/prepare", { appid: game.appid });
 
     this.toast(`Launching ${game.name}...`, "success");
-    const selectedMethod = (document.querySelector(`.launch-method-select[data-appid="${game.appid}"]`) as HTMLSelectElement)?.value ?? "native";
-    const launchResult = await this.api<{ ok: boolean; pid?: number; error?: string; gameType?: string }>("POST", "/game/launch-auto", {
+    const selectedMethod =
+      (document.querySelector(`.launch-method-select[data-appid="${game.appid}"]`) as HTMLSelectElement)?.value ??
+      "native";
+    const launchResult = await this.api<{
+      ok: boolean;
+      pid?: number;
+      error?: string;
+      gameType?: string;
+    }>("POST", "/game/launch-auto", {
       appid: game.appid,
       launchMethod: selectedMethod,
     });
@@ -935,7 +1010,10 @@ class App {
   }
 
   private async stopGame(game: SteamGame) {
-    await this.api("POST", "/kill", { pid: this.runningPid, appid: game.appid });
+    await this.api("POST", "/kill", {
+      pid: this.runningPid,
+      appid: game.appid,
+    });
     this.runningPid = null;
     this.runningAppId = null;
     this.toast(`Stopped ${game.name}`);
@@ -1004,12 +1082,14 @@ class App {
           </div>
           <div class="settings-value">
             <div style="display:flex;gap:8px;align-items:center;">
-              ${this.wineSteamInstalled
-                ? `<span class="badge badge-ok">Installed</span>`
-                : this.metalsharpWineAvailable
+              ${
+                this.wineSteamInstalled
+                  ? `<span class="badge badge-ok">Installed</span>`
+                  : this.metalsharpWineAvailable
                     ? `<button class="btn btn-primary btn-sm" id="btn-install-steam">Install Steam</button>`
-                    : `<span class="badge badge-warn">MetalSharp Wine Required</span>`}
-              ${this.wineSteamInstalled ? `<button class="btn btn-secondary btn-sm" id="btn-steam-launch">${this.wineSteamRunning ? 'Stop Steam' : 'Start Steam'}</button>` : ''}
+                    : `<span class="badge badge-warn">MetalSharp Wine Required</span>`
+              }
+              ${this.wineSteamInstalled ? `<button class="btn btn-secondary btn-sm" id="btn-steam-launch">${this.wineSteamRunning ? "Stop Steam" : "Start Steam"}</button>` : ""}
             </div>
           </div>
         </div>
@@ -1121,7 +1201,9 @@ class App {
           </div>
           <div class="settings-value">Enabled</div>
         </div>
-        ${this.updateStatus?.available ? `
+        ${
+          this.updateStatus?.available
+            ? `
         <div class="settings-row">
           <div>
             <div class="settings-label">Update Available</div>
@@ -1131,7 +1213,8 @@ class App {
             <a href="${this.updateStatus.download_url}" target="_blank" class="btn btn-primary btn-sm">Download</a>
           </div>
         </div>
-        ` : `
+        `
+            : `
         <div class="settings-row">
           <div>
             <div class="settings-label">Version</div>
@@ -1141,7 +1224,8 @@ class App {
             <span class="badge badge-ok">v${this.updateStatus?.current_version ?? "0.1.0"}</span>
           </div>
         </div>
-        `}
+        `
+        }
       </div>
 
       <div class="settings-section">
@@ -1216,7 +1300,9 @@ class App {
     el.querySelector("#btn-view-crashes")?.addEventListener("click", async () => {
       const reports = await this.api<CrashReportSummary[]>("GET", "/crash-reports");
       if (reports && Array.isArray(reports) && reports.length > 0) {
-        const lines = reports.map((r: CrashReportSummary) => `[${r.timestamp}] ${r.game} (exit ${r.exit_code})`).join("\n");
+        const lines = reports
+          .map((r: CrashReportSummary) => `[${r.timestamp}] ${r.game} (exit ${r.exit_code})`)
+          .join("\n");
         this.toast(`${reports.length} crash report(s) found. See Logs.`, "success");
       } else {
         this.toast("No crash reports found.");
@@ -1241,7 +1327,9 @@ class App {
 
     el.querySelector("#btn-refresh-logs")?.addEventListener("click", () => this.renderLogs());
 
-    const result = await this.api<{ logs: { name: string; lines: string[] }[] }>("GET", "/logs");
+    const result = await this.api<{
+      logs: { name: string; lines: string[] }[];
+    }>("GET", "/logs");
     const content = el.querySelector("#log-content")!;
     if (result && result.logs && result.logs.length > 0) {
       const latest = result.logs[result.logs.length - 1];
@@ -1290,15 +1378,18 @@ class App {
 
   private platformIcon(platform: string): string {
     switch (platform) {
-      case "steam": return "\u2699";
-      case "local": return "\uD83D\uDD33";
-      default: return "\uD83C\uDFAE";
+      case "steam":
+        return "\u2699";
+      case "local":
+        return "\uD83D\uDD33";
+      default:
+        return "\uD83C\uDFAE";
     }
   }
 
   private isGameInLocalDir(appid: number): boolean {
     if (!this.library) return false;
-    return this.library.games.some(g => g.appid === appid && g.installed);
+    return this.library.games.some((g) => g.appid === appid && g.installed);
   }
 
   private async toggleWineSteam() {
@@ -1320,7 +1411,7 @@ class App {
   private pollWineSteamInstall(game: SteamGame) {
     const interval = setInterval(async () => {
       await this.loadLibrary();
-      const installed = this.library?.games.find(g => g.appid === game.appid)?.installed;
+      const installed = this.library?.games.find((g) => g.appid === game.appid)?.installed;
       if (installed) {
         clearInterval(interval);
         this.toast(`${game.name} installed!`, "success");

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -26,7 +26,9 @@
   --border: rgba(221, 214, 254, 0.22);
   --success: #5cb870;
   --error: #d45050;
-  --gradient-main: radial-gradient(circle at 22% 10%, rgba(196, 181, 253, 0.22), transparent 34%), linear-gradient(135deg, rgba(43, 32, 64, 0.94) 0%, rgba(32, 23, 49, 0.92) 48%, rgba(52, 39, 76, 0.9) 100%);
+  --gradient-main:
+    radial-gradient(circle at 22% 10%, rgba(196, 181, 253, 0.22), transparent 34%),
+    linear-gradient(135deg, rgba(43, 32, 64, 0.94) 0%, rgba(32, 23, 49, 0.92) 48%, rgba(52, 39, 76, 0.9) 100%);
   --gradient-accent: linear-gradient(135deg, #7c3aed 0%, #a78bfa 48%, #c4b5fd 100%);
   --gradient-card: linear-gradient(160deg, rgba(196, 181, 253, 0.16) 0%, rgba(124, 58, 237, 0.07) 100%);
   --shadow-card: 0 18px 50px rgba(31, 18, 55, 0.22);
@@ -56,7 +58,9 @@
   --text-dim: #8b78a0;
   --text-muted: #8b78a0;
   --border: rgba(124, 58, 237, 0.16);
-  --gradient-main: radial-gradient(circle at 18% 8%, rgba(167, 139, 250, 0.28), transparent 32%), linear-gradient(135deg, #fbf8ff 0%, #f1eaff 48%, #ffffff 100%);
+  --gradient-main:
+    radial-gradient(circle at 18% 8%, rgba(167, 139, 250, 0.28), transparent 32%),
+    linear-gradient(135deg, #fbf8ff 0%, #f1eaff 48%, #ffffff 100%);
   --gradient-card: linear-gradient(160deg, rgba(255, 255, 255, 0.82) 0%, rgba(238, 231, 255, 0.56) 100%);
   --shadow-card: 0 18px 44px rgba(83, 56, 128, 0.13);
 }
@@ -232,7 +236,10 @@ body {
   font-size: 10px;
   min-height: 38px;
   outline: none;
-  transition: border-color var(--transition), background var(--transition), box-shadow var(--transition);
+  transition:
+    border-color var(--transition),
+    background var(--transition),
+    box-shadow var(--transition);
 }
 
 .control-input:focus {
@@ -248,8 +255,12 @@ body {
   width: 150px;
 }
 
-.view { display: block; }
-.view.hidden { display: none; }
+.view {
+  display: block;
+}
+.view.hidden {
+  display: none;
+}
 
 /* Library header */
 .library-header {
@@ -373,7 +384,9 @@ body {
 
 .game-card:hover {
   border-color: rgba(196, 181, 253, 0.6);
-  box-shadow: var(--shadow-card), 0 0 24px rgba(124, 58, 237, 0.2);
+  box-shadow:
+    var(--shadow-card),
+    0 0 24px rgba(124, 58, 237, 0.2);
   transform: translateY(-2px);
 }
 
@@ -636,8 +649,14 @@ body {
 }
 
 @keyframes slideUp {
-  from { transform: translateY(20px); opacity: 0; }
-  to { transform: translateY(0); opacity: 1; }
+  from {
+    transform: translateY(20px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
 }
 
 /* Loading spinner */
@@ -652,7 +671,9 @@ body {
 }
 
 @keyframes spin {
-  to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .launching-indicator {
@@ -674,8 +695,13 @@ body {
 }
 
 @keyframes launchPulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.4; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
 }
 
 /* Scrollbar */
@@ -699,7 +725,9 @@ body {
 /* Running game highlight */
 .game-card.running {
   border-color: rgba(167, 139, 250, 0.5);
-  box-shadow: var(--shadow-glow-orange), 0 0 24px rgba(124, 58, 237, 0.15);
+  box-shadow:
+    var(--shadow-glow-orange),
+    0 0 24px rgba(124, 58, 237, 0.15);
 }
 
 .game-card.running .game-card-banner {
@@ -846,7 +874,7 @@ body {
   justify-content: center;
   padding: 24px 40px;
   gap: 0;
-  background: rgba(0,0,0,0.2);
+  background: rgba(0, 0, 0, 0.2);
   border-bottom: 1px solid var(--border);
 }
 
@@ -1152,12 +1180,12 @@ body {
   animation: spin 0.6s linear infinite;
 }
 
- .setup-dep-error {
-   font-size: 11px;
-   color: var(--error);
-   margin-top: 4px;
-   line-height: 1.4;
- }
+.setup-dep-error {
+  font-size: 11px;
+  color: var(--error);
+  margin-top: 4px;
+  line-height: 1.4;
+}
 
 .setup-install-buttons {
   display: flex;
@@ -1179,7 +1207,7 @@ body {
 
 .setup-install-btn:hover {
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
 }
 
 .setup-install-btn-label {
@@ -1224,7 +1252,7 @@ body {
   font-size: 12px;
   font-weight: 600;
   color: var(--text-primary);
-  text-shadow: 0 1px 2px rgba(0,0,0,0.4);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
 }
 
 .setup-install-log {
@@ -1234,7 +1262,7 @@ body {
   padding: 12px 16px;
   max-height: 240px;
   overflow-y: auto;
-  font-family: 'SF Mono', Menlo, monospace;
+  font-family: "SF Mono", Menlo, monospace;
   font-size: 12px;
   line-height: 1.6;
 }
@@ -1242,7 +1270,7 @@ body {
 .setup-log-line {
   padding: 2px 0;
   color: var(--text-secondary);
-  border-bottom: 1px solid rgba(255,255,255,0.03);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.03);
 }
 
 .setup-log-line.active {

--- a/include/d3d/D3D11.h
+++ b/include/d3d/D3D11.h
@@ -5,23 +5,35 @@
 typedef UINT DXGI_FORMAT;
 
 static const GUID IID_ID3D11Device = {0x2e8f6e0c, 0x3e86, 0x4a63, {0x9e, 0xa5, 0x7b, 0x52, 0xd9, 0x5e, 0x08, 0xc1}};
-static const GUID IID_ID3D11DeviceContext = {0xaec81fb3, 0x4e01, 0x4dfe, {0xa0, 0xa3, 0xd0, 0xa9, 0x75, 0x7d, 0x88, 0x6b}};
-static const GUID IID_ID3D11DeviceChild = {0xdb6f6ddb, 0xac77, 0x4e88, {0x82, 0x53, 0x81, 0x9d, 0xf9, 0xbb, 0xf1, 0x40}};
+static const GUID IID_ID3D11DeviceContext = {
+    0xaec81fb3, 0x4e01, 0x4dfe, {0xa0, 0xa3, 0xd0, 0xa9, 0x75, 0x7d, 0x88, 0x6b}};
+static const GUID IID_ID3D11DeviceChild = {
+    0xdb6f6ddb, 0xac77, 0x4e88, {0x82, 0x53, 0x81, 0x9d, 0xf9, 0xbb, 0xf1, 0x40}};
 static const GUID IID_ID3D11Buffer = {0x4eddea9b, 0x3239, 0x4e14, {0x8c, 0xb4, 0x4e, 0xe4, 0x3d, 0x72, 0x0d, 0x50}};
 static const GUID IID_ID3D11Texture2D = {0x6f15aaf2, 0xd208, 0x4e89, {0x9a, 0xb4, 0x48, 0x95, 0x35, 0xd3, 0x4f, 0x9c}};
-static const GUID IID_ID3D11RenderTargetView = {0xdfdba067, 0x0b8d, 0x4865, {0x87, 0x5b, 0x5d, 0x1e, 0x9c, 0x88, 0x4e, 0x36}};
-static const GUID IID_ID3D11DepthStencilView = {0x9fdac92a, 0x187f, 0x4f1e, {0xa7, 0x24, 0x55, 0x8c, 0x1c, 0x8b, 0x2b, 0x49}};
-static const GUID IID_ID3D11ShaderResourceView = {0xb0e06fe0, 0x8192, 0x4e05, {0xa9, 0x81, 0x22, 0x1a, 0x45, 0x6f, 0x10, 0x73}};
-static const GUID IID_ID3D11InputLayout = {0xe0aac9bd, 0xd237, 0x4d80, {0xa8, 0x2f, 0x6e, 0x88, 0x6c, 0x8e, 0x54, 0x83}};
-static const GUID IID_ID3D11VertexShader = {0xe4e6e4c1, 0x3a30, 0x4a65, {0x9c, 0x41, 0x82, 0xbc, 0x91, 0x5b, 0x62, 0x54}};
-static const GUID IID_ID3D11PixelShader = {0xea82e2e4, 0x4e41, 0x4e80, {0xa8, 0xf7, 0x77, 0x81, 0x1f, 0xbe, 0x6c, 0x82}};
+static const GUID IID_ID3D11RenderTargetView = {
+    0xdfdba067, 0x0b8d, 0x4865, {0x87, 0x5b, 0x5d, 0x1e, 0x9c, 0x88, 0x4e, 0x36}};
+static const GUID IID_ID3D11DepthStencilView = {
+    0x9fdac92a, 0x187f, 0x4f1e, {0xa7, 0x24, 0x55, 0x8c, 0x1c, 0x8b, 0x2b, 0x49}};
+static const GUID IID_ID3D11ShaderResourceView = {
+    0xb0e06fe0, 0x8192, 0x4e05, {0xa9, 0x81, 0x22, 0x1a, 0x45, 0x6f, 0x10, 0x73}};
+static const GUID IID_ID3D11InputLayout = {
+    0xe0aac9bd, 0xd237, 0x4d80, {0xa8, 0x2f, 0x6e, 0x88, 0x6c, 0x8e, 0x54, 0x83}};
+static const GUID IID_ID3D11VertexShader = {
+    0xe4e6e4c1, 0x3a30, 0x4a65, {0x9c, 0x41, 0x82, 0xbc, 0x91, 0x5b, 0x62, 0x54}};
+static const GUID IID_ID3D11PixelShader = {
+    0xea82e2e4, 0x4e41, 0x4e80, {0xa8, 0xf7, 0x77, 0x81, 0x1f, 0xbe, 0x6c, 0x82}};
 static const GUID IID_ID3D11Resource = {0xdb8d2769, 0x6ef3, 0x44ee, {0x8b, 0x8e, 0x10, 0x8f, 0x33, 0x36, 0x6d, 0xe0}};
 static const GUID IID_ID3D11View = {0x839d1216, 0xbb2e, 0x412b, {0xb7, 0xf4, 0xa9, 0xdb, 0xeb, 0xe0, 0x8e, 0xd1}};
-static const GUID IID_ID3D11SamplerState = {0x38e4f8a8, 0xcc78, 0x4a48, {0x84, 0x24, 0x66, 0x72, 0x38, 0x63, 0x74, 0x4b}};
-static const GUID IID_ID3D11RasterizerState = {0x1e9c9db7, 0x21b3, 0x4a30, {0x84, 0xc1, 0x3a, 0xcf, 0x16, 0xd2, 0x61, 0x8b}};
-static const GUID IID_ID3D11DepthStencilState = {0x431583c5, 0x1c9d, 0x4e72, {0x90, 0xa7, 0x3e, 0x42, 0x03, 0xfb, 0x9f, 0xf3}};
+static const GUID IID_ID3D11SamplerState = {
+    0x38e4f8a8, 0xcc78, 0x4a48, {0x84, 0x24, 0x66, 0x72, 0x38, 0x63, 0x74, 0x4b}};
+static const GUID IID_ID3D11RasterizerState = {
+    0x1e9c9db7, 0x21b3, 0x4a30, {0x84, 0xc1, 0x3a, 0xcf, 0x16, 0xd2, 0x61, 0x8b}};
+static const GUID IID_ID3D11DepthStencilState = {
+    0x431583c5, 0x1c9d, 0x4e72, {0x90, 0xa7, 0x3e, 0x42, 0x03, 0xfb, 0x9f, 0xf3}};
 static const GUID IID_ID3D11BlendState = {0x46e71f5a, 0x2501, 0x41a2, {0xac, 0xfb, 0x7a, 0x7f, 0x09, 0xe2, 0x81, 0x7b}};
-static const GUID IID_ID3D11CommandList = {0xa24bc4d1, 0x762e, 0x4c3e, {0x82, 0x27, 0x09, 0x3d, 0x26, 0x8e, 0x4a, 0xbf}};
+static const GUID IID_ID3D11CommandList = {
+    0xa24bc4d1, 0x762e, 0x4c3e, {0x82, 0x27, 0x09, 0x3d, 0x26, 0x8e, 0x4a, 0xbf}};
 
 class ID3D11Device;
 class ID3D11DeviceContext;
@@ -35,80 +47,79 @@ class ID3D11UnorderedAccessView;
 class ID3D11Query;
 class ID3D11Predicate;
 
-constexpr UINT D3D11_BIND_VERTEX_BUFFER    = 0x1;
-constexpr UINT D3D11_BIND_INDEX_BUFFER     = 0x2;
-constexpr UINT D3D11_BIND_CONSTANT_BUFFER  = 0x4;
-constexpr UINT D3D11_BIND_SHADER_RESOURCE  = 0x8;
-constexpr UINT D3D11_BIND_STREAM_OUTPUT    = 0x10;
-constexpr UINT D3D11_BIND_RENDER_TARGET    = 0x20;
-constexpr UINT D3D11_BIND_DEPTH_STENCIL    = 0x40;
+constexpr UINT D3D11_BIND_VERTEX_BUFFER = 0x1;
+constexpr UINT D3D11_BIND_INDEX_BUFFER = 0x2;
+constexpr UINT D3D11_BIND_CONSTANT_BUFFER = 0x4;
+constexpr UINT D3D11_BIND_SHADER_RESOURCE = 0x8;
+constexpr UINT D3D11_BIND_STREAM_OUTPUT = 0x10;
+constexpr UINT D3D11_BIND_RENDER_TARGET = 0x20;
+constexpr UINT D3D11_BIND_DEPTH_STENCIL = 0x40;
 constexpr UINT D3D11_BIND_UNORDERED_ACCESS = 0x80;
 
-constexpr UINT D3D11_USAGE_DEFAULT   = 0;
+constexpr UINT D3D11_USAGE_DEFAULT = 0;
 constexpr UINT D3D11_USAGE_IMMUTABLE = 1;
-constexpr UINT D3D11_USAGE_DYNAMIC   = 2;
-constexpr UINT D3D11_USAGE_STAGING   = 3;
+constexpr UINT D3D11_USAGE_DYNAMIC = 2;
+constexpr UINT D3D11_USAGE_STAGING = 3;
 
-constexpr UINT D3D11_CPU_ACCESS_READ  = 0x10000;
+constexpr UINT D3D11_CPU_ACCESS_READ = 0x10000;
 constexpr UINT D3D11_CPU_ACCESS_WRITE = 0x20000;
 
-constexpr UINT D3D11_MAP_READ              = 1;
-constexpr UINT D3D11_MAP_WRITE             = 2;
-constexpr UINT D3D11_MAP_READ_WRITE        = 3;
-constexpr UINT D3D11_MAP_WRITE_DISCARD     = 4;
+constexpr UINT D3D11_MAP_READ = 1;
+constexpr UINT D3D11_MAP_WRITE = 2;
+constexpr UINT D3D11_MAP_READ_WRITE = 3;
+constexpr UINT D3D11_MAP_WRITE_DISCARD = 4;
 constexpr UINT D3D11_MAP_WRITE_NO_OVERWRITE = 5;
 
-constexpr UINT D3D11_CLEAR_DEPTH   = 0x1;
+constexpr UINT D3D11_CLEAR_DEPTH = 0x1;
 constexpr UINT D3D11_CLEAR_STENCIL = 0x2;
 
-constexpr UINT D3D11_PRIMITIVE_TOPOLOGY_POINTLIST     = 1;
-constexpr UINT D3D11_PRIMITIVE_TOPOLOGY_LINELIST      = 2;
-constexpr UINT D3D11_PRIMITIVE_TOPOLOGY_LINESTRIP     = 3;
-constexpr UINT D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST  = 4;
+constexpr UINT D3D11_PRIMITIVE_TOPOLOGY_POINTLIST = 1;
+constexpr UINT D3D11_PRIMITIVE_TOPOLOGY_LINELIST = 2;
+constexpr UINT D3D11_PRIMITIVE_TOPOLOGY_LINESTRIP = 3;
+constexpr UINT D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST = 4;
 constexpr UINT D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP = 5;
-constexpr UINT D3D11_PRIMITIVE_TOPOLOGY_LINELIST_ADJ         = 10;
-constexpr UINT D3D11_PRIMITIVE_TOPOLOGY_LINESTRIP_ADJ        = 11;
-constexpr UINT D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST_ADJ     = 12;
-constexpr UINT D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP_ADJ    = 13;
+constexpr UINT D3D11_PRIMITIVE_TOPOLOGY_LINELIST_ADJ = 10;
+constexpr UINT D3D11_PRIMITIVE_TOPOLOGY_LINESTRIP_ADJ = 11;
+constexpr UINT D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST_ADJ = 12;
+constexpr UINT D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP_ADJ = 13;
 
-constexpr DXGI_FORMAT DXGI_FORMAT_UNKNOWN              = 0;
-constexpr DXGI_FORMAT DXGI_FORMAT_R32G32B32A32_FLOAT   = 2;
-constexpr DXGI_FORMAT DXGI_FORMAT_R32G32B32_FLOAT      = 6;
-constexpr DXGI_FORMAT DXGI_FORMAT_R16G16B16A16_FLOAT   = 10;
-constexpr DXGI_FORMAT DXGI_FORMAT_R32G32_FLOAT         = 16;
-constexpr DXGI_FORMAT DXGI_FORMAT_R10G10B10A2_UNORM    = 24;
-constexpr DXGI_FORMAT DXGI_FORMAT_R8G8B8A8_UNORM       = 28;
-constexpr DXGI_FORMAT DXGI_FORMAT_R8G8B8A8_UNORM_SRGB  = 29;
-constexpr DXGI_FORMAT DXGI_FORMAT_R16G16_FLOAT         = 34;
-constexpr DXGI_FORMAT DXGI_FORMAT_R32_FLOAT            = 41;
-constexpr DXGI_FORMAT DXGI_FORMAT_R8G8_UNORM           = 49;
-constexpr DXGI_FORMAT DXGI_FORMAT_R16_FLOAT            = 56;
-constexpr DXGI_FORMAT DXGI_FORMAT_R16_UNORM            = 57;
-constexpr DXGI_FORMAT DXGI_FORMAT_R8_UNORM             = 61;
-constexpr DXGI_FORMAT DXGI_FORMAT_R8G8_B8G8_UNORM      = 68;
-constexpr DXGI_FORMAT DXGI_FORMAT_B8G8R8A8_UNORM       = 87;
-constexpr DXGI_FORMAT DXGI_FORMAT_B8G8R8A8_UNORM_SRGB  = 91;
-constexpr DXGI_FORMAT DXGI_FORMAT_D32_FLOAT            = 40;
-constexpr DXGI_FORMAT DXGI_FORMAT_D24_UNORM_S8_UINT    = 45;
+constexpr DXGI_FORMAT DXGI_FORMAT_UNKNOWN = 0;
+constexpr DXGI_FORMAT DXGI_FORMAT_R32G32B32A32_FLOAT = 2;
+constexpr DXGI_FORMAT DXGI_FORMAT_R32G32B32_FLOAT = 6;
+constexpr DXGI_FORMAT DXGI_FORMAT_R16G16B16A16_FLOAT = 10;
+constexpr DXGI_FORMAT DXGI_FORMAT_R32G32_FLOAT = 16;
+constexpr DXGI_FORMAT DXGI_FORMAT_R10G10B10A2_UNORM = 24;
+constexpr DXGI_FORMAT DXGI_FORMAT_R8G8B8A8_UNORM = 28;
+constexpr DXGI_FORMAT DXGI_FORMAT_R8G8B8A8_UNORM_SRGB = 29;
+constexpr DXGI_FORMAT DXGI_FORMAT_R16G16_FLOAT = 34;
+constexpr DXGI_FORMAT DXGI_FORMAT_R32_FLOAT = 41;
+constexpr DXGI_FORMAT DXGI_FORMAT_R8G8_UNORM = 49;
+constexpr DXGI_FORMAT DXGI_FORMAT_R16_FLOAT = 56;
+constexpr DXGI_FORMAT DXGI_FORMAT_R16_UNORM = 57;
+constexpr DXGI_FORMAT DXGI_FORMAT_R8_UNORM = 61;
+constexpr DXGI_FORMAT DXGI_FORMAT_R8G8_B8G8_UNORM = 68;
+constexpr DXGI_FORMAT DXGI_FORMAT_B8G8R8A8_UNORM = 87;
+constexpr DXGI_FORMAT DXGI_FORMAT_B8G8R8A8_UNORM_SRGB = 91;
+constexpr DXGI_FORMAT DXGI_FORMAT_D32_FLOAT = 40;
+constexpr DXGI_FORMAT DXGI_FORMAT_D24_UNORM_S8_UINT = 45;
 constexpr DXGI_FORMAT DXGI_FORMAT_D32_FLOAT_S8X24_UINT = 20;
-constexpr DXGI_FORMAT DXGI_FORMAT_R16G16B16A16_UNORM   = 11;
-constexpr DXGI_FORMAT DXGI_FORMAT_R16G16B16A16_UINT    = 14;
-constexpr DXGI_FORMAT DXGI_FORMAT_R32G32_UINT          = 17;
-constexpr DXGI_FORMAT DXGI_FORMAT_R32G32B32_UINT       = 7;
-constexpr DXGI_FORMAT DXGI_FORMAT_R32G32B32A32_UINT    = 3;
-constexpr DXGI_FORMAT DXGI_FORMAT_R16_UINT             = 57;
-constexpr DXGI_FORMAT DXGI_FORMAT_R32_UINT             = 42;
-constexpr DXGI_FORMAT DXGI_FORMAT_BC1_UNORM            = 71;
-constexpr DXGI_FORMAT DXGI_FORMAT_BC2_UNORM            = 74;
-constexpr DXGI_FORMAT DXGI_FORMAT_BC3_UNORM            = 77;
-constexpr DXGI_FORMAT DXGI_FORMAT_BC4_UNORM            = 80;
-constexpr DXGI_FORMAT DXGI_FORMAT_BC5_UNORM            = 83;
-constexpr DXGI_FORMAT DXGI_FORMAT_BC6H_SF16            = 96;
-constexpr DXGI_FORMAT DXGI_FORMAT_BC7_UNORM            = 98;
+constexpr DXGI_FORMAT DXGI_FORMAT_R16G16B16A16_UNORM = 11;
+constexpr DXGI_FORMAT DXGI_FORMAT_R16G16B16A16_UINT = 14;
+constexpr DXGI_FORMAT DXGI_FORMAT_R32G32_UINT = 17;
+constexpr DXGI_FORMAT DXGI_FORMAT_R32G32B32_UINT = 7;
+constexpr DXGI_FORMAT DXGI_FORMAT_R32G32B32A32_UINT = 3;
+constexpr DXGI_FORMAT DXGI_FORMAT_R16_UINT = 57;
+constexpr DXGI_FORMAT DXGI_FORMAT_R32_UINT = 42;
+constexpr DXGI_FORMAT DXGI_FORMAT_BC1_UNORM = 71;
+constexpr DXGI_FORMAT DXGI_FORMAT_BC2_UNORM = 74;
+constexpr DXGI_FORMAT DXGI_FORMAT_BC3_UNORM = 77;
+constexpr DXGI_FORMAT DXGI_FORMAT_BC4_UNORM = 80;
+constexpr DXGI_FORMAT DXGI_FORMAT_BC5_UNORM = 83;
+constexpr DXGI_FORMAT DXGI_FORMAT_BC6H_SF16 = 96;
+constexpr DXGI_FORMAT DXGI_FORMAT_BC7_UNORM = 98;
 
-class MIDL_INTERFACE("db6f6ddb-ac77-4e88-8253-819df9bbf140")
-ID3D11DeviceChild : public IUnknown {
-public:
+class MIDL_INTERFACE("db6f6ddb-ac77-4e88-8253-819df9bbf140") ID3D11DeviceChild : public IUnknown {
+  public:
     STDMETHOD(GetDevice)(THIS_ struct ID3D11Device** ppDevice) PURE;
     STDMETHOD(GetPrivateData)(THIS_ const GUID& guid, UINT* pDataSize, void* pData) PURE;
     STDMETHOD(SetPrivateData)(THIS_ const GUID& guid, UINT DataSize, const void* pData) PURE;
@@ -180,31 +191,31 @@ struct D3D11_VIEWPORT {
     FLOAT MaxDepth;
 };
 
-constexpr UINT D3D11_BLEND_ZERO            = 1;
-constexpr UINT D3D11_BLEND_ONE             = 2;
-constexpr UINT D3D11_BLEND_SRC_COLOR       = 3;
-constexpr UINT D3D11_BLEND_INV_SRC_COLOR   = 4;
-constexpr UINT D3D11_BLEND_SRC_ALPHA       = 5;
-constexpr UINT D3D11_BLEND_INV_SRC_ALPHA   = 6;
-constexpr UINT D3D11_BLEND_DEST_ALPHA      = 7;
-constexpr UINT D3D11_BLEND_INV_DEST_ALPHA  = 8;
-constexpr UINT D3D11_BLEND_DEST_COLOR      = 9;
-constexpr UINT D3D11_BLEND_INV_DEST_COLOR  = 10;
-constexpr UINT D3D11_BLEND_SRC_ALPHA_SAT   = 11;
-constexpr UINT D3D11_BLEND_BLEND_FACTOR    = 14;
+constexpr UINT D3D11_BLEND_ZERO = 1;
+constexpr UINT D3D11_BLEND_ONE = 2;
+constexpr UINT D3D11_BLEND_SRC_COLOR = 3;
+constexpr UINT D3D11_BLEND_INV_SRC_COLOR = 4;
+constexpr UINT D3D11_BLEND_SRC_ALPHA = 5;
+constexpr UINT D3D11_BLEND_INV_SRC_ALPHA = 6;
+constexpr UINT D3D11_BLEND_DEST_ALPHA = 7;
+constexpr UINT D3D11_BLEND_INV_DEST_ALPHA = 8;
+constexpr UINT D3D11_BLEND_DEST_COLOR = 9;
+constexpr UINT D3D11_BLEND_INV_DEST_COLOR = 10;
+constexpr UINT D3D11_BLEND_SRC_ALPHA_SAT = 11;
+constexpr UINT D3D11_BLEND_BLEND_FACTOR = 14;
 constexpr UINT D3D11_BLEND_INV_BLEND_FACTOR = 15;
 
-constexpr UINT D3D11_BLEND_OP_ADD          = 1;
-constexpr UINT D3D11_BLEND_OP_SUBTRACT     = 2;
+constexpr UINT D3D11_BLEND_OP_ADD = 1;
+constexpr UINT D3D11_BLEND_OP_SUBTRACT = 2;
 constexpr UINT D3D11_BLEND_OP_REV_SUBTRACT = 3;
-constexpr UINT D3D11_BLEND_OP_MIN          = 4;
-constexpr UINT D3D11_BLEND_OP_MAX          = 5;
+constexpr UINT D3D11_BLEND_OP_MIN = 4;
+constexpr UINT D3D11_BLEND_OP_MAX = 5;
 
-constexpr UINT D3D11_COLOR_WRITE_ENABLE_RED   = 1;
+constexpr UINT D3D11_COLOR_WRITE_ENABLE_RED = 1;
 constexpr UINT D3D11_COLOR_WRITE_ENABLE_GREEN = 2;
-constexpr UINT D3D11_COLOR_WRITE_ENABLE_BLUE  = 4;
+constexpr UINT D3D11_COLOR_WRITE_ENABLE_BLUE = 4;
 constexpr UINT D3D11_COLOR_WRITE_ENABLE_ALPHA = 8;
-constexpr UINT D3D11_COLOR_WRITE_ENABLE_ALL   = 15;
+constexpr UINT D3D11_COLOR_WRITE_ENABLE_ALL = 15;
 
 struct D3D11_RENDER_TARGET_BLEND_DESC {
     INT BlendEnable;
@@ -224,11 +235,11 @@ struct D3D11_BLEND_DESC {
 };
 
 constexpr UINT D3D11_FILL_WIREFRAME = 2;
-constexpr UINT D3D11_FILL_SOLID     = 3;
+constexpr UINT D3D11_FILL_SOLID = 3;
 
-constexpr UINT D3D11_CULL_NONE  = 1;
+constexpr UINT D3D11_CULL_NONE = 1;
 constexpr UINT D3D11_CULL_FRONT = 2;
-constexpr UINT D3D11_CULL_BACK  = 3;
+constexpr UINT D3D11_CULL_BACK = 3;
 
 struct D3D11_RASTERIZER_DESC {
     UINT FillMode;
@@ -243,23 +254,23 @@ struct D3D11_RASTERIZER_DESC {
     INT AntialiasedLineEnable;
 };
 
-constexpr UINT D3D11_COMPARISON_NEVER         = 1;
-constexpr UINT D3D11_COMPARISON_LESS          = 2;
-constexpr UINT D3D11_COMPARISON_EQUAL         = 3;
-constexpr UINT D3D11_COMPARISON_LESS_EQUAL    = 4;
-constexpr UINT D3D11_COMPARISON_GREATER       = 5;
-constexpr UINT D3D11_COMPARISON_NOT_EQUAL     = 6;
+constexpr UINT D3D11_COMPARISON_NEVER = 1;
+constexpr UINT D3D11_COMPARISON_LESS = 2;
+constexpr UINT D3D11_COMPARISON_EQUAL = 3;
+constexpr UINT D3D11_COMPARISON_LESS_EQUAL = 4;
+constexpr UINT D3D11_COMPARISON_GREATER = 5;
+constexpr UINT D3D11_COMPARISON_NOT_EQUAL = 6;
 constexpr UINT D3D11_COMPARISON_GREATER_EQUAL = 7;
-constexpr UINT D3D11_COMPARISON_ALWAYS        = 8;
+constexpr UINT D3D11_COMPARISON_ALWAYS = 8;
 
-constexpr UINT D3D11_STENCIL_OP_KEEP     = 1;
-constexpr UINT D3D11_STENCIL_OP_ZERO     = 2;
-constexpr UINT D3D11_STENCIL_OP_REPLACE  = 3;
+constexpr UINT D3D11_STENCIL_OP_KEEP = 1;
+constexpr UINT D3D11_STENCIL_OP_ZERO = 2;
+constexpr UINT D3D11_STENCIL_OP_REPLACE = 3;
 constexpr UINT D3D11_STENCIL_OP_INCR_SAT = 4;
 constexpr UINT D3D11_STENCIL_OP_DECR_SAT = 5;
-constexpr UINT D3D11_STENCIL_OP_INVERT   = 6;
-constexpr UINT D3D11_STENCIL_OP_INCR     = 7;
-constexpr UINT D3D11_STENCIL_OP_DECR     = 8;
+constexpr UINT D3D11_STENCIL_OP_INVERT = 6;
+constexpr UINT D3D11_STENCIL_OP_INCR = 7;
+constexpr UINT D3D11_STENCIL_OP_DECR = 8;
 
 struct D3D11_DEPTH_STENCILOP_DESC {
     UINT StencilFailOp;
@@ -282,22 +293,22 @@ struct D3D11_DEPTH_STENCIL_DESC {
 constexpr UINT D3D11_DEPTH_WRITE_MASK_ALL = 1;
 constexpr UINT D3D11_DEPTH_WRITE_MASK_ZERO = 0;
 
-constexpr UINT D3D11_FILTER_MIN_MAG_MIP_POINT          = 0;
-constexpr UINT D3D11_FILTER_MIN_MAG_POINT_MIP_LINEAR   = 0x1;
+constexpr UINT D3D11_FILTER_MIN_MAG_MIP_POINT = 0;
+constexpr UINT D3D11_FILTER_MIN_MAG_POINT_MIP_LINEAR = 0x1;
 constexpr UINT D3D11_FILTER_MIN_POINT_MAG_LINEAR_MIP_POINT = 0x4;
-constexpr UINT D3D11_FILTER_MIN_POINT_MAG_MIP_LINEAR   = 0x5;
-constexpr UINT D3D11_FILTER_MIN_LINEAR_MAG_MIP_POINT   = 0x10;
+constexpr UINT D3D11_FILTER_MIN_POINT_MAG_MIP_LINEAR = 0x5;
+constexpr UINT D3D11_FILTER_MIN_LINEAR_MAG_MIP_POINT = 0x10;
 constexpr UINT D3D11_FILTER_MIN_LINEAR_MAG_POINT_MIP_LINEAR = 0x11;
-constexpr UINT D3D11_FILTER_MIN_MAG_LINEAR_MIP_POINT   = 0x14;
-constexpr UINT D3D11_FILTER_MIN_MAG_MIP_LINEAR          = 0x15;
-constexpr UINT D3D11_FILTER_ANISOTROPIC                 = 0x55;
+constexpr UINT D3D11_FILTER_MIN_MAG_LINEAR_MIP_POINT = 0x14;
+constexpr UINT D3D11_FILTER_MIN_MAG_MIP_LINEAR = 0x15;
+constexpr UINT D3D11_FILTER_ANISOTROPIC = 0x55;
 constexpr UINT D3D11_FILTER_COMPARISON_MIN_MAG_MIP_POINT = 0x80;
 constexpr UINT D3D11_FILTER_COMPARISON_MIN_MAG_MIP_LINEAR = 0x95;
 
-constexpr UINT D3D11_TEXTURE_ADDRESS_WRAP       = 1;
-constexpr UINT D3D11_TEXTURE_ADDRESS_MIRROR     = 2;
-constexpr UINT D3D11_TEXTURE_ADDRESS_CLAMP      = 3;
-constexpr UINT D3D11_TEXTURE_ADDRESS_BORDER     = 4;
+constexpr UINT D3D11_TEXTURE_ADDRESS_WRAP = 1;
+constexpr UINT D3D11_TEXTURE_ADDRESS_MIRROR = 2;
+constexpr UINT D3D11_TEXTURE_ADDRESS_CLAMP = 3;
+constexpr UINT D3D11_TEXTURE_ADDRESS_BORDER = 4;
 constexpr UINT D3D11_TEXTURE_ADDRESS_MIRROR_ONCE = 5;
 
 struct D3D11_SAMPLER_DESC {
@@ -313,7 +324,7 @@ struct D3D11_SAMPLER_DESC {
     FLOAT MaxLOD;
 };
 
-constexpr UINT D3D11_INPUT_PER_VERTEX_DATA   = 0;
+constexpr UINT D3D11_INPUT_PER_VERTEX_DATA = 0;
 constexpr UINT D3D11_INPUT_PER_INSTANCE_DATA = 1;
 
 struct D3D11_INPUT_ELEMENT_DESC {
@@ -330,14 +341,38 @@ struct D3D11_RENDER_TARGET_VIEW_DESC {
     DXGI_FORMAT Format;
     UINT ViewDimension;
     union {
-        struct { UINT BufferElementOffset; UINT BufferElementWidth; } Buffer;
-        struct { UINT MipSlice; } Texture1D;
-        struct { UINT MipSlice; UINT FirstArraySlice; UINT ArraySize; } Texture1DArray;
-        struct { UINT MipSlice; } Texture2D;
-        struct { UINT MipSlice; UINT FirstArraySlice; UINT ArraySize; } Texture2DArray;
-        struct { UINT MipSlice; } Texture2DMS;
-        struct { UINT FirstArraySlice; UINT ArraySize; } Texture2DMSArray;
-        struct { UINT MipSlice; UINT FirstWSlice; UINT WSize; } Texture3D;
+        struct {
+            UINT BufferElementOffset;
+            UINT BufferElementWidth;
+        } Buffer;
+        struct {
+            UINT MipSlice;
+        } Texture1D;
+        struct {
+            UINT MipSlice;
+            UINT FirstArraySlice;
+            UINT ArraySize;
+        } Texture1DArray;
+        struct {
+            UINT MipSlice;
+        } Texture2D;
+        struct {
+            UINT MipSlice;
+            UINT FirstArraySlice;
+            UINT ArraySize;
+        } Texture2DArray;
+        struct {
+            UINT MipSlice;
+        } Texture2DMS;
+        struct {
+            UINT FirstArraySlice;
+            UINT ArraySize;
+        } Texture2DMSArray;
+        struct {
+            UINT MipSlice;
+            UINT FirstWSlice;
+            UINT WSize;
+        } Texture3D;
     };
 };
 
@@ -346,12 +381,29 @@ struct D3D11_DEPTH_STENCIL_VIEW_DESC {
     UINT ViewDimension;
     UINT Flags;
     union {
-        struct { UINT MipSlice; } Texture1D;
-        struct { UINT MipSlice; UINT FirstArraySlice; UINT ArraySize; } Texture1DArray;
-        struct { UINT MipSlice; } Texture2D;
-        struct { UINT MipSlice; UINT FirstArraySlice; UINT ArraySize; } Texture2DArray;
-        struct { UINT UnusedFlags_NothingToDefine; } Texture2DMS;
-        struct { UINT FirstArraySlice; UINT ArraySize; } Texture2DMSArray;
+        struct {
+            UINT MipSlice;
+        } Texture1D;
+        struct {
+            UINT MipSlice;
+            UINT FirstArraySlice;
+            UINT ArraySize;
+        } Texture1DArray;
+        struct {
+            UINT MipSlice;
+        } Texture2D;
+        struct {
+            UINT MipSlice;
+            UINT FirstArraySlice;
+            UINT ArraySize;
+        } Texture2DArray;
+        struct {
+            UINT UnusedFlags_NothingToDefine;
+        } Texture2DMS;
+        struct {
+            UINT FirstArraySlice;
+            UINT ArraySize;
+        } Texture2DMSArray;
     };
 };
 
@@ -359,26 +411,62 @@ struct D3D11_SHADER_RESOURCE_VIEW_DESC {
     DXGI_FORMAT Format;
     UINT ViewDimension;
     union {
-        struct { UINT ElementOffset; UINT ElementWidth; } Buffer;
-        struct { UINT FirstElement; UINT NumElements; UINT Flags; } BufferEx;
-        struct { UINT MostDetailedMip; UINT MipLevels; } Texture1D;
-        struct { UINT MostDetailedMip; UINT MipLevels; UINT FirstArraySlice; UINT ArraySize; } Texture1DArray;
-        struct { UINT MostDetailedMip; UINT MipLevels; } Texture2D;
-        struct { UINT MostDetailedMip; UINT MipLevels; UINT FirstArraySlice; UINT ArraySize; } Texture2DArray;
-        struct { UINT Unused; } Texture2DMS;
-        struct { UINT FirstArraySlice; UINT ArraySize; } Texture2DMSArray;
-        struct { UINT MostDetailedMip; UINT MipLevels; } Texture3D;
-        struct { UINT First2DArrayFace; UINT NumCubes; UINT MostDetailedMip; UINT MipLevels; } TextureCubeArray;
+        struct {
+            UINT ElementOffset;
+            UINT ElementWidth;
+        } Buffer;
+        struct {
+            UINT FirstElement;
+            UINT NumElements;
+            UINT Flags;
+        } BufferEx;
+        struct {
+            UINT MostDetailedMip;
+            UINT MipLevels;
+        } Texture1D;
+        struct {
+            UINT MostDetailedMip;
+            UINT MipLevels;
+            UINT FirstArraySlice;
+            UINT ArraySize;
+        } Texture1DArray;
+        struct {
+            UINT MostDetailedMip;
+            UINT MipLevels;
+        } Texture2D;
+        struct {
+            UINT MostDetailedMip;
+            UINT MipLevels;
+            UINT FirstArraySlice;
+            UINT ArraySize;
+        } Texture2DArray;
+        struct {
+            UINT Unused;
+        } Texture2DMS;
+        struct {
+            UINT FirstArraySlice;
+            UINT ArraySize;
+        } Texture2DMSArray;
+        struct {
+            UINT MostDetailedMip;
+            UINT MipLevels;
+        } Texture3D;
+        struct {
+            UINT First2DArrayFace;
+            UINT NumCubes;
+            UINT MostDetailedMip;
+            UINT MipLevels;
+        } TextureCubeArray;
     };
 };
 
-constexpr UINT D3D11_UAV_DIMENSION_UNKNOWN       = 0;
-constexpr UINT D3D11_UAV_DIMENSION_BUFFER         = 1;
-constexpr UINT D3D11_UAV_DIMENSION_TEXTURE1D      = 2;
+constexpr UINT D3D11_UAV_DIMENSION_UNKNOWN = 0;
+constexpr UINT D3D11_UAV_DIMENSION_BUFFER = 1;
+constexpr UINT D3D11_UAV_DIMENSION_TEXTURE1D = 2;
 constexpr UINT D3D11_UAV_DIMENSION_TEXTURE1DARRAY = 3;
-constexpr UINT D3D11_UAV_DIMENSION_TEXTURE2D      = 4;
+constexpr UINT D3D11_UAV_DIMENSION_TEXTURE2D = 4;
 constexpr UINT D3D11_UAV_DIMENSION_TEXTURE2DARRAY = 5;
-constexpr UINT D3D11_UAV_DIMENSION_TEXTURE3D      = 8;
+constexpr UINT D3D11_UAV_DIMENSION_TEXTURE3D = 8;
 
 constexpr UINT D3D11_BUFFER_UAV_FLAG_RAW = 0x1;
 
@@ -386,12 +474,32 @@ struct D3D11_UNORDERED_ACCESS_VIEW_DESC {
     DXGI_FORMAT Format;
     UINT ViewDimension;
     union {
-        struct { UINT FirstElement; UINT NumElements; UINT Flags; } Buffer;
-        struct { UINT MipSlice; } Texture1D;
-        struct { UINT MipSlice; UINT FirstArraySlice; UINT ArraySize; } Texture1DArray;
-        struct { UINT MipSlice; } Texture2D;
-        struct { UINT MipSlice; UINT FirstArraySlice; UINT ArraySize; } Texture2DArray;
-        struct { UINT MipSlice; UINT FirstWSlice; UINT WSize; } Texture3D;
+        struct {
+            UINT FirstElement;
+            UINT NumElements;
+            UINT Flags;
+        } Buffer;
+        struct {
+            UINT MipSlice;
+        } Texture1D;
+        struct {
+            UINT MipSlice;
+            UINT FirstArraySlice;
+            UINT ArraySize;
+        } Texture1DArray;
+        struct {
+            UINT MipSlice;
+        } Texture2D;
+        struct {
+            UINT MipSlice;
+            UINT FirstArraySlice;
+            UINT ArraySize;
+        } Texture2DArray;
+        struct {
+            UINT MipSlice;
+            UINT FirstWSlice;
+            UINT WSize;
+        } Texture3D;
     };
 };
 
@@ -401,14 +509,14 @@ struct D3D11_MAPPED_SUBRESOURCE {
     UINT DepthPitch;
 };
 
-constexpr UINT D3D11_RESOURCE_DIMENSION_UNKNOWN  = 0;
-constexpr UINT D3D11_RESOURCE_DIMENSION_BUFFER   = 1;
+constexpr UINT D3D11_RESOURCE_DIMENSION_UNKNOWN = 0;
+constexpr UINT D3D11_RESOURCE_DIMENSION_BUFFER = 1;
 constexpr UINT D3D11_RESOURCE_DIMENSION_TEXTURE1D = 2;
 constexpr UINT D3D11_RESOURCE_DIMENSION_TEXTURE2D = 3;
 constexpr UINT D3D11_RESOURCE_DIMENSION_TEXTURE3D = 4;
 
 class ID3D11Resource : public ID3D11DeviceChild {
-public:
+  public:
     STDMETHOD(GetType)(THIS_ UINT* pResourceDimension) PURE;
     STDMETHOD(SetEvictionPriority)(THIS_ UINT EvictionPriority) PURE;
     STDMETHOD_(UINT, GetEvictionPriority)(THIS) PURE;
@@ -419,78 +527,69 @@ public:
     virtual UINT __getUsage() const { return D3D11_USAGE_DEFAULT; }
 };
 
-class ID3D11Buffer : public ID3D11Resource {
-};
+class ID3D11Buffer : public ID3D11Resource {};
 
 class ID3D11Texture1D : public ID3D11Resource {
-public:
+  public:
     virtual void GetDesc(struct D3D11_TEXTURE1D_DESC* pDesc) = 0;
 };
 
 class ID3D11Texture2D : public ID3D11Resource {
-public:
+  public:
     virtual void GetDesc(struct D3D11_TEXTURE2D_DESC* pDesc) = 0;
 };
 
 class ID3D11Texture3D : public ID3D11Resource {
-public:
+  public:
     virtual void GetDesc(struct D3D11_TEXTURE3D_DESC* pDesc) = 0;
 };
 
 class ID3D11View : public ID3D11DeviceChild {
-public:
+  public:
     STDMETHOD(GetResource)(THIS_ ID3D11Resource** ppResource) PURE;
     virtual void* __metalTexturePtr() const { return nullptr; }
     virtual void* __metalBufferPtr() const { return nullptr; }
 };
 
-class ID3D11RenderTargetView : public ID3D11View {
-};
+class ID3D11RenderTargetView : public ID3D11View {};
 
-class ID3D11DepthStencilView : public ID3D11View {
-};
+class ID3D11DepthStencilView : public ID3D11View {};
 
-class ID3D11ShaderResourceView : public ID3D11View {
-};
+class ID3D11ShaderResourceView : public ID3D11View {};
 
-class ID3D11UnorderedAccessView : public ID3D11View {
-};
+class ID3D11UnorderedAccessView : public ID3D11View {};
 
 class ID3D11InputLayout : public ID3D11DeviceChild {
-public:
+  public:
     virtual UINT __getNumElements() const { return 0; }
     virtual const void* __getElements() const { return nullptr; }
 };
 
 class ID3D11VertexShader : public ID3D11DeviceChild {
-public:
+  public:
     virtual void* __metalVertexFunction() const { return nullptr; }
 };
 
 class ID3D11PixelShader : public ID3D11DeviceChild {
-public:
+  public:
     virtual void* __metalFragmentFunction() const { return nullptr; }
 };
 
-class ID3D11GeometryShader : public ID3D11DeviceChild {
-};
+class ID3D11GeometryShader : public ID3D11DeviceChild {};
 
-class ID3D11ComputeShader : public ID3D11DeviceChild {
-};
+class ID3D11ComputeShader : public ID3D11DeviceChild {};
 
-class ID3D11HullShader : public ID3D11DeviceChild {
-};
+class ID3D11HullShader : public ID3D11DeviceChild {};
 
-class ID3D11DomainShader : public ID3D11DeviceChild {
-};
+class ID3D11DomainShader : public ID3D11DeviceChild {};
 
 class ID3D11SamplerState : public ID3D11DeviceChild {
-public:
+  public:
     virtual void* __metalSamplerState() const { return nullptr; }
 };
 
 class ID3D11RasterizerState : public ID3D11DeviceChild {
-public:
+  public:
     virtual INT __getCullMode() const { return D3D11_CULL_BACK; }
     virtual INT __getFillMode() const { return D3D11_FILL_SOLID; }
     virtual INT __getDepthClipEnable() const { return TRUE; }
@@ -500,7 +599,7 @@ public:
 };
 
 class ID3D11DepthStencilState : public ID3D11DeviceChild {
-public:
+  public:
     virtual INT __getDepthEnable() const { return TRUE; }
     virtual UINT __getDepthWriteMask() const { return D3D11_DEPTH_WRITE_MASK_ALL; }
     virtual UINT __getDepthFunc() const { return D3D11_COMPARISON_LESS; }
@@ -510,7 +609,7 @@ public:
 };
 
 class ID3D11BlendState : public ID3D11DeviceChild {
-public:
+  public:
     virtual INT __getBlendEnable(UINT rtIndex) const { return 0; }
     virtual UINT __getSrcBlend(UINT rtIndex) const { return D3D11_BLEND_ONE; }
     virtual UINT __getDestBlend(UINT rtIndex) const { return D3D11_BLEND_ZERO; }
@@ -522,14 +621,14 @@ public:
     virtual INT __getAlphaToCoverageEnable() const { return FALSE; }
 };
 
-constexpr UINT D3D11_QUERY_EVENT                   = 0;
-constexpr UINT D3D11_QUERY_OCCLUSION               = 1;
-constexpr UINT D3D11_QUERY_TIMESTAMP               = 2;
-constexpr UINT D3D11_QUERY_TIMESTAMP_DISJOINT      = 3;
-constexpr UINT D3D11_QUERY_PIPELINE_STATISTICS     = 4;
-constexpr UINT D3D11_QUERY_OCCLUSION_PREDICATE     = 5;
-constexpr UINT D3D11_QUERY_SO_STATISTICS           = 6;
-constexpr UINT D3D11_QUERY_SO_OVERFLOW_PREDICATE   = 7;
+constexpr UINT D3D11_QUERY_EVENT = 0;
+constexpr UINT D3D11_QUERY_OCCLUSION = 1;
+constexpr UINT D3D11_QUERY_TIMESTAMP = 2;
+constexpr UINT D3D11_QUERY_TIMESTAMP_DISJOINT = 3;
+constexpr UINT D3D11_QUERY_PIPELINE_STATISTICS = 4;
+constexpr UINT D3D11_QUERY_OCCLUSION_PREDICATE = 5;
+constexpr UINT D3D11_QUERY_SO_STATISTICS = 6;
+constexpr UINT D3D11_QUERY_SO_OVERFLOW_PREDICATE = 7;
 
 struct D3D11_QUERY_DESC {
     UINT Query;
@@ -537,39 +636,43 @@ struct D3D11_QUERY_DESC {
 };
 
 class ID3D11Query : public ID3D11DeviceChild {
-public:
+  public:
     virtual void GetDesc(D3D11_QUERY_DESC* pDesc) = 0;
     virtual void* __metalBufferPtr() const { return nullptr; }
     virtual UINT __getQueryType() const { return D3D11_QUERY_EVENT; }
 };
 
-class ID3D11Predicate : public ID3D11DeviceChild {
-};
+class ID3D11Predicate : public ID3D11DeviceChild {};
 
 class ID3D11CommandList : public ID3D11DeviceChild {
-public:
+  public:
     STDMETHOD_(UINT, GetContextFlags)() { return 0; }
 };
 
-class MIDL_INTERFACE("aec81fb3-4e01-4dfe-a0a3-d0a9757d886b")
-ID3D11DeviceContext : public ID3D11DeviceChild {
-public:
+class MIDL_INTERFACE("aec81fb3-4e01-4dfe-a0a3-d0a9757d886b") ID3D11DeviceContext : public ID3D11DeviceChild {
+  public:
     STDMETHOD(IASetInputLayout)(THIS_ ID3D11InputLayout* pInputLayout) PURE;
-    STDMETHOD(IASetVertexBuffers)(THIS_ UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppVertexBuffers, const UINT* pStrides, const UINT* pOffsets) PURE;
+    STDMETHOD(IASetVertexBuffers)(THIS_ UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppVertexBuffers,
+                                  const UINT* pStrides, const UINT* pOffsets) PURE;
     STDMETHOD(IASetIndexBuffer)(THIS_ ID3D11Buffer* pIndexBuffer, DXGI_FORMAT Format, UINT Offset) PURE;
     STDMETHOD(IASetPrimitiveTopology)(THIS_ UINT Topology) PURE;
 
-    STDMETHOD(VSSetShader)(THIS_ ID3D11VertexShader* pVertexShader, ID3D11ClassInstance* const* ppClassInstances, UINT NumClassInstances) PURE;
+    STDMETHOD(VSSetShader)(THIS_ ID3D11VertexShader* pVertexShader, ID3D11ClassInstance* const* ppClassInstances,
+                           UINT NumClassInstances) PURE;
     STDMETHOD(VSSetConstantBuffers)(THIS_ UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppConstantBuffers) PURE;
-    STDMETHOD(VSSetShaderResources)(THIS_ UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView* const* ppShaderResourceViews) PURE;
+    STDMETHOD(VSSetShaderResources)(THIS_ UINT StartSlot, UINT NumViews,
+                                    ID3D11ShaderResourceView* const* ppShaderResourceViews) PURE;
     STDMETHOD(VSSetSamplers)(THIS_ UINT StartSlot, UINT NumSamplers, ID3D11SamplerState* const* ppSamplers) PURE;
 
-    STDMETHOD(PSSetShader)(THIS_ ID3D11PixelShader* pPixelShader, ID3D11ClassInstance* const* ppClassInstances, UINT NumClassInstances) PURE;
+    STDMETHOD(PSSetShader)(THIS_ ID3D11PixelShader* pPixelShader, ID3D11ClassInstance* const* ppClassInstances,
+                           UINT NumClassInstances) PURE;
     STDMETHOD(PSSetConstantBuffers)(THIS_ UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppConstantBuffers) PURE;
-    STDMETHOD(PSSetShaderResources)(THIS_ UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView* const* ppShaderResourceViews) PURE;
+    STDMETHOD(PSSetShaderResources)(THIS_ UINT StartSlot, UINT NumViews,
+                                    ID3D11ShaderResourceView* const* ppShaderResourceViews) PURE;
     STDMETHOD(PSSetSamplers)(THIS_ UINT StartSlot, UINT NumSamplers, ID3D11SamplerState* const* ppSamplers) PURE;
 
-    STDMETHOD(GSSetShader)(THIS_ ID3D11GeometryShader* pShader, ID3D11ClassInstance* const* ppClassInstances, UINT NumClassInstances) PURE;
+    STDMETHOD(GSSetShader)(THIS_ ID3D11GeometryShader* pShader, ID3D11ClassInstance* const* ppClassInstances,
+                           UINT NumClassInstances) PURE;
 
     STDMETHOD(CSSetShader)(THIS_ ID3D11ComputeShader* pComputeShader, ID3D11ClassInstance* const*, UINT) PURE;
     STDMETHOD(CSSetConstantBuffers)(THIS_ UINT, UINT, ID3D11Buffer* const*) PURE;
@@ -578,8 +681,11 @@ public:
     STDMETHOD(CSSetSamplers)(THIS_ UINT, UINT, ID3D11SamplerState* const*) PURE;
     STDMETHOD(Dispatch)(THIS_ UINT, UINT, UINT) PURE;
 
-    STDMETHOD(OMSetRenderTargets)(THIS_ UINT NumViews, ID3D11RenderTargetView* const* ppRenderTargetViews, ID3D11DepthStencilView* pDepthStencilView) PURE;
-    STDMETHOD(OMSetRenderTargetsAndUnorderedAccessViews)(THIS_ UINT NumRTVs, ID3D11RenderTargetView* const*, ID3D11DepthStencilView*, UINT, UINT, ID3D11UnorderedAccessView* const*, const UINT*) PURE;
+    STDMETHOD(OMSetRenderTargets)(THIS_ UINT NumViews, ID3D11RenderTargetView* const* ppRenderTargetViews,
+                                  ID3D11DepthStencilView* pDepthStencilView) PURE;
+    STDMETHOD(OMSetRenderTargetsAndUnorderedAccessViews)(THIS_ UINT NumRTVs, ID3D11RenderTargetView* const*,
+                                                         ID3D11DepthStencilView*, UINT, UINT,
+                                                         ID3D11UnorderedAccessView* const*, const UINT*) PURE;
     STDMETHOD(OMSetBlendState)(THIS_ ID3D11BlendState* pBlendState, const FLOAT BlendFactor[4], UINT SampleMask) PURE;
     STDMETHOD(OMSetDepthStencilState)(THIS_ ID3D11DepthStencilState* pDepthStencilState, UINT StencilRef) PURE;
 
@@ -588,21 +694,29 @@ public:
     STDMETHOD(RSSetScissorRects)(THIS_ UINT NumRects, const RECT* pRects) PURE;
 
     STDMETHOD(ClearRenderTargetView)(THIS_ ID3D11RenderTargetView* pRenderTargetView, const FLOAT ColorRGBA[4]) PURE;
-    STDMETHOD(ClearDepthStencilView)(THIS_ ID3D11DepthStencilView* pDepthStencilView, UINT ClearFlags, FLOAT Depth, UINT8 Stencil) PURE;
+    STDMETHOD(ClearDepthStencilView)(THIS_ ID3D11DepthStencilView* pDepthStencilView, UINT ClearFlags, FLOAT Depth,
+                                     UINT8 Stencil) PURE;
 
     STDMETHOD(DrawIndexed)(THIS_ UINT IndexCount, UINT StartIndexLocation, INT BaseVertexLocation) PURE;
     STDMETHOD(Draw)(THIS_ UINT VertexCount, UINT StartVertexLocation) PURE;
-    STDMETHOD(DrawIndexedInstanced)(THIS_ UINT IndexCountPerInstance, UINT InstanceCount, UINT StartIndexLocation, INT BaseVertexLocation, UINT StartInstanceLocation) PURE;
-    STDMETHOD(DrawInstanced)(THIS_ UINT VertexCountPerInstance, UINT InstanceCount, UINT StartVertexLocation, UINT StartInstanceLocation) PURE;
+    STDMETHOD(DrawIndexedInstanced)(THIS_ UINT IndexCountPerInstance, UINT InstanceCount, UINT StartIndexLocation,
+                                    INT BaseVertexLocation, UINT StartInstanceLocation) PURE;
+    STDMETHOD(DrawInstanced)(THIS_ UINT VertexCountPerInstance, UINT InstanceCount, UINT StartVertexLocation,
+                             UINT StartInstanceLocation) PURE;
 
-    STDMETHOD(Map)(THIS_ ID3D11Resource* pResource, UINT Subresource, UINT MapType, UINT MapFlags, void* pMappedResource) PURE;
+    STDMETHOD(Map)(THIS_ ID3D11Resource* pResource, UINT Subresource, UINT MapType, UINT MapFlags,
+                   void* pMappedResource) PURE;
     STDMETHOD(Unmap)(THIS_ ID3D11Resource* pResource, UINT Subresource) PURE;
 
     STDMETHOD(GenerateMips)(THIS_ ID3D11ShaderResourceView* pShaderResourceView) PURE;
     STDMETHOD(CopyResource)(THIS_ ID3D11Resource* pDstResource, ID3D11Resource* pSrcResource) PURE;
-    STDMETHOD(UpdateSubresource)(THIS_ ID3D11Resource* pDstResource, UINT DstSubresource, const void* pDstBox, const void* pSrcData, UINT SrcRowPitch, UINT SrcDepthPitch) PURE;
-    STDMETHOD(CopySubresourceRegion)(THIS_ ID3D11Resource* pDstResource, UINT DstSubresource, UINT DstX, UINT DstY, UINT DstZ, ID3D11Resource* pSrcResource, UINT SrcSubresource, const void* pSrcBox) PURE;
-    STDMETHOD(ResolveSubresource)(THIS_ ID3D11Resource* pDstResource, UINT DstSubresource, ID3D11Resource* pSrcResource, UINT SrcSubresource, DXGI_FORMAT Format) PURE;
+    STDMETHOD(UpdateSubresource)(THIS_ ID3D11Resource* pDstResource, UINT DstSubresource, const void* pDstBox,
+                                 const void* pSrcData, UINT SrcRowPitch, UINT SrcDepthPitch) PURE;
+    STDMETHOD(CopySubresourceRegion)(THIS_ ID3D11Resource* pDstResource, UINT DstSubresource, UINT DstX, UINT DstY,
+                                     UINT DstZ, ID3D11Resource* pSrcResource, UINT SrcSubresource,
+                                     const void* pSrcBox) PURE;
+    STDMETHOD(ResolveSubresource)(THIS_ ID3D11Resource* pDstResource, UINT DstSubresource, ID3D11Resource* pSrcResource,
+                                  UINT SrcSubresource, DXGI_FORMAT Format) PURE;
     STDMETHOD(Begin)(THIS_ ID3D11Query* pQuery) PURE;
     STDMETHOD(End)(THIS_ ID3D11Query* pQuery) PURE;
     STDMETHOD(GetData)(THIS_ ID3D11Query* pQuery, void* pData, UINT DataSize, UINT GetDataFlags) PURE;
@@ -632,25 +746,39 @@ typedef struct DXGI_SWAP_CHAIN_DESC {
     UINT Flags;
 } DXGI_SWAP_CHAIN_DESC;
 
-class MIDL_INTERFACE("2e8f6e0c-3e86-4a63-9ea5-7b52d95e08c1")
-ID3D11Device : public IUnknown {
-public:
-    STDMETHOD(CreateBuffer)(THIS_ const D3D11_BUFFER_DESC* pDesc, const D3D11_SUBRESOURCE_DATA* pInitialData, ID3D11Buffer** ppBuffer) PURE;
-    STDMETHOD(CreateTexture1D)(THIS_ const D3D11_TEXTURE1D_DESC* pDesc, const D3D11_SUBRESOURCE_DATA* pInitialData, ID3D11Texture1D** ppTexture1D) PURE;
-    STDMETHOD(CreateTexture2D)(THIS_ const D3D11_TEXTURE2D_DESC* pDesc, const D3D11_SUBRESOURCE_DATA* pInitialData, ID3D11Texture2D** ppTexture2D) PURE;
-    STDMETHOD(CreateTexture3D)(THIS_ const D3D11_TEXTURE3D_DESC* pDesc, const D3D11_SUBRESOURCE_DATA* pInitialData, ID3D11Texture3D** ppTexture3D) PURE;
-    STDMETHOD(CreateShaderResourceView)(THIS_ ID3D11Resource* pResource, const void* pDesc, ID3D11ShaderResourceView** ppSRView) PURE;
-    STDMETHOD(CreateRenderTargetView)(THIS_ ID3D11Resource* pResource, const void* pDesc, ID3D11RenderTargetView** ppRTView) PURE;
-    STDMETHOD(CreateDepthStencilView)(THIS_ ID3D11Resource* pResource, const void* pDesc, ID3D11DepthStencilView** ppDepthStencilView) PURE;
-    STDMETHOD(CreateUnorderedAccessView)(THIS_ ID3D11Resource* pResource, const D3D11_UNORDERED_ACCESS_VIEW_DESC* pDesc, ID3D11UnorderedAccessView** ppUAView) PURE;
-    STDMETHOD(CreateVertexShader)(THIS_ const void* pShaderBytecode, SIZE_T BytecodeLength, ID3D11ClassLinkage* pClassLinkage, ID3D11VertexShader** ppVertexShader) PURE;
-    STDMETHOD(CreatePixelShader)(THIS_ const void* pShaderBytecode, SIZE_T BytecodeLength, ID3D11ClassLinkage* pClassLinkage, ID3D11PixelShader** ppPixelShader) PURE;
-    STDMETHOD(CreateGeometryShader)(THIS_ const void* pShaderBytecode, SIZE_T BytecodeLength, ID3D11ClassLinkage* pClassLinkage, ID3D11GeometryShader** ppGeometryShader) PURE;
-    STDMETHOD(CreateComputeShader)(THIS_ const void* pShaderBytecode, SIZE_T BytecodeLength, ID3D11ClassLinkage* pClassLinkage, ID3D11ComputeShader** ppComputeShader) PURE;
-    STDMETHOD(CreateInputLayout)(THIS_ const void* pInputElementDescs, UINT NumElements, const void* pShaderBytecodeWithInputSignature, SIZE_T BytecodeLength, ID3D11InputLayout** ppInputLayout) PURE;
+class MIDL_INTERFACE("2e8f6e0c-3e86-4a63-9ea5-7b52d95e08c1") ID3D11Device : public IUnknown {
+  public:
+    STDMETHOD(CreateBuffer)(THIS_ const D3D11_BUFFER_DESC* pDesc, const D3D11_SUBRESOURCE_DATA* pInitialData,
+                            ID3D11Buffer** ppBuffer) PURE;
+    STDMETHOD(CreateTexture1D)(THIS_ const D3D11_TEXTURE1D_DESC* pDesc, const D3D11_SUBRESOURCE_DATA* pInitialData,
+                               ID3D11Texture1D** ppTexture1D) PURE;
+    STDMETHOD(CreateTexture2D)(THIS_ const D3D11_TEXTURE2D_DESC* pDesc, const D3D11_SUBRESOURCE_DATA* pInitialData,
+                               ID3D11Texture2D** ppTexture2D) PURE;
+    STDMETHOD(CreateTexture3D)(THIS_ const D3D11_TEXTURE3D_DESC* pDesc, const D3D11_SUBRESOURCE_DATA* pInitialData,
+                               ID3D11Texture3D** ppTexture3D) PURE;
+    STDMETHOD(CreateShaderResourceView)(THIS_ ID3D11Resource* pResource, const void* pDesc,
+                                        ID3D11ShaderResourceView** ppSRView) PURE;
+    STDMETHOD(CreateRenderTargetView)(THIS_ ID3D11Resource* pResource, const void* pDesc,
+                                      ID3D11RenderTargetView** ppRTView) PURE;
+    STDMETHOD(CreateDepthStencilView)(THIS_ ID3D11Resource* pResource, const void* pDesc,
+                                      ID3D11DepthStencilView** ppDepthStencilView) PURE;
+    STDMETHOD(CreateUnorderedAccessView)(THIS_ ID3D11Resource* pResource, const D3D11_UNORDERED_ACCESS_VIEW_DESC* pDesc,
+                                         ID3D11UnorderedAccessView** ppUAView) PURE;
+    STDMETHOD(CreateVertexShader)(THIS_ const void* pShaderBytecode, SIZE_T BytecodeLength,
+                                  ID3D11ClassLinkage* pClassLinkage, ID3D11VertexShader** ppVertexShader) PURE;
+    STDMETHOD(CreatePixelShader)(THIS_ const void* pShaderBytecode, SIZE_T BytecodeLength,
+                                 ID3D11ClassLinkage* pClassLinkage, ID3D11PixelShader** ppPixelShader) PURE;
+    STDMETHOD(CreateGeometryShader)(THIS_ const void* pShaderBytecode, SIZE_T BytecodeLength,
+                                    ID3D11ClassLinkage* pClassLinkage, ID3D11GeometryShader** ppGeometryShader) PURE;
+    STDMETHOD(CreateComputeShader)(THIS_ const void* pShaderBytecode, SIZE_T BytecodeLength,
+                                   ID3D11ClassLinkage* pClassLinkage, ID3D11ComputeShader** ppComputeShader) PURE;
+    STDMETHOD(CreateInputLayout)(THIS_ const void* pInputElementDescs, UINT NumElements,
+                                 const void* pShaderBytecodeWithInputSignature, SIZE_T BytecodeLength,
+                                 ID3D11InputLayout** ppInputLayout) PURE;
     STDMETHOD(CreateSamplerState)(THIS_ const void* pSamplerDesc, ID3D11SamplerState** ppSamplerState) PURE;
     STDMETHOD(CreateRasterizerState)(THIS_ const void* pRasterizerDesc, ID3D11RasterizerState** ppRasterizerState) PURE;
-    STDMETHOD(CreateDepthStencilState)(THIS_ const void* pDepthStencilDesc, ID3D11DepthStencilState** ppDepthStencilState) PURE;
+    STDMETHOD(CreateDepthStencilState)(THIS_ const void* pDepthStencilDesc,
+                                       ID3D11DepthStencilState** ppDepthStencilState) PURE;
     STDMETHOD(CreateBlendState)(THIS_ const void* pBlendStateDesc, ID3D11BlendState** ppBlendState) PURE;
     STDMETHOD(CreateQuery)(THIS_ const D3D11_QUERY_DESC* pQueryDesc, ID3D11Query** ppQuery) PURE;
     STDMETHOD(CreatePredicate)(THIS_ const D3D11_QUERY_DESC* pPredicateDesc, ID3D11Predicate** ppPredicate) PURE;

--- a/include/d3d/D3D12.h
+++ b/include/d3d/D3D12.h
@@ -4,15 +4,22 @@
 
 static const GUID IID_ID3D12Object = {0xc4fec28f, 0x7966, 0x4e14, {0x8a, 0x15, 0x79, 0x57, 0x1c, 0x60, 0x9d, 0xab}};
 static const GUID IID_ID3D12Device = {0x189819f1, 0x1db6, 0x4b57, {0xbe, 0x54, 0x18, 0x29, 0x48, 0x31, 0x1a, 0x47}};
-static const GUID IID_ID3D12CommandQueue = {0x0ec870a6, 0x5d7e, 0x4c22, {0xa4, 0x89, 0x7a, 0xb2, 0x27, 0x6a, 0x3a, 0x0a}};
-static const GUID IID_ID3D12CommandAllocator = {0x6102dee4, 0xaf59, 0x4b09, {0xb6, 0x59, 0xbd, 0x02, 0x62, 0x8e, 0x22, 0x4a}};
-static const GUID IID_ID3D12GraphicsCommandList = {0x5b160d0f, 0xac1b, 0x4185, {0x8b, 0xa8, 0xb3, 0xae, 0x42, 0xa5, 0xa4, 0xd3}};
+static const GUID IID_ID3D12CommandQueue = {
+    0x0ec870a6, 0x5d7e, 0x4c22, {0xa4, 0x89, 0x7a, 0xb2, 0x27, 0x6a, 0x3a, 0x0a}};
+static const GUID IID_ID3D12CommandAllocator = {
+    0x6102dee4, 0xaf59, 0x4b09, {0xb6, 0x59, 0xbd, 0x02, 0x62, 0x8e, 0x22, 0x4a}};
+static const GUID IID_ID3D12GraphicsCommandList = {
+    0x5b160d0f, 0xac1b, 0x4185, {0x8b, 0xa8, 0xb3, 0xae, 0x42, 0xa5, 0xa4, 0xd3}};
 static const GUID IID_ID3D12Resource = {0x696442be, 0xa72e, 0x4056, {0xbc, 0x83, 0x34, 0x96, 0x4d, 0x34, 0xe2, 0xf3}};
-static const GUID IID_ID3D12DescriptorHeap = {0x8efb471d, 0x616c, 0x4f49, {0x90, 0xf7, 0x12, 0x76, 0x30, 0x56, 0x31, 0x8d}};
-static const GUID IID_ID3D12RootSignature = {0xc54a6b66, 0x72df, 0x4ee8, {0x8b, 0xe5, 0xa9, 0x46, 0xa1, 0x42, 0x12, 0x32}};
-static const GUID IID_ID3D12PipelineState = {0x765a30f3, 0xf624, 0x4c6f, {0xa8, 0x28, 0xac, 0xe9, 0x48, 0x62, 0x44, 0x5e}};
+static const GUID IID_ID3D12DescriptorHeap = {
+    0x8efb471d, 0x616c, 0x4f49, {0x90, 0xf7, 0x12, 0x76, 0x30, 0x56, 0x31, 0x8d}};
+static const GUID IID_ID3D12RootSignature = {
+    0xc54a6b66, 0x72df, 0x4ee8, {0x8b, 0xe5, 0xa9, 0x46, 0xa1, 0x42, 0x12, 0x32}};
+static const GUID IID_ID3D12PipelineState = {
+    0x765a30f3, 0xf624, 0x4c6f, {0xa8, 0x28, 0xac, 0xe9, 0x48, 0x62, 0x44, 0x5e}};
 static const GUID IID_ID3D12Fence = {0x0a753dcf, 0xc4d8, 0x4b91, {0x9d, 0x7f, 0x41, 0x5e, 0xfb, 0x14, 0x8c, 0x5f}};
-static const GUID IID_ID3D12CommandSignature = {0xc36a797c, 0xec80, 0x4f0a, {0x89, 0x64, 0x02, 0xe1, 0x31, 0x74, 0x70, 0xb4}};
+static const GUID IID_ID3D12CommandSignature = {
+    0xc36a797c, 0xec80, 0x4f0a, {0x89, 0x64, 0x02, 0xe1, 0x31, 0x74, 0x70, 0xb4}};
 
 typedef UINT64 D3D12_GPU_VIRTUAL_ADDRESS;
 
@@ -71,11 +78,24 @@ constexpr UINT D3D12_TILE_RANGE_FLAG_NULL = 1;
 constexpr UINT D3D12_TILE_RANGE_FLAG_SKIP = 2;
 constexpr UINT D3D12_TILE_RANGE_FLAG_REUSE_SINGLE_TILE = 4;
 
-struct D3D12_TILE_REGION_SIZE { UINT NumTiles; UINT Width; UINT Height; UINT Depth; BOOL bUseBox; };
+struct D3D12_TILE_REGION_SIZE {
+    UINT NumTiles;
+    UINT Width;
+    UINT Height;
+    UINT Depth;
+    BOOL bUseBox;
+};
 
-struct D3D12_TILED_RESOURCE_COORDINATE { UINT X; UINT Y; UINT Z; UINT Subresource; };
+struct D3D12_TILED_RESOURCE_COORDINATE {
+    UINT X;
+    UINT Y;
+    UINT Z;
+    UINT Subresource;
+};
 
-struct D3D12_TILE_RANGE_FLAGS { UINT Flags; };
+struct D3D12_TILE_RANGE_FLAGS {
+    UINT Flags;
+};
 
 struct D3D12_PACKED_MIP_INFO {
     UINT NumStandardMips;
@@ -232,22 +252,58 @@ constexpr UINT DXGI_FORMAT_R32_UINT = 42;
 constexpr UINT DXGI_FORMAT_R8_UNORM = 61;
 constexpr UINT DXGI_FORMAT_R8G8_UNORM = 49;
 
-struct D3D12_HEAP_PROPERTIES { UINT Type; UINT CPUPageProperty; UINT MemoryPoolPreference; UINT CreationNodeMask; UINT VisibleNodeMask; };
-
-struct D3D12_RESOURCE_DESC {
-    UINT Dimension; UINT64 Alignment; UINT64 Width; UINT Height;
-    UINT DepthOrArraySize; UINT MipLevels; UINT Format;
-    struct { UINT Count; UINT Quality; } SampleDesc;
-    UINT Layout; UINT Flags;
+struct D3D12_HEAP_PROPERTIES {
+    UINT Type;
+    UINT CPUPageProperty;
+    UINT MemoryPoolPreference;
+    UINT CreationNodeMask;
+    UINT VisibleNodeMask;
 };
 
-struct D3D12_DESCRIPTOR_HEAP_DESC { UINT Type; UINT NumDescriptors; UINT Flags; UINT NodeMask; };
+struct D3D12_RESOURCE_DESC {
+    UINT Dimension;
+    UINT64 Alignment;
+    UINT64 Width;
+    UINT Height;
+    UINT DepthOrArraySize;
+    UINT MipLevels;
+    UINT Format;
+    struct {
+        UINT Count;
+        UINT Quality;
+    } SampleDesc;
+    UINT Layout;
+    UINT Flags;
+};
 
-struct D3D12_ROOT_CONSTANTS { UINT ShaderRegister; UINT RegisterSpace; UINT Num32BitValues; };
-struct D3D12_ROOT_DESCRIPTOR { UINT ShaderRegister; UINT RegisterSpace; };
-struct D3D12_DESCRIPTOR_RANGE { UINT RangeType; UINT NumDescriptors; UINT BaseShaderRegister; UINT RegisterSpace; UINT OffsetInDescriptorsFromTableStart; };
+struct D3D12_DESCRIPTOR_HEAP_DESC {
+    UINT Type;
+    UINT NumDescriptors;
+    UINT Flags;
+    UINT NodeMask;
+};
 
-struct D3D12_ROOT_DESCRIPTOR_TABLE { UINT NumDescriptorRanges; const D3D12_DESCRIPTOR_RANGE* pDescriptorRanges; };
+struct D3D12_ROOT_CONSTANTS {
+    UINT ShaderRegister;
+    UINT RegisterSpace;
+    UINT Num32BitValues;
+};
+struct D3D12_ROOT_DESCRIPTOR {
+    UINT ShaderRegister;
+    UINT RegisterSpace;
+};
+struct D3D12_DESCRIPTOR_RANGE {
+    UINT RangeType;
+    UINT NumDescriptors;
+    UINT BaseShaderRegister;
+    UINT RegisterSpace;
+    UINT OffsetInDescriptorsFromTableStart;
+};
+
+struct D3D12_ROOT_DESCRIPTOR_TABLE {
+    UINT NumDescriptorRanges;
+    const D3D12_DESCRIPTOR_RANGE* pDescriptorRanges;
+};
 
 struct D3D12_ROOT_PARAMETER {
     UINT ParameterType;
@@ -258,52 +314,128 @@ struct D3D12_ROOT_PARAMETER {
 };
 
 struct D3D12_STATIC_SAMPLER_DESC {
-    UINT Filter; UINT AddressU; UINT AddressV; UINT AddressW;
-    FLOAT MipLODBias; UINT MaxAnisotropy; UINT ComparisonFunc;
-    UINT BorderColor; FLOAT MinLOD; FLOAT MaxLOD;
-    UINT ShaderRegister; UINT RegisterSpace; UINT ShaderVisibility;
+    UINT Filter;
+    UINT AddressU;
+    UINT AddressV;
+    UINT AddressW;
+    FLOAT MipLODBias;
+    UINT MaxAnisotropy;
+    UINT ComparisonFunc;
+    UINT BorderColor;
+    FLOAT MinLOD;
+    FLOAT MaxLOD;
+    UINT ShaderRegister;
+    UINT RegisterSpace;
+    UINT ShaderVisibility;
 };
 
 struct D3D12_ROOT_SIGNATURE_DESC {
-    UINT NumParameters; const D3D12_ROOT_PARAMETER* pParameters;
-    UINT NumStaticSamplers; const D3D12_STATIC_SAMPLER_DESC* pStaticSamplers;
+    UINT NumParameters;
+    const D3D12_ROOT_PARAMETER* pParameters;
+    UINT NumStaticSamplers;
+    const D3D12_STATIC_SAMPLER_DESC* pStaticSamplers;
     UINT Flags;
 };
 
 struct D3D12_BLEND_DESC {
-    BOOL AlphaToCoverageEnable; BOOL IndependentBlendEnable;
-    struct RT { BOOL BlendEnable; BOOL LogicOpEnable; UINT SrcBlend; UINT DestBlend; UINT BlendOp; UINT SrcBlendAlpha; UINT DestBlendAlpha; UINT BlendOpAlpha; UINT LogicOp; UINT RenderTargetWriteMask; };
+    BOOL AlphaToCoverageEnable;
+    BOOL IndependentBlendEnable;
+    struct RT {
+        BOOL BlendEnable;
+        BOOL LogicOpEnable;
+        UINT SrcBlend;
+        UINT DestBlend;
+        UINT BlendOp;
+        UINT SrcBlendAlpha;
+        UINT DestBlendAlpha;
+        UINT BlendOpAlpha;
+        UINT LogicOp;
+        UINT RenderTargetWriteMask;
+    };
     RT RenderTarget[8];
 };
 
 struct D3D12_RASTERIZER_DESC {
-    UINT FillMode; UINT CullMode; BOOL FrontCounterClockwise;
-    INT DepthBias; FLOAT DepthBiasClamp; FLOAT SlopeScaledDepthBias;
-    BOOL DepthClipEnable; BOOL MultisampleEnable; BOOL AntialiasedLineEnable;
-    UINT ForcedSampleCount; BOOL ConservativeRaster;
+    UINT FillMode;
+    UINT CullMode;
+    BOOL FrontCounterClockwise;
+    INT DepthBias;
+    FLOAT DepthBiasClamp;
+    FLOAT SlopeScaledDepthBias;
+    BOOL DepthClipEnable;
+    BOOL MultisampleEnable;
+    BOOL AntialiasedLineEnable;
+    UINT ForcedSampleCount;
+    BOOL ConservativeRaster;
 };
 
 struct D3D12_DEPTH_STENCIL_DESC {
-    BOOL DepthEnable; UINT DepthWriteMask; UINT DepthFunc;
-    BOOL StencilEnable; UINT StencilReadMask; UINT StencilWriteMask;
-    struct Face { UINT StencilFailOp; UINT StencilDepthFailOp; UINT StencilPassOp; UINT StencilFunc; } FrontFace, BackFace;
+    BOOL DepthEnable;
+    UINT DepthWriteMask;
+    UINT DepthFunc;
+    BOOL StencilEnable;
+    UINT StencilReadMask;
+    UINT StencilWriteMask;
+    struct Face {
+        UINT StencilFailOp;
+        UINT StencilDepthFailOp;
+        UINT StencilPassOp;
+        UINT StencilFunc;
+    } FrontFace, BackFace;
 };
 
 struct D3D12_INPUT_ELEMENT_DESC {
-    const char* SemanticName; UINT SemanticIndex; UINT Format;
-    UINT InputSlot; UINT AlignedByteOffset; UINT InputSlotClass; UINT InstanceDataStepRate;
+    const char* SemanticName;
+    UINT SemanticIndex;
+    UINT Format;
+    UINT InputSlot;
+    UINT AlignedByteOffset;
+    UINT InputSlotClass;
+    UINT InstanceDataStepRate;
 };
 
-struct D3D12_VIEWPORT { FLOAT TopLeftX; FLOAT TopLeftY; FLOAT Width; FLOAT Height; FLOAT MinDepth; FLOAT MaxDepth; };
-struct D3D12_RECT { LONG left; LONG top; LONG right; LONG bottom; };
-struct D3D12_RANGE { SIZE_T Begin; SIZE_T End; };
+struct D3D12_VIEWPORT {
+    FLOAT TopLeftX;
+    FLOAT TopLeftY;
+    FLOAT Width;
+    FLOAT Height;
+    FLOAT MinDepth;
+    FLOAT MaxDepth;
+};
+struct D3D12_RECT {
+    LONG left;
+    LONG top;
+    LONG right;
+    LONG bottom;
+};
+struct D3D12_RANGE {
+    SIZE_T Begin;
+    SIZE_T End;
+};
 
-struct D3D12_VERTEX_BUFFER_VIEW { D3D12_GPU_VIRTUAL_ADDRESS BufferLocation; UINT SizeInBytes; UINT StrideInBytes; };
-struct D3D12_INDEX_BUFFER_VIEW { D3D12_GPU_VIRTUAL_ADDRESS BufferLocation; UINT SizeInBytes; UINT Format; };
-struct D3D12_GPU_DESCRIPTOR_HANDLE { UINT64 ptr; };
-struct D3D12_CPU_DESCRIPTOR_HANDLE { UINT64 ptr; };
+struct D3D12_VERTEX_BUFFER_VIEW {
+    D3D12_GPU_VIRTUAL_ADDRESS BufferLocation;
+    UINT SizeInBytes;
+    UINT StrideInBytes;
+};
+struct D3D12_INDEX_BUFFER_VIEW {
+    D3D12_GPU_VIRTUAL_ADDRESS BufferLocation;
+    UINT SizeInBytes;
+    UINT Format;
+};
+struct D3D12_GPU_DESCRIPTOR_HANDLE {
+    UINT64 ptr;
+};
+struct D3D12_CPU_DESCRIPTOR_HANDLE {
+    UINT64 ptr;
+};
 
-struct D3D12_COMMAND_SIGNATURE_DESC { UINT ByteStride; UINT NumArgumentDescs; const void* pArgumentDescs; UINT NodeMask; };
+struct D3D12_COMMAND_SIGNATURE_DESC {
+    UINT ByteStride;
+    UINT NumArgumentDescs;
+    const void* pArgumentDescs;
+    UINT NodeMask;
+};
 
 struct D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS {
     UINT Type;
@@ -384,7 +516,7 @@ struct D3D12_STATE_OBJECT_DESC {
 };
 
 class ID3D12Object : public IUnknown {
-public:
+  public:
     STDMETHOD(GetPrivateData)(const GUID& guid, UINT* pDataSize, void* pData) { return E_NOTIMPL; }
     STDMETHOD(SetPrivateData)(const GUID& guid, UINT DataSize, const void* pData) { return E_NOTIMPL; }
     STDMETHOD(SetPrivateDataInterface)(const GUID& guid, const IUnknown* pData) { return E_NOTIMPL; }
@@ -392,7 +524,7 @@ public:
 };
 
 class ID3D12Fence : public ID3D12Object {
-public:
+  public:
     STDMETHOD(GetCompletedValue)(UINT64* pValue) PURE;
     STDMETHOD(SetEventOnCompletion)(UINT64 Value, HANDLE hEvent) PURE;
     STDMETHOD(Signal)(UINT64 Value) PURE;
@@ -407,12 +539,19 @@ struct D3D12_GLOBAL_ROOT_SIGNATURE {
 struct D3D12_LOCAL_ROOT_SIGNATURE {
     ID3D12RootSignature* pRootSignature;
 };
-class ID3D12PipelineState : public ID3D12Object { public: virtual void* __metalRenderPipelineState() const { return nullptr; } virtual void* __metalComputePipelineState() const { return nullptr; } };
+class ID3D12PipelineState : public ID3D12Object {
+  public:
+    virtual void* __metalRenderPipelineState() const { return nullptr; }
+    virtual void* __metalComputePipelineState() const { return nullptr; }
+};
 class ID3D12CommandSignature : public ID3D12Object {};
-class ID3D12CommandAllocator : public ID3D12Object { public: STDMETHOD(Reset)() PURE; };
+class ID3D12CommandAllocator : public ID3D12Object {
+  public:
+    STDMETHOD(Reset)() PURE;
+};
 
 class ID3D12Resource : public ID3D12Object {
-public:
+  public:
     STDMETHOD(Map)(UINT Subresource, const D3D12_RANGE* pReadRange, void** ppData) PURE;
     STDMETHOD(Unmap)(UINT Subresource, const D3D12_RANGE* pWrittenRange) PURE;
     STDMETHOD(GetDesc)(D3D12_RESOURCE_DESC* pDesc) PURE;
@@ -423,10 +562,16 @@ public:
     virtual void __setResourceState(UINT state) {}
 };
 
-struct D3D12_RESOURCE_BARRIER { UINT Type; UINT Flags; UINT StateBefore; UINT StateAfter; ID3D12Resource* pResource; };
+struct D3D12_RESOURCE_BARRIER {
+    UINT Type;
+    UINT Flags;
+    UINT StateBefore;
+    UINT StateAfter;
+    ID3D12Resource* pResource;
+};
 
 class ID3D12DescriptorHeap : public ID3D12Object {
-public:
+  public:
     virtual D3D12_CPU_DESCRIPTOR_HANDLE __getCPUDescriptorHandleForHeapStart() { return {0}; }
     virtual D3D12_GPU_DESCRIPTOR_HANDLE __getGPUDescriptorHandleForHeapStart() { return {0}; }
     virtual UINT __getDescriptorCount() const { return 0; }
@@ -434,12 +579,12 @@ public:
 };
 
 class ID3D12CommandList : public ID3D12Object {
-public:
+  public:
     virtual void __execute(void* metalDevice) {}
 };
 
 class ID3D12CommandQueue : public ID3D12Object {
-public:
+  public:
     STDMETHOD(ExecuteCommandLists)(UINT NumCommandLists, ID3D12CommandList* const* ppCommandLists) PURE;
     STDMETHOD(Signal)(ID3D12Fence* pFence, UINT64 Value) PURE;
     STDMETHOD(Wait)(ID3D12Fence* pFence, UINT64 Value) PURE;
@@ -447,11 +592,16 @@ public:
 
 struct D3D12_GRAPHICS_PIPELINE_STATE_DESC {
     ID3D12RootSignature* pRootSignature;
-    const void* VS; SIZE_T VSsize;
-    const void* PS; SIZE_T PSsize;
-    const void* GS; SIZE_T GSsize;
-    const void* DS; SIZE_T DSsize;
-    const void* HS; SIZE_T HSsize;
+    const void* VS;
+    SIZE_T VSsize;
+    const void* PS;
+    SIZE_T PSsize;
+    const void* GS;
+    SIZE_T GSsize;
+    const void* DS;
+    SIZE_T DSsize;
+    const void* HS;
+    SIZE_T HSsize;
     UINT StreamOutput;
     D3D12_BLEND_DESC BlendState;
     UINT SampleMask;
@@ -463,11 +613,14 @@ struct D3D12_GRAPHICS_PIPELINE_STATE_DESC {
     UINT NumRenderTargets;
     UINT RTVFormats[8];
     UINT DSVFormat;
-    struct { UINT Count; UINT Quality; } SampleDesc;
+    struct {
+        UINT Count;
+        UINT Quality;
+    } SampleDesc;
 };
 
 class ID3D12GraphicsCommandList : public ID3D12CommandList {
-public:
+  public:
     STDMETHOD(Close)() PURE;
     STDMETHOD(Reset)(ID3D12CommandAllocator* pAllocator, ID3D12PipelineState* pInitialState) PURE;
     STDMETHOD(IASetPrimitiveTopology)(UINT PrimitiveTopology) PURE;
@@ -476,70 +629,113 @@ public:
     STDMETHOD(SetPipelineState)(ID3D12PipelineState* pPipelineState) PURE;
     STDMETHOD(SetGraphicsRootSignature)(ID3D12RootSignature* pRootSignature) PURE;
     STDMETHOD(SetGraphicsRootDescriptorTable)(UINT RootParameterIndex, D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor) PURE;
-    STDMETHOD(SetGraphicsRootConstantBufferView)(UINT RootParameterIndex, D3D12_GPU_VIRTUAL_ADDRESS BufferLocation) PURE;
-    STDMETHOD(SetGraphicsRootShaderResourceView)(UINT RootParameterIndex, D3D12_GPU_VIRTUAL_ADDRESS BufferLocation) PURE;
-    STDMETHOD(SetGraphicsRootUnorderedAccessView)(UINT RootParameterIndex, D3D12_GPU_VIRTUAL_ADDRESS BufferLocation) PURE;
-    STDMETHOD(SetGraphicsRoot32BitConstants)(UINT RootParameterIndex, UINT Num32BitValues, const void* pData, UINT DestOffsetIn32BitValues) PURE;
-    STDMETHOD(OMSetRenderTargets)(UINT NumRenderTargetDescriptors, const D3D12_CPU_DESCRIPTOR_HANDLE* pRenderTargetDescriptors, BOOL RTsSingleHandleToDescriptorRange, const D3D12_CPU_DESCRIPTOR_HANDLE* pDepthStencilDescriptor) PURE;
+    STDMETHOD(SetGraphicsRootConstantBufferView)(UINT RootParameterIndex,
+                                                 D3D12_GPU_VIRTUAL_ADDRESS BufferLocation) PURE;
+    STDMETHOD(SetGraphicsRootShaderResourceView)(UINT RootParameterIndex,
+                                                 D3D12_GPU_VIRTUAL_ADDRESS BufferLocation) PURE;
+    STDMETHOD(SetGraphicsRootUnorderedAccessView)(UINT RootParameterIndex,
+                                                  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation) PURE;
+    STDMETHOD(SetGraphicsRoot32BitConstants)(UINT RootParameterIndex, UINT Num32BitValues, const void* pData,
+                                             UINT DestOffsetIn32BitValues) PURE;
+    STDMETHOD(OMSetRenderTargets)(UINT NumRenderTargetDescriptors,
+                                  const D3D12_CPU_DESCRIPTOR_HANDLE* pRenderTargetDescriptors,
+                                  BOOL RTsSingleHandleToDescriptorRange,
+                                  const D3D12_CPU_DESCRIPTOR_HANDLE* pDepthStencilDescriptor) PURE;
     STDMETHOD(OMSetStencilRef)(UINT StencilRef) PURE;
     STDMETHOD(OMSetBlendFactor)(const FLOAT BlendFactor[4]) PURE;
     STDMETHOD(RSSetViewports)(UINT NumViewports, const D3D12_VIEWPORT* pViewports) PURE;
     STDMETHOD(RSSetScissorRects)(UINT NumRects, const D3D12_RECT* pRects) PURE;
-    STDMETHOD(ClearRenderTargetView)(D3D12_CPU_DESCRIPTOR_HANDLE RenderTargetView, const FLOAT ColorRGBA[4], UINT NumRects, const D3D12_RECT* pRects) PURE;
-    STDMETHOD(ClearDepthStencilView)(D3D12_CPU_DESCRIPTOR_HANDLE DepthStencilView, UINT ClearFlags, FLOAT Depth, UINT8 Stencil, UINT NumRects, const D3D12_RECT* pRects) PURE;
-    STDMETHOD(DrawInstanced)(UINT VertexCountPerInstance, UINT InstanceCount, UINT StartVertexLocation, UINT StartInstanceLocation) PURE;
-    STDMETHOD(DrawIndexedInstanced)(UINT IndexCountPerInstance, UINT InstanceCount, UINT StartIndexLocation, INT BaseVertexLocation, UINT StartInstanceLocation) PURE;
+    STDMETHOD(ClearRenderTargetView)(D3D12_CPU_DESCRIPTOR_HANDLE RenderTargetView, const FLOAT ColorRGBA[4],
+                                     UINT NumRects, const D3D12_RECT* pRects) PURE;
+    STDMETHOD(ClearDepthStencilView)(D3D12_CPU_DESCRIPTOR_HANDLE DepthStencilView, UINT ClearFlags, FLOAT Depth,
+                                     UINT8 Stencil, UINT NumRects, const D3D12_RECT* pRects) PURE;
+    STDMETHOD(DrawInstanced)(UINT VertexCountPerInstance, UINT InstanceCount, UINT StartVertexLocation,
+                             UINT StartInstanceLocation) PURE;
+    STDMETHOD(DrawIndexedInstanced)(UINT IndexCountPerInstance, UINT InstanceCount, UINT StartIndexLocation,
+                                    INT BaseVertexLocation, UINT StartInstanceLocation) PURE;
     STDMETHOD(Dispatch)(UINT ThreadGroupCountX, UINT ThreadGroupCountY, UINT ThreadGroupCountZ) PURE;
     STDMETHOD(CopyResource)(ID3D12Resource* pDstResource, ID3D12Resource* pSrcResource) PURE;
-    STDMETHOD(CopyBufferRegion)(ID3D12Resource* pDstResource, UINT64 DstOffset, ID3D12Resource* pSrcResource, UINT64 SrcOffset, UINT64 NumBytes) PURE;
-    STDMETHOD(CopyTextureRegion)(const void* pDst, UINT DstX, UINT DstY, UINT DstZ, ID3D12Resource* pSrcResource, UINT SrcSubresource, const void* pSrcBox) PURE;
+    STDMETHOD(CopyBufferRegion)(ID3D12Resource* pDstResource, UINT64 DstOffset, ID3D12Resource* pSrcResource,
+                                UINT64 SrcOffset, UINT64 NumBytes) PURE;
+    STDMETHOD(CopyTextureRegion)(const void* pDst, UINT DstX, UINT DstY, UINT DstZ, ID3D12Resource* pSrcResource,
+                                 UINT SrcSubresource, const void* pSrcBox) PURE;
     STDMETHOD(ResourceBarrier)(UINT NumBarriers, const D3D12_RESOURCE_BARRIER* pBarriers) PURE;
     STDMETHOD(SetDescriptorHeaps)(UINT NumDescriptorHeaps, ID3D12DescriptorHeap* const* ppDescriptorHeaps) PURE;
     STDMETHOD(IASetInputLayout)(UINT NumElements, const D3D12_INPUT_ELEMENT_DESC* pInputElementDescs) PURE;
     STDMETHOD(Map)(ID3D12Resource* pResource, UINT Subresource, const D3D12_RANGE* pReadRange, void** ppData) PURE;
     STDMETHOD(Unmap)(ID3D12Resource* pResource, UINT Subresource, const D3D12_RANGE* pWrittenRange) PURE;
-    STDMETHOD(ExecuteIndirect)(ID3D12CommandSignature* pCommandSignature, UINT MaxCommandCount, ID3D12Resource* pCommandBuffer, UINT64 CommandBufferOffset, ID3D12Resource* pCountBuffer, UINT64 CountBufferOffset) PURE;
+    STDMETHOD(ExecuteIndirect)(ID3D12CommandSignature* pCommandSignature, UINT MaxCommandCount,
+                               ID3D12Resource* pCommandBuffer, UINT64 CommandBufferOffset, ID3D12Resource* pCountBuffer,
+                               UINT64 CountBufferOffset) PURE;
 
-    STDMETHOD(CopyTiles)(ID3D12Resource* pTiledResource, const D3D12_TILED_RESOURCE_COORDINATE* pTileRegionStartCoordinate, const D3D12_TILE_REGION_SIZE* pTileRegionSize, ID3D12Resource* pBuffer, UINT64 BufferStartOffset, UINT Flags) PURE;
+    STDMETHOD(CopyTiles)(ID3D12Resource* pTiledResource,
+                         const D3D12_TILED_RESOURCE_COORDINATE* pTileRegionStartCoordinate,
+                         const D3D12_TILE_REGION_SIZE* pTileRegionSize, ID3D12Resource* pBuffer,
+                         UINT64 BufferStartOffset, UINT Flags) PURE;
 
     STDMETHOD(DispatchRays)(const D3D12_DISPATCH_RAYS_DESC* pDesc) PURE;
-    STDMETHOD(BuildRaytracingAccelerationStructure)(const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC* pDesc, UINT NumPostbuildInfoDescs, const void* pPostbuildInfoDescs) PURE;
-    STDMETHOD(CopyRaytracingAccelerationStructure)(UINT64 DestAccelerationStructureData, UINT64 SourceAccelerationStructureData, UINT Mode) PURE;
-    STDMETHOD(EmitRaytracingAccelerationStructurePostbuildInfo)(const void* pDesc, UINT NumAccelerationStructures, const UINT64* pAccelerationStructureData) PURE;
+    STDMETHOD(BuildRaytracingAccelerationStructure)(const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC* pDesc,
+                                                    UINT NumPostbuildInfoDescs, const void* pPostbuildInfoDescs) PURE;
+    STDMETHOD(CopyRaytracingAccelerationStructure)(UINT64 DestAccelerationStructureData,
+                                                   UINT64 SourceAccelerationStructureData, UINT Mode) PURE;
+    STDMETHOD(EmitRaytracingAccelerationStructurePostbuildInfo)(const void* pDesc, UINT NumAccelerationStructures,
+                                                                const UINT64* pAccelerationStructureData) PURE;
     STDMETHOD(DispatchMesh)(UINT ThreadGroupCountX, UINT ThreadGroupCountY, UINT ThreadGroupCountZ) PURE;
     STDMETHOD(SetComputeRootSignature)(ID3D12RootSignature* pRootSignature) PURE;
-    STDMETHOD(SetComputeRoot32BitConstants)(UINT RootParameterIndex, UINT Num32BitValues, const void* pData, UINT DestOffsetIn32BitValues) PURE;
+    STDMETHOD(SetComputeRoot32BitConstants)(UINT RootParameterIndex, UINT Num32BitValues, const void* pData,
+                                            UINT DestOffsetIn32BitValues) PURE;
     STDMETHOD(SetComputeRootDescriptorTable)(UINT RootParameterIndex, D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor) PURE;
     STDMETHOD(SetComputeRootConstantBufferView)(UINT RootParameterIndex, D3D12_GPU_VIRTUAL_ADDRESS BufferLocation) PURE;
     STDMETHOD(SetComputeRootShaderResourceView)(UINT RootParameterIndex, D3D12_GPU_VIRTUAL_ADDRESS BufferLocation) PURE;
-    STDMETHOD(SetComputeRootUnorderedAccessView)(UINT RootParameterIndex, D3D12_GPU_VIRTUAL_ADDRESS BufferLocation) PURE;
+    STDMETHOD(SetComputeRootUnorderedAccessView)(UINT RootParameterIndex,
+                                                 D3D12_GPU_VIRTUAL_ADDRESS BufferLocation) PURE;
 };
 
 class ID3D12Device : public ID3D12Object {
-public:
+  public:
     STDMETHOD(CreateCommandQueue)(const void* pDesc, REFIID riid, void** ppCommandQueue) PURE;
     STDMETHOD(CreateCommandAllocator)(UINT type, REFIID riid, void** ppCommandAllocator) PURE;
-    STDMETHOD(CreateCommandList)(UINT nodeMask, UINT type, ID3D12CommandAllocator* pAllocator, ID3D12PipelineState* pInitialState, REFIID riid, void** ppCommandList) PURE;
-    STDMETHOD(CreateRenderTargetView)(ID3D12Resource* pResource, const void* pDesc, D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor) PURE;
-    STDMETHOD(CreateDepthStencilView)(ID3D12Resource* pResource, const void* pDesc, D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor) PURE;
-    STDMETHOD(CreateShaderResourceView)(ID3D12Resource* pResource, const void* pDesc, D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor) PURE;
-    STDMETHOD(CreateUnorderedAccessView)(ID3D12Resource* pResource, ID3D12Resource* pCounterResource, const void* pDesc, D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor) PURE;
+    STDMETHOD(CreateCommandList)(UINT nodeMask, UINT type, ID3D12CommandAllocator* pAllocator,
+                                 ID3D12PipelineState* pInitialState, REFIID riid, void** ppCommandList) PURE;
+    STDMETHOD(CreateRenderTargetView)(ID3D12Resource* pResource, const void* pDesc,
+                                      D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor) PURE;
+    STDMETHOD(CreateDepthStencilView)(ID3D12Resource* pResource, const void* pDesc,
+                                      D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor) PURE;
+    STDMETHOD(CreateShaderResourceView)(ID3D12Resource* pResource, const void* pDesc,
+                                        D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor) PURE;
+    STDMETHOD(CreateUnorderedAccessView)(ID3D12Resource* pResource, ID3D12Resource* pCounterResource, const void* pDesc,
+                                         D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor) PURE;
     STDMETHOD(CreateConstantBufferView)(const void* pDesc, D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor) PURE;
-    STDMETHOD(CreateCommittedResource)(const D3D12_HEAP_PROPERTIES* pHeapProperties, UINT HeapFlags, const D3D12_RESOURCE_DESC* pDesc, UINT InitialResourceState, const void* pOptimizedClearValue, REFIID riid, void** ppvResource) PURE;
-    STDMETHOD(CreateDescriptorHeap)(const D3D12_DESCRIPTOR_HEAP_DESC* pDescriptorHeapDesc, REFIID riid, void** ppvDescriptorHeap) PURE;
-    STDMETHOD(CreateRootSignature)(UINT nodeMask, const void* pBlobWithRootSignature, SIZE_T blobLengthInBytes, REFIID riid, void** ppvRootSignature) PURE;
-    STDMETHOD(CreateGraphicsPipelineState)(const D3D12_GRAPHICS_PIPELINE_STATE_DESC* pDesc, REFIID riid, void** ppPipelineState) PURE;
+    STDMETHOD(CreateCommittedResource)(const D3D12_HEAP_PROPERTIES* pHeapProperties, UINT HeapFlags,
+                                       const D3D12_RESOURCE_DESC* pDesc, UINT InitialResourceState,
+                                       const void* pOptimizedClearValue, REFIID riid, void** ppvResource) PURE;
+    STDMETHOD(CreateDescriptorHeap)(const D3D12_DESCRIPTOR_HEAP_DESC* pDescriptorHeapDesc, REFIID riid,
+                                    void** ppvDescriptorHeap) PURE;
+    STDMETHOD(CreateRootSignature)(UINT nodeMask, const void* pBlobWithRootSignature, SIZE_T blobLengthInBytes,
+                                   REFIID riid, void** ppvRootSignature) PURE;
+    STDMETHOD(CreateGraphicsPipelineState)(const D3D12_GRAPHICS_PIPELINE_STATE_DESC* pDesc, REFIID riid,
+                                           void** ppPipelineState) PURE;
     STDMETHOD(CreateComputePipelineState)(const void* pDesc, REFIID riid, void** ppPipelineState) PURE;
     STDMETHOD(CreateFence)(UINT64 InitialValue, UINT Flags, REFIID riid, void** ppFence) PURE;
-    STDMETHOD(CreateCommandSignature)(const D3D12_COMMAND_SIGNATURE_DESC* pDesc, ID3D12RootSignature* pRootSignature, REFIID riid, void** ppCommandSignature) PURE;
+    STDMETHOD(CreateCommandSignature)(const D3D12_COMMAND_SIGNATURE_DESC* pDesc, ID3D12RootSignature* pRootSignature,
+                                      REFIID riid, void** ppCommandSignature) PURE;
     STDMETHOD(CreateSampler)(const void* pDesc, D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor) PURE;
     STDMETHOD_(UINT, GetDescriptorHandleIncrementSize)(UINT DescriptorHeapType) PURE;
 
-    STDMETHOD(ReserveTiles)(ID3D12Resource* pTiledResource, UINT NumTileRegions, const D3D12_TILED_RESOURCE_COORDINATE* pTileRegionStartCoordinates, const D3D12_TILE_REGION_SIZE* pTileRegionSizes, BOOL bSingleTile) PURE;
-    STDMETHOD(GetResourceTiling)(ID3D12Resource* pTiledResource, UINT* pNumTilesForResource, D3D12_PACKED_MIP_INFO* pPackedMipDesc, D3D12_TILE_SHAPE* pStandardTileShapeForNonPackedMips, UINT* pNumSubresourceTilings, UINT FirstSubresourceTilingToGet, D3D12_SUBRESOURCE_TILING* pSubresourceTilingsForNonPackedMips) PURE;
-    STDMETHOD_(UINT64, GetTiledResourceSize)(UINT64 Width, UINT Height, UINT DepthOrArraySize, UINT Format, UINT MipLevels) PURE;
-    STDMETHOD(CreateSamplerFeedback)(ID3D12Resource* pTargetResource, UINT FeedbackType, REFIID riid, void** ppFeedbackResource) PURE;
-    STDMETHOD(WriteSamplerFeedback)(ID3D12Resource* pTargetResource, ID3D12Resource* pFeedbackResource, UINT FeedbackType) PURE;
+    STDMETHOD(ReserveTiles)(ID3D12Resource* pTiledResource, UINT NumTileRegions,
+                            const D3D12_TILED_RESOURCE_COORDINATE* pTileRegionStartCoordinates,
+                            const D3D12_TILE_REGION_SIZE* pTileRegionSizes, BOOL bSingleTile) PURE;
+    STDMETHOD(GetResourceTiling)(ID3D12Resource* pTiledResource, UINT* pNumTilesForResource,
+                                 D3D12_PACKED_MIP_INFO* pPackedMipDesc,
+                                 D3D12_TILE_SHAPE* pStandardTileShapeForNonPackedMips, UINT* pNumSubresourceTilings,
+                                 UINT FirstSubresourceTilingToGet,
+                                 D3D12_SUBRESOURCE_TILING* pSubresourceTilingsForNonPackedMips) PURE;
+    STDMETHOD_(UINT64, GetTiledResourceSize)(UINT64 Width, UINT Height, UINT DepthOrArraySize, UINT Format,
+                                             UINT MipLevels) PURE;
+    STDMETHOD(CreateSamplerFeedback)(ID3D12Resource* pTargetResource, UINT FeedbackType, REFIID riid,
+                                     void** ppFeedbackResource) PURE;
+    STDMETHOD(WriteSamplerFeedback)(ID3D12Resource* pTargetResource, ID3D12Resource* pFeedbackResource,
+                                    UINT FeedbackType) PURE;
     STDMETHOD(ResolveSamplerFeedback)(ID3D12Resource* pFeedbackResource, ID3D12Resource* pDestResource) PURE;
 
     STDMETHOD(CreateStateObject)(const void* pDesc, REFIID riid, void** ppStateObject) PURE;
@@ -562,7 +758,9 @@ struct D3D12_RAYTRACING_GEOMETRY_DESC {
     } Triangles;
 };
 
-struct D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS { UINT Flags; };
+struct D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS {
+    UINT Flags;
+};
 
 struct D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO {
     UINT64 ResultDataMaxSizeInBytes;
@@ -571,12 +769,12 @@ struct D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO {
 };
 
 class ID3D12StateObject : public ID3D12Object {
-public:
+  public:
     virtual void* __metalRTPipeline() const { return nullptr; }
 };
 
 class ID3D12StateObjectProperties : public IUnknown {
-public:
+  public:
     virtual void* GetShaderIdentifier(const char* pExportName) = 0;
     virtual UINT64 GetRaytracingAccelerationStructureGPUAddress(ID3D12Resource* pAS) = 0;
 };

--- a/include/dxgi/DXGI.h
+++ b/include/dxgi/DXGI.h
@@ -8,7 +8,7 @@ class ID3D11ClassInstance;
 class ID3D11ClassLinkage;
 
 class IDXGIObject : public IUnknown {
-public:
+  public:
     STDMETHOD(GetDevice)(const GUID& riid, void** ppDevice) PURE;
     STDMETHOD(GetPrivateData)(const GUID& guid, UINT* pDataSize, void* pData) PURE;
     STDMETHOD(SetPrivateData)(const GUID& guid, UINT DataSize, const void* pData) PURE;
@@ -20,9 +20,8 @@ class IDXGIAdapter;
 class IDXGIOutput;
 class IDXGISwapChain;
 
-class MIDL_INTERFACE("770aae78-f26f-4dba-a829-253c83d1b387")
-IDXGIFactory : public IUnknown {
-public:
+class MIDL_INTERFACE("770aae78-f26f-4dba-a829-253c83d1b387") IDXGIFactory : public IUnknown {
+  public:
     STDMETHOD(EnumAdapters)(UINT Adapter, IDXGIAdapter** ppAdapter) PURE;
     STDMETHOD(MakeWindowAssociation)(HWND WindowHandle, UINT Flags) PURE;
     STDMETHOD(GetWindowAssociation)(HWND* pWindowHandle) PURE;
@@ -30,24 +29,17 @@ public:
     STDMETHOD(CreateSoftwareAdapter)(HMODULE Module, IDXGIAdapter** ppAdapter) PURE;
 };
 
-class MIDL_INTERFACE("2411e7e1-12ac-4ccf-bd14-9798e8534dc0")
-IDXGIFactory1 : public IDXGIFactory {
-public:
+class MIDL_INTERFACE("2411e7e1-12ac-4ccf-bd14-9798e8534dc0") IDXGIFactory1 : public IDXGIFactory {
+  public:
     STDMETHOD(EnumAdapters1)(UINT Adapter, IDXGIAdapter** ppAdapter) PURE;
     STDMETHOD_(INT, IsCurrent)() PURE;
 };
 
-class MIDL_INTERFACE("790a45f7-0d42-4876-983a-0a55c2762d7f")
-IDXGIFactory2 : public IDXGIFactory1 {
-};
+class MIDL_INTERFACE("790a45f7-0d42-4876-983a-0a55c2762d7f") IDXGIFactory2 : public IDXGIFactory1 {};
 
-class MIDL_INTERFACE("3103a90d-34de-4ec3-988a-743f4c28c6d5")
-IDXGIFactory3 : public IDXGIFactory2 {
-};
+class MIDL_INTERFACE("3103a90d-34de-4ec3-988a-743f4c28c6d5") IDXGIFactory3 : public IDXGIFactory2 {};
 
-class MIDL_INTERFACE("1bc6ea02-ef36-464f-bf0c-21ca39e5cd85")
-IDXGIFactory4 : public IDXGIFactory3 {
-};
+class MIDL_INTERFACE("1bc6ea02-ef36-464f-bf0c-21ca39e5cd85") IDXGIFactory4 : public IDXGIFactory3 {};
 
 typedef struct {
     DXGI_FORMAT Format;
@@ -59,20 +51,19 @@ typedef struct {
     UINT RefreshRateDenominator;
 } DXGI_MODE_DESC;
 
-class MIDL_INTERFACE("2411e7e1-12ac-4ccf-bd14-9798e8534dc0")
-IDXGIAdapter : public IDXGIObject {
-public:
+class MIDL_INTERFACE("2411e7e1-12ac-4ccf-bd14-9798e8534dc0") IDXGIAdapter : public IDXGIObject {
+  public:
     STDMETHOD(EnumOutputs)(UINT Output, IDXGIOutput** ppOutput) PURE;
     STDMETHOD(GetDesc)(void* pDesc) PURE;
     STDMETHOD(CheckInterfaceSupport)(const GUID& guid, UINT64* pUMDVersion) PURE;
 };
 
-class MIDL_INTERFACE("ae02eedb-c735-4690-8d52-5a8dc20213aa")
-IDXGIOutput : public IDXGIObject {
-public:
+class MIDL_INTERFACE("ae02eedb-c735-4690-8d52-5a8dc20213aa") IDXGIOutput : public IDXGIObject {
+  public:
     STDMETHOD(GetDesc)(void* pDesc) PURE;
     STDMETHOD(GetDisplayModeList)(DXGI_FORMAT EnumFormat, UINT Flags, UINT* pNumModes, DXGI_MODE_DESC* pDesc) PURE;
-    STDMETHOD(FindClosestMatchingMode)(const DXGI_MODE_DESC* pModeToMatch, DXGI_MODE_DESC* pClosestMatch, IUnknown* pConcernedDevice) PURE;
+    STDMETHOD(FindClosestMatchingMode)(const DXGI_MODE_DESC* pModeToMatch, DXGI_MODE_DESC* pClosestMatch,
+                                       IUnknown* pConcernedDevice) PURE;
     STDMETHOD(WaitForVBlank)() PURE;
     STDMETHOD(TakeOwnership)(IUnknown* pDevice, INT Exclusive) PURE;
     STDMETHOD_(void, ReleaseOwnership)() PURE;
@@ -84,24 +75,23 @@ public:
     STDMETHOD(GetFrameStatistics)(void* pStats) PURE;
 };
 
-class MIDL_INTERFACE("310d36a0-d2e7-4c0a-aa04-6a9d23b8886a")
-IDXGISwapChain : public IDXGIObject {
-public:
+class MIDL_INTERFACE("310d36a0-d2e7-4c0a-aa04-6a9d23b8886a") IDXGISwapChain : public IDXGIObject {
+  public:
     STDMETHOD(Present)(UINT SyncInterval, UINT Flags) PURE;
     STDMETHOD(GetBuffer)(UINT Buffer, const GUID& riid, void** ppSurface) PURE;
     STDMETHOD(SetFullscreenState)(INT Fullscreen, IDXGIOutput* pTarget) PURE;
     STDMETHOD(GetFullscreenState)(INT* pFullscreen, IDXGIOutput** ppTarget) PURE;
     STDMETHOD(GetDesc)(void* pDesc) PURE;
-    STDMETHOD(ResizeBuffers)(UINT BufferCount, UINT Width, UINT Height, DXGI_FORMAT NewFormat, UINT SwapChainFlags) PURE;
+    STDMETHOD(ResizeBuffers)(UINT BufferCount, UINT Width, UINT Height, DXGI_FORMAT NewFormat,
+                             UINT SwapChainFlags) PURE;
     STDMETHOD(ResizeTarget)(const DXGI_MODE_DESC* pNewTargetParameters) PURE;
     STDMETHOD(GetContainingOutput)(IDXGIOutput** ppOutput) PURE;
     STDMETHOD(GetFrameStatistics)(void* pStats) PURE;
     STDMETHOD(GetLastPresentCount)(UINT* pLastPresentCount) PURE;
 };
 
-class MIDL_INTERFACE("a8ece026-1812-4191-a6f5-6d80c1fbb60c")
-IDXGISwapChain1 : public IDXGISwapChain {
-public:
+class MIDL_INTERFACE("a8ece026-1812-4191-a6f5-6d80c1fbb60c") IDXGISwapChain1 : public IDXGISwapChain {
+  public:
     STDMETHOD(Present1)(UINT SyncInterval, UINT PresentFlags, const void* pPresentParameters) PURE;
 };
 

--- a/include/metalsharp/AntiCheatDB.h
+++ b/include/metalsharp/AntiCheatDB.h
@@ -24,24 +24,26 @@ struct AntiCheatEntry {
 };
 
 static const AntiCheatEntry kAntiCheatDatabase[] = {
-    {"Easy Anti-Cheat (EAC)",       "Anti-cheat",  true,  false, "Kernel driver integrity checks — requires real Windows kernel"},
-    {"BattlEye",                     "Anti-cheat",  true,  false, "Kernel driver — similar to EAC, impossible without kernel access"},
-    {"Valve Anti-Cheat (VAC)",       "Anti-cheat",  false, true,  "Signature-based, less aggressive — should work with PE loader"},
-    {"Ricochet (CoD)",               "Anti-cheat",  true,  false, "Kernel driver — impossible"},
-    {"PunkBuster",                   "Anti-cheat",  false, true,  "User-mode, older — should work"},
-    {"nProtect GameGuard",           "Anti-cheat",  true,  false, "Kernel driver — impossible"},
-    {"XignCode3",                    "Anti-cheat",  false, true,  "User-mode primarily — may work with timing shims"},
-    {"Denuvo Anti-Tamper",           "DRM",         false, true,  "Code obfuscation + hardware checks — CPUID/MAC/disk shims needed"},
-    {"Denuvo Anti-Cheat",            "Anti-cheat",  false, true,  "User-mode component of Denuvo — should work with shims"},
-    {"Steam Stub DRM",               "DRM",         false, true,  "Basic Steam DRM wrapper — PE loader handles this"},
-    {"SecuROM",                      "DRM",         false, true,  "Older DRM — may need registry entries"},
-    {"SafeDisc",                     "DRM",         false, true,  "Legacy DRM — DEP-compatible shim needed"},
-    {"VMProtect",                    "DRM",         false, true,  "Code virtualization — Rosetta 2 handles x86, timing shims help"},
-    {"Themida/WinLicense",           "DRM",         false, true,  "Code protection — Rosetta 2 handles, may need anti-debug shims"},
-    {"Arxan",                        "DRM",         false, true,  "Code obfuscation — similar to VMProtect"},
-    {"Epic Online Services",         "Anti-cheat",  false, true,  "User-mode component — should work"},
-    {"EA AntiCheat",                 "Anti-cheat",  true,  false, "Kernel driver — impossible"},
-    {"ACE (Tencent)",                "Anti-cheat",  true,  false, "Kernel driver — impossible"},
+    {"Easy Anti-Cheat (EAC)", "Anti-cheat", true, false,
+     "Kernel driver integrity checks — requires real Windows kernel"},
+    {"BattlEye", "Anti-cheat", true, false, "Kernel driver — similar to EAC, impossible without kernel access"},
+    {"Valve Anti-Cheat (VAC)", "Anti-cheat", false, true,
+     "Signature-based, less aggressive — should work with PE loader"},
+    {"Ricochet (CoD)", "Anti-cheat", true, false, "Kernel driver — impossible"},
+    {"PunkBuster", "Anti-cheat", false, true, "User-mode, older — should work"},
+    {"nProtect GameGuard", "Anti-cheat", true, false, "Kernel driver — impossible"},
+    {"XignCode3", "Anti-cheat", false, true, "User-mode primarily — may work with timing shims"},
+    {"Denuvo Anti-Tamper", "DRM", false, true, "Code obfuscation + hardware checks — CPUID/MAC/disk shims needed"},
+    {"Denuvo Anti-Cheat", "Anti-cheat", false, true, "User-mode component of Denuvo — should work with shims"},
+    {"Steam Stub DRM", "DRM", false, true, "Basic Steam DRM wrapper — PE loader handles this"},
+    {"SecuROM", "DRM", false, true, "Older DRM — may need registry entries"},
+    {"SafeDisc", "DRM", false, true, "Legacy DRM — DEP-compatible shim needed"},
+    {"VMProtect", "DRM", false, true, "Code virtualization — Rosetta 2 handles x86, timing shims help"},
+    {"Themida/WinLicense", "DRM", false, true, "Code protection — Rosetta 2 handles, may need anti-debug shims"},
+    {"Arxan", "DRM", false, true, "Code obfuscation — similar to VMProtect"},
+    {"Epic Online Services", "Anti-cheat", false, true, "User-mode component — should work"},
+    {"EA AntiCheat", "Anti-cheat", true, false, "Kernel driver — impossible"},
+    {"ACE (Tencent)", "Anti-cheat", true, false, "Kernel driver — impossible"},
 };
 
 static constexpr size_t kAntiCheatEntryCount = sizeof(kAntiCheatDatabase) / sizeof(kAntiCheatDatabase[0]);
@@ -58,7 +60,8 @@ inline const AntiCheatEntry* findAntiCheat(const char* name) {
 inline size_t getCompatibleCount() {
     size_t count = 0;
     for (size_t i = 0; i < kAntiCheatEntryCount; ++i) {
-        if (kAntiCheatDatabase[i].compatible) ++count;
+        if (kAntiCheatDatabase[i].compatible)
+            ++count;
     }
     return count;
 }
@@ -66,10 +69,11 @@ inline size_t getCompatibleCount() {
 inline size_t getIncompatibleCount() {
     size_t count = 0;
     for (size_t i = 0; i < kAntiCheatEntryCount; ++i) {
-        if (!kAntiCheatDatabase[i].compatible) ++count;
+        if (!kAntiCheatDatabase[i].compatible)
+            ++count;
     }
     return count;
 }
 
-}
-}
+} // namespace win32
+} // namespace metalsharp

--- a/include/metalsharp/ArgumentBufferBinding.h
+++ b/include/metalsharp/ArgumentBufferBinding.h
@@ -10,14 +10,14 @@
 
 #pragma once
 
+#include <cstdint>
+#include <metalsharp/IRConverterBridge.h>
 #include <metalsharp/Platform.h>
 #include <metalsharp/ShaderStage.h>
-#include <metalsharp/IRConverterBridge.h>
-#include <cstdint>
-#include <vector>
-#include <unordered_map>
-#include <string>
 #include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 namespace metalsharp {
 
@@ -46,59 +46,31 @@ struct ArgumentBufferLayout {
 };
 
 class ArgumentBufferManager {
-public:
+  public:
     static ArgumentBufferManager& instance();
 
-    ArgumentBufferLayout buildLayoutFromReflection(
-        const IRConverterReflection& reflection,
-        ShaderStage stage
-    );
+    ArgumentBufferLayout buildLayoutFromReflection(const IRConverterReflection& reflection, ShaderStage stage);
 
-    ArgumentBufferLayout buildLayoutFromRootSignature(
-        const void* rootSignatureData,
-        size_t rootSignatureSize
-    );
+    ArgumentBufferLayout buildLayoutFromRootSignature(const void* rootSignatureData, size_t rootSignatureSize);
 
-    bool encodeResource(
-        const ArgumentBufferLayout& layout,
-        uint32_t rootParameterIndex,
-        void* argumentBufferData,
-        size_t argumentBufferSize,
-        const void* resourceData,
-        size_t resourceDataSize
-    );
+    bool encodeResource(const ArgumentBufferLayout& layout, uint32_t rootParameterIndex, void* argumentBufferData,
+                        size_t argumentBufferSize, const void* resourceData, size_t resourceDataSize);
 
-    bool encodeRootConstants(
-        const ArgumentBufferLayout& layout,
-        uint32_t rootParameterIndex,
-        void* argumentBufferData,
-        size_t argumentBufferSize,
-        const uint32_t* constants,
-        uint32_t numConstants
-    );
+    bool encodeRootConstants(const ArgumentBufferLayout& layout, uint32_t rootParameterIndex, void* argumentBufferData,
+                             size_t argumentBufferSize, const uint32_t* constants, uint32_t numConstants);
 
-    bool encodeDescriptorTable(
-        const ArgumentBufferLayout& layout,
-        uint32_t rootParameterIndex,
-        void* argumentBufferData,
-        size_t argumentBufferSize,
-        uint64_t gpuAddress
-    );
+    bool encodeDescriptorTable(const ArgumentBufferLayout& layout, uint32_t rootParameterIndex,
+                               void* argumentBufferData, size_t argumentBufferSize, uint64_t gpuAddress);
 
-    bool encodeRootDescriptor(
-        const ArgumentBufferLayout& layout,
-        uint32_t rootParameterIndex,
-        void* argumentBufferData,
-        size_t argumentBufferSize,
-        uint64_t gpuAddress
-    );
+    bool encodeRootDescriptor(const ArgumentBufferLayout& layout, uint32_t rootParameterIndex, void* argumentBufferData,
+                              size_t argumentBufferSize, uint64_t gpuAddress);
 
     ArgumentBufferManager(const ArgumentBufferManager&) = delete;
     ArgumentBufferManager& operator=(const ArgumentBufferManager&) = delete;
 
-private:
+  private:
     ArgumentBufferManager() = default;
     std::mutex m_mutex;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/BufferPool.h
+++ b/include/metalsharp/BufferPool.h
@@ -9,10 +9,10 @@
 
 #pragma once
 
-#include <metalsharp/Platform.h>
-#include <vector>
 #include <cstdint>
+#include <metalsharp/Platform.h>
 #include <mutex>
+#include <vector>
 
 namespace metalsharp {
 
@@ -23,7 +23,7 @@ struct BufferPoolEntry {
 };
 
 class BufferPool {
-public:
+  public:
     static BufferPool& instance();
 
     void init(void* metalDevice);
@@ -39,7 +39,7 @@ public:
 
     void setMaxPoolSize(uint64_t maxBytes) { m_maxPoolSize = maxBytes; }
 
-private:
+  private:
     BufferPool() = default;
 
     void* createBuffer(size_t size);
@@ -54,4 +54,4 @@ private:
     std::mutex m_mutex;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/CommandBatcher.h
+++ b/include/metalsharp/CommandBatcher.h
@@ -9,10 +9,10 @@
 
 #pragma once
 
+#include <cstdint>
+#include <functional>
 #include <metalsharp/Platform.h>
 #include <vector>
-#include <functional>
-#include <cstdint>
 
 namespace metalsharp {
 
@@ -45,7 +45,7 @@ struct BatchedCommand {
 };
 
 class CommandBatcher {
-public:
+  public:
     static CommandBatcher& instance();
 
     void init();
@@ -65,7 +65,7 @@ public:
     using ExecuteFn = std::function<void(const BatchedCommand&)>;
     void setExecuteFunction(ExecuteFn fn);
 
-private:
+  private:
     CommandBatcher() = default;
 
     std::vector<BatchedCommand> m_batch;
@@ -76,4 +76,4 @@ private:
     ExecuteFn m_execute;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/CompatDatabase.h
+++ b/include/metalsharp/CompatDatabase.h
@@ -10,11 +10,11 @@
 
 #pragma once
 
+#include <cstdint>
 #include <metalsharp/Platform.h>
 #include <string>
-#include <vector>
 #include <unordered_map>
-#include <cstdint>
+#include <vector>
 
 namespace metalsharp {
 
@@ -64,7 +64,7 @@ struct GameEntry {
 };
 
 class CompatDatabase {
-public:
+  public:
     static CompatDatabase& instance();
 
     bool init(const std::string& dbPath);
@@ -91,7 +91,7 @@ public:
 
     std::string generateReport(const std::string& gameId) const;
 
-private:
+  private:
     CompatDatabase() = default;
 
     std::unordered_map<std::string, GameEntry> m_entries;
@@ -99,4 +99,4 @@ private:
     bool m_initialized = false;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/CoreAudioBackend.h
+++ b/include/metalsharp/CoreAudioBackend.h
@@ -9,8 +9,8 @@
 
 #pragma once
 
-#include <metalsharp/Platform.h>
 #include <cstdint>
+#include <metalsharp/Platform.h>
 
 namespace metalsharp {
 
@@ -24,7 +24,7 @@ struct XAudio2WaveFormat {
 };
 
 class CoreAudioBackend {
-public:
+  public:
     CoreAudioBackend();
     ~CoreAudioBackend();
 
@@ -46,8 +46,8 @@ public:
 
     struct Impl;
 
-private:
+  private:
     Impl* m_impl;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/CrashDiagnostics.h
+++ b/include/metalsharp/CrashDiagnostics.h
@@ -9,9 +9,9 @@
 
 #pragma once
 
+#include <cstdint>
 #include <metalsharp/Platform.h>
 #include <string>
-#include <cstdint>
 
 namespace metalsharp {
 
@@ -31,7 +31,7 @@ struct CrashInfo {
 };
 
 class CrashDiagnostics {
-public:
+  public:
     static CrashDiagnostics& instance();
 
     void init(const std::string& diagDir);
@@ -48,7 +48,7 @@ public:
 
     uint32_t crashCount() const { return m_crashCount; }
 
-private:
+  private:
     CrashDiagnostics() = default;
 
     std::string m_diagDir;
@@ -60,4 +60,4 @@ private:
     bool m_initialized = false;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/CrashReporter.h
+++ b/include/metalsharp/CrashReporter.h
@@ -8,9 +8,9 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
-#include <cstdint>
 
 namespace metalsharp {
 
@@ -29,7 +29,7 @@ struct CrashReport {
 };
 
 class CrashReporter {
-public:
+  public:
     static CrashReporter& instance();
 
     void beginSession(const std::string& gameName, const std::string& exePath);
@@ -46,7 +46,7 @@ public:
     static std::string generateId();
     static std::string formatTimestamp(int64_t epoch);
 
-private:
+  private:
     CrashReporter() = default;
     std::string m_currentGame;
     std::string m_currentExe;
@@ -54,4 +54,4 @@ private:
     bool m_inSession = false;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/D3D11Device.h
+++ b/include/metalsharp/D3D11Device.h
@@ -13,38 +13,53 @@
 #pragma once
 
 #include <d3d/D3D11.h>
+#include <memory>
 #include <metalsharp/MetalBackend.h>
 #include <metalsharp/ShaderTranslator.h>
 #include <mutex>
 #include <unordered_map>
-#include <memory>
 
 namespace metalsharp {
 
 class D3D11Device : public ID3D11Device {
-public:
+  public:
     static HRESULT create(D3D11Device** ppDevice);
 
     STDMETHOD(QueryInterface)(REFIID riid, void** ppvObject) override;
     STDMETHOD_(ULONG, AddRef)() override;
     STDMETHOD_(ULONG, Release)() override;
 
-    STDMETHOD(CreateBuffer)(const D3D11_BUFFER_DESC* pDesc, const D3D11_SUBRESOURCE_DATA* pInitialData, ID3D11Buffer** ppBuffer) override;
-    STDMETHOD(CreateTexture1D)(const D3D11_TEXTURE1D_DESC* pDesc, const D3D11_SUBRESOURCE_DATA* pInitialData, ID3D11Texture1D** ppTexture1D) override;
-    STDMETHOD(CreateTexture2D)(const D3D11_TEXTURE2D_DESC* pDesc, const D3D11_SUBRESOURCE_DATA* pInitialData, ID3D11Texture2D** ppTexture2D) override;
-    STDMETHOD(CreateTexture3D)(const D3D11_TEXTURE3D_DESC* pDesc, const D3D11_SUBRESOURCE_DATA* pInitialData, ID3D11Texture3D** ppTexture3D) override;
-    STDMETHOD(CreateShaderResourceView)(ID3D11Resource* pResource, const void* pDesc, ID3D11ShaderResourceView** ppSRView) override;
-    STDMETHOD(CreateRenderTargetView)(ID3D11Resource* pResource, const void* pDesc, ID3D11RenderTargetView** ppRTView) override;
-    STDMETHOD(CreateDepthStencilView)(ID3D11Resource* pResource, const void* pDesc, ID3D11DepthStencilView** ppDepthStencilView) override;
-    STDMETHOD(CreateUnorderedAccessView)(ID3D11Resource* pResource, const D3D11_UNORDERED_ACCESS_VIEW_DESC* pDesc, ID3D11UnorderedAccessView** ppUAView) override;
-    STDMETHOD(CreateVertexShader)(const void* pShaderBytecode, SIZE_T BytecodeLength, ID3D11ClassLinkage*, ID3D11VertexShader** ppVertexShader) override;
-    STDMETHOD(CreatePixelShader)(const void* pShaderBytecode, SIZE_T BytecodeLength, ID3D11ClassLinkage*, ID3D11PixelShader** ppPixelShader) override;
-    STDMETHOD(CreateGeometryShader)(const void* pShaderBytecode, SIZE_T BytecodeLength, ID3D11ClassLinkage*, ID3D11GeometryShader** ppGeometryShader) override;
-    STDMETHOD(CreateComputeShader)(const void* pShaderBytecode, SIZE_T BytecodeLength, ID3D11ClassLinkage*, ID3D11ComputeShader** ppComputeShader) override;
-    STDMETHOD(CreateInputLayout)(const void* pInputElementDescs, UINT NumElements, const void* pShaderBytecodeWithInputSignature, SIZE_T BytecodeLength, ID3D11InputLayout** ppInputLayout) override;
+    STDMETHOD(CreateBuffer)(const D3D11_BUFFER_DESC* pDesc, const D3D11_SUBRESOURCE_DATA* pInitialData,
+                            ID3D11Buffer** ppBuffer) override;
+    STDMETHOD(CreateTexture1D)(const D3D11_TEXTURE1D_DESC* pDesc, const D3D11_SUBRESOURCE_DATA* pInitialData,
+                               ID3D11Texture1D** ppTexture1D) override;
+    STDMETHOD(CreateTexture2D)(const D3D11_TEXTURE2D_DESC* pDesc, const D3D11_SUBRESOURCE_DATA* pInitialData,
+                               ID3D11Texture2D** ppTexture2D) override;
+    STDMETHOD(CreateTexture3D)(const D3D11_TEXTURE3D_DESC* pDesc, const D3D11_SUBRESOURCE_DATA* pInitialData,
+                               ID3D11Texture3D** ppTexture3D) override;
+    STDMETHOD(CreateShaderResourceView)(ID3D11Resource* pResource, const void* pDesc,
+                                        ID3D11ShaderResourceView** ppSRView) override;
+    STDMETHOD(CreateRenderTargetView)(ID3D11Resource* pResource, const void* pDesc,
+                                      ID3D11RenderTargetView** ppRTView) override;
+    STDMETHOD(CreateDepthStencilView)(ID3D11Resource* pResource, const void* pDesc,
+                                      ID3D11DepthStencilView** ppDepthStencilView) override;
+    STDMETHOD(CreateUnorderedAccessView)(ID3D11Resource* pResource, const D3D11_UNORDERED_ACCESS_VIEW_DESC* pDesc,
+                                         ID3D11UnorderedAccessView** ppUAView) override;
+    STDMETHOD(CreateVertexShader)(const void* pShaderBytecode, SIZE_T BytecodeLength, ID3D11ClassLinkage*,
+                                  ID3D11VertexShader** ppVertexShader) override;
+    STDMETHOD(CreatePixelShader)(const void* pShaderBytecode, SIZE_T BytecodeLength, ID3D11ClassLinkage*,
+                                 ID3D11PixelShader** ppPixelShader) override;
+    STDMETHOD(CreateGeometryShader)(const void* pShaderBytecode, SIZE_T BytecodeLength, ID3D11ClassLinkage*,
+                                    ID3D11GeometryShader** ppGeometryShader) override;
+    STDMETHOD(CreateComputeShader)(const void* pShaderBytecode, SIZE_T BytecodeLength, ID3D11ClassLinkage*,
+                                   ID3D11ComputeShader** ppComputeShader) override;
+    STDMETHOD(CreateInputLayout)(const void* pInputElementDescs, UINT NumElements,
+                                 const void* pShaderBytecodeWithInputSignature, SIZE_T BytecodeLength,
+                                 ID3D11InputLayout** ppInputLayout) override;
     STDMETHOD(CreateSamplerState)(const void* pSamplerDesc, ID3D11SamplerState** ppSamplerState) override;
     STDMETHOD(CreateRasterizerState)(const void* pRasterizerDesc, ID3D11RasterizerState** ppRasterizerState) override;
-    STDMETHOD(CreateDepthStencilState)(const void* pDepthStencilDesc, ID3D11DepthStencilState** ppDepthStencilState) override;
+    STDMETHOD(CreateDepthStencilState)(const void* pDepthStencilDesc,
+                                       ID3D11DepthStencilState** ppDepthStencilState) override;
     STDMETHOD(CreateBlendState)(const void* pBlendStateDesc, ID3D11BlendState** ppBlendState) override;
     STDMETHOD(CreateQuery)(const D3D11_QUERY_DESC* pQueryDesc, ID3D11Query** ppQuery) override;
     STDMETHOD(CreatePredicate)(const D3D11_QUERY_DESC* pPredicateDesc, ID3D11Predicate** ppPredicate) override;
@@ -54,7 +69,7 @@ public:
 
     MetalDevice& metalDevice() { return *m_metalDevice; }
 
-private:
+  private:
     D3D11Device();
     ~D3D11Device();
 
@@ -64,4 +79,4 @@ private:
     std::unique_ptr<ShaderTranslator> m_shaderTranslator;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/D3D11DeviceContext.h
+++ b/include/metalsharp/D3D11DeviceContext.h
@@ -12,18 +12,18 @@
 
 #pragma once
 
+#include <array>
 #include <d3d/D3D11.h>
+#include <memory>
 #include <metalsharp/MetalBackend.h>
 #include <metalsharp/PipelineState.h>
-#include <array>
-#include <memory>
 
 namespace metalsharp {
 
 class D3D11Device;
 
 class D3D11DeviceContext : public ID3D11DeviceContext {
-public:
+  public:
     explicit D3D11DeviceContext(D3D11Device& device);
     virtual ~D3D11DeviceContext() = default;
 
@@ -36,18 +36,21 @@ public:
     STDMETHOD(SetPrivateDataInterface)(const GUID& guid, const IUnknown* pData) override;
 
     STDMETHOD(IASetInputLayout)(ID3D11InputLayout* pInputLayout) override;
-    STDMETHOD(IASetVertexBuffers)(UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppVertexBuffers, const UINT* pStrides, const UINT* pOffsets) override;
+    STDMETHOD(IASetVertexBuffers)(UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppVertexBuffers,
+                                  const UINT* pStrides, const UINT* pOffsets) override;
     STDMETHOD(IASetIndexBuffer)(ID3D11Buffer* pIndexBuffer, DXGI_FORMAT Format, UINT Offset) override;
     STDMETHOD(IASetPrimitiveTopology)(UINT Topology) override;
 
     STDMETHOD(VSSetShader)(ID3D11VertexShader* pVertexShader, ID3D11ClassInstance* const*, UINT) override;
     STDMETHOD(VSSetConstantBuffers)(UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppConstantBuffers) override;
-    STDMETHOD(VSSetShaderResources)(UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView* const* ppShaderResourceViews) override;
+    STDMETHOD(VSSetShaderResources)(UINT StartSlot, UINT NumViews,
+                                    ID3D11ShaderResourceView* const* ppShaderResourceViews) override;
     STDMETHOD(VSSetSamplers)(UINT StartSlot, UINT NumSamplers, ID3D11SamplerState* const* ppSamplers) override;
 
     STDMETHOD(PSSetShader)(ID3D11PixelShader* pPixelShader, ID3D11ClassInstance* const*, UINT) override;
     STDMETHOD(PSSetConstantBuffers)(UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppConstantBuffers) override;
-    STDMETHOD(PSSetShaderResources)(UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView* const* ppShaderResourceViews) override;
+    STDMETHOD(PSSetShaderResources)(UINT StartSlot, UINT NumViews,
+                                    ID3D11ShaderResourceView* const* ppShaderResourceViews) override;
     STDMETHOD(PSSetSamplers)(UINT StartSlot, UINT NumSamplers, ID3D11SamplerState* const* ppSamplers) override;
 
     STDMETHOD(GSSetShader)(ID3D11GeometryShader* pShader, ID3D11ClassInstance* const*, UINT) override;
@@ -59,8 +62,11 @@ public:
     STDMETHOD(CSSetSamplers)(UINT, UINT, ID3D11SamplerState* const*) override;
     STDMETHOD(Dispatch)(UINT, UINT, UINT) override;
 
-    STDMETHOD(OMSetRenderTargets)(UINT NumViews, ID3D11RenderTargetView* const* ppRenderTargetViews, ID3D11DepthStencilView* pDepthStencilView) override;
-    STDMETHOD(OMSetRenderTargetsAndUnorderedAccessViews)(UINT, ID3D11RenderTargetView* const*, ID3D11DepthStencilView*, UINT, UINT, ID3D11UnorderedAccessView* const*, const UINT*) override;
+    STDMETHOD(OMSetRenderTargets)(UINT NumViews, ID3D11RenderTargetView* const* ppRenderTargetViews,
+                                  ID3D11DepthStencilView* pDepthStencilView) override;
+    STDMETHOD(OMSetRenderTargetsAndUnorderedAccessViews)(UINT, ID3D11RenderTargetView* const*, ID3D11DepthStencilView*,
+                                                         UINT, UINT, ID3D11UnorderedAccessView* const*,
+                                                         const UINT*) override;
     STDMETHOD(OMSetBlendState)(ID3D11BlendState* pBlendState, const FLOAT BlendFactor[4], UINT SampleMask) override;
     STDMETHOD(OMSetDepthStencilState)(ID3D11DepthStencilState* pDepthStencilState, UINT StencilRef) override;
 
@@ -69,21 +75,26 @@ public:
     STDMETHOD(RSSetScissorRects)(UINT NumRects, const RECT* pRects) override;
 
     STDMETHOD(ClearRenderTargetView)(ID3D11RenderTargetView* pRenderTargetView, const FLOAT ColorRGBA[4]) override;
-    STDMETHOD(ClearDepthStencilView)(ID3D11DepthStencilView* pDepthStencilView, UINT ClearFlags, FLOAT Depth, UINT8 Stencil) override;
+    STDMETHOD(ClearDepthStencilView)(ID3D11DepthStencilView* pDepthStencilView, UINT ClearFlags, FLOAT Depth,
+                                     UINT8 Stencil) override;
 
     STDMETHOD(DrawIndexed)(UINT IndexCount, UINT StartIndexLocation, INT BaseVertexLocation) override;
     STDMETHOD(Draw)(UINT VertexCount, UINT StartVertexLocation) override;
     STDMETHOD(DrawIndexedInstanced)(UINT, UINT, UINT, INT, UINT) override;
     STDMETHOD(DrawInstanced)(UINT, UINT, UINT, UINT) override;
 
-    STDMETHOD(Map)(ID3D11Resource* pResource, UINT Subresource, UINT MapType, UINT MapFlags, void* pMappedResource) override;
+    STDMETHOD(Map)(ID3D11Resource* pResource, UINT Subresource, UINT MapType, UINT MapFlags,
+                   void* pMappedResource) override;
     STDMETHOD(Unmap)(ID3D11Resource* pResource, UINT Subresource) override;
 
     STDMETHOD(GenerateMips)(ID3D11ShaderResourceView* pShaderResourceView) override;
     STDMETHOD(CopyResource)(ID3D11Resource* pDstResource, ID3D11Resource* pSrcResource) override;
-    STDMETHOD(UpdateSubresource)(ID3D11Resource* pDstResource, UINT DstSubresource, const void* pDstBox, const void* pSrcData, UINT SrcRowPitch, UINT SrcDepthPitch) override;
-    STDMETHOD(CopySubresourceRegion)(ID3D11Resource* pDstResource, UINT DstSubresource, UINT DstX, UINT DstY, UINT DstZ, ID3D11Resource* pSrcResource, UINT SrcSubresource, const void* pSrcBox) override;
-    STDMETHOD(ResolveSubresource)(ID3D11Resource* pDstResource, UINT DstSubresource, ID3D11Resource* pSrcResource, UINT SrcSubresource, DXGI_FORMAT Format) override;
+    STDMETHOD(UpdateSubresource)(ID3D11Resource* pDstResource, UINT DstSubresource, const void* pDstBox,
+                                 const void* pSrcData, UINT SrcRowPitch, UINT SrcDepthPitch) override;
+    STDMETHOD(CopySubresourceRegion)(ID3D11Resource* pDstResource, UINT DstSubresource, UINT DstX, UINT DstY, UINT DstZ,
+                                     ID3D11Resource* pSrcResource, UINT SrcSubresource, const void* pSrcBox) override;
+    STDMETHOD(ResolveSubresource)(ID3D11Resource* pDstResource, UINT DstSubresource, ID3D11Resource* pSrcResource,
+                                  UINT SrcSubresource, DXGI_FORMAT Format) override;
     STDMETHOD(Begin)(ID3D11Query* pQuery) override;
     STDMETHOD(End)(ID3D11Query* pQuery) override;
     STDMETHOD(GetData)(ID3D11Query* pQuery, void* pData, UINT DataSize, UINT GetDataFlags) override;
@@ -92,9 +103,10 @@ public:
     STDMETHOD(FinishCommandList)(INT RestoreDeferredContextState, ID3D11CommandList** ppCommandList) override;
     STDMETHOD(ExecuteCommandList)(ID3D11CommandList* pCommandList, INT RestoreContextState) override;
 
-private:
+  private:
     void ensurePipeline();
-    void commitDraw(UINT vertexCount, UINT instanceCount, UINT startIndexLocation, INT baseVertexLocation, bool indexed);
+    void commitDraw(UINT vertexCount, UINT instanceCount, UINT startIndexLocation, INT baseVertexLocation,
+                    bool indexed);
 
     ULONG m_refCount = 1;
     D3D11Device& m_device;
@@ -136,8 +148,8 @@ private:
 
     std::unique_ptr<PipelineState> m_cachedPipeline;
     D3D11_VIEWPORT m_viewport = {};
-    FLOAT m_blendFactor[4] = {1,1,1,1};
+    FLOAT m_blendFactor[4] = {1, 1, 1, 1};
     UINT m_sampleMask = 0xFFFFFFFF;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/D3D12Device.h
+++ b/include/metalsharp/D3D12Device.h
@@ -50,58 +50,83 @@
 ///   ResourceBarrier            → Implicit (Metal tracks resource state)
 ///   D3D12_TEXTURE_LAYOUT_UNKNOWN → MTLStorageModeShared/Private
 
+#include <cstring>
 #include <d3d/D3D12.h>
-#include <metalsharp/MetalBackend.h>
 #include <metalsharp/FormatTranslation.h>
+#include <metalsharp/MetalBackend.h>
 #include <metalsharp/PipelineState.h>
 #include <metalsharp/ShaderTranslator.h>
-#include <cstring>
-#include <vector>
-#include <unordered_map>
 #include <mutex>
+#include <unordered_map>
+#include <vector>
 
 namespace metalsharp {
 
 static HRESULT E_NOT_IMPL = E_NOTIMPL;
 
 class D3D12FenceImpl final : public ID3D12Fence {
-public:
+  public:
     ULONG refCount = 1;
     UINT64 m_value = 0;
     UINT64 m_completed = 0;
 
     HRESULT QueryInterface(REFIID riid, void** ppv) override {
-        if (!ppv) return E_POINTER;
-        if (riid == IID_ID3D12Fence || riid == IID_IUnknown) { AddRef(); *ppv = this; return S_OK; }
+        if (!ppv)
+            return E_POINTER;
+        if (riid == IID_ID3D12Fence || riid == IID_IUnknown) {
+            AddRef();
+            *ppv = this;
+            return S_OK;
+        }
         return E_NOINTERFACE;
     }
     ULONG AddRef() override { return ++refCount; }
-    ULONG Release() override { ULONG c = --refCount; if (c == 0) delete this; return c; }
+    ULONG Release() override {
+        ULONG c = --refCount;
+        if (c == 0)
+            delete this;
+        return c;
+    }
     STDMETHOD(GetPrivateData)(const GUID&, UINT*, void*) override { return E_NOTIMPL; }
     STDMETHOD(SetPrivateData)(const GUID&, UINT, const void*) override { return E_NOTIMPL; }
     STDMETHOD(SetPrivateDataInterface)(const GUID&, const IUnknown*) override { return E_NOTIMPL; }
     STDMETHOD(SetName)(const char*) override { return S_OK; }
 
     HRESULT GetCompletedValue(UINT64* pValue) override {
-        if (!pValue) return E_POINTER;
+        if (!pValue)
+            return E_POINTER;
         *pValue = m_completed;
         return S_OK;
     }
     HRESULT SetEventOnCompletion(UINT64 Value, HANDLE hEvent) override { return S_OK; }
-    HRESULT Signal(UINT64 Value) override { m_value = Value; m_completed = Value; return S_OK; }
+    HRESULT Signal(UINT64 Value) override {
+        m_value = Value;
+        m_completed = Value;
+        return S_OK;
+    }
 };
 
 class D3D12CommandAllocatorImpl final : public ID3D12CommandAllocator {
-public:
+  public:
     ULONG refCount = 1;
 
     HRESULT QueryInterface(REFIID riid, void** ppv) override {
-        if (!ppv) return E_POINTER;
-        if (riid == IID_ID3D12CommandAllocator || riid == IID_IUnknown) { AddRef(); *ppv = this; return S_OK; }
+        if (!ppv)
+            return E_POINTER;
+        if (riid == IID_ID3D12CommandAllocator || riid == IID_IUnknown) {
+            AddRef();
+            *ppv = this;
+            return S_OK;
+        }
         return E_NOINTERFACE;
     }
     ULONG AddRef() override { return ++refCount; }
-    ULONG Release() override { ULONG c = --refCount; if (c == 0) delete this; return c; }
+    ULONG Release() override {
+        ULONG c = --refCount;
+        if (c == 0)
+            delete this;
+        return c;
+    }
     STDMETHOD(GetPrivateData)(const GUID&, UINT*, void*) override { return E_NOTIMPL; }
     STDMETHOD(SetPrivateData)(const GUID&, UINT, const void*) override { return E_NOTIMPL; }
     STDMETHOD(SetPrivateDataInterface)(const GUID&, const IUnknown*) override { return E_NOTIMPL; }
@@ -110,19 +135,29 @@ public:
 };
 
 class D3D12CommandQueueImpl final : public ID3D12CommandQueue {
-public:
+  public:
     ULONG refCount = 1;
     MetalDevice& metalDevice;
 
     explicit D3D12CommandQueueImpl(MetalDevice& dev) : metalDevice(dev) {}
 
     HRESULT QueryInterface(REFIID riid, void** ppv) override {
-        if (!ppv) return E_POINTER;
-        if (riid == IID_ID3D12CommandQueue || riid == IID_IUnknown) { AddRef(); *ppv = this; return S_OK; }
+        if (!ppv)
+            return E_POINTER;
+        if (riid == IID_ID3D12CommandQueue || riid == IID_IUnknown) {
+            AddRef();
+            *ppv = this;
+            return S_OK;
+        }
         return E_NOINTERFACE;
     }
     ULONG AddRef() override { return ++refCount; }
-    ULONG Release() override { ULONG c = --refCount; if (c == 0) delete this; return c; }
+    ULONG Release() override {
+        ULONG c = --refCount;
+        if (c == 0)
+            delete this;
+        return c;
+    }
     STDMETHOD(GetPrivateData)(const GUID&, UINT*, void*) override { return E_NOTIMPL; }
     STDMETHOD(SetPrivateData)(const GUID&, UINT, const void*) override { return E_NOTIMPL; }
     STDMETHOD(SetPrivateDataInterface)(const GUID&, const IUnknown*) override { return E_NOTIMPL; }
@@ -130,7 +165,8 @@ public:
 
     HRESULT ExecuteCommandLists(UINT NumCommandLists, ID3D12CommandList* const* ppCommandLists) override;
     HRESULT Signal(ID3D12Fence* pFence, UINT64 Value) override {
-        if (!pFence) return E_INVALIDARG;
+        if (!pFence)
+            return E_INVALIDARG;
         return pFence->Signal(Value);
     }
     HRESULT Wait(ID3D12Fence* pFence, UINT64 Value) override { return S_OK; }
@@ -152,7 +188,7 @@ struct D3D12Descriptor {
 };
 
 class D3D12DescriptorHeapImpl final : public ID3D12DescriptorHeap {
-public:
+  public:
     ULONG refCount = 1;
     D3D12_DESCRIPTOR_HEAP_DESC desc;
     std::vector<D3D12Descriptor> descriptors;
@@ -161,46 +197,64 @@ public:
     D3D12DescriptorHeapImpl(const D3D12_DESCRIPTOR_HEAP_DESC* d) : desc(*d), descriptors(d->NumDescriptors) {}
 
     HRESULT QueryInterface(REFIID riid, void** ppv) override {
-        if (!ppv) return E_POINTER;
-        if (riid == IID_ID3D12DescriptorHeap || riid == IID_IUnknown) { AddRef(); *ppv = this; return S_OK; }
+        if (!ppv)
+            return E_POINTER;
+        if (riid == IID_ID3D12DescriptorHeap || riid == IID_IUnknown) {
+            AddRef();
+            *ppv = this;
+            return S_OK;
+        }
         return E_NOINTERFACE;
     }
     ULONG AddRef() override { return ++refCount; }
-    ULONG Release() override { ULONG c = --refCount; if (c == 0) delete this; return c; }
+    ULONG Release() override {
+        ULONG c = --refCount;
+        if (c == 0)
+            delete this;
+        return c;
+    }
     STDMETHOD(GetPrivateData)(const GUID&, UINT*, void*) override { return E_NOTIMPL; }
     STDMETHOD(SetPrivateData)(const GUID&, UINT, const void*) override { return E_NOTIMPL; }
     STDMETHOD(SetPrivateDataInterface)(const GUID&, const IUnknown*) override { return E_NOTIMPL; }
     STDMETHOD(SetName)(const char*) override { return S_OK; }
 
     D3D12_CPU_DESCRIPTOR_HANDLE __getCPUDescriptorHandleForHeapStart() override { return {1}; }
-    D3D12_GPU_DESCRIPTOR_HANDLE __getGPUDescriptorHandleForHeapStart() override { return {reinterpret_cast<UINT64>(this) + 1}; }
+    D3D12_GPU_DESCRIPTOR_HANDLE __getGPUDescriptorHandleForHeapStart() override {
+        return {reinterpret_cast<UINT64>(this) + 1};
+    }
     UINT __getDescriptorCount() const override { return desc.NumDescriptors; }
     UINT __getHeapType() const override { return desc.Type; }
 
     D3D12Descriptor* getDescriptor(D3D12_CPU_DESCRIPTOR_HANDLE handle) {
-        if (handle.ptr == 0 || handle.ptr > desc.NumDescriptors) return nullptr;
+        if (handle.ptr == 0 || handle.ptr > desc.NumDescriptors)
+            return nullptr;
         return &descriptors[handle.ptr - 1];
     }
 
     D3D12Descriptor* getDescriptorByIndex(UINT index) {
-        if (index >= desc.NumDescriptors) return nullptr;
+        if (index >= desc.NumDescriptors)
+            return nullptr;
         return &descriptors[index];
     }
 
     UINT handleToIndex(D3D12_CPU_DESCRIPTOR_HANDLE handle) const {
-        if (handle.ptr == 0 || handle.ptr > desc.NumDescriptors) return UINT_MAX;
+        if (handle.ptr == 0 || handle.ptr > desc.NumDescriptors)
+            return UINT_MAX;
         return static_cast<UINT>(handle.ptr - 1);
     }
 
     UINT gpuHandleToIndex(D3D12_GPU_DESCRIPTOR_HANDLE handle) const {
         UINT64 base = reinterpret_cast<UINT64>(this) + 1;
-        if (handle.ptr < base) return UINT_MAX;
+        if (handle.ptr < base)
+            return UINT_MAX;
         UINT64 offset = handle.ptr - base;
-        if (offset >= desc.NumDescriptors) return UINT_MAX;
+        if (offset >= desc.NumDescriptors)
+            return UINT_MAX;
         return static_cast<UINT>(offset);
     }
 
-    void copyDescriptors(UINT numDescriptors, D3D12_CPU_DESCRIPTOR_HANDLE dstStart, D3D12_CPU_DESCRIPTOR_HANDLE srcStart) {
+    void copyDescriptors(UINT numDescriptors, D3D12_CPU_DESCRIPTOR_HANDLE dstStart,
+                         D3D12_CPU_DESCRIPTOR_HANDLE srcStart) {
         UINT dstIdx = handleToIndex(dstStart);
         UINT srcIdx = handleToIndex(srcStart);
         for (UINT i = 0; i < numDescriptors; ++i) {
@@ -212,7 +266,7 @@ public:
 };
 
 class D3D12RootSignatureImpl final : public ID3D12RootSignature {
-public:
+  public:
     ULONG refCount = 1;
     std::vector<D3D12_ROOT_PARAMETER> parameters;
     std::vector<D3D12_STATIC_SAMPLER_DESC> staticSamplers;
@@ -230,12 +284,22 @@ public:
     std::vector<RootParameterLayout> parameterLayouts;
 
     HRESULT QueryInterface(REFIID riid, void** ppv) override {
-        if (!ppv) return E_POINTER;
-        if (riid == IID_ID3D12RootSignature || riid == IID_IUnknown) { AddRef(); *ppv = this; return S_OK; }
+        if (!ppv)
+            return E_POINTER;
+        if (riid == IID_ID3D12RootSignature || riid == IID_IUnknown) {
+            AddRef();
+            *ppv = this;
+            return S_OK;
+        }
         return E_NOINTERFACE;
     }
     ULONG AddRef() override { return ++refCount; }
-    ULONG Release() override { ULONG c = --refCount; if (c == 0) delete this; return c; }
+    ULONG Release() override {
+        ULONG c = --refCount;
+        if (c == 0)
+            delete this;
+        return c;
+    }
     STDMETHOD(GetPrivateData)(const GUID&, UINT*, void*) override { return E_NOTIMPL; }
     STDMETHOD(SetPrivateData)(const GUID&, UINT, const void*) override { return E_NOTIMPL; }
     STDMETHOD(SetPrivateDataInterface)(const GUID&, const IUnknown*) override { return E_NOTIMPL; }
@@ -251,23 +315,24 @@ public:
             layout.shaderVisibility = (i < parameters.size()) ? parameters[i].ShaderVisibility : 0;
 
             switch (layout.type) {
-                case D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS: {
-                    uint32_t numConst = (i < parameters.size()) ? parameters[i].Constants.Num32BitValues : 0;
-                    layout.size = numConst * sizeof(uint32_t);
-                    if (layout.size < 4) layout.size = 4;
-                    break;
-                }
-                case D3D12_ROOT_PARAMETER_TYPE_CBV:
-                case D3D12_ROOT_PARAMETER_TYPE_SRV:
-                case D3D12_ROOT_PARAMETER_TYPE_UAV:
-                    layout.size = sizeof(uint64_t);
-                    break;
-                case D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE:
-                    layout.size = sizeof(uint64_t);
-                    break;
-                default:
-                    layout.size = sizeof(uint64_t);
-                    break;
+            case D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS: {
+                uint32_t numConst = (i < parameters.size()) ? parameters[i].Constants.Num32BitValues : 0;
+                layout.size = numConst * sizeof(uint32_t);
+                if (layout.size < 4)
+                    layout.size = 4;
+                break;
+            }
+            case D3D12_ROOT_PARAMETER_TYPE_CBV:
+            case D3D12_ROOT_PARAMETER_TYPE_SRV:
+            case D3D12_ROOT_PARAMETER_TYPE_UAV:
+                layout.size = sizeof(uint64_t);
+                break;
+            case D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE:
+                layout.size = sizeof(uint64_t);
+                break;
+            default:
+                layout.size = sizeof(uint64_t);
+                break;
             }
 
             parameterLayouts.push_back(layout);
@@ -279,18 +344,28 @@ public:
 };
 
 class D3D12PipelineStateImpl final : public ID3D12PipelineState {
-public:
+  public:
     ULONG refCount = 1;
     void* m_renderPipeline = nullptr;
     void* m_computePipeline = nullptr;
 
     HRESULT QueryInterface(REFIID riid, void** ppv) override {
-        if (!ppv) return E_POINTER;
-        if (riid == IID_ID3D12PipelineState || riid == IID_IUnknown) { AddRef(); *ppv = this; return S_OK; }
+        if (!ppv)
+            return E_POINTER;
+        if (riid == IID_ID3D12PipelineState || riid == IID_IUnknown) {
+            AddRef();
+            *ppv = this;
+            return S_OK;
+        }
         return E_NOINTERFACE;
     }
     ULONG AddRef() override { return ++refCount; }
-    ULONG Release() override { ULONG c = --refCount; if (c == 0) delete this; return c; }
+    ULONG Release() override {
+        ULONG c = --refCount;
+        if (c == 0)
+            delete this;
+        return c;
+    }
     STDMETHOD(GetPrivateData)(const GUID&, UINT*, void*) override { return E_NOTIMPL; }
     STDMETHOD(SetPrivateData)(const GUID&, UINT, const void*) override { return E_NOTIMPL; }
     STDMETHOD(SetPrivateDataInterface)(const GUID&, const IUnknown*) override { return E_NOTIMPL; }
@@ -300,15 +375,25 @@ public:
 };
 
 class D3D12CommandSignatureImpl final : public ID3D12CommandSignature {
-public:
+  public:
     ULONG refCount = 1;
     HRESULT QueryInterface(REFIID riid, void** ppv) override {
-        if (!ppv) return E_POINTER;
-        if (riid == IID_ID3D12CommandSignature || riid == IID_IUnknown) { AddRef(); *ppv = this; return S_OK; }
+        if (!ppv)
+            return E_POINTER;
+        if (riid == IID_ID3D12CommandSignature || riid == IID_IUnknown) {
+            AddRef();
+            *ppv = this;
+            return S_OK;
+        }
         return E_NOINTERFACE;
     }
     ULONG AddRef() override { return ++refCount; }
-    ULONG Release() override { ULONG c = --refCount; if (c == 0) delete this; return c; }
+    ULONG Release() override {
+        ULONG c = --refCount;
+        if (c == 0)
+            delete this;
+        return c;
+    }
     STDMETHOD(GetPrivateData)(const GUID&, UINT*, void*) override { return E_NOTIMPL; }
     STDMETHOD(SetPrivateData)(const GUID&, UINT, const void*) override { return E_NOTIMPL; }
     STDMETHOD(SetPrivateDataInterface)(const GUID&, const IUnknown*) override { return E_NOTIMPL; }
@@ -316,18 +401,28 @@ public:
 };
 
 class D3D12StateObjectImpl final : public ID3D12StateObject {
-public:
+  public:
     ULONG refCount = 1;
     void* m_rtPipeline = nullptr;
     std::vector<uint8_t> m_shaderIdentifierData;
 
     HRESULT QueryInterface(REFIID riid, void** ppv) override {
-        if (!ppv) return E_POINTER;
-        if (riid == IID_IUnknown) { AddRef(); *ppv = this; return S_OK; }
+        if (!ppv)
+            return E_POINTER;
+        if (riid == IID_IUnknown) {
+            AddRef();
+            *ppv = this;
+            return S_OK;
+        }
         return E_NOINTERFACE;
     }
     ULONG AddRef() override { return ++refCount; }
-    ULONG Release() override { ULONG c = --refCount; if (c == 0) delete this; return c; }
+    ULONG Release() override {
+        ULONG c = --refCount;
+        if (c == 0)
+            delete this;
+        return c;
+    }
     STDMETHOD(GetPrivateData)(const GUID&, UINT*, void*) override { return E_NOTIMPL; }
     STDMETHOD(SetPrivateData)(const GUID&, UINT, const void*) override { return E_NOTIMPL; }
     STDMETHOD(SetPrivateDataInterface)(const GUID&, const IUnknown*) override { return E_NOTIMPL; }
@@ -336,7 +431,7 @@ public:
 };
 
 class D3D12ResourceImpl final : public ID3D12Resource {
-public:
+  public:
     ULONG refCount = 1;
     D3D12_RESOURCE_DESC desc;
     std::unique_ptr<MetalBuffer> metalBuffer;
@@ -347,30 +442,46 @@ public:
     D3D12ResourceImpl(const D3D12_RESOURCE_DESC& d) : desc(d), m_resourceState(D3D12_RESOURCE_STATE_COMMON) {}
 
     HRESULT QueryInterface(REFIID riid, void** ppv) override {
-        if (!ppv) return E_POINTER;
-        if (riid == IID_ID3D12Resource || riid == IID_IUnknown) { AddRef(); *ppv = this; return S_OK; }
+        if (!ppv)
+            return E_POINTER;
+        if (riid == IID_ID3D12Resource || riid == IID_IUnknown) {
+            AddRef();
+            *ppv = this;
+            return S_OK;
+        }
         return E_NOINTERFACE;
     }
     ULONG AddRef() override { return ++refCount; }
-    ULONG Release() override { ULONG c = --refCount; if (c == 0) delete this; return c; }
+    ULONG Release() override {
+        ULONG c = --refCount;
+        if (c == 0)
+            delete this;
+        return c;
+    }
     STDMETHOD(GetPrivateData)(const GUID&, UINT*, void*) override { return E_NOTIMPL; }
     STDMETHOD(SetPrivateData)(const GUID&, UINT, const void*) override { return E_NOTIMPL; }
     STDMETHOD(SetPrivateDataInterface)(const GUID&, const IUnknown*) override { return E_NOTIMPL; }
     STDMETHOD(SetName)(const char*) override { return S_OK; }
 
     HRESULT Map(UINT, const D3D12_RANGE*, void** ppData) override {
-        if (!ppData) return E_POINTER;
-        if (metalBuffer) { *ppData = metalBuffer->contents(); return S_OK; }
+        if (!ppData)
+            return E_POINTER;
+        if (metalBuffer) {
+            *ppData = metalBuffer->contents();
+            return S_OK;
+        }
         return E_FAIL;
     }
     HRESULT Unmap(UINT, const D3D12_RANGE*) override { return S_OK; }
     HRESULT GetDesc(D3D12_RESOURCE_DESC* pDesc) override {
-        if (!pDesc) return E_POINTER;
+        if (!pDesc)
+            return E_POINTER;
         *pDesc = desc;
         return S_OK;
     }
     HRESULT GetGPUVirtualAddress(D3D12_GPU_VIRTUAL_ADDRESS* pAddress) override {
-        if (!pAddress) return E_POINTER;
+        if (!pAddress)
+            return E_POINTER;
         *pAddress = m_gpuAddress;
         return S_OK;
     }
@@ -381,12 +492,16 @@ public:
 };
 
 class D3D12DeviceImpl final : public ID3D12Device {
-public:
+  public:
     static HRESULT create(D3D12DeviceImpl** ppDevice) {
-        if (!ppDevice) return E_POINTER;
+        if (!ppDevice)
+            return E_POINTER;
         auto* device = new D3D12DeviceImpl();
         device->m_metalDevice = std::unique_ptr<MetalDevice>(MetalDevice::create());
-        if (!device->m_metalDevice) { delete device; return E_FAIL; }
+        if (!device->m_metalDevice) {
+            delete device;
+            return E_FAIL;
+        }
         device->m_shaderTranslator = std::make_unique<ShaderTranslator>();
         *ppDevice = device;
         return S_OK;
@@ -399,61 +514,82 @@ public:
     std::unique_ptr<ShaderTranslator> m_shaderTranslator;
 
     HRESULT QueryInterface(REFIID riid, void** ppv) override {
-        if (!ppv) return E_POINTER;
-        if (riid == IID_ID3D12Device || riid == IID_IUnknown) { AddRef(); *ppv = this; return S_OK; }
+        if (!ppv)
+            return E_POINTER;
+        if (riid == IID_ID3D12Device || riid == IID_IUnknown) {
+            AddRef();
+            *ppv = this;
+            return S_OK;
+        }
         return E_NOINTERFACE;
     }
     ULONG AddRef() override { return ++m_refCount; }
-    ULONG Release() override { ULONG c = --m_refCount; if (c == 0) delete this; return c; }
+    ULONG Release() override {
+        ULONG c = --m_refCount;
+        if (c == 0)
+            delete this;
+        return c;
+    }
     STDMETHOD(GetPrivateData)(const GUID&, UINT*, void*) override { return E_NOTIMPL; }
     STDMETHOD(SetPrivateData)(const GUID&, UINT, const void*) override { return E_NOTIMPL; }
     STDMETHOD(SetPrivateDataInterface)(const GUID&, const IUnknown*) override { return E_NOTIMPL; }
     STDMETHOD(SetName)(const char*) override { return S_OK; }
 
     HRESULT CreateCommandQueue(const void* pDesc, REFIID riid, void** ppCommandQueue) override {
-        if (!ppCommandQueue) return E_POINTER;
+        if (!ppCommandQueue)
+            return E_POINTER;
         *ppCommandQueue = new D3D12CommandQueueImpl(*m_metalDevice);
         return S_OK;
     }
 
     HRESULT CreateCommandAllocator(UINT type, REFIID riid, void** ppAllocator) override {
-        if (!ppAllocator) return E_POINTER;
+        if (!ppAllocator)
+            return E_POINTER;
         *ppAllocator = new D3D12CommandAllocatorImpl();
         return S_OK;
     }
 
-    HRESULT CreateCommandList(UINT nodeMask, UINT type, ID3D12CommandAllocator* pAllocator, ID3D12PipelineState* pInitialState, REFIID riid, void** ppCommandList) override;
+    HRESULT CreateCommandList(UINT nodeMask, UINT type, ID3D12CommandAllocator* pAllocator,
+                              ID3D12PipelineState* pInitialState, REFIID riid, void** ppCommandList) override;
 
-    HRESULT CreateCommittedResource(const D3D12_HEAP_PROPERTIES* pHeap, UINT HeapFlags, const D3D12_RESOURCE_DESC* pDesc, UINT InitialState, const void* pClearVal, REFIID riid, void** ppvResource) override {
-        if (!pDesc || !ppvResource) return E_INVALIDARG;
+    HRESULT CreateCommittedResource(const D3D12_HEAP_PROPERTIES* pHeap, UINT HeapFlags,
+                                    const D3D12_RESOURCE_DESC* pDesc, UINT InitialState, const void* pClearVal,
+                                    REFIID riid, void** ppvResource) override {
+        if (!pDesc || !ppvResource)
+            return E_INVALIDARG;
 
         auto* res = new D3D12ResourceImpl(*pDesc);
         res->m_resourceState = InitialState;
 
         if (pDesc->Dimension == D3D12_RESOURCE_DIMENSION_BUFFER) {
-            res->metalBuffer = std::unique_ptr<MetalBuffer>(MetalBuffer::create(*m_metalDevice, (size_t)pDesc->Width, nullptr));
+            res->metalBuffer =
+                std::unique_ptr<MetalBuffer>(MetalBuffer::create(*m_metalDevice, (size_t)pDesc->Width, nullptr));
             if (res->metalBuffer) {
                 res->m_gpuAddress = reinterpret_cast<UINT64>(res->metalBuffer->nativeBuffer());
             }
         } else {
             uint32_t fmt = dxgiFormatToMetal((DXGITranslation)pDesc->Format);
             uint32_t usage = 0;
-            if (pDesc->Flags & D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET) usage |= 0x1;
-            if (pDesc->Flags & D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL) usage |= 0x1;
-            if (pDesc->Flags & D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS) usage |= 0x4;
-            if (!(pDesc->Flags & D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE)) usage |= 0x2 | 0x8;
+            if (pDesc->Flags & D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET)
+                usage |= 0x1;
+            if (pDesc->Flags & D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL)
+                usage |= 0x1;
+            if (pDesc->Flags & D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS)
+                usage |= 0x4;
+            if (!(pDesc->Flags & D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE))
+                usage |= 0x2 | 0x8;
             uint32_t mips = pDesc->MipLevels > 0 ? pDesc->MipLevels : 1;
             uint32_t samples = pDesc->SampleDesc.Count > 0 ? pDesc->SampleDesc.Count : 1;
 
             if (pDesc->Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE2D) {
-                res->metalTexture = std::unique_ptr<MetalTexture>(
-                    MetalTexture::create2D(*m_metalDevice, (uint32_t)pDesc->Width, pDesc->Height, fmt, usage, mips, samples));
+                res->metalTexture = std::unique_ptr<MetalTexture>(MetalTexture::create2D(
+                    *m_metalDevice, (uint32_t)pDesc->Width, pDesc->Height, fmt, usage, mips, samples));
             } else if (pDesc->Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE1D) {
                 res->metalTexture = std::unique_ptr<MetalTexture>(
                     MetalTexture::create1D(*m_metalDevice, (uint32_t)pDesc->Width, fmt, usage, mips));
             } else if (pDesc->Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE3D) {
-                res->metalTexture = std::unique_ptr<MetalTexture>(
-                    MetalTexture::create3D(*m_metalDevice, (uint32_t)pDesc->Width, pDesc->Height, pDesc->DepthOrArraySize, fmt, usage, mips));
+                res->metalTexture = std::unique_ptr<MetalTexture>(MetalTexture::create3D(
+                    *m_metalDevice, (uint32_t)pDesc->Width, pDesc->Height, pDesc->DepthOrArraySize, fmt, usage, mips));
             }
         }
 
@@ -462,7 +598,8 @@ public:
     }
 
     HRESULT CreateDescriptorHeap(const D3D12_DESCRIPTOR_HEAP_DESC* pDesc, REFIID riid, void** ppHeap) override {
-        if (!pDesc || !ppHeap) return E_INVALIDARG;
+        if (!pDesc || !ppHeap)
+            return E_INVALIDARG;
         auto* heap = new D3D12DescriptorHeapImpl(pDesc);
         m_trackedHeaps.push_back(heap);
         *ppHeap = heap;
@@ -470,7 +607,8 @@ public:
     }
 
     HRESULT CreateRootSignature(UINT, const void* pBlob, SIZE_T blobSize, REFIID riid, void** ppRS) override {
-        if (!ppRS) return E_POINTER;
+        if (!ppRS)
+            return E_POINTER;
         auto* rs = new D3D12RootSignatureImpl();
         rs->rawBytecode.assign(static_cast<const uint8_t*>(pBlob), static_cast<const uint8_t*>(pBlob) + blobSize);
 
@@ -486,14 +624,17 @@ public:
                 memcpy(&chunkCount, data + 28, 4);
                 for (uint32_t i = 0; i < chunkCount; ++i) {
                     uint32_t offset;
-                    if (32 + i * 4 + 4 > size) break;
+                    if (32 + i * 4 + 4 > size)
+                        break;
                     memcpy(&offset, data + 32 + i * 4, 4);
-                    if (offset + 8 > size) continue;
+                    if (offset + 8 > size)
+                        continue;
                     uint32_t chunkMagic;
                     memcpy(&chunkMagic, data + offset, 4);
                     uint32_t chunkSize;
                     memcpy(&chunkSize, data + offset + 4, 4);
-                    if (offset + 8 + chunkSize > size) continue;
+                    if (offset + 8 + chunkSize > size)
+                        continue;
 
                     if (chunkMagic == 0x30535452) {
                         parseRootSignatureBlob(data + offset + 8, chunkSize, rs);
@@ -510,7 +651,8 @@ public:
     }
 
     void parseRootSignatureBlob(const uint8_t* data, size_t size, D3D12RootSignatureImpl* rs) {
-        if (size < 16) return;
+        if (size < 16)
+            return;
         uint32_t version;
         memcpy(&version, data, 4);
         uint32_t numParams;
@@ -530,47 +672,50 @@ public:
             memcpy(&param.ShaderVisibility, data + paramOffset + 4, 4);
 
             switch (param.ParameterType) {
-                case D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS:
-                    memcpy(&param.Constants.ShaderRegister, data + paramOffset + 8, 4);
-                    memcpy(&param.Constants.RegisterSpace, data + paramOffset + 12, 4);
-                    memcpy(&param.Constants.Num32BitValues, data + paramOffset + 16, 4);
-                    paramOffset += 20;
-                    break;
-                case D3D12_ROOT_PARAMETER_TYPE_CBV:
-                case D3D12_ROOT_PARAMETER_TYPE_SRV:
-                case D3D12_ROOT_PARAMETER_TYPE_UAV:
-                    memcpy(&param.Descriptor.ShaderRegister, data + paramOffset + 8, 4);
-                    memcpy(&param.Descriptor.RegisterSpace, data + paramOffset + 12, 4);
-                    paramOffset += 16;
-                    break;
-                case D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE: {
-                    uint32_t numRanges;
-                    memcpy(&numRanges, data + paramOffset + 8, 4);
-                    paramOffset += 16;
-                    D3D12_ROOT_DESCRIPTOR_TABLE table = {};
-                    table.NumDescriptorRanges = numRanges;
-                    param.DescriptorTable = table;
-                    paramOffset += numRanges * 20;
-                    break;
-                }
-                default:
-                    paramOffset += 16;
-                    break;
+            case D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS:
+                memcpy(&param.Constants.ShaderRegister, data + paramOffset + 8, 4);
+                memcpy(&param.Constants.RegisterSpace, data + paramOffset + 12, 4);
+                memcpy(&param.Constants.Num32BitValues, data + paramOffset + 16, 4);
+                paramOffset += 20;
+                break;
+            case D3D12_ROOT_PARAMETER_TYPE_CBV:
+            case D3D12_ROOT_PARAMETER_TYPE_SRV:
+            case D3D12_ROOT_PARAMETER_TYPE_UAV:
+                memcpy(&param.Descriptor.ShaderRegister, data + paramOffset + 8, 4);
+                memcpy(&param.Descriptor.RegisterSpace, data + paramOffset + 12, 4);
+                paramOffset += 16;
+                break;
+            case D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE: {
+                uint32_t numRanges;
+                memcpy(&numRanges, data + paramOffset + 8, 4);
+                paramOffset += 16;
+                D3D12_ROOT_DESCRIPTOR_TABLE table = {};
+                table.NumDescriptorRanges = numRanges;
+                param.DescriptorTable = table;
+                paramOffset += numRanges * 20;
+                break;
+            }
+            default:
+                paramOffset += 16;
+                break;
             }
             rs->parameters.push_back(param);
         }
     }
 
-    HRESULT CreateGraphicsPipelineState(const D3D12_GRAPHICS_PIPELINE_STATE_DESC* pDesc, REFIID riid, void** ppPSO) override;
+    HRESULT CreateGraphicsPipelineState(const D3D12_GRAPHICS_PIPELINE_STATE_DESC* pDesc, REFIID riid,
+                                        void** ppPSO) override;
 
     HRESULT CreateComputePipelineState(const void* pDesc, REFIID riid, void** ppPSO) override {
-        if (!ppPSO) return E_POINTER;
+        if (!ppPSO)
+            return E_POINTER;
         *ppPSO = new D3D12PipelineStateImpl();
         return S_OK;
     }
 
     HRESULT CreateFence(UINT64 InitialValue, UINT Flags, REFIID riid, void** ppFence) override {
-        if (!ppFence) return E_POINTER;
+        if (!ppFence)
+            return E_POINTER;
         auto* fence = new D3D12FenceImpl();
         fence->m_value = InitialValue;
         fence->m_completed = InitialValue;
@@ -578,39 +723,54 @@ public:
         return S_OK;
     }
 
-    HRESULT CreateCommandSignature(const D3D12_COMMAND_SIGNATURE_DESC*, ID3D12RootSignature*, REFIID, void** ppSig) override {
-        if (!ppSig) return E_POINTER;
+    HRESULT CreateCommandSignature(const D3D12_COMMAND_SIGNATURE_DESC*, ID3D12RootSignature*, REFIID,
+                                   void** ppSig) override {
+        if (!ppSig)
+            return E_POINTER;
         *ppSig = new D3D12CommandSignatureImpl();
         return S_OK;
     }
 
-    HRESULT CreateRenderTargetView(ID3D12Resource* pResource, const void* pDesc, D3D12_CPU_DESCRIPTOR_HANDLE handle) override {
+    HRESULT CreateRenderTargetView(ID3D12Resource* pResource, const void* pDesc,
+                                   D3D12_CPU_DESCRIPTOR_HANDLE handle) override {
         return createView(pResource, D3D12_DESCRIPTOR_HEAP_TYPE_RTV, DXGI_FORMAT_UNKNOWN, handle);
     }
 
-    HRESULT CreateDepthStencilView(ID3D12Resource* pResource, const void* pDesc, D3D12_CPU_DESCRIPTOR_HANDLE handle) override {
+    HRESULT CreateDepthStencilView(ID3D12Resource* pResource, const void* pDesc,
+                                   D3D12_CPU_DESCRIPTOR_HANDLE handle) override {
         return createView(pResource, D3D12_DESCRIPTOR_HEAP_TYPE_DSV, DXGI_FORMAT_UNKNOWN, handle);
     }
 
-    HRESULT CreateShaderResourceView(ID3D12Resource* pResource, const void* pDesc, D3D12_CPU_DESCRIPTOR_HANDLE handle) override {
+    HRESULT CreateShaderResourceView(ID3D12Resource* pResource, const void* pDesc,
+                                     D3D12_CPU_DESCRIPTOR_HANDLE handle) override {
         return createView(pResource, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, DXGI_FORMAT_UNKNOWN, handle);
     }
 
-    HRESULT CreateUnorderedAccessView(ID3D12Resource* pResource, ID3D12Resource*, const void* pDesc, D3D12_CPU_DESCRIPTOR_HANDLE handle) override {
+    HRESULT CreateUnorderedAccessView(ID3D12Resource* pResource, ID3D12Resource*, const void* pDesc,
+                                      D3D12_CPU_DESCRIPTOR_HANDLE handle) override {
         return createView(pResource, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, DXGI_FORMAT_UNKNOWN, handle);
     }
 
     HRESULT CreateConstantBufferView(const void* pDesc, D3D12_CPU_DESCRIPTOR_HANDLE handle) override {
-        if (!pDesc || handle.ptr == 0) return E_INVALIDARG;
+        if (!pDesc || handle.ptr == 0)
+            return E_INVALIDARG;
         D3D12DescriptorHeapImpl* heap = nullptr;
         for (auto* h : m_trackedHeaps) {
-            if (h->handleToIndex(handle) != UINT_MAX) { heap = h; break; }
+            if (h->handleToIndex(handle) != UINT_MAX) {
+                heap = h;
+                break;
+            }
         }
-        if (!heap) return S_OK;
+        if (!heap)
+            return S_OK;
         auto* desc = heap->getDescriptor(handle);
-        if (!desc) return S_OK;
+        if (!desc)
+            return S_OK;
 
-        struct CBVDesc { D3D12_GPU_VIRTUAL_ADDRESS BufferLocation; UINT SizeInBytes; };
+        struct CBVDesc {
+            D3D12_GPU_VIRTUAL_ADDRESS BufferLocation;
+            UINT SizeInBytes;
+        };
         auto* cbv = static_cast<const CBVDesc*>(pDesc);
         desc->gpuAddress = cbv->BufferLocation;
         desc->bufferSize = cbv->SizeInBytes;
@@ -619,14 +779,20 @@ public:
     }
 
     HRESULT CreateSampler(const void* pDesc, D3D12_CPU_DESCRIPTOR_HANDLE handle) override {
-        if (!pDesc || handle.ptr == 0) return E_INVALIDARG;
+        if (!pDesc || handle.ptr == 0)
+            return E_INVALIDARG;
         D3D12DescriptorHeapImpl* heap = nullptr;
         for (auto* h : m_trackedHeaps) {
-            if (h->handleToIndex(handle) != UINT_MAX) { heap = h; break; }
+            if (h->handleToIndex(handle) != UINT_MAX) {
+                heap = h;
+                break;
+            }
         }
-        if (!heap) return S_OK;
+        if (!heap)
+            return S_OK;
         auto* desc = heap->getDescriptor(handle);
-        if (!desc) return S_OK;
+        if (!desc)
+            return S_OK;
 
         desc->type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
         auto* samplerDesc = static_cast<const D3D12_STATIC_SAMPLER_DESC*>(pDesc);
@@ -639,16 +805,24 @@ public:
 
     UINT GetDescriptorHandleIncrementSize(UINT) override { return 1; }
 
-    HRESULT ReserveTiles(ID3D12Resource* pTiledResource, UINT NumTileRegions, const D3D12_TILED_RESOURCE_COORDINATE* pCoords, const D3D12_TILE_REGION_SIZE* pSizes, BOOL bSingleTile) override {
-        if (!pTiledResource) return E_INVALIDARG;
+    HRESULT ReserveTiles(ID3D12Resource* pTiledResource, UINT NumTileRegions,
+                         const D3D12_TILED_RESOURCE_COORDINATE* pCoords, const D3D12_TILE_REGION_SIZE* pSizes,
+                         BOOL bSingleTile) override {
+        if (!pTiledResource)
+            return E_INVALIDARG;
         return S_OK;
     }
 
-    HRESULT GetResourceTiling(ID3D12Resource* pTiledResource, UINT* pNumTilesForResource, D3D12_PACKED_MIP_INFO* pPackedMipDesc, D3D12_TILE_SHAPE* pStandardTileShape, UINT* pNumSubresourceTilings, UINT FirstSubresourceTilingToGet, D3D12_SUBRESOURCE_TILING* pSubresourceTilings) override {
-        if (!pTiledResource) return E_INVALIDARG;
+    HRESULT GetResourceTiling(ID3D12Resource* pTiledResource, UINT* pNumTilesForResource,
+                              D3D12_PACKED_MIP_INFO* pPackedMipDesc, D3D12_TILE_SHAPE* pStandardTileShape,
+                              UINT* pNumSubresourceTilings, UINT FirstSubresourceTilingToGet,
+                              D3D12_SUBRESOURCE_TILING* pSubresourceTilings) override {
+        if (!pTiledResource)
+            return E_INVALIDARG;
 
         D3D12_RESOURCE_DESC desc;
-        if (FAILED(pTiledResource->GetDesc(&desc))) return E_FAIL;
+        if (FAILED(pTiledResource->GetDesc(&desc)))
+            return E_FAIL;
 
         const UINT TILE_W = 128;
         const UINT TILE_H = 128;
@@ -659,7 +833,10 @@ public:
         if (totalMips > 1) {
             UINT w = (UINT)desc.Width, h = desc.Height, d = desc.DepthOrArraySize;
             for (UINT i = 0; i < totalMips; i++) {
-                if (w < TILE_W && h < TILE_H) { packedMips = totalMips - i; break; }
+                if (w < TILE_W && h < TILE_H) {
+                    packedMips = totalMips - i;
+                    break;
+                }
                 w = w > 1 ? w >> 1 : 1;
                 h = h > 1 ? h >> 1 : 1;
                 d = d > 1 ? d >> 1 : 1;
@@ -669,9 +846,15 @@ public:
 
         UINT totalTiles = 0;
         for (UINT i = 0; i < standardMips; i++) {
-            UINT w = (UINT)desc.Width >> i; if (w == 0) w = 1;
-            UINT h = desc.Height >> i; if (h == 0) h = 1;
-            UINT d = desc.DepthOrArraySize >> i; if (d == 0) d = 1;
+            UINT w = (UINT)desc.Width >> i;
+            if (w == 0)
+                w = 1;
+            UINT h = desc.Height >> i;
+            if (h == 0)
+                h = 1;
+            UINT d = desc.DepthOrArraySize >> i;
+            if (d == 0)
+                d = 1;
             UINT tw = (w + TILE_W - 1) / TILE_W;
             UINT th = (h + TILE_H - 1) / TILE_H;
             totalTiles += tw * th * d;
@@ -696,13 +879,20 @@ public:
             UINT count = 0;
             for (UINT i = FirstSubresourceTilingToGet; i < totalMips && count < *pNumSubresourceTilings; i++, count++) {
                 if (i < standardMips) {
-                    UINT w = (UINT)desc.Width >> i; if (w == 0) w = 1;
-                    UINT h = desc.Height >> i; if (h == 0) h = 1;
-                    UINT d = desc.DepthOrArraySize >> i; if (d == 0) d = 1;
+                    UINT w = (UINT)desc.Width >> i;
+                    if (w == 0)
+                        w = 1;
+                    UINT h = desc.Height >> i;
+                    if (h == 0)
+                        h = 1;
+                    UINT d = desc.DepthOrArraySize >> i;
+                    if (d == 0)
+                        d = 1;
                     pSubresourceTilings[i - FirstSubresourceTilingToGet].WidthInTiles = (w + TILE_W - 1) / TILE_W;
                     pSubresourceTilings[i - FirstSubresourceTilingToGet].HeightInTiles = (h + TILE_H - 1) / TILE_H;
                     pSubresourceTilings[i - FirstSubresourceTilingToGet].DepthInTiles = d;
-                    pSubresourceTilings[i - FirstSubresourceTilingToGet].StartTileIndexInOverallResource = i == 0 ? 0 : 0;
+                    pSubresourceTilings[i - FirstSubresourceTilingToGet].StartTileIndexInOverallResource =
+                        i == 0 ? 0 : 0;
                     pSubresourceTilings[i - FirstSubresourceTilingToGet].NumTiles =
                         pSubresourceTilings[i - FirstSubresourceTilingToGet].WidthInTiles *
                         pSubresourceTilings[i - FirstSubresourceTilingToGet].HeightInTiles * d;
@@ -720,7 +910,8 @@ public:
         return S_OK;
     }
 
-    UINT64 GetTiledResourceSize(UINT64 Width, UINT Height, UINT DepthOrArraySize, UINT Format, UINT MipLevels) override {
+    UINT64 GetTiledResourceSize(UINT64 Width, UINT Height, UINT DepthOrArraySize, UINT Format,
+                                UINT MipLevels) override {
         const UINT TILE_W = 128;
         const UINT TILE_H = 128;
         const UINT64 TILE_BYTES = D3D12_TILED_RESOURCE_TILE_SIZE_IN_BYTES;
@@ -728,9 +919,15 @@ public:
         UINT totalMips = MipLevels > 0 ? MipLevels : 1;
         UINT totalTiles = 0;
         for (UINT i = 0; i < totalMips; i++) {
-            UINT w = (UINT)(Width >> i); if (w == 0) w = 1;
-            UINT h = (UINT)(Height >> i); if (h == 0) h = 1;
-            UINT d = (UINT)(DepthOrArraySize >> i); if (d == 0) d = 1;
+            UINT w = (UINT)(Width >> i);
+            if (w == 0)
+                w = 1;
+            UINT h = (UINT)(Height >> i);
+            if (h == 0)
+                h = 1;
+            UINT d = (UINT)(DepthOrArraySize >> i);
+            if (d == 0)
+                d = 1;
             UINT tw = (w + TILE_W - 1) / TILE_W;
             UINT th = (h + TILE_H - 1) / TILE_H;
             totalTiles += tw * th * d;
@@ -738,10 +935,13 @@ public:
         return totalTiles * TILE_BYTES;
     }
 
-    HRESULT CreateSamplerFeedback(ID3D12Resource* pTargetResource, UINT FeedbackType, REFIID riid, void** ppFeedbackResource) override {
-        if (!pTargetResource || !ppFeedbackResource) return E_INVALIDARG;
+    HRESULT CreateSamplerFeedback(ID3D12Resource* pTargetResource, UINT FeedbackType, REFIID riid,
+                                  void** ppFeedbackResource) override {
+        if (!pTargetResource || !ppFeedbackResource)
+            return E_INVALIDARG;
         D3D12_RESOURCE_DESC targetDesc;
-        if (FAILED(pTargetResource->GetDesc(&targetDesc))) return E_FAIL;
+        if (FAILED(pTargetResource->GetDesc(&targetDesc)))
+            return E_FAIL;
 
         auto* feedbackRes = new D3D12ResourceImpl(targetDesc);
         feedbackRes->m_resourceState = D3D12_RESOURCE_STATE_COMMON;
@@ -749,18 +949,22 @@ public:
         return S_OK;
     }
 
-    HRESULT WriteSamplerFeedback(ID3D12Resource* pTargetResource, ID3D12Resource* pFeedbackResource, UINT FeedbackType) override {
-        if (!pTargetResource || !pFeedbackResource) return E_INVALIDARG;
+    HRESULT WriteSamplerFeedback(ID3D12Resource* pTargetResource, ID3D12Resource* pFeedbackResource,
+                                 UINT FeedbackType) override {
+        if (!pTargetResource || !pFeedbackResource)
+            return E_INVALIDARG;
         return S_OK;
     }
 
     HRESULT ResolveSamplerFeedback(ID3D12Resource* pFeedbackResource, ID3D12Resource* pDestResource) override {
-        if (!pFeedbackResource || !pDestResource) return E_INVALIDARG;
+        if (!pFeedbackResource || !pDestResource)
+            return E_INVALIDARG;
         return S_OK;
     }
 
     HRESULT CreateStateObject(const void* pDesc, REFIID riid, void** ppStateObject) override {
-        if (!pDesc || !ppStateObject) return E_INVALIDARG;
+        if (!pDesc || !ppStateObject)
+            return E_INVALIDARG;
         auto* desc = static_cast<const D3D12_STATE_OBJECT_DESC*>(pDesc);
 
         auto* stateObj = new D3D12StateObjectImpl();
@@ -773,34 +977,33 @@ public:
         for (UINT i = 0; i < desc->NumSubobjects; ++i) {
             auto& sub = desc->pSubobjects[i];
             switch (sub.Type) {
-                case 0: {
-                    auto* config = static_cast<const D3D12_RAYTRACING_PIPELINE_CONFIG*>(sub.pDesc);
-                    if (config) maxRecursion = config->MaxTraceRecursionDepth;
-                    break;
+            case 0: {
+                auto* config = static_cast<const D3D12_RAYTRACING_PIPELINE_CONFIG*>(sub.pDesc);
+                if (config)
+                    maxRecursion = config->MaxTraceRecursionDepth;
+                break;
+            }
+            case 1: {
+                auto* config = static_cast<const D3D12_RAYTRACING_SHADER_CONFIG*>(sub.pDesc);
+                if (config) {
+                    maxPayloadSize = config->MaxPayloadSizeInBytes;
+                    maxAttributeSize = config->MaxAttributeSizeInBytes;
                 }
-                case 1: {
-                    auto* config = static_cast<const D3D12_RAYTRACING_SHADER_CONFIG*>(sub.pDesc);
-                    if (config) {
-                        maxPayloadSize = config->MaxPayloadSizeInBytes;
-                        maxAttributeSize = config->MaxAttributeSizeInBytes;
-                    }
-                    break;
+                break;
+            }
+            case 2: {
+                auto* lib = static_cast<const D3D12_DXIL_LIBRARY_DESC*>(sub.pDesc);
+                if (lib && lib->DXILLibrary && lib->DXILLibrarySize > 0) {
+                    libraries.emplace_back(static_cast<const uint8_t*>(lib->DXILLibrary), lib->DXILLibrarySize);
                 }
-                case 2: {
-                    auto* lib = static_cast<const D3D12_DXIL_LIBRARY_DESC*>(sub.pDesc);
-                    if (lib && lib->DXILLibrary && lib->DXILLibrarySize > 0) {
-                        libraries.emplace_back(
-                            static_cast<const uint8_t*>(lib->DXILLibrary),
-                            lib->DXILLibrarySize
-                        );
-                    }
-                    break;
-                }
-                case 5: {
-                    auto* config1 = static_cast<const D3D12_RAYTRACING_PIPELINE_CONFIG1*>(sub.pDesc);
-                    if (config1) maxRecursion = config1->MaxTraceRecursionDepth;
-                    break;
-                }
+                break;
+            }
+            case 5: {
+                auto* config1 = static_cast<const D3D12_RAYTRACING_PIPELINE_CONFIG1*>(sub.pDesc);
+                if (config1)
+                    maxRecursion = config1->MaxTraceRecursionDepth;
+                break;
+            }
             }
         }
 
@@ -809,15 +1012,8 @@ public:
             IRConverterReflection reflection;
             std::vector<uint8_t> metallib;
             for (auto& [data, size] : libraries) {
-                bridge.compileRayTracingShader(
-                    data, size,
-                    ShaderStage::RayGeneration,
-                    nullptr,
-                    maxRecursion,
-                    maxAttributeSize > 0 ? maxAttributeSize : 32,
-                    metallib,
-                    reflection
-                );
+                bridge.compileRayTracingShader(data, size, ShaderStage::RayGeneration, nullptr, maxRecursion,
+                                               maxAttributeSize > 0 ? maxAttributeSize : 32, metallib, reflection);
             }
             stateObj->m_shaderIdentifierData.resize(64, 0);
         }
@@ -827,7 +1023,8 @@ public:
     }
 
     HRESULT GetRaytracingAccelerationStructurePrebuildInfo(const void* pDesc, void* pInfo) override {
-        if (!pDesc || !pInfo) return E_INVALIDARG;
+        if (!pDesc || !pInfo)
+            return E_INVALIDARG;
         auto* info = static_cast<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO*>(pInfo);
         info->ResultDataMaxSizeInBytes = 64 * 1024 * 1024;
         info->ScratchDataSizeInBytes = 32 * 1024 * 1024;
@@ -835,22 +1032,26 @@ public:
         return S_OK;
     }
 
-    HRESULT DecodeRaytracingAccelerationStructure(ID3D12Resource*, void*) override {
-        return E_NOTIMPL;
-    }
+    HRESULT DecodeRaytracingAccelerationStructure(ID3D12Resource*, void*) override { return E_NOTIMPL; }
 
-private:
+  private:
     HRESULT createView(ID3D12Resource* pResource, UINT type, UINT format, D3D12_CPU_DESCRIPTOR_HANDLE handle) {
-        if (handle.ptr == 0) return E_INVALIDARG;
+        if (handle.ptr == 0)
+            return E_INVALIDARG;
 
         D3D12DescriptorHeapImpl* heap = nullptr;
         for (auto* h : m_trackedHeaps) {
-            if (h->handleToIndex(handle) != UINT_MAX) { heap = h; break; }
+            if (h->handleToIndex(handle) != UINT_MAX) {
+                heap = h;
+                break;
+            }
         }
-        if (!heap) return S_OK;
+        if (!heap)
+            return S_OK;
 
         auto* desc = heap->getDescriptor(handle);
-        if (!desc) return S_OK;
+        if (!desc)
+            return S_OK;
 
         desc->resource = pResource;
         desc->type = type;
@@ -875,4 +1076,4 @@ private:
     D3D12DescriptorHeapImpl* findHeapForHandle(D3D12_CPU_DESCRIPTOR_HANDLE handle) const;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/D3DShims.h
+++ b/include/metalsharp/D3DShims.h
@@ -17,5 +17,5 @@ ShimLibrary createD3D11Shim();
 ShimLibrary createD3D12Shim();
 ShimLibrary createDxgiShim();
 
-}
-}
+} // namespace win32
+} // namespace metalsharp

--- a/include/metalsharp/DRMDetector.h
+++ b/include/metalsharp/DRMDetector.h
@@ -9,10 +9,10 @@
 
 #pragma once
 
+#include <cstdint>
 #include <metalsharp/Platform.h>
 #include <string>
 #include <vector>
-#include <cstdint>
 
 namespace metalsharp {
 
@@ -25,7 +25,7 @@ struct DRMDetection {
 };
 
 class DRMDetector {
-public:
+  public:
     static DRMDetector& instance();
 
     std::vector<DRMDetection> scanFile(const std::string& exePath);
@@ -35,7 +35,7 @@ public:
     bool isCompatible(const std::vector<DRMDetection>& results) const;
     std::string summary(const std::vector<DRMDetection>& results) const;
 
-private:
+  private:
     DRMDetector() = default;
 
     struct Signature {
@@ -48,8 +48,7 @@ private:
 
     static const Signature kSignatures[];
 
-    bool matchPattern(const uint8_t* data, size_t dataLen,
-                       const char* pattern, size_t patternLen) const;
+    bool matchPattern(const uint8_t* data, size_t dataLen, const char* pattern, size_t patternLen) const;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/DXBCParser.h
+++ b/include/metalsharp/DXBCParser.h
@@ -9,10 +9,10 @@
 
 #pragma once
 
-#include <stdint.h>
 #include <stddef.h>
-#include <vector>
+#include <stdint.h>
 #include <string>
+#include <vector>
 
 namespace metalsharp {
 
@@ -61,14 +61,15 @@ struct ParsedDXBC {
 };
 
 class DXBCParser {
-public:
+  public:
     static bool parse(const uint8_t* data, size_t size, ParsedDXBC& out);
 
-private:
+  private:
     static bool parseContainer(const uint8_t* data, size_t size, ParsedDXBC& out);
     static bool parseBytecode(const uint32_t* tokens, size_t tokenCount, ParsedDXBC& out);
-    static bool parseSignature(const uint8_t* chunkData, size_t chunkSize, std::vector<DXBCSignatureElement>& out, const uint8_t* containerBase);
+    static bool parseSignature(const uint8_t* chunkData, size_t chunkSize, std::vector<DXBCSignatureElement>& out,
+                               const uint8_t* containerBase);
     static bool parseOperand(const uint32_t* tokens, size_t maxTokens, DXBCOperand& operand, size_t& tokensConsumed);
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/DXBCtoMSL.h
+++ b/include/metalsharp/DXBCtoMSL.h
@@ -15,13 +15,13 @@
 namespace metalsharp {
 
 class DXBCtoMSL {
-public:
+  public:
     static std::string translate(const ParsedDXBC& dxbc);
 
-private:
+  private:
     static const char* semanticToMSL(const std::string& semantic, uint32_t index, uint32_t componentType);
     static std::string operandToString(const DXBCOperand& operand, uint32_t componentType);
     static std::string opcodeToMSL(uint32_t opcode);
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/DXGI.h
+++ b/include/metalsharp/DXGI.h
@@ -10,14 +10,15 @@
 #pragma once
 
 #include <dxgi/DXGI.h>
-#include <metalsharp/MetalBackend.h>
 #include <memory>
+#include <metalsharp/MetalBackend.h>
 
 namespace metalsharp {
 
 class MetalSwapChain {
-public:
-    static MetalSwapChain* create(MetalDevice& device, void* window, uint32_t width, uint32_t height, uint32_t bufferCount);
+  public:
+    static MetalSwapChain* create(MetalDevice& device, void* window, uint32_t width, uint32_t height,
+                                  uint32_t bufferCount);
     ~MetalSwapChain();
 
     void present(uint32_t syncInterval);
@@ -26,7 +27,7 @@ public:
     void resize(uint32_t width, uint32_t height);
     void* metalLayer() const;
 
-private:
+  private:
     MetalSwapChain();
     bool init(MetalDevice& device, void* window, uint32_t width, uint32_t height, uint32_t bufferCount);
 
@@ -37,8 +38,9 @@ private:
 class D3D11Device;
 
 class DXGISwapChainImpl : public IDXGISwapChain1 {
-public:
-    static HRESULT create(MetalDevice* metalDevice, HWND window, uint32_t width, uint32_t height, uint32_t bufferCount, DXGI_FORMAT format, IDXGISwapChain** ppSwapChain);
+  public:
+    static HRESULT create(MetalDevice* metalDevice, HWND window, uint32_t width, uint32_t height, uint32_t bufferCount,
+                          DXGI_FORMAT format, IDXGISwapChain** ppSwapChain);
 
     STDMETHOD(QueryInterface)(REFIID riid, void** ppvObject) override;
     STDMETHOD_(ULONG, AddRef)() override;
@@ -53,14 +55,15 @@ public:
     STDMETHOD(SetFullscreenState)(INT Fullscreen, IDXGIOutput* pTarget) override;
     STDMETHOD(GetFullscreenState)(INT* pFullscreen, IDXGIOutput** ppTarget) override;
     STDMETHOD(GetDesc)(void* pDesc) override;
-    STDMETHOD(ResizeBuffers)(UINT BufferCount, UINT Width, UINT Height, DXGI_FORMAT NewFormat, UINT SwapChainFlags) override;
+    STDMETHOD(ResizeBuffers)(UINT BufferCount, UINT Width, UINT Height, DXGI_FORMAT NewFormat,
+                             UINT SwapChainFlags) override;
     STDMETHOD(ResizeTarget)(const DXGI_MODE_DESC* pNewTargetParameters) override;
     STDMETHOD(GetContainingOutput)(IDXGIOutput** ppOutput) override;
     STDMETHOD(GetFrameStatistics)(void* pStats) override;
     STDMETHOD(GetLastPresentCount)(UINT* pLastPresentCount) override;
     STDMETHOD(Present1)(UINT SyncInterval, UINT PresentFlags, const void* pPresentParameters) override;
 
-private:
+  private:
     DXGISwapChainImpl() = default;
     ~DXGISwapChainImpl();
 
@@ -76,7 +79,7 @@ private:
 };
 
 class DXGIFactory : public IDXGIFactory4 {
-public:
+  public:
     static HRESULT create(const GUID& riid, void** ppFactory);
 
     STDMETHOD(QueryInterface)(REFIID riid, void** ppvObject) override;
@@ -90,10 +93,10 @@ public:
     STDMETHOD(EnumAdapters1)(UINT, IDXGIAdapter**) override { return DXGI_ERROR_NOT_FOUND; }
     STDMETHOD_(INT, IsCurrent)() override { return TRUE; }
 
-private:
+  private:
     DXGIFactory() = default;
     ~DXGIFactory() = default;
     ULONG m_refCount = 1;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/DXGIOutput.h
+++ b/include/metalsharp/DXGIOutput.h
@@ -10,8 +10,8 @@
 #pragma once
 
 #include <dxgi/DXGI.h>
-#include <vector>
 #include <string>
+#include <vector>
 
 namespace metalsharp {
 
@@ -23,11 +23,11 @@ struct DisplayMode {
 };
 
 class DXGIOutputImpl {
-public:
+  public:
     static std::vector<DisplayMode> enumerateDisplayModes();
     static DisplayMode getCurrentDisplayMode();
     static bool createWindow(void* parent, uint32_t width, uint32_t height, void** outWindow);
     static bool createMetalLayer(void* window, void** outLayer);
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/DeferredContext.h
+++ b/include/metalsharp/DeferredContext.h
@@ -14,15 +14,15 @@
 
 #include <d3d/D3D11.h>
 #include <functional>
-#include <vector>
 #include <memory>
+#include <vector>
 
 namespace metalsharp {
 
 class D3D11Device;
 
 class CommandList final : public ID3D11CommandList {
-public:
+  public:
     using Cmd = std::function<void(ID3D11DeviceContext*)>;
 
     STDMETHOD(QueryInterface)(REFIID riid, void** ppvObject) override;
@@ -36,17 +36,18 @@ public:
 
     void record(Cmd cmd) { m_commands.push_back(std::move(cmd)); }
     void replay(ID3D11DeviceContext* target) {
-        for (auto& cmd : m_commands) cmd(target);
+        for (auto& cmd : m_commands)
+            cmd(target);
     }
     void clear() { m_commands.clear(); }
 
-private:
+  private:
     ULONG m_refCount = 1;
     std::vector<Cmd> m_commands;
 };
 
 class DeferredContext final : public ID3D11DeviceContext {
-public:
+  public:
     explicit DeferredContext(D3D11Device& device);
 
     STDMETHOD(QueryInterface)(REFIID riid, void** ppvObject) override;
@@ -82,7 +83,9 @@ public:
     STDMETHOD(Dispatch)(UINT, UINT, UINT) override;
 
     STDMETHOD(OMSetRenderTargets)(UINT, ID3D11RenderTargetView* const*, ID3D11DepthStencilView*) override;
-    STDMETHOD(OMSetRenderTargetsAndUnorderedAccessViews)(UINT, ID3D11RenderTargetView* const*, ID3D11DepthStencilView*, UINT, UINT, ID3D11UnorderedAccessView* const*, const UINT*) override;
+    STDMETHOD(OMSetRenderTargetsAndUnorderedAccessViews)(UINT, ID3D11RenderTargetView* const*, ID3D11DepthStencilView*,
+                                                         UINT, UINT, ID3D11UnorderedAccessView* const*,
+                                                         const UINT*) override;
     STDMETHOD(OMSetBlendState)(ID3D11BlendState*, const FLOAT[4], UINT) override;
     STDMETHOD(OMSetDepthStencilState)(ID3D11DepthStencilState*, UINT) override;
 
@@ -104,7 +107,8 @@ public:
     STDMETHOD(GenerateMips)(ID3D11ShaderResourceView*) override;
     STDMETHOD(CopyResource)(ID3D11Resource*, ID3D11Resource*) override;
     STDMETHOD(UpdateSubresource)(ID3D11Resource*, UINT, const void*, const void*, UINT, UINT) override;
-    STDMETHOD(CopySubresourceRegion)(ID3D11Resource*, UINT, UINT, UINT, UINT, ID3D11Resource*, UINT, const void*) override;
+    STDMETHOD(CopySubresourceRegion)(ID3D11Resource*, UINT, UINT, UINT, UINT, ID3D11Resource*, UINT,
+                                     const void*) override;
     STDMETHOD(ResolveSubresource)(ID3D11Resource*, UINT, ID3D11Resource*, UINT, DXGI_FORMAT) override;
     STDMETHOD(Begin)(ID3D11Query*) override;
     STDMETHOD(End)(ID3D11Query*) override;
@@ -114,10 +118,10 @@ public:
     STDMETHOD(FinishCommandList)(INT, ID3D11CommandList**) override;
     STDMETHOD(ExecuteCommandList)(ID3D11CommandList*, INT) override;
 
-private:
-    template<typename F>
-    void record(F&& fn) {
-        if (m_commandList) m_commandList->record(std::forward<F>(fn));
+  private:
+    template <typename F> void record(F&& fn) {
+        if (m_commandList)
+            m_commandList->record(std::forward<F>(fn));
     }
 
     ULONG m_refCount = 1;
@@ -125,4 +129,4 @@ private:
     CommandList* m_commandList = new CommandList();
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/DirectSoundBackend.h
+++ b/include/metalsharp/DirectSoundBackend.h
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include <metalsharp/Platform.h>
 #include <cstdint>
+#include <metalsharp/Platform.h>
 #include <vector>
 
 namespace metalsharp {
@@ -42,7 +42,7 @@ static constexpr UINT WHDR_ENDLOOP = 0x00000008;
 static constexpr UINT WHDR_INQUEUE = 0x00000010;
 
 class DirectSoundBackend {
-public:
+  public:
     static DirectSoundBackend& instance();
 
     bool init();
@@ -56,7 +56,7 @@ public:
     bool setVolume(void* buffer, float volume);
     float getVolume(void* buffer) const;
 
-private:
+  private:
     DirectSoundBackend() = default;
 
     struct DSBuffer {
@@ -71,4 +71,4 @@ private:
     bool m_initialized = false;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/ExtraShims.h
+++ b/include/metalsharp/ExtraShims.h
@@ -31,5 +31,5 @@ ShimLibrary createWsock32Shim();
 void addMissingKernel32(ShimLibrary& lib);
 void addDRMShims(ShimLibrary& kernel32, ShimLibrary& winmm);
 
-}
-}
+} // namespace win32
+} // namespace metalsharp

--- a/include/metalsharp/FormatTranslation.h
+++ b/include/metalsharp/FormatTranslation.h
@@ -40,4 +40,4 @@ bool dxgiFormatIsDepth(DXGITranslation format);
 bool dxgiFormatIsStencil(DXGITranslation format);
 bool dxgiFormatIsCompressed(DXGITranslation format);
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/FramePacer.h
+++ b/include/metalsharp/FramePacer.h
@@ -10,9 +10,9 @@
 
 #pragma once
 
-#include <metalsharp/Platform.h>
 #include <cstdint>
 #include <functional>
+#include <metalsharp/Platform.h>
 #include <vector>
 
 namespace metalsharp {
@@ -34,7 +34,7 @@ enum class PresentMode {
 };
 
 class FramePacer {
-public:
+  public:
     static FramePacer& instance();
 
     void init(double targetFPS = 60.0);
@@ -63,7 +63,7 @@ public:
     uint32_t tripleBufferCount() const { return m_tripleBufferCount; }
     void setTripleBufferCount(uint32_t count) { m_tripleBufferCount = count; }
 
-private:
+  private:
     FramePacer() = default;
 
     double m_targetFPS = 60.0;
@@ -83,4 +83,4 @@ private:
     std::function<void()> m_presentCallback;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/GPUProfiler.h
+++ b/include/metalsharp/GPUProfiler.h
@@ -9,11 +9,11 @@
 
 #pragma once
 
+#include <cstdint>
+#include <functional>
 #include <metalsharp/Platform.h>
 #include <string>
 #include <unordered_map>
-#include <cstdint>
-#include <functional>
 
 namespace metalsharp {
 
@@ -24,7 +24,7 @@ struct GPUCounter {
 };
 
 class GPUProfiler {
-public:
+  public:
     static GPUProfiler& instance();
 
     void init();
@@ -37,7 +37,8 @@ public:
     void endPass(const std::string& name);
 
     void recordDraw(const std::string& passName, uint32_t vertexCount, uint32_t instanceCount);
-    void recordCompute(const std::string& passName, uint32_t threadgroupsX, uint32_t threadgroupsY, uint32_t threadgroupsZ);
+    void recordCompute(const std::string& passName, uint32_t threadgroupsX, uint32_t threadgroupsY,
+                       uint32_t threadgroupsZ);
     void recordGPUTiming(void* commandBuffer);
 
     struct FrameStats {
@@ -60,7 +61,7 @@ public:
     using StatsCallback = std::function<void(const FrameStats&)>;
     void setStatsCallback(StatsCallback callback);
 
-private:
+  private:
     GPUProfiler() = default;
 
     struct PassTimer {
@@ -93,4 +94,4 @@ private:
     StatsCallback m_callback;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/GameControllerBridge.h
+++ b/include/metalsharp/GameControllerBridge.h
@@ -33,11 +33,14 @@ struct XInputCapabilities {
     BYTE SubType;
     WORD Flags;
     XInputGamepad Gamepad;
-    struct Vibration { WORD wLeftMotorSpeed; WORD wRightMotorSpeed; } Vibration;
+    struct Vibration {
+        WORD wLeftMotorSpeed;
+        WORD wRightMotorSpeed;
+    } Vibration;
 };
 
 class GameControllerBridge {
-public:
+  public:
     GameControllerBridge();
     ~GameControllerBridge();
 
@@ -47,7 +50,7 @@ public:
     bool setState(uint32_t index, uint16_t leftMotor, uint16_t rightMotor);
     bool getCapabilities(uint32_t index, XInputCapabilities* pCaps);
 
-private:
+  private:
     struct Impl;
     static constexpr uint32_t MAX_CONTROLLERS = 4;
     XInputState m_states[MAX_CONTROLLERS] = {};
@@ -55,4 +58,4 @@ private:
     Impl* m_impl;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/GameDetector.h
+++ b/include/metalsharp/GameDetector.h
@@ -9,9 +9,9 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
-#include <cstdint>
 
 namespace metalsharp {
 
@@ -37,7 +37,7 @@ struct DetectedGame {
 };
 
 class GameDetector {
-public:
+  public:
     static std::vector<DetectedGame> detectAll();
     static std::vector<DetectedGame> detectSteam();
     static std::vector<DetectedGame> detectEpic();
@@ -51,7 +51,7 @@ public:
     static std::string findEpicManifestDir();
     static std::string findGOGDbPath();
 
-private:
+  private:
     static std::vector<DetectedGame> parseSteamLibraryFolders(const std::string& vdfPath);
     static std::vector<DetectedGame> scanSteamApps(const std::string& libraryDir);
     static std::vector<DetectedGame> parseEpicManifests(const std::string& manifestDir);
@@ -62,4 +62,4 @@ private:
     static bool fileExists(const std::string& path);
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/GameValidator.h
+++ b/include/metalsharp/GameValidator.h
@@ -9,11 +9,11 @@
 
 #pragma once
 
-#include <metalsharp/Platform.h>
+#include <cstdint>
 #include <metalsharp/CompatDatabase.h>
 #include <metalsharp/DRMDetector.h>
+#include <metalsharp/Platform.h>
 #include <string>
-#include <cstdint>
 
 namespace metalsharp {
 
@@ -27,7 +27,7 @@ struct ValidationResult {
 };
 
 class GameValidator {
-public:
+  public:
     static GameValidator& instance();
 
     void init(const std::string& dataDir);
@@ -41,7 +41,7 @@ public:
 
     std::string generateFullReport(const std::string& gameId) const;
 
-private:
+  private:
     GameValidator() = default;
 
     CompatStatus estimateStatus(const ValidationResult& result) const;
@@ -50,4 +50,4 @@ private:
     bool m_initialized = false;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/IRConverterBridge.h
+++ b/include/metalsharp/IRConverterBridge.h
@@ -10,18 +10,18 @@
 
 #pragma once
 
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <functional>
+#include <future>
 #include <metalsharp/Platform.h>
 #include <metalsharp/ShaderStage.h>
-#include <cstdint>
-#include <string>
-#include <vector>
-#include <functional>
 #include <mutex>
-#include <thread>
-#include <condition_variable>
 #include <queue>
-#include <future>
-#include <atomic>
+#include <string>
+#include <thread>
+#include <vector>
 
 namespace metalsharp {
 
@@ -47,41 +47,22 @@ struct IRConverterReflection {
 };
 
 class IRConverterBridge {
-public:
+  public:
     static IRConverterBridge& instance();
 
     bool isAvailable() const;
 
-    bool compileDXILToMetallib(
-        const uint8_t* dxilData,
-        size_t dxilSize,
-        ShaderStage stage,
-        const char* entryPoint,
-        std::vector<uint8_t>& outMetallib,
-        IRConverterReflection& outReflection
-    );
+    bool compileDXILToMetallib(const uint8_t* dxilData, size_t dxilSize, ShaderStage stage, const char* entryPoint,
+                               std::vector<uint8_t>& outMetallib, IRConverterReflection& outReflection);
 
-    bool compileDXILToMetallibWithRootSignature(
-        const uint8_t* dxilData,
-        size_t dxilSize,
-        ShaderStage stage,
-        const char* entryPoint,
-        const void* rootSignatureData,
-        size_t rootSignatureSize,
-        std::vector<uint8_t>& outMetallib,
-        IRConverterReflection& outReflection
-    );
+    bool compileDXILToMetallibWithRootSignature(const uint8_t* dxilData, size_t dxilSize, ShaderStage stage,
+                                                const char* entryPoint, const void* rootSignatureData,
+                                                size_t rootSignatureSize, std::vector<uint8_t>& outMetallib,
+                                                IRConverterReflection& outReflection);
 
-    bool compileRayTracingShader(
-        const uint8_t* dxilData,
-        size_t dxilSize,
-        ShaderStage stage,
-        const char* entryPoint,
-        uint32_t maxRecursionDepth,
-        uint32_t maxAttributeSize,
-        std::vector<uint8_t>& outMetallib,
-        IRConverterReflection& outReflection
-    );
+    bool compileRayTracingShader(const uint8_t* dxilData, size_t dxilSize, ShaderStage stage, const char* entryPoint,
+                                 uint32_t maxRecursionDepth, uint32_t maxAttributeSize,
+                                 std::vector<uint8_t>& outMetallib, IRConverterReflection& outReflection);
 
     struct ShaderModelCapabilities {
         bool waveOps = false;
@@ -96,11 +77,7 @@ public:
 
     ShaderModelCapabilities getShaderModelCapabilities(uint32_t smVersion) const;
 
-    bool extractDXILFromDXBC(
-        const uint8_t* dxbcData,
-        size_t dxbcSize,
-        std::vector<uint8_t>& outDXIL
-    );
+    bool extractDXILFromDXBC(const uint8_t* dxbcData, size_t dxbcSize, std::vector<uint8_t>& outDXIL);
 
     bool isDXIL(const uint8_t* data, size_t size) const;
     uint32_t detectShaderModel(const uint8_t* data, size_t size) const;
@@ -108,7 +85,7 @@ public:
     IRConverterBridge(const IRConverterBridge&) = delete;
     IRConverterBridge& operator=(const IRConverterBridge&) = delete;
 
-private:
+  private:
     IRConverterBridge();
     ~IRConverterBridge();
 
@@ -140,7 +117,7 @@ struct ShaderCompileResult {
 };
 
 class ShaderCompileService {
-public:
+  public:
     static ShaderCompileService& instance();
 
     bool init(uint32_t numThreads = 0);
@@ -156,7 +133,7 @@ public:
     ShaderCompileService(const ShaderCompileService&) = delete;
     ShaderCompileService& operator=(const ShaderCompileService&) = delete;
 
-private:
+  private:
     ShaderCompileService() = default;
     ~ShaderCompileService();
 
@@ -174,4 +151,4 @@ private:
     std::string m_cacheDir;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/ImportReporter.h
+++ b/include/metalsharp/ImportReporter.h
@@ -9,10 +9,10 @@
 
 #pragma once
 
+#include <cstdint>
 #include <metalsharp/Platform.h>
 #include <string>
 #include <vector>
-#include <cstdint>
 
 namespace metalsharp {
 
@@ -25,7 +25,7 @@ struct ImportReport {
 };
 
 class ImportReporter {
-public:
+  public:
     static ImportReporter& instance();
 
     void beginModule(const std::string& modulePath);
@@ -45,11 +45,11 @@ public:
     std::string generateSummary() const;
     void clear();
 
-private:
+  private:
     ImportReporter() = default;
 
     std::vector<ImportReport> m_reports;
     std::string m_currentModule;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/Kernel32Shim.h
+++ b/include/metalsharp/Kernel32Shim.h
@@ -9,10 +9,10 @@
 
 #pragma once
 
-#include <unordered_map>
-#include <string>
-#include <functional>
 #include "PELoader.h"
+#include <functional>
+#include <string>
+#include <unordered_map>
 
 namespace metalsharp {
 namespace win32 {
@@ -20,7 +20,7 @@ namespace win32 {
 void setExePath(const char* path);
 
 class Kernel32Shim {
-public:
+  public:
     static ShimLibrary create();
 
     static bool s_initialized;
@@ -29,5 +29,5 @@ public:
     static uintptr_t s_nextHandle;
 };
 
-}
-}
+} // namespace win32
+} // namespace metalsharp

--- a/include/metalsharp/Logger.h
+++ b/include/metalsharp/Logger.h
@@ -9,8 +9,8 @@
 
 #pragma once
 
-#include <cstdio>
 #include <cstdarg>
+#include <cstdio>
 #include <string>
 
 namespace metalsharp {
@@ -18,19 +18,19 @@ namespace metalsharp {
 enum class LogLevel { Trace, Info, Warn, Error };
 
 class Logger {
-public:
+  public:
     static void init(const std::string& logPath);
     static void shutdown();
 
     static void log(LogLevel level, const char* fmt, ...);
     static void setLevel(LogLevel level);
 
-private:
+  private:
     static LogLevel s_level;
     static FILE* s_file;
 };
 
-}
+} // namespace metalsharp
 
 #define MS_TRACE(fmt, ...) metalsharp::Logger::log(metalsharp::LogLevel::Trace, fmt, ##__VA_ARGS__)
 #define MS_INFO(fmt, ...)  metalsharp::Logger::log(metalsharp::LogLevel::Info, fmt, ##__VA_ARGS__)

--- a/include/metalsharp/MSABITrampolines.h
+++ b/include/metalsharp/MSABITrampolines.h
@@ -10,93 +10,256 @@
 
 #pragma once
 
-#include <metalsharp/Win32Types.h>
-#include <cstdlib>
-#include <cstdio>
-#include <cstring>
-#include <cmath>
 #include <cctype>
+#include <clocale>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <ctime>
 #include <cwchar>
-#include <clocale>
+#include <metalsharp/Win32Types.h>
 
 namespace metalsharp {
 namespace win32 {
 
-static void* MSABI msabi_malloc(size_t s) { return malloc(s); }
-static void MSABI msabi_free(void* p) { free(p); }
-static void* MSABI msabi_realloc(void* p, size_t s) { return realloc(p, s); }
-static void* MSABI msabi_calloc(size_t n, size_t s) { return calloc(n, s); }
-static void* MSABI msabi_memset(void* d, int c, size_t n) { return memset(d, c, n); }
-static void* MSABI msabi_memcpy(void* d, const void* s, size_t n) { return memcpy(d, s, n); }
-static void* MSABI msabi_memmove(void* d, const void* s, size_t n) { return memmove(d, s, n); }
-static int MSABI msabi_memcmp(const void* a, const void* b, size_t n) { return memcmp(a, b, n); }
-static size_t MSABI msabi_strlen(const char* s) { return strlen(s); }
-static char* MSABI msabi_strcpy(char* d, const char* s) { return strcpy(d, s); }
-static char* MSABI msabi_strcat(char* d, const char* s) { return strcat(d, s); }
-static int MSABI msabi_strcmp(const char* a, const char* b) { return strcmp(a, b); }
-static int MSABI msabi_strncmp(const char* a, const char* b, size_t n) { return strncmp(a, b, n); }
-static char* MSABI msabi_strncpy(char* d, const char* s, size_t n) { return strncpy(d, s, n); }
-static char* MSABI msabi_strstr(const char* h, const char* n) { return const_cast<char*>(strstr(h, n)); }
-static char* MSABI msabi_strchr(const char* s, int c) { return const_cast<char*>(strchr(s, c)); }
-static char* MSABI msabi_strrchr(const char* s, int c) { return const_cast<char*>(strrchr(s, c)); }
-static int MSABI msabi_atoi(const char* s) { return atoi(s); }
-static double MSABI msabi_atof(const char* s) { return atof(s); }
-static long MSABI msabi_strtol(const char* s, char** e, int b) { return strtol(s, e, b); }
-static double MSABI msabi_strtod(const char* s, char** e) { return strtod(s, e); }
-static unsigned long MSABI msabi_strtoul(const char* s, char** e, int b) { return strtoul(s, e, b); }
-static int MSABI msabi_sprintf(char* buf, const char* fmt, ...) { (void)fmt; if(buf) buf[0]=0; return 0; }
-static int MSABI msabi_snprintf(char* buf, size_t n, const char* fmt, ...) { (void)fmt; if(buf&&n) buf[0]=0; return 0; }
-static int MSABI msabi_sscanf(const char* s, const char* fmt, ...) { (void)s; (void)fmt; return 0; }
-static int MSABI msabi_printf(const char* fmt, ...) { (void)fmt; return 0; }
-static int MSABI msabi_fprintf(void* f, const char* fmt, ...) { (void)f; (void)fmt; return 0; }
-static void* MSABI msabi_fopen(const char* p, const char* m) { return (void*)fopen(p, m); }
-static int MSABI msabi_fclose(void* f) { return fclose((FILE*)f); }
-static size_t MSABI msabi_fread(void* b, size_t s, size_t n, void* f) { return fread(b, s, n, (FILE*)f); }
-static size_t MSABI msabi_fwrite(const void* b, size_t s, size_t n, void* f) { return fwrite(b, s, n, (FILE*)f); }
-static int MSABI msabi_fseek(void* f, long o, int w) { return fseek((FILE*)f, o, w); }
-static long MSABI msabi_ftell(void* f) { return ftell((FILE*)f); }
-static char* MSABI msabi_fgets(char* b, int n, void* f) { return fgets(b, n, (FILE*)f); }
-static int MSABI msabi_vsnprintf(char* b, size_t n, const char* fmt, void* ap) { (void)ap; if(b&&n) b[0]=0; (void)fmt; return 0; }
-static int MSABI msabi_strcasecmp(const char* a, const char* b) { return strcasecmp(a, b); }
-static int MSABI msabi_strncasecmp(const char* a, const char* b, size_t n) { return strncasecmp(a, b, n); }
-static size_t MSABI msabi_wcslen(const wchar_t* s) { return wcslen(s); }
-static wchar_t* MSABI msabi_wcscpy(wchar_t* d, const wchar_t* s) { return wcscpy(d, s); }
-static wchar_t* MSABI msabi_wcscat(wchar_t* d, const wchar_t* s) { return wcscat(d, s); }
-static int MSABI msabi_wcscmp(const wchar_t* a, const wchar_t* b) { return wcscmp(a, b); }
-static int MSABI msabi_tolower(int c) { return tolower(c); }
-static int MSABI msabi_toupper(int c) { return toupper(c); }
-static int MSABI msabi_isalpha(int c) { return isalpha(c); }
-static int MSABI msabi_isdigit(int c) { return isdigit(c); }
-static int MSABI msabi_isspace(int c) { return isspace(c); }
-static void MSABI msabi_qsort(void* b, size_t n, size_t s, int(*c)(const void*, const void*)) { qsort(b, n, s, c); }
-static int MSABI msabi_rand() { return rand(); }
-static void MSABI msabi_srand(unsigned int s) { srand(s); }
-static int MSABI msabi_abs(int n) { return abs(n); }
-static long MSABI msabi_labs(long n) { return labs(n); }
-static double MSABI msabi_floor(double x) { return floor(x); }
-static double MSABI msabi_ceil(double x) { return ceil(x); }
-static double MSABI msabi_sqrt(double x) { return sqrt(x); }
-static double MSABI msabi_sin(double x) { return sin(x); }
-static double MSABI msabi_cos(double x) { return cos(x); }
-static double MSABI msabi_tan(double x) { return tan(x); }
-static double MSABI msabi_atan2(double y, double x) { return atan2(y, x); }
-static double MSABI msabi_pow(double x, double y) { return pow(x, y); }
-static double MSABI msabi_log(double x) { return log(x); }
-static double MSABI msabi_log10(double x) { return log10(x); }
-static double MSABI msabi_exp(double x) { return exp(x); }
-static double MSABI msabi_fabs(double x) { return fabs(x); }
-static double MSABI msabi_fmod(double x, double y) { return fmod(x, y); }
-static double MSABI msabi_modf(double x, double* i) { return modf(x, i); }
-static double MSABI msabi_ldexp(double x, int e) { return ldexp(x, e); }
-static double MSABI msabi_frexp(double x, int* e) { return frexp(x, e); }
-static void MSABI msabi_exit(int c) { exit(c); }
-static void MSABI msabi__Exit(int c) { _Exit(c); }
-static void MSABI msabi_abort() { abort(); }
-static clock_t MSABI msabi_clock() { return clock(); }
-static time_t MSABI msabi_time(time_t* t) { return time(t); }
-static size_t MSABI msabi_strftime(char* b, size_t m, const char* f, const void* tm) { return strftime(b, m, f, (const struct tm*)tm); }
-static char* MSABI msabi_setlocale(int c, const char* l) { return setlocale(c, l); }
+static void* MSABI msabi_malloc(size_t s) {
+    return malloc(s);
+}
+static void MSABI msabi_free(void* p) {
+    free(p);
+}
+static void* MSABI msabi_realloc(void* p, size_t s) {
+    return realloc(p, s);
+}
+static void* MSABI msabi_calloc(size_t n, size_t s) {
+    return calloc(n, s);
+}
+static void* MSABI msabi_memset(void* d, int c, size_t n) {
+    return memset(d, c, n);
+}
+static void* MSABI msabi_memcpy(void* d, const void* s, size_t n) {
+    return memcpy(d, s, n);
+}
+static void* MSABI msabi_memmove(void* d, const void* s, size_t n) {
+    return memmove(d, s, n);
+}
+static int MSABI msabi_memcmp(const void* a, const void* b, size_t n) {
+    return memcmp(a, b, n);
+}
+static size_t MSABI msabi_strlen(const char* s) {
+    return strlen(s);
+}
+static char* MSABI msabi_strcpy(char* d, const char* s) {
+    return strcpy(d, s);
+}
+static char* MSABI msabi_strcat(char* d, const char* s) {
+    return strcat(d, s);
+}
+static int MSABI msabi_strcmp(const char* a, const char* b) {
+    return strcmp(a, b);
+}
+static int MSABI msabi_strncmp(const char* a, const char* b, size_t n) {
+    return strncmp(a, b, n);
+}
+static char* MSABI msabi_strncpy(char* d, const char* s, size_t n) {
+    return strncpy(d, s, n);
+}
+static char* MSABI msabi_strstr(const char* h, const char* n) {
+    return const_cast<char*>(strstr(h, n));
+}
+static char* MSABI msabi_strchr(const char* s, int c) {
+    return const_cast<char*>(strchr(s, c));
+}
+static char* MSABI msabi_strrchr(const char* s, int c) {
+    return const_cast<char*>(strrchr(s, c));
+}
+static int MSABI msabi_atoi(const char* s) {
+    return atoi(s);
+}
+static double MSABI msabi_atof(const char* s) {
+    return atof(s);
+}
+static long MSABI msabi_strtol(const char* s, char** e, int b) {
+    return strtol(s, e, b);
+}
+static double MSABI msabi_strtod(const char* s, char** e) {
+    return strtod(s, e);
+}
+static unsigned long MSABI msabi_strtoul(const char* s, char** e, int b) {
+    return strtoul(s, e, b);
+}
+static int MSABI msabi_sprintf(char* buf, const char* fmt, ...) {
+    (void)fmt;
+    if (buf)
+        buf[0] = 0;
+    return 0;
+}
+static int MSABI msabi_snprintf(char* buf, size_t n, const char* fmt, ...) {
+    (void)fmt;
+    if (buf && n)
+        buf[0] = 0;
+    return 0;
+}
+static int MSABI msabi_sscanf(const char* s, const char* fmt, ...) {
+    (void)s;
+    (void)fmt;
+    return 0;
+}
+static int MSABI msabi_printf(const char* fmt, ...) {
+    (void)fmt;
+    return 0;
+}
+static int MSABI msabi_fprintf(void* f, const char* fmt, ...) {
+    (void)f;
+    (void)fmt;
+    return 0;
+}
+static void* MSABI msabi_fopen(const char* p, const char* m) {
+    return (void*)fopen(p, m);
+}
+static int MSABI msabi_fclose(void* f) {
+    return fclose((FILE*)f);
+}
+static size_t MSABI msabi_fread(void* b, size_t s, size_t n, void* f) {
+    return fread(b, s, n, (FILE*)f);
+}
+static size_t MSABI msabi_fwrite(const void* b, size_t s, size_t n, void* f) {
+    return fwrite(b, s, n, (FILE*)f);
+}
+static int MSABI msabi_fseek(void* f, long o, int w) {
+    return fseek((FILE*)f, o, w);
+}
+static long MSABI msabi_ftell(void* f) {
+    return ftell((FILE*)f);
+}
+static char* MSABI msabi_fgets(char* b, int n, void* f) {
+    return fgets(b, n, (FILE*)f);
+}
+static int MSABI msabi_vsnprintf(char* b, size_t n, const char* fmt, void* ap) {
+    (void)ap;
+    if (b && n)
+        b[0] = 0;
+    (void)fmt;
+    return 0;
+}
+static int MSABI msabi_strcasecmp(const char* a, const char* b) {
+    return strcasecmp(a, b);
+}
+static int MSABI msabi_strncasecmp(const char* a, const char* b, size_t n) {
+    return strncasecmp(a, b, n);
+}
+static size_t MSABI msabi_wcslen(const wchar_t* s) {
+    return wcslen(s);
+}
+static wchar_t* MSABI msabi_wcscpy(wchar_t* d, const wchar_t* s) {
+    return wcscpy(d, s);
+}
+static wchar_t* MSABI msabi_wcscat(wchar_t* d, const wchar_t* s) {
+    return wcscat(d, s);
+}
+static int MSABI msabi_wcscmp(const wchar_t* a, const wchar_t* b) {
+    return wcscmp(a, b);
+}
+static int MSABI msabi_tolower(int c) {
+    return tolower(c);
+}
+static int MSABI msabi_toupper(int c) {
+    return toupper(c);
+}
+static int MSABI msabi_isalpha(int c) {
+    return isalpha(c);
+}
+static int MSABI msabi_isdigit(int c) {
+    return isdigit(c);
+}
+static int MSABI msabi_isspace(int c) {
+    return isspace(c);
+}
+static void MSABI msabi_qsort(void* b, size_t n, size_t s, int (*c)(const void*, const void*)) {
+    qsort(b, n, s, c);
+}
+static int MSABI msabi_rand() {
+    return rand();
+}
+static void MSABI msabi_srand(unsigned int s) {
+    srand(s);
+}
+static int MSABI msabi_abs(int n) {
+    return abs(n);
+}
+static long MSABI msabi_labs(long n) {
+    return labs(n);
+}
+static double MSABI msabi_floor(double x) {
+    return floor(x);
+}
+static double MSABI msabi_ceil(double x) {
+    return ceil(x);
+}
+static double MSABI msabi_sqrt(double x) {
+    return sqrt(x);
+}
+static double MSABI msabi_sin(double x) {
+    return sin(x);
+}
+static double MSABI msabi_cos(double x) {
+    return cos(x);
+}
+static double MSABI msabi_tan(double x) {
+    return tan(x);
+}
+static double MSABI msabi_atan2(double y, double x) {
+    return atan2(y, x);
+}
+static double MSABI msabi_pow(double x, double y) {
+    return pow(x, y);
+}
+static double MSABI msabi_log(double x) {
+    return log(x);
+}
+static double MSABI msabi_log10(double x) {
+    return log10(x);
+}
+static double MSABI msabi_exp(double x) {
+    return exp(x);
+}
+static double MSABI msabi_fabs(double x) {
+    return fabs(x);
+}
+static double MSABI msabi_fmod(double x, double y) {
+    return fmod(x, y);
+}
+static double MSABI msabi_modf(double x, double* i) {
+    return modf(x, i);
+}
+static double MSABI msabi_ldexp(double x, int e) {
+    return ldexp(x, e);
+}
+static double MSABI msabi_frexp(double x, int* e) {
+    return frexp(x, e);
+}
+static void MSABI msabi_exit(int c) {
+    exit(c);
+}
+static void MSABI msabi__Exit(int c) {
+    _Exit(c);
+}
+static void MSABI msabi_abort() {
+    abort();
+}
+static clock_t MSABI msabi_clock() {
+    return clock();
+}
+static time_t MSABI msabi_time(time_t* t) {
+    return time(t);
+}
+static size_t MSABI msabi_strftime(char* b, size_t m, const char* f, const void* tm) {
+    return strftime(b, m, f, (const struct tm*)tm);
+}
+static char* MSABI msabi_setlocale(int c, const char* l) {
+    return setlocale(c, l);
+}
 
-}
-}
+} // namespace win32
+} // namespace metalsharp

--- a/include/metalsharp/MetalBackend.h
+++ b/include/metalsharp/MetalBackend.h
@@ -42,7 +42,7 @@ struct MTLCommandQueue;
 namespace metalsharp {
 
 class MetalDevice {
-public:
+  public:
     static MetalDevice* create();
 
     void* nativeDevice() const;
@@ -52,7 +52,7 @@ public:
     MetalDevice(const MetalDevice&) = delete;
     MetalDevice& operator=(const MetalDevice&) = delete;
 
-private:
+  private:
     MetalDevice();
     bool init();
 
@@ -61,7 +61,7 @@ private:
 };
 
 class MetalCommandBuffer {
-public:
+  public:
     explicit MetalCommandBuffer(MetalDevice& device);
     ~MetalCommandBuffer();
 
@@ -76,13 +76,13 @@ public:
     MetalCommandBuffer(const MetalCommandBuffer&) = delete;
     MetalCommandBuffer& operator=(const MetalCommandBuffer&) = delete;
 
-private:
+  private:
     struct Impl;
     Impl* m_impl;
 };
 
 class MetalBuffer {
-public:
+  public:
     static MetalBuffer* create(MetalDevice& device, size_t size, const void* data);
     ~MetalBuffer();
 
@@ -90,7 +90,7 @@ public:
     void* contents();
     size_t size() const;
 
-private:
+  private:
     MetalBuffer();
     bool init(MetalDevice& device, size_t size, const void* data);
 
@@ -99,10 +99,13 @@ private:
 };
 
 class MetalTexture {
-public:
-    static MetalTexture* create1D(MetalDevice& device, uint32_t width, uint32_t format, uint32_t usage, uint32_t mipLevels = 1);
-    static MetalTexture* create2D(MetalDevice& device, uint32_t width, uint32_t height, uint32_t format, uint32_t usage, uint32_t mipLevels = 1, uint32_t sampleCount = 1);
-    static MetalTexture* create3D(MetalDevice& device, uint32_t width, uint32_t height, uint32_t depth, uint32_t format, uint32_t usage, uint32_t mipLevels = 1);
+  public:
+    static MetalTexture* create1D(MetalDevice& device, uint32_t width, uint32_t format, uint32_t usage,
+                                  uint32_t mipLevels = 1);
+    static MetalTexture* create2D(MetalDevice& device, uint32_t width, uint32_t height, uint32_t format, uint32_t usage,
+                                  uint32_t mipLevels = 1, uint32_t sampleCount = 1);
+    static MetalTexture* create3D(MetalDevice& device, uint32_t width, uint32_t height, uint32_t depth, uint32_t format,
+                                  uint32_t usage, uint32_t mipLevels = 1);
     ~MetalTexture();
 
     void* nativeTexture() const;
@@ -112,39 +115,40 @@ public:
     uint32_t mipLevels() const;
     uint32_t sampleCount() const;
 
-    void uploadData(uint32_t mipLevel, uint32_t slice, const void* data, uint32_t rowPitch, uint32_t width, uint32_t height, uint32_t depth = 1);
+    void uploadData(uint32_t mipLevel, uint32_t slice, const void* data, uint32_t rowPitch, uint32_t width,
+                    uint32_t height, uint32_t depth = 1);
 
-private:
+  private:
     MetalTexture();
     bool init1D(MetalDevice& device, uint32_t width, uint32_t format, uint32_t usage, uint32_t mipLevels);
-    bool init2D(MetalDevice& device, uint32_t width, uint32_t height, uint32_t format, uint32_t usage, uint32_t mipLevels, uint32_t sampleCount);
-    bool init3D(MetalDevice& device, uint32_t width, uint32_t height, uint32_t depth, uint32_t format, uint32_t usage, uint32_t mipLevels);
+    bool init2D(MetalDevice& device, uint32_t width, uint32_t height, uint32_t format, uint32_t usage,
+                uint32_t mipLevels, uint32_t sampleCount);
+    bool init3D(MetalDevice& device, uint32_t width, uint32_t height, uint32_t depth, uint32_t format, uint32_t usage,
+                uint32_t mipLevels);
 
     struct Impl;
     Impl* m_impl;
 };
 
 class MetalSampler {
-public:
-    static MetalSampler* create(MetalDevice& device,
-        uint32_t filter, uint32_t addressU, uint32_t addressV, uint32_t addressW,
-        float mipLodBias, uint32_t maxAnisotropy, uint32_t comparisonFunc);
+  public:
+    static MetalSampler* create(MetalDevice& device, uint32_t filter, uint32_t addressU, uint32_t addressV,
+                                uint32_t addressW, float mipLodBias, uint32_t maxAnisotropy, uint32_t comparisonFunc);
     ~MetalSampler();
 
     void* nativeSamplerState() const;
 
-private:
+  private:
     MetalSampler();
-    bool init(MetalDevice& device,
-        uint32_t filter, uint32_t addressU, uint32_t addressV, uint32_t addressW,
-        float mipLodBias, uint32_t maxAnisotropy, uint32_t comparisonFunc);
+    bool init(MetalDevice& device, uint32_t filter, uint32_t addressU, uint32_t addressV, uint32_t addressW,
+              float mipLodBias, uint32_t maxAnisotropy, uint32_t comparisonFunc);
 
     struct Impl;
     Impl* m_impl;
 };
 
 class MetalFramebuffer {
-public:
+  public:
     MetalFramebuffer();
     ~MetalFramebuffer();
 
@@ -154,9 +158,9 @@ public:
 
     void* nativeRenderPassDescriptor() const;
 
-private:
+  private:
     struct Impl;
     Impl* m_impl;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/MetalFXUpscaler.h
+++ b/include/metalsharp/MetalFXUpscaler.h
@@ -10,25 +10,22 @@
 
 #pragma once
 
-#include <metalsharp/Platform.h>
 #include <cstdint>
+#include <metalsharp/Platform.h>
 
 namespace metalsharp {
 
 class MetalFXUpscaler {
-public:
+  public:
     static MetalFXUpscaler* create(void* metalDevice);
     ~MetalFXUpscaler();
 
-    bool init(uint32_t inputWidth, uint32_t inputHeight,
-              uint32_t outputWidth, uint32_t outputHeight,
+    bool init(uint32_t inputWidth, uint32_t inputHeight, uint32_t outputWidth, uint32_t outputHeight,
               uint32_t format = 87);
     void shutdown();
 
-    bool process(void* inputTexture, void* outputTexture,
-                 void* depthTexture, void* motionTexture,
-                 float jitterOffsetX, float jitterOffsetY,
-                 float motionScaleX, float motionScaleY);
+    bool process(void* inputTexture, void* outputTexture, void* depthTexture, void* motionTexture, float jitterOffsetX,
+                 float jitterOffsetY, float motionScaleX, float motionScaleY);
 
     bool isAvailable() const { return m_available; }
     uint32_t inputWidth() const { return m_inputWidth; }
@@ -39,7 +36,7 @@ public:
     float sharpness() const { return m_sharpness; }
     void setSharpness(float s) { m_sharpness = s; }
 
-private:
+  private:
     MetalFXUpscaler() = default;
 
     void* m_scaler = nullptr;
@@ -54,20 +51,19 @@ private:
 };
 
 class MetalFXInterpolator {
-public:
+  public:
     static MetalFXInterpolator* create(void* metalDevice);
     ~MetalFXInterpolator();
 
     bool init(uint32_t width, uint32_t height, uint32_t format = 87);
     void shutdown();
 
-    bool process(void* outputTexture,
-                 void* depthTexture, void* motionTexture,
-                 float jitterOffsetX, float jitterOffsetY);
+    bool process(void* outputTexture, void* depthTexture, void* motionTexture, float jitterOffsetX,
+                 float jitterOffsetY);
 
     bool isAvailable() const { return m_available; }
 
-private:
+  private:
     MetalFXInterpolator() = default;
 
     void* m_interpolator = nullptr;
@@ -76,4 +72,4 @@ private:
     bool m_initialized = false;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/NetworkContext.h
+++ b/include/metalsharp/NetworkContext.h
@@ -10,10 +10,10 @@
 #pragma once
 
 #include <cstdint>
-#include <unordered_map>
-#include <string>
-#include <mutex>
 #include <functional>
+#include <mutex>
+#include <string>
+#include <unordered_map>
 
 namespace metalsharp {
 namespace win32 {
@@ -66,7 +66,10 @@ struct WSAOVERLAPPED {
     void* Internal;
     void* InternalHigh;
     union {
-        struct { void* Offset; void* OffsetHigh; };
+        struct {
+            void* Offset;
+            void* OffsetHigh;
+        };
         void* Pointer;
     };
     void* hEvent;
@@ -85,7 +88,7 @@ struct PipeInstance {
 };
 
 class NetworkContext {
-public:
+  public:
     static NetworkContext& instance();
 
     int allocSocket(int fd);
@@ -107,7 +110,7 @@ public:
 
     void initialize();
 
-private:
+  private:
     NetworkContext() = default;
 
     struct SocketEntry {
@@ -126,5 +129,5 @@ private:
     static thread_local uint32_t t_wsaError;
 };
 
-}
-}
+} // namespace win32
+} // namespace metalsharp

--- a/include/metalsharp/NtdllShim.h
+++ b/include/metalsharp/NtdllShim.h
@@ -16,4 +16,4 @@ namespace win32 {
 ShimLibrary createNtdllShim();
 
 }
-}
+} // namespace metalsharp

--- a/include/metalsharp/PEHeader.h
+++ b/include/metalsharp/PEHeader.h
@@ -10,8 +10,8 @@
 
 #pragma once
 
-#include <cstdint>
 #include <cstddef>
+#include <cstdint>
 
 namespace metalsharp {
 
@@ -36,7 +36,7 @@ struct IMAGE_DOS_HEADER {
     uint16_t e_oemid;
     uint16_t e_oeminfo;
     uint16_t e_res2[10];
-    int32_t  e_lfanew;
+    int32_t e_lfanew;
 };
 
 static_assert(sizeof(IMAGE_DOS_HEADER) == 64);
@@ -58,8 +58,8 @@ struct IMAGE_DATA_DIRECTORY {
 
 struct IMAGE_OPTIONAL_HEADER64 {
     uint16_t Magic;
-    uint8_t  MajorLinkerVersion;
-    uint8_t  MinorLinkerVersion;
+    uint8_t MajorLinkerVersion;
+    uint8_t MinorLinkerVersion;
     uint32_t SizeOfCode;
     uint32_t SizeOfInitializedData;
     uint32_t SizeOfUninitializedData;
@@ -92,7 +92,7 @@ struct IMAGE_OPTIONAL_HEADER64 {
 static_assert(sizeof(IMAGE_OPTIONAL_HEADER64) == 240);
 
 struct IMAGE_SECTION_HEADER {
-    uint8_t  Name[8];
+    uint8_t Name[8];
     uint32_t VirtualSize;
     uint32_t VirtualAddress;
     uint32_t SizeOfRawData;
@@ -118,7 +118,7 @@ struct IMAGE_THUNK_DATA64 {
 
 struct IMAGE_IMPORT_BY_NAME {
     uint16_t Hint;
-    uint8_t  Name[1];
+    uint8_t Name[1];
 };
 
 struct IMAGE_BASE_RELOCATION {
@@ -183,33 +183,33 @@ struct IMAGE_DELAY_IMPORT_DESCRIPTOR {
 
 #pragma pack(pop)
 
-constexpr uint16_t IMAGE_DOS_SIGNATURE     = 0x5A4D;
-constexpr uint32_t IMAGE_PE_SIGNATURE      = 0x00004550;
+constexpr uint16_t IMAGE_DOS_SIGNATURE = 0x5A4D;
+constexpr uint32_t IMAGE_PE_SIGNATURE = 0x00004550;
 constexpr uint16_t IMAGE_FILE_MACHINE_AMD64 = 0x8664;
-constexpr uint16_t IMAGE_FILE_MACHINE_I386  = 0x014C;
-constexpr uint16_t IMAGE_FILE_DLL          = 0x2000;
+constexpr uint16_t IMAGE_FILE_MACHINE_I386 = 0x014C;
+constexpr uint16_t IMAGE_FILE_DLL = 0x2000;
 
 constexpr uint16_t IMAGE_OPTIONAL_MAGIC_PE32PLUS = 0x20B;
-constexpr uint16_t IMAGE_OPTIONAL_MAGIC_PE32     = 0x10B;
+constexpr uint16_t IMAGE_OPTIONAL_MAGIC_PE32 = 0x10B;
 
 constexpr uint32_t IMAGE_SCN_MEM_EXECUTE = 0x20000000;
-constexpr uint32_t IMAGE_SCN_MEM_READ    = 0x40000000;
-constexpr uint32_t IMAGE_SCN_MEM_WRITE   = 0x80000000;
-constexpr uint32_t IMAGE_SCN_CNT_CODE    = 0x00000020;
+constexpr uint32_t IMAGE_SCN_MEM_READ = 0x40000000;
+constexpr uint32_t IMAGE_SCN_MEM_WRITE = 0x80000000;
+constexpr uint32_t IMAGE_SCN_CNT_CODE = 0x00000020;
 constexpr uint32_t IMAGE_SCN_CNT_INITIALIZED_DATA = 0x00000040;
 constexpr uint32_t IMAGE_SCN_CNT_UNINITIALIZED_DATA = 0x00000080;
 
 constexpr uint32_t IMAGE_REL_BASED_ABSOLUTE = 0;
-constexpr uint32_t IMAGE_REL_BASED_DIR64    = 10;
+constexpr uint32_t IMAGE_REL_BASED_DIR64 = 10;
 
-constexpr int DIRECTORY_EXPORT    = 0;
-constexpr int DIRECTORY_IMPORT    = 1;
-constexpr int DIRECTORY_RESOURCE  = 2;
+constexpr int DIRECTORY_EXPORT = 0;
+constexpr int DIRECTORY_IMPORT = 1;
+constexpr int DIRECTORY_RESOURCE = 2;
 constexpr int DIRECTORY_EXCEPTION = 3;
-constexpr int DIRECTORY_SECURITY  = 4;
+constexpr int DIRECTORY_SECURITY = 4;
 constexpr int DIRECTORY_BASERELOC = 5;
-constexpr int DIRECTORY_DEBUG     = 6;
-constexpr int DIRECTORY_TLS       = 9;
+constexpr int DIRECTORY_DEBUG = 6;
+constexpr int DIRECTORY_TLS = 9;
 constexpr int DIRECTORY_LOAD_CONFIG = 10;
 constexpr int DIRECTORY_DELAY_IMPORT = 13;
 
@@ -218,4 +218,4 @@ constexpr uint32_t DLL_THREAD_ATTACH = 2;
 constexpr uint32_t DLL_THREAD_DETACH = 3;
 constexpr uint32_t DLL_PROCESS_DETACH = 0;
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/PEHook.h
+++ b/include/metalsharp/PEHook.h
@@ -19,7 +19,7 @@ struct DylibMapping {
 };
 
 class PEHook {
-public:
+  public:
     static bool injectDylibs(const std::string& winePrefix);
     static bool setupEnvironment(const std::string& winePrefix, bool debugMetal);
     static std::vector<DylibMapping> getDylibMappings();
@@ -27,4 +27,4 @@ public:
     static const char* DYLIB_MAPPINGS[];
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/PELoader.h
+++ b/include/metalsharp/PELoader.h
@@ -22,11 +22,10 @@
 
 #pragma once
 
-#include <string>
-#include <vector>
-#include <unordered_map>
-#include <functional>
 #include <cstdint>
+#include <functional>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace metalsharp {
@@ -41,7 +40,8 @@ struct LoadedModule {
     bool isPE = false;
 
     uint8_t* rvaToPtr(uint32_t rva) const {
-        if (!base || rva >= size) return nullptr;
+        if (!base || rva >= size)
+            return nullptr;
         return base + rva;
     }
 };
@@ -55,7 +55,7 @@ struct ShimLibrary {
 };
 
 class PELoader {
-public:
+  public:
     PELoader();
     ~PELoader();
 
@@ -79,7 +79,7 @@ public:
 
     static PELoader* instance();
 
-private:
+  private:
     bool parsePE(LoadedModule& module, const uint8_t* rawData, size_t rawSize);
     bool mapSections(LoadedModule& module, const uint8_t* rawData, size_t rawSize);
     bool processRelocations(LoadedModule& module);
@@ -94,9 +94,7 @@ private:
     void* getExportAddress(LoadedModule& module, const std::string& funcName, uint16_t ordinal = 0xFFFF);
     void* resolveForwardedExport(const char* forwardString);
 
-    uint64_t alignUp(uint64_t value, uint64_t alignment) {
-        return (value + alignment - 1) & ~(alignment - 1);
-    }
+    uint64_t alignUp(uint64_t value, uint64_t alignment) { return (value + alignment - 1) & ~(alignment - 1); }
 
     LoadedModule m_mainModule;
     std::unordered_map<std::string, LoadedModule> m_loadedDLLs;
@@ -113,4 +111,4 @@ private:
     static void* s_cfgAllowFn;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/PipelineCache.h
+++ b/include/metalsharp/PipelineCache.h
@@ -9,14 +9,14 @@
 
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <deque>
 #include <metalsharp/Platform.h>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <deque>
-#include <cstdint>
-#include <mutex>
-#include <chrono>
 
 namespace metalsharp {
 
@@ -29,7 +29,7 @@ struct PipelineCacheEntry {
 };
 
 class PipelineCache {
-public:
+  public:
     static PipelineCache& instance();
 
     bool init(const std::string& cacheDir);
@@ -49,7 +49,7 @@ public:
 
     void setMaxEntries(uint64_t max) { m_maxEntries = max; }
 
-private:
+  private:
     PipelineCache() = default;
 
     bool loadFromDisk();
@@ -67,4 +67,4 @@ private:
     std::mutex m_mutex;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/PipelineState.h
+++ b/include/metalsharp/PipelineState.h
@@ -46,7 +46,7 @@ struct PipelineStateDesc {
 };
 
 class PipelineState {
-public:
+  public:
     static PipelineState* create(MetalDevice& device, const PipelineStateDesc& desc);
     ~PipelineState();
 
@@ -55,7 +55,7 @@ public:
     PipelineState(const PipelineState&) = delete;
     PipelineState& operator=(const PipelineState&) = delete;
 
-private:
+  private:
     PipelineState();
     bool init(MetalDevice& device, const PipelineStateDesc& desc);
 
@@ -63,4 +63,4 @@ private:
     Impl* m_impl;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/Platform.h
+++ b/include/metalsharp/Platform.h
@@ -8,9 +8,9 @@
 
 #pragma once
 
-#include <stdint.h>
-#include <stddef.h>
 #include <cstring>
+#include <stddef.h>
+#include <stdint.h>
 
 typedef uint32_t DWORD;
 typedef int32_t LONG;
@@ -35,7 +35,7 @@ typedef size_t SIZE_T;
 typedef int BOOL;
 #endif
 
-#define MS_TRUE 1
+#define MS_TRUE  1
 #define MS_FALSE 0
 #ifndef TRUE
 #define TRUE 1
@@ -49,29 +49,27 @@ typedef struct GUID {
     uint16_t Data2;
     uint16_t Data3;
     uint8_t Data4[8];
-    bool operator==(const GUID& other) const {
-        return memcmp(this, &other, sizeof(GUID)) == 0;
-    }
+    bool operator==(const GUID& other) const { return memcmp(this, &other, sizeof(GUID)) == 0; }
     bool operator!=(const GUID& other) const { return !(*this == other); }
 } GUID, REFIID, IID;
 
-#define S_OK ((HRESULT)0L)
-#define S_FALSE ((HRESULT)1L)
-#define E_NOTIMPL ((HRESULT)0x80004001L)
-#define E_NOINTERFACE ((HRESULT)0x80004002L)
-#define E_POINTER ((HRESULT)0x80004003L)
-#define E_FAIL ((HRESULT)0x80004005L)
-#define E_INVALIDARG ((HRESULT)0x80070057L)
-#define E_OUTOFMEMORY ((HRESULT)0x8007000EL)
+#define S_OK                    ((HRESULT)0L)
+#define S_FALSE                 ((HRESULT)1L)
+#define E_NOTIMPL               ((HRESULT)0x80004001L)
+#define E_NOINTERFACE           ((HRESULT)0x80004002L)
+#define E_POINTER               ((HRESULT)0x80004003L)
+#define E_FAIL                  ((HRESULT)0x80004005L)
+#define E_INVALIDARG            ((HRESULT)0x80070057L)
+#define E_OUTOFMEMORY           ((HRESULT)0x8007000EL)
 #define DXGI_ERROR_INVALID_CALL ((HRESULT)0x887A0001L)
-#define DXGI_ERROR_NOT_FOUND ((HRESULT)0x887A0002L)
+#define DXGI_ERROR_NOT_FOUND    ((HRESULT)0x887A0002L)
 
-#define FAILED(hr) (((HRESULT)(hr)) < 0)
+#define FAILED(hr)    (((HRESULT)(hr)) < 0)
 #define SUCCEEDED(hr) (((HRESULT)(hr)) >= 0)
 
-#define STDMETHOD(method) virtual HRESULT method
+#define STDMETHOD(method)        virtual HRESULT method
 #define STDMETHOD_(type, method) virtual type method
-#define PURE = 0
+#define PURE                     = 0
 #define THIS_
 #define THIS
 #define MIDL_INTERFACE(str)
@@ -79,7 +77,7 @@ typedef struct GUID {
 #define __uuidof(x) IID_##x
 
 class IUnknown {
-public:
+  public:
     virtual HRESULT QueryInterface(REFIID riid, void** ppvObject) = 0;
     virtual ULONG AddRef() = 0;
     virtual ULONG Release() = 0;

--- a/include/metalsharp/Registry.h
+++ b/include/metalsharp/Registry.h
@@ -10,10 +10,10 @@
 #pragma once
 
 #include <cstdint>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <mutex>
 
 namespace metalsharp {
 namespace win32 {
@@ -33,15 +33,15 @@ struct RegistryValue {
 };
 
 class Registry {
-public:
+  public:
     static Registry& instance();
 
     void init(const std::string& prefix);
 
     LONG openKey(HKEY hKey, const std::string& subKey, HKEY* result);
     LONG openKeyEx(HKEY hKey, const std::string& subKey, DWORD ulOptions, DWORD samDesired, HKEY* result);
-    LONG createKeyEx(HKEY hKey, const std::string& subKey, DWORD reserved, char* lpClass,
-        DWORD dwOptions, DWORD samDesired, void* lpSecurityAttributes, HKEY* phkResult, void* lpdwDisposition);
+    LONG createKeyEx(HKEY hKey, const std::string& subKey, DWORD reserved, char* lpClass, DWORD dwOptions,
+                     DWORD samDesired, void* lpSecurityAttributes, HKEY* phkResult, void* lpdwDisposition);
     LONG closeKey(HKEY hKey);
     LONG queryValue(HKEY hKey, const std::string& valueName, DWORD* lpType, BYTE* lpData, DWORD* lpcbData);
     LONG setValue(HKEY hKey, const std::string& valueName, DWORD dwType, const BYTE* lpData, DWORD cbData);
@@ -51,7 +51,7 @@ public:
     void saveToFile(const std::string& path);
     void loadFromFile(const std::string& path);
 
-private:
+  private:
     Registry();
 
     std::string normalizePath(HKEY hKey, const std::string& subKey);
@@ -65,5 +65,5 @@ private:
     std::mutex m_mutex;
 };
 
-}
-}
+} // namespace win32
+} // namespace metalsharp

--- a/include/metalsharp/RenderThreadPool.h
+++ b/include/metalsharp/RenderThreadPool.h
@@ -9,15 +9,15 @@
 
 #pragma once
 
-#include <metalsharp/Platform.h>
-#include <vector>
-#include <deque>
-#include <thread>
-#include <mutex>
-#include <condition_variable>
-#include <functional>
 #include <atomic>
+#include <condition_variable>
 #include <cstdint>
+#include <deque>
+#include <functional>
+#include <metalsharp/Platform.h>
+#include <mutex>
+#include <thread>
+#include <vector>
 
 namespace metalsharp {
 
@@ -28,7 +28,7 @@ struct RenderTask {
 };
 
 class RenderThreadPool {
-public:
+  public:
     static RenderThreadPool& instance();
 
     void init(uint32_t threadCount = 0);
@@ -43,7 +43,7 @@ public:
     uint64_t tasksCompleted() const { return m_tasksCompleted; }
     bool isInitialized() const { return m_initialized; }
 
-private:
+  private:
     RenderThreadPool() = default;
     void workerLoop();
 
@@ -61,7 +61,7 @@ private:
 };
 
 class CommandBufferPool {
-public:
+  public:
     static CommandBufferPool& instance();
 
     void init(void* commandQueue);
@@ -73,7 +73,7 @@ public:
     uint64_t activeCount() const;
     uint64_t pooledCount() const;
 
-private:
+  private:
     CommandBufferPool() = default;
 
     struct PooledBuffer {
@@ -87,4 +87,4 @@ private:
     bool m_initialized = false;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/SecureTransport.h
+++ b/include/metalsharp/SecureTransport.h
@@ -9,9 +9,9 @@
 #pragma once
 
 #include <cstdint>
+#include <mutex>
 #include <string>
 #include <unordered_map>
-#include <mutex>
 
 namespace metalsharp {
 namespace win32 {
@@ -23,7 +23,7 @@ struct SSLSession {
 };
 
 class SecureTransport {
-public:
+  public:
     static SecureTransport& instance();
 
     void* createSSLSession(int socketFd);
@@ -34,7 +34,7 @@ public:
 
     void initialize();
 
-private:
+  private:
     SecureTransport() = default;
 
     mutable std::mutex m_mutex;
@@ -42,5 +42,5 @@ private:
     int m_nextHandle = 10000;
 };
 
-}
-}
+} // namespace win32
+} // namespace metalsharp

--- a/include/metalsharp/SettingsManager.h
+++ b/include/metalsharp/SettingsManager.h
@@ -9,8 +9,8 @@
 
 #pragma once
 
-#include <string>
 #include <cstdint>
+#include <string>
 #include <vector>
 
 namespace metalsharp {
@@ -53,7 +53,7 @@ struct SettingsState {
 };
 
 class SettingsManager {
-public:
+  public:
     static SettingsManager& instance();
 
     bool load(const std::string& path = "");
@@ -72,10 +72,10 @@ public:
     void clearPipelineCache();
     uint64_t shaderCacheSize();
 
-private:
+  private:
     SettingsManager() = default;
     SettingsState m_state;
     std::string m_path;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/ShaderCache.h
+++ b/include/metalsharp/ShaderCache.h
@@ -9,12 +9,12 @@
 
 #pragma once
 
+#include <cstdint>
 #include <metalsharp/Platform.h>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <cstdint>
-#include <mutex>
 
 namespace metalsharp {
 
@@ -30,7 +30,7 @@ struct CachedShader {
 };
 
 class ShaderCache {
-public:
+  public:
     static ShaderCache& instance();
 
     bool init(const std::string& cacheDir);
@@ -53,7 +53,7 @@ public:
     void setMaxCacheSize(uint64_t bytes) { m_maxCacheSize = bytes; }
     uint64_t maxCacheSize() const { return m_maxCacheSize; }
 
-private:
+  private:
     ShaderCache() = default;
     ~ShaderCache() = default;
 
@@ -74,4 +74,4 @@ private:
     std::mutex m_mutex;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/ShaderModelValidator.h
+++ b/include/metalsharp/ShaderModelValidator.h
@@ -9,56 +9,53 @@
 
 #pragma once
 
-#include <metalsharp/Logger.h>
 #include <cstdint>
+#include <metalsharp/Logger.h>
 
 namespace metalsharp {
 
 class ShaderModelValidator {
-public:
+  public:
     struct ValidationWarning {
         uint32_t smVersion;
         const char* message;
     };
 
-    static void validateComputeShader(
-        uint32_t smVersion,
-        uint32_t threadgroupSizeX,
-        uint32_t threadgroupSizeY,
-        uint32_t threadgroupSizeZ,
-        bool usesDerivatives,
-        bool usesQuadOps,
-        bool usesTextureSamples
-    ) {
-        if (smVersion < 66) return;
+    static void validateComputeShader(uint32_t smVersion, uint32_t threadgroupSizeX, uint32_t threadgroupSizeY,
+                                      uint32_t threadgroupSizeZ, bool usesDerivatives, bool usesQuadOps,
+                                      bool usesTextureSamples) {
+        if (smVersion < 66)
+            return;
 
         if (usesDerivatives && (threadgroupSizeY > 1 || threadgroupSizeZ > 1)) {
             MS_WARN("SM 6.6: Compute derivatives only supported with 1D threadgroup size "
-                     "(got %ux%ux%u) — may produce incorrect results",
-                     threadgroupSizeX, threadgroupSizeY, threadgroupSizeZ);
+                    "(got %ux%ux%u) — may produce incorrect results",
+                    threadgroupSizeX, threadgroupSizeY, threadgroupSizeZ);
         }
 
         if (usesQuadOps && (threadgroupSizeY > 1 || threadgroupSizeZ > 1)) {
             MS_WARN("SM 6.6: Compute quad ops only supported with 1D threadgroup size "
-                     "(got %ux%ux%u) — may produce incorrect results",
-                     threadgroupSizeX, threadgroupSizeY, threadgroupSizeZ);
+                    "(got %ux%ux%u) — may produce incorrect results",
+                    threadgroupSizeX, threadgroupSizeY, threadgroupSizeZ);
         }
 
         if (usesTextureSamples && (threadgroupSizeY > 1 || threadgroupSizeZ > 1)) {
             MS_WARN("SM 6.6: Compute texture samples only supported with 1D threadgroup size "
-                     "(got %ux%ux%u) — may produce incorrect results",
-                     threadgroupSizeX, threadgroupSizeY, threadgroupSizeZ);
+                    "(got %ux%ux%u) — may produce incorrect results",
+                    threadgroupSizeX, threadgroupSizeY, threadgroupSizeZ);
         }
     }
 
     static void validateWaveSize(uint32_t smVersion, uint32_t requestedWaveSize) {
-        if (smVersion < 66) return;
+        if (smVersion < 66)
+            return;
 
         if (requestedWaveSize != 32) {
             MS_WARN("SM 6.6: Wave size must be 32 on Apple GPU (requested %u) — "
-                     "behavior undefined with other sizes", requestedWaveSize);
+                    "behavior undefined with other sizes",
+                    requestedWaveSize);
         }
     }
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/ShaderTranslator.h
+++ b/include/metalsharp/ShaderTranslator.h
@@ -19,9 +19,9 @@
 
 #pragma once
 
+#include <metalsharp/IRConverterBridge.h>
 #include <metalsharp/Platform.h>
 #include <metalsharp/ShaderStage.h>
-#include <metalsharp/IRConverterBridge.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string>
@@ -38,7 +38,7 @@ struct CompiledShader {
 };
 
 class ShaderTranslator {
-public:
+  public:
     ShaderTranslator();
     ~ShaderTranslator();
 
@@ -46,27 +46,19 @@ public:
     bool translateDXIL(const uint8_t* data, size_t size, ShaderStage stage, CompiledShader& out);
     bool translateDXBC(const uint8_t* data, size_t size, ShaderStage stage, CompiledShader& out);
 
-    bool translateDXBCWithRootSignature(
-        const uint8_t* data, size_t size,
-        ShaderStage stage,
-        const void* rootSigData, size_t rootSigSize,
-        CompiledShader& out
-    );
+    bool translateDXBCWithRootSignature(const uint8_t* data, size_t size, ShaderStage stage, const void* rootSigData,
+                                        size_t rootSigSize, CompiledShader& out);
 
     ShaderTranslator(const ShaderTranslator&) = delete;
     ShaderTranslator& operator=(const ShaderTranslator&) = delete;
 
-private:
-    bool translateViaIRConverter(
-        const uint8_t* dxilData, size_t dxilSize,
-        ShaderStage stage, const char* entryPoint,
-        const void* rootSigData, size_t rootSigSize,
-        CompiledShader& out
-    );
+  private:
+    bool translateViaIRConverter(const uint8_t* dxilData, size_t dxilSize, ShaderStage stage, const char* entryPoint,
+                                 const void* rootSigData, size_t rootSigSize, CompiledShader& out);
     bool translateViaFallbackDXBC(const uint8_t* data, size_t size, ShaderStage stage, CompiledShader& out);
 
     struct Impl;
     Impl* m_impl;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/SyncContext.h
+++ b/include/metalsharp/SyncContext.h
@@ -9,25 +9,19 @@
 
 #pragma once
 
-#include <metalsharp/Win32Types.h>
+#include <atomic>
+#include <condition_variable>
 #include <cstdint>
+#include <metalsharp/Win32Types.h>
+#include <mutex>
+#include <pthread.h>
 #include <string>
 #include <unordered_map>
-#include <mutex>
-#include <atomic>
-#include <pthread.h>
-#include <condition_variable>
 
 namespace metalsharp {
 namespace win32 {
 
-enum class SyncHandleType : uint8_t {
-    Event,
-    Mutex,
-    Semaphore,
-    Thread,
-    Timer
-};
+enum class SyncHandleType : uint8_t { Event, Mutex, Semaphore, Thread, Timer };
 
 struct SyncEventState {
     pthread_mutex_t mutex;
@@ -65,7 +59,7 @@ struct SyncHandle {
 };
 
 class SyncContext {
-public:
+  public:
     static SyncContext& instance();
 
     void* createEvent(bool manualReset, bool initialState, const std::string& name);
@@ -88,7 +82,7 @@ public:
 
     void initialize();
 
-private:
+  private:
     SyncContext() = default;
 
     uint32_t waitForEvent(SyncEventState* evt, uint32_t ms);
@@ -102,5 +96,5 @@ private:
     int m_nextHandle = 10000;
 };
 
-}
-}
+} // namespace win32
+} // namespace metalsharp

--- a/include/metalsharp/UpdateChecker.h
+++ b/include/metalsharp/UpdateChecker.h
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include <string>
 #include <cstdint>
+#include <string>
 
 namespace metalsharp {
 
@@ -36,14 +36,14 @@ struct UpdateInfo {
 };
 
 class UpdateChecker {
-public:
+  public:
     static UpdateInfo checkForUpdates(const std::string& repo = "aaf2tbz/metalsharp");
     static Version getCurrentVersion();
     static std::string getUserAgent();
     static UpdateInfo parseGitHubRelease(const std::string& json, const Version& current);
 
-private:
+  private:
     static std::string fetchLatestRelease(const std::string& repo);
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/VirtualFileSystem.h
+++ b/include/metalsharp/VirtualFileSystem.h
@@ -9,26 +9,16 @@
 
 #pragma once
 
+#include <dirent.h>
 #include <metalsharp/Win32Types.h>
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <dirent.h>
 
 namespace metalsharp {
 namespace win32 {
 
-enum class HandleType : uint8_t {
-    File,
-    Find,
-    Event,
-    Mutex,
-    Semaphore,
-    Thread,
-    Pipe,
-    Socket,
-    Null
-};
+enum class HandleType : uint8_t { File, Find, Event, Mutex, Semaphore, Thread, Pipe, Socket, Null };
 
 struct FileState {
     int fd;
@@ -49,7 +39,7 @@ struct HandleEntry {
 };
 
 class VirtualFileSystem {
-public:
+  public:
     static VirtualFileSystem& instance();
 
     void setPrefix(const std::string& prefix);
@@ -61,8 +51,8 @@ public:
     HandleEntry* getHandle(HANDLE h);
     bool closeHandle(HANDLE h);
 
-    HANDLE createFile(const char* lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode,
-        DWORD dwCreationDisposition, DWORD dwFlagsAndAttributes);
+    HANDLE createFile(const char* lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode, DWORD dwCreationDisposition,
+                      DWORD dwFlagsAndAttributes);
     BOOL readFile(HANDLE hFile, void* lpBuffer, DWORD nNumberOfBytesToRead, DWORD* lpNumberOfBytesRead);
     BOOL writeFile(HANDLE hFile, const void* lpBuffer, DWORD nNumberOfBytesToWrite, DWORD* lpNumberOfBytesWritten);
     DWORD getFileSize(HANDLE hFile, DWORD* lpFileSizeHigh);
@@ -84,7 +74,7 @@ public:
 
     HANDLE registerPipeFd(int fd);
 
-private:
+  private:
     VirtualFileSystem();
 
     std::string m_prefix;
@@ -92,5 +82,5 @@ private:
     std::unordered_map<uintptr_t, HandleEntry> m_handles;
 };
 
-}
-}
+} // namespace win32
+} // namespace metalsharp

--- a/include/metalsharp/Win32Types.h
+++ b/include/metalsharp/Win32Types.h
@@ -10,8 +10,8 @@
 
 #pragma once
 
-#include <cstdint>
 #include <cstddef>
+#include <cstdint>
 
 #define MSABI __attribute__((ms_abi))
 
@@ -98,39 +98,39 @@ struct SYSTEM_INFO {
     WORD wProcessorRevision;
 };
 
-constexpr uint32_t MEM_COMMIT   = 0x1000;
-constexpr uint32_t MEM_RESERVE  = 0x2000;
-constexpr uint32_t MEM_RELEASE  = 0x8000;
+constexpr uint32_t MEM_COMMIT = 0x1000;
+constexpr uint32_t MEM_RESERVE = 0x2000;
+constexpr uint32_t MEM_RELEASE = 0x8000;
 constexpr uint32_t MEM_DECOMMIT = 0x4000;
 
-constexpr uint32_t PAGE_NOACCESS    = 0x01;
-constexpr uint32_t PAGE_READONLY    = 0x02;
-constexpr uint32_t PAGE_READWRITE   = 0x04;
-constexpr uint32_t PAGE_EXECUTE     = 0x10;
+constexpr uint32_t PAGE_NOACCESS = 0x01;
+constexpr uint32_t PAGE_READONLY = 0x02;
+constexpr uint32_t PAGE_READWRITE = 0x04;
+constexpr uint32_t PAGE_EXECUTE = 0x10;
 constexpr uint32_t PAGE_EXECUTE_READ = 0x20;
 constexpr uint32_t PAGE_EXECUTE_READWRITE = 0x40;
 
-constexpr uint32_t GENERIC_READ    = 0x80000000;
-constexpr uint32_t GENERIC_WRITE   = 0x40000000;
+constexpr uint32_t GENERIC_READ = 0x80000000;
+constexpr uint32_t GENERIC_WRITE = 0x40000000;
 constexpr uint32_t FILE_SHARE_READ = 0x00000001;
 
-constexpr uint32_t CREATE_NEW        = 1;
-constexpr uint32_t CREATE_ALWAYS     = 2;
-constexpr uint32_t OPEN_EXISTING     = 3;
-constexpr uint32_t OPEN_ALWAYS       = 4;
+constexpr uint32_t CREATE_NEW = 1;
+constexpr uint32_t CREATE_ALWAYS = 2;
+constexpr uint32_t OPEN_EXISTING = 3;
+constexpr uint32_t OPEN_ALWAYS = 4;
 constexpr uint32_t TRUNCATE_EXISTING = 5;
 
 constexpr uint32_t FILE_ATTRIBUTE_NORMAL = 0x80;
 
-constexpr uint32_t STD_INPUT_HANDLE  = 0xFFFFFFF6;
+constexpr uint32_t STD_INPUT_HANDLE = 0xFFFFFFF6;
 constexpr uint32_t STD_OUTPUT_HANDLE = 0xFFFFFFF5;
-constexpr uint32_t STD_ERROR_HANDLE  = 0xFFFFFFF4;
+constexpr uint32_t STD_ERROR_HANDLE = 0xFFFFFFF4;
 
 constexpr uint32_t INFINITE = 0xFFFFFFFF;
 
 constexpr uint32_t WAIT_OBJECT_0 = 0;
-constexpr uint32_t WAIT_TIMEOUT  = 258;
-constexpr uint32_t WAIT_FAILED   = 0xFFFFFFFF;
+constexpr uint32_t WAIT_TIMEOUT = 258;
+constexpr uint32_t WAIT_FAILED = 0xFFFFFFFF;
 
-}
-}
+} // namespace win32
+} // namespace metalsharp

--- a/include/metalsharp/WindowManager.h
+++ b/include/metalsharp/WindowManager.h
@@ -10,12 +10,12 @@
 
 #pragma once
 
+#include <functional>
 #include <metalsharp/Win32Types.h>
+#include <mutex>
+#include <queue>
 #include <string>
 #include <unordered_map>
-#include <queue>
-#include <functional>
-#include <mutex>
 
 namespace metalsharp {
 namespace win32 {
@@ -55,7 +55,7 @@ struct MSG {
     POINT pt;
 };
 
-typedef intptr_t (MSABI *WNDPROC)(HANDLE, UINT, uintptr_t, intptr_t);
+typedef intptr_t(MSABI* WNDPROC)(HANDLE, UINT, uintptr_t, intptr_t);
 
 struct WNDCLASS_STORE {
     std::string className;
@@ -65,14 +65,14 @@ struct WNDCLASS_STORE {
 };
 
 class WindowManager {
-public:
+  public:
     static WindowManager& instance();
 
     void init();
 
-    HANDLE createWindow(DWORD dwExStyle, const wchar_t* lpClassName, const wchar_t* lpWindowName,
-        DWORD dwStyle, int x, int y, int nWidth, int nHeight,
-        HANDLE hWndParent, HANDLE hMenu, HANDLE hInstance, void* lpParam);
+    HANDLE createWindow(DWORD dwExStyle, const wchar_t* lpClassName, const wchar_t* lpWindowName, DWORD dwStyle, int x,
+                        int y, int nWidth, int nHeight, HANDLE hWndParent, HANDLE hMenu, HANDLE hInstance,
+                        void* lpParam);
 
     WORD registerClass(const void* lpwcx);
     BOOL destroyWindow(HANDLE hWnd);
@@ -97,7 +97,7 @@ public:
 
     void* getNSWindow(HANDLE hWnd);
 
-private:
+  private:
     WindowManager();
 
     std::unordered_map<std::string, WNDCLASS_STORE> m_classes;
@@ -114,5 +114,5 @@ private:
     std::mutex m_mutex;
 };
 
-}
-}
+} // namespace win32
+} // namespace metalsharp

--- a/include/metalsharp/X3DAudioEngine.h
+++ b/include/metalsharp/X3DAudioEngine.h
@@ -9,8 +9,8 @@
 
 #pragma once
 
-#include <metalsharp/Platform.h>
 #include <cstdint>
+#include <metalsharp/Platform.h>
 
 namespace metalsharp {
 
@@ -55,17 +55,14 @@ struct Audio3DOutput {
 };
 
 class X3DAudioEngine {
-public:
+  public:
     static X3DAudioEngine& instance();
 
     void init(uint32_t speakerChannelMask);
     void shutdown();
 
-    void calculate(const Audio3DListener& listener,
-                   const Audio3DEmitter& emitter,
-                   uint32_t flags,
-                   uint32_t dstChannelCount,
-                   Audio3DOutput& output);
+    void calculate(const Audio3DListener& listener, const Audio3DEmitter& emitter, uint32_t flags,
+                   uint32_t dstChannelCount, Audio3DOutput& output);
 
     void setDistanceCurve(float nearDist, float farDist, float rolloff);
     void setDopplerFactor(float factor);
@@ -74,7 +71,7 @@ public:
     float computeDistanceAttenuation(float distance);
     float computeDoppler(const Audio3DListener& listener, const Audio3DEmitter& emitter);
 
-private:
+  private:
     X3DAudioEngine() = default;
 
     bool m_initialized = false;
@@ -86,4 +83,4 @@ private:
     float m_speedOfSound = 343.0f;
 };
 
-}
+} // namespace metalsharp

--- a/include/metalsharp/XAudio2Engine.h
+++ b/include/metalsharp/XAudio2Engine.h
@@ -8,13 +8,13 @@
 
 #pragma once
 
-#include <metalsharp/Platform.h>
 #include <metalsharp/CoreAudioBackend.h>
+#include <metalsharp/Platform.h>
 
 namespace metalsharp {
 
 class XAudio2Engine {
-public:
+  public:
     XAudio2Engine();
     ~XAudio2Engine();
 
@@ -25,9 +25,9 @@ public:
     HRESULT stop(void* pVoice);
     HRESULT setVolume(void* pVoice, float volume);
 
-private:
+  private:
     CoreAudioBackend m_backend;
     bool m_initialized = false;
 };
 
-}
+} // namespace metalsharp

--- a/src/audio/CoreAudioBackend.cpp
+++ b/src/audio/CoreAudioBackend.cpp
@@ -1,9 +1,8 @@
 /// @file CoreAudioBackend.cpp
 /// @brief CoreAudio backend stub (platform-agnostic declarations).
 ///
-/// Empty platform-agnostic implementation file for the CoreAudio backend interface. Actual AudioUnit rendering logic lives in the .mm counterpart.
+/// Empty platform-agnostic implementation file for the CoreAudio backend interface. Actual AudioUnit rendering logic
+/// lives in the .mm counterpart.
 #include <metalsharp/CoreAudioBackend.h>
 
-namespace metalsharp {
-
-}
+namespace metalsharp {}

--- a/src/audio/CoreAudioBackend.mm
+++ b/src/audio/CoreAudioBackend.mm
@@ -1,15 +1,16 @@
 /// @file CoreAudioBackend.mm
 /// @brief CoreAudio AudioUnit rendering backend for XAudio2.
 ///
-/// Creates and manages an AUAudioUnit (or AudioUnit) render pipeline that accepts PCM float/int16 buffers from XAudio2 voices. Handles sample rate conversion, channel mapping, and ring buffer management for real-time audio output.
-#include <metalsharp/CoreAudioBackend.h>
-#include <metalsharp/Logger.h>
-#include <deque>
-#include <mutex>
-#include <vector>
-#include <cstring>
+/// Creates and manages an AUAudioUnit (or AudioUnit) render pipeline that accepts PCM float/int16 buffers from XAudio2
+/// voices. Handles sample rate conversion, channel mapping, and ring buffer management for real-time audio output.
 #import <AudioUnit/AudioUnit.h>
 #import <AVFoundation/AVFoundation.h>
+#include <cstring>
+#include <deque>
+#include <metalsharp/CoreAudioBackend.h>
+#include <metalsharp/Logger.h>
+#include <mutex>
+#include <vector>
 
 namespace metalsharp {
 
@@ -31,12 +32,9 @@ struct CoreAudioBackend::Impl {
     mutable std::mutex bufferMutex;
 };
 
-static OSStatus audioRenderCallback(void* inRefCon,
-                                      AudioUnitRenderActionFlags* ioActionFlags,
-                                      const AudioTimeStamp* inTimeStamp,
-                                      UInt32 inBusNumber,
-                                      UInt32 inNumberFrames,
-                                      AudioBufferList* ioData) {
+static OSStatus audioRenderCallback(void* inRefCon, AudioUnitRenderActionFlags* ioActionFlags,
+                                    const AudioTimeStamp* inTimeStamp, UInt32 inBusNumber, UInt32 inNumberFrames,
+                                    AudioBufferList* ioData) {
     auto* impl = static_cast<CoreAudioBackend::Impl*>(inRefCon);
 
     if (!impl->playing || !ioData) {
@@ -90,7 +88,10 @@ static OSStatus audioRenderCallback(void* inRefCon,
 }
 
 CoreAudioBackend::CoreAudioBackend() : m_impl(new Impl()) {}
-CoreAudioBackend::~CoreAudioBackend() { shutdown(); delete m_impl; }
+CoreAudioBackend::~CoreAudioBackend() {
+    shutdown();
+    delete m_impl;
+}
 
 bool CoreAudioBackend::init() {
     m_impl->active = true;
@@ -138,12 +139,8 @@ bool CoreAudioBackend::init() {
     asbd.mChannelsPerFrame = 2;
     asbd.mBitsPerChannel = 16;
 
-    status = AudioUnitSetProperty(audioUnit,
-                                   kAudioUnitProperty_StreamFormat,
-                                   kAudioUnitScope_Input,
-                                   0,
-                                   &asbd,
-                                   sizeof(asbd));
+    status =
+        AudioUnitSetProperty(audioUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &asbd, sizeof(asbd));
     if (status != noErr) {
         MS_WARN("CoreAudioBackend: failed to set stream format (%d)", (int)status);
     }
@@ -152,12 +149,8 @@ bool CoreAudioBackend::init() {
     callback.inputProc = audioRenderCallback;
     callback.inputProcRefCon = m_impl;
 
-    status = AudioUnitSetProperty(audioUnit,
-                                   kAudioUnitProperty_SetRenderCallback,
-                                   kAudioUnitScope_Input,
-                                   0,
-                                   &callback,
-                                   sizeof(callback));
+    status = AudioUnitSetProperty(audioUnit, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Input, 0, &callback,
+                                  sizeof(callback));
     if (status != noErr) {
         MS_WARN("CoreAudioBackend: failed to set render callback (%d)", (int)status);
     }
@@ -172,7 +165,8 @@ bool CoreAudioBackend::init() {
 }
 
 void CoreAudioBackend::shutdown() {
-    if (m_impl->playing) stop();
+    if (m_impl->playing)
+        stop();
 
     if (m_impl->audioUnit) {
         AudioOutputUnitStop(m_impl->audioUnit);
@@ -185,22 +179,25 @@ void CoreAudioBackend::shutdown() {
     m_impl->bufferQueue.clear();
 }
 
-bool CoreAudioBackend::isActive() const { return m_impl->active; }
+bool CoreAudioBackend::isActive() const {
+    return m_impl->active;
+}
 
 bool CoreAudioBackend::submitBuffer(const void* data, uint32_t size, const XAudio2WaveFormat& format) {
-    if (!data || size == 0) return false;
+    if (!data || size == 0)
+        return false;
 
     std::lock_guard<std::mutex> lock(m_impl->bufferMutex);
     m_impl->format = format;
 
-    m_impl->bytesPerSample = format.bitsPerSample == 8 ? 1 :
-                              format.bitsPerSample == 16 ? 2 :
-                              format.bitsPerSample == 24 ? 3 :
-                              format.bitsPerSample == 32 ? 4 : 2;
+    m_impl->bytesPerSample = format.bitsPerSample == 8    ? 1
+                             : format.bitsPerSample == 16 ? 2
+                             : format.bitsPerSample == 24 ? 3
+                             : format.bitsPerSample == 32 ? 4
+                                                          : 2;
 
     AudioBufferEntry buf;
-    buf.data.assign(static_cast<const uint8_t*>(data),
-                    static_cast<const uint8_t*>(data) + size);
+    buf.data.assign(static_cast<const uint8_t*>(data), static_cast<const uint8_t*>(data) + size);
     buf.readPos = 0;
     buf.loopCount = 0;
     m_impl->bufferQueue.push_back(std::move(buf));
@@ -210,16 +207,13 @@ bool CoreAudioBackend::submitBuffer(const void* data, uint32_t size, const XAudi
 void CoreAudioBackend::setVolume(float v) {
     m_impl->volume = v < 0 ? 0 : (v > 1 ? 1 : v);
     if (m_impl->audioUnit) {
-        AudioUnitSetParameter(m_impl->audioUnit,
-                              kHALOutputParam_Volume,
-                              kAudioUnitScope_Output,
-                              0,
-                              m_impl->volume,
-                              0);
+        AudioUnitSetParameter(m_impl->audioUnit, kHALOutputParam_Volume, kAudioUnitScope_Output, 0, m_impl->volume, 0);
     }
 }
 
-float CoreAudioBackend::volume() const { return m_impl->volume; }
+float CoreAudioBackend::volume() const {
+    return m_impl->volume;
+}
 
 void CoreAudioBackend::play() {
     m_impl->playing = true;
@@ -246,7 +240,9 @@ void CoreAudioBackend::setFrequencyRatio(float ratio) {
     m_impl->frequencyRatio = ratio < 0.0f ? 0.0f : ratio;
 }
 
-float CoreAudioBackend::frequencyRatio() const { return m_impl->frequencyRatio; }
+float CoreAudioBackend::frequencyRatio() const {
+    return m_impl->frequencyRatio;
+}
 
 uint32_t CoreAudioBackend::queuedBufferCount() const {
     std::lock_guard<std::mutex> lock(m_impl->bufferMutex);
@@ -258,4 +254,4 @@ void CoreAudioBackend::flushBuffers() {
     m_impl->bufferQueue.clear();
 }
 
-}
+} // namespace metalsharp

--- a/src/audio/DirectSoundBackend.cpp
+++ b/src/audio/DirectSoundBackend.cpp
@@ -1,11 +1,12 @@
 /// @file DirectSoundBackend.cpp
 /// @brief DirectSound buffer emulation via CoreAudio ring buffer.
 ///
-/// Implements IDirectSound and IDirectSoundBuffer COM interfaces by writing captured audio into the same CoreAudio ring buffer used by XAudio2. Supports primary/secondary buffer semantics and write cursor tracking.
+/// Implements IDirectSound and IDirectSoundBuffer COM interfaces by writing captured audio into the same CoreAudio ring
+/// buffer used by XAudio2. Supports primary/secondary buffer semantics and write cursor tracking.
+#include <algorithm>
+#include <cstring>
 #include <metalsharp/DirectSoundBackend.h>
 #include <metalsharp/Logger.h>
-#include <cstring>
-#include <algorithm>
 
 namespace metalsharp {
 
@@ -36,13 +37,14 @@ void* DirectSoundBackend::createBuffer(uint32_t size, const WAVEFORMAT& format) 
     buf->playing = false;
     buf->writeCursor = 0;
     m_buffers.push_back(buf);
-    MS_TRACE("DirectSoundBackend: buffer created (%u bytes, %u Hz, %u-bit, %u ch)",
-             size, format.nSamplesPerSec, format.wBitsPerSample, format.nChannels);
+    MS_TRACE("DirectSoundBackend: buffer created (%u bytes, %u Hz, %u-bit, %u ch)", size, format.nSamplesPerSec,
+             format.wBitsPerSample, format.nChannels);
     return buf;
 }
 
 void DirectSoundBackend::destroyBuffer(void* buffer) {
-    if (!buffer) return;
+    if (!buffer)
+        return;
     auto* buf = static_cast<DSBuffer*>(buffer);
     auto it = std::find(m_buffers.begin(), m_buffers.end(), buf);
     if (it != m_buffers.end()) {
@@ -52,36 +54,42 @@ void DirectSoundBackend::destroyBuffer(void* buffer) {
 }
 
 bool DirectSoundBackend::writeBuffer(void* buffer, const void* data, uint32_t offset, uint32_t size) {
-    if (!buffer || !data) return false;
+    if (!buffer || !data)
+        return false;
     auto* buf = static_cast<DSBuffer*>(buffer);
-    if (offset + size > buf->data.size()) return false;
+    if (offset + size > buf->data.size())
+        return false;
     memcpy(buf->data.data() + offset, data, size);
     return true;
 }
 
 bool DirectSoundBackend::playBuffer(void* buffer, uint32_t flags) {
-    if (!buffer) return false;
+    if (!buffer)
+        return false;
     auto* buf = static_cast<DSBuffer*>(buffer);
     buf->playing = true;
     return true;
 }
 
 bool DirectSoundBackend::stopBuffer(void* buffer) {
-    if (!buffer) return false;
+    if (!buffer)
+        return false;
     auto* buf = static_cast<DSBuffer*>(buffer);
     buf->playing = false;
     return true;
 }
 
 bool DirectSoundBackend::setVolume(void* buffer, float volume) {
-    if (!buffer) return false;
+    if (!buffer)
+        return false;
     static_cast<DSBuffer*>(buffer)->volume = volume;
     return true;
 }
 
 float DirectSoundBackend::getVolume(void* buffer) const {
-    if (!buffer) return 0;
+    if (!buffer)
+        return 0;
     return static_cast<DSBuffer*>(buffer)->volume;
 }
 
-}
+} // namespace metalsharp

--- a/src/audio/EntryPoint.cpp
+++ b/src/audio/EntryPoint.cpp
@@ -1,7 +1,8 @@
 /// @file EntryPoint.cpp
 /// @brief XAudio2 DLL entry point with COM class factory exports.
 ///
-/// Exports DllGetClassObject and DllCanUnloadNow so the PE loader can instantiate XAudio2 COM objects. Acts as the xaudio2_9.dll entry point that games load.
+/// Exports DllGetClassObject and DllCanUnloadNow so the PE loader can instantiate XAudio2 COM objects. Acts as the
+/// xaudio2_9.dll entry point that games load.
 #include <metalsharp/XAudio2Engine.h>
 
 using namespace metalsharp;
@@ -11,13 +12,16 @@ extern "C" {
 static XAudio2Engine* g_engine = nullptr;
 
 HRESULT XAudio2Create(void** ppXAudio2, UINT Flags, UINT XAudio2Processor) {
-    if (!ppXAudio2) return E_POINTER;
+    if (!ppXAudio2)
+        return E_POINTER;
     auto* engine = new XAudio2Engine();
     HRESULT hr = engine->init();
-    if (FAILED(hr)) { delete engine; return hr; }
+    if (FAILED(hr)) {
+        delete engine;
+        return hr;
+    }
     *ppXAudio2 = engine;
     g_engine = engine;
     return S_OK;
 }
-
 }

--- a/src/audio/X3DAudioEngine.cpp
+++ b/src/audio/X3DAudioEngine.cpp
@@ -1,11 +1,12 @@
 /// @file X3DAudioEngine.cpp
 /// @brief X3DAudio spatial audio calculations.
 ///
-/// Implements X3DAudioCalculate for 3D positional audio: distance attenuation, Doppler pitch shift, panning, and LF/RF matrix calculations. Used by games to place sound sources in 3D space relative to the listener.
-#include <metalsharp/X3DAudioEngine.h>
-#include <metalsharp/Logger.h>
+/// Implements X3DAudioCalculate for 3D positional audio: distance attenuation, Doppler pitch shift, panning, and LF/RF
+/// matrix calculations. Used by games to place sound sources in 3D space relative to the listener.
 #include <cmath>
 #include <cstring>
+#include <metalsharp/Logger.h>
+#include <metalsharp/X3DAudioEngine.h>
 
 namespace metalsharp {
 
@@ -34,7 +35,8 @@ static float length(const Audio3DVector& v) {
 
 static Audio3DVector normalize(const Audio3DVector& v) {
     float len = length(v);
-    if (len < 1e-6f) return {0, 0, 0};
+    if (len < 1e-6f)
+        return {0, 0, 0};
     return {v.x / len, v.y / len, v.z / len};
 }
 
@@ -44,17 +46,17 @@ static Audio3DVector sub(const Audio3DVector& a, const Audio3DVector& b) {
 
 float X3DAudioEngine::computePan(const Audio3DListener& listener, const Audio3DEmitter& emitter) {
     auto dir = normalize(sub(emitter.position, listener.position));
-    auto right = Audio3DVector{
-        listener.front.y * listener.top.z - listener.front.z * listener.top.y,
-        listener.front.z * listener.top.x - listener.front.x * listener.top.z,
-        listener.front.x * listener.top.y - listener.front.y * listener.top.x
-    };
+    auto right = Audio3DVector{listener.front.y * listener.top.z - listener.front.z * listener.top.y,
+                               listener.front.z * listener.top.x - listener.front.x * listener.top.z,
+                               listener.front.x * listener.top.y - listener.front.y * listener.top.x};
     return dot(dir, right);
 }
 
 float X3DAudioEngine::computeDistanceAttenuation(float distance) {
-    if (distance <= m_nearDistance) return 1.0f;
-    if (distance >= m_farDistance) return 0.0f;
+    if (distance <= m_nearDistance)
+        return 1.0f;
+    if (distance >= m_farDistance)
+        return 0.0f;
 
     float ratio = (m_farDistance - distance) / (m_farDistance - m_nearDistance);
     return std::pow(ratio, m_rolloffFactor);
@@ -63,7 +65,8 @@ float X3DAudioEngine::computeDistanceAttenuation(float distance) {
 float X3DAudioEngine::computeDoppler(const Audio3DListener& listener, const Audio3DEmitter& emitter) {
     auto toListener = sub(listener.position, emitter.position);
     float dist = length(toListener);
-    if (dist < 1e-6f) return 1.0f;
+    if (dist < 1e-6f)
+        return 1.0f;
 
     auto normDir = normalize(toListener);
     float emitterVel = dot(emitter.velocity, normDir);
@@ -72,16 +75,15 @@ float X3DAudioEngine::computeDoppler(const Audio3DListener& listener, const Audi
     float denom = m_speedOfSound - listenerVel * m_dopplerFactor;
     float numer = m_speedOfSound - emitterVel * m_dopplerFactor;
 
-    if (denom < 1e-6f) denom = 1e-6f;
+    if (denom < 1e-6f)
+        denom = 1e-6f;
     return numer / denom;
 }
 
-void X3DAudioEngine::calculate(const Audio3DListener& listener,
-                                const Audio3DEmitter& emitter,
-                                uint32_t flags,
-                                uint32_t dstChannelCount,
-                                Audio3DOutput& output) {
-    if (!m_initialized) return;
+void X3DAudioEngine::calculate(const Audio3DListener& listener, const Audio3DEmitter& emitter, uint32_t flags,
+                               uint32_t dstChannelCount, Audio3DOutput& output) {
+    if (!m_initialized)
+        return;
 
     memset(&output, 0, sizeof(Audio3DOutput));
 
@@ -121,4 +123,4 @@ void X3DAudioEngine::setDopplerFactor(float factor) {
     m_dopplerFactor = factor;
 }
 
-}
+} // namespace metalsharp

--- a/src/audio/XAudio2Buffer.cpp
+++ b/src/audio/XAudio2Buffer.cpp
@@ -4,5 +4,4 @@
 /// Placeholder for XAUDIO2_BUFFER allocation, recycling, and format conversion. Buffer pool logic will be added here.
 #include <metalsharp/Platform.h>
 
-namespace metalsharp {
-}
+namespace metalsharp {}

--- a/src/audio/XAudio2Engine.cpp
+++ b/src/audio/XAudio2Engine.cpp
@@ -1,11 +1,12 @@
 /// @file XAudio2Engine.cpp
 /// @brief XAudio2 engine implementation delegating to CoreAudio backend.
 ///
-/// Implements IXAudio2 engine initialization, voice creation, and mastering voice setup. Translates XAudio2 API calls to the CoreAudio backend's AudioUnit pipeline. Manages the XAudio2 processing graph lifecycle.
-#include <metalsharp/XAudio2Engine.h>
+/// Implements IXAudio2 engine initialization, voice creation, and mastering voice setup. Translates XAudio2 API calls
+/// to the CoreAudio backend's AudioUnit pipeline. Manages the XAudio2 processing graph lifecycle.
+#include <cstring>
 #include <metalsharp/CoreAudioBackend.h>
 #include <metalsharp/Logger.h>
-#include <cstring>
+#include <metalsharp/XAudio2Engine.h>
 
 namespace metalsharp {
 
@@ -31,28 +32,34 @@ struct MasteringVoice {
 };
 
 XAudio2Engine::XAudio2Engine() {}
-XAudio2Engine::~XAudio2Engine() { m_backend.shutdown(); }
+XAudio2Engine::~XAudio2Engine() {
+    m_backend.shutdown();
+}
 
 HRESULT XAudio2Engine::init() {
-    if (m_initialized) return S_OK;
-    if (!m_backend.init()) return E_FAIL;
+    if (m_initialized)
+        return S_OK;
+    if (!m_backend.init())
+        return E_FAIL;
     m_initialized = true;
     MS_INFO("XAudio2Engine initialized");
     return S_OK;
 }
 
 HRESULT XAudio2Engine::createSourceVoice(void** ppVoice, const XAudio2WaveFormat* pFormat) {
-    if (!ppVoice || !pFormat) return E_POINTER;
+    if (!ppVoice || !pFormat)
+        return E_POINTER;
     auto* voice = new SourceVoice();
     voice->format = *pFormat;
     *ppVoice = voice;
-    MS_TRACE("XAudio2Engine: source voice created (%u Hz, %u-bit, %u ch)",
-             pFormat->samplesPerSec, pFormat->bitsPerSample, pFormat->channels);
+    MS_TRACE("XAudio2Engine: source voice created (%u Hz, %u-bit, %u ch)", pFormat->samplesPerSec,
+             pFormat->bitsPerSample, pFormat->channels);
     return S_OK;
 }
 
 HRESULT XAudio2Engine::submitSourceBuffer(void* pVoice, const void* pBufferDesc) {
-    if (!pVoice) return E_POINTER;
+    if (!pVoice)
+        return E_POINTER;
     auto* voice = static_cast<SourceVoice*>(pVoice);
 
     struct XAudio2Buffer {
@@ -80,24 +87,27 @@ HRESULT XAudio2Engine::submitSourceBuffer(void* pVoice, const void* pBufferDesc)
 }
 
 HRESULT XAudio2Engine::start(void* pVoice) {
-    if (!pVoice) return E_POINTER;
+    if (!pVoice)
+        return E_POINTER;
     static_cast<SourceVoice*>(pVoice)->playing = true;
     m_backend.play();
     return S_OK;
 }
 
 HRESULT XAudio2Engine::stop(void* pVoice) {
-    if (!pVoice) return E_POINTER;
+    if (!pVoice)
+        return E_POINTER;
     static_cast<SourceVoice*>(pVoice)->playing = false;
     m_backend.stop();
     return S_OK;
 }
 
 HRESULT XAudio2Engine::setVolume(void* pVoice, float volume) {
-    if (!pVoice) return E_POINTER;
+    if (!pVoice)
+        return E_POINTER;
     static_cast<SourceVoice*>(pVoice)->volume = volume;
     m_backend.setVolume(volume);
     return S_OK;
 }
 
-}
+} // namespace metalsharp

--- a/src/audio/XAudio2Voice.cpp
+++ b/src/audio/XAudio2Voice.cpp
@@ -1,8 +1,8 @@
 /// @file XAudio2Voice.cpp
 /// @brief XAudio2 voice stubs (placeholder implementation).
 ///
-/// Placeholder for IXAudio2SourceVoice and IXAudio2SubmixVoice implementations. Voice submit-buffer and processing logic will be added here.
+/// Placeholder for IXAudio2SourceVoice and IXAudio2SubmixVoice implementations. Voice submit-buffer and processing
+/// logic will be added here.
 #include <metalsharp/Platform.h>
 
-namespace metalsharp {
-}
+namespace metalsharp {}

--- a/src/d3d/d3d11/D3D11BlendState.cpp
+++ b/src/d3d/d3d11/D3D11BlendState.cpp
@@ -6,6 +6,4 @@
 
 #include <metalsharp/Platform.h>
 
-namespace metalsharp {
-
-}
+namespace metalsharp {}

--- a/src/d3d/d3d11/D3D11Buffer.cpp
+++ b/src/d3d/d3d11/D3D11Buffer.cpp
@@ -6,6 +6,4 @@
 
 #include <metalsharp/Platform.h>
 
-namespace metalsharp {
-
-}
+namespace metalsharp {}

--- a/src/d3d/d3d11/D3D11ComputeShader.cpp
+++ b/src/d3d/d3d11/D3D11ComputeShader.cpp
@@ -6,6 +6,4 @@
 
 #include <metalsharp/Platform.h>
 
-namespace metalsharp {
-
-}
+namespace metalsharp {}

--- a/src/d3d/d3d11/D3D11DepthStencilState.cpp
+++ b/src/d3d/d3d11/D3D11DepthStencilState.cpp
@@ -6,6 +6,4 @@
 
 #include <metalsharp/Platform.h>
 
-namespace metalsharp {
-
-}
+namespace metalsharp {}

--- a/src/d3d/d3d11/D3D11DepthStencilView.cpp
+++ b/src/d3d/d3d11/D3D11DepthStencilView.cpp
@@ -6,6 +6,4 @@
 
 #include <metalsharp/Platform.h>
 
-namespace metalsharp {
-
-}
+namespace metalsharp {}

--- a/src/d3d/d3d11/D3D11Device.cpp
+++ b/src/d3d/d3d11/D3D11Device.cpp
@@ -4,31 +4,50 @@
 /// The central ID3D11Device COM class. Handles creation of buffers, textures, shaders,
 /// views, and all pipeline state objects, delegating to the Metal backend.
 
+#include <cstring>
 #include <metalsharp/D3D11Device.h>
 #include <metalsharp/D3D11DeviceContext.h>
 #include <metalsharp/DeferredContext.h>
 #include <metalsharp/FormatTranslation.h>
 #include <metalsharp/PipelineState.h>
-#include <cstring>
 #include <vector>
 
 namespace metalsharp {
 
-#define MS_COM_BODY() \
-    ULONG refCount = 1; \
-    HRESULT QueryInterface(REFIID riid, void** ppv) override { \
-        if (!ppv) return E_POINTER; \
-        AddRef(); *ppv = this; return S_OK; \
-    } \
-    ULONG AddRef() override { return ++refCount; } \
-    ULONG Release() override { ULONG c = --refCount; if (c == 0) delete this; return c; } \
-    STDMETHOD(GetDevice)(ID3D11Device**) override { return E_NOTIMPL; } \
-    STDMETHOD(GetPrivateData)(const GUID&, UINT*, void*) override { return E_NOTIMPL; } \
-    STDMETHOD(SetPrivateData)(const GUID&, UINT, const void*) override { return E_NOTIMPL; } \
-    STDMETHOD(SetPrivateDataInterface)(const GUID&, const IUnknown*) override { return E_NOTIMPL; }
+#define MS_COM_BODY()                                                                                                  \
+    ULONG refCount = 1;                                                                                                \
+    HRESULT QueryInterface(REFIID riid, void** ppv) override {                                                         \
+        if (!ppv)                                                                                                      \
+            return E_POINTER;                                                                                          \
+        AddRef();                                                                                                      \
+        *ppv = this;                                                                                                   \
+        return S_OK;                                                                                                   \
+    }                                                                                                                  \
+    ULONG AddRef() override {                                                                                          \
+        return ++refCount;                                                                                             \
+    }                                                                                                                  \
+    ULONG Release() override {                                                                                         \
+        ULONG c = --refCount;                                                                                          \
+        if (c == 0)                                                                                                    \
+            delete this;                                                                                               \
+        return c;                                                                                                      \
+    }                                                                                                                  \
+    STDMETHOD(GetDevice)(ID3D11Device**) override {                                                                    \
+        return E_NOTIMPL;                                                                                              \
+    }                                                                                                                  \
+    STDMETHOD(GetPrivateData)(const GUID&, UINT*, void*) override {                                                    \
+        return E_NOTIMPL;                                                                                              \
+    }                                                                                                                  \
+    STDMETHOD(SetPrivateData)(const GUID&, UINT, const void*) override {                                               \
+        return E_NOTIMPL;                                                                                              \
+    }                                                                                                                  \
+    STDMETHOD(SetPrivateDataInterface)(const GUID&, const IUnknown*) override {                                        \
+        return E_NOTIMPL;                                                                                              \
+    }
 
 HRESULT D3D11Device::create(D3D11Device** ppDevice) {
-    if (!ppDevice) return E_POINTER;
+    if (!ppDevice)
+        return E_POINTER;
     auto* device = new D3D11Device();
     device->m_metalDevice = std::unique_ptr<MetalDevice>(MetalDevice::create());
     if (!device->m_metalDevice) {
@@ -45,7 +64,8 @@ D3D11Device::D3D11Device() = default;
 D3D11Device::~D3D11Device() = default;
 
 HRESULT D3D11Device::QueryInterface(REFIID riid, void** ppvObject) {
-    if (!ppvObject) return E_POINTER;
+    if (!ppvObject)
+        return E_POINTER;
     if (riid == __uuidof(IUnknown) || riid == __uuidof(ID3D11Device)) {
         AddRef();
         *ppvObject = this;
@@ -54,23 +74,33 @@ HRESULT D3D11Device::QueryInterface(REFIID riid, void** ppvObject) {
     return E_NOINTERFACE;
 }
 
-ULONG D3D11Device::AddRef() { return ++m_refCount; }
+ULONG D3D11Device::AddRef() {
+    return ++m_refCount;
+}
 
 ULONG D3D11Device::Release() {
     ULONG count = --m_refCount;
-    if (count == 0) delete this;
+    if (count == 0)
+        delete this;
     return count;
 }
 
-HRESULT D3D11Device::CreateBuffer(const D3D11_BUFFER_DESC* pDesc, const D3D11_SUBRESOURCE_DATA* pInitialData, ID3D11Buffer** ppBuffer) {
-    if (!pDesc || !ppBuffer) return E_INVALIDARG;
+HRESULT D3D11Device::CreateBuffer(const D3D11_BUFFER_DESC* pDesc, const D3D11_SUBRESOURCE_DATA* pInitialData,
+                                  ID3D11Buffer** ppBuffer) {
+    if (!pDesc || !ppBuffer)
+        return E_INVALIDARG;
     size_t size = pDesc->ByteWidth;
     MetalBuffer* metalBuf = MetalBuffer::create(*m_metalDevice, size, pInitialData ? pInitialData->pSysMem : nullptr);
-    if (!metalBuf) return E_OUTOFMEMORY;
+    if (!metalBuf)
+        return E_OUTOFMEMORY;
 
     struct Impl : public ID3D11Buffer {
         MS_COM_BODY()
-        STDMETHOD(GetType)(UINT* p) override { if(p) *p = D3D11_RESOURCE_DIMENSION_BUFFER; return S_OK; }
+        STDMETHOD(GetType)(UINT* p) override {
+            if (p)
+                *p = D3D11_RESOURCE_DIMENSION_BUFFER;
+            return S_OK;
+        }
         STDMETHOD(SetEvictionPriority)(UINT) override { return S_OK; }
         STDMETHOD_(UINT, GetEvictionPriority)() override { return 0; }
         std::unique_ptr<MetalBuffer> metalBuffer;
@@ -88,22 +118,31 @@ HRESULT D3D11Device::CreateBuffer(const D3D11_BUFFER_DESC* pDesc, const D3D11_SU
     return S_OK;
 }
 
-HRESULT D3D11Device::CreateTexture2D(const D3D11_TEXTURE2D_DESC* pDesc, const D3D11_SUBRESOURCE_DATA* pInitialData, ID3D11Texture2D** ppTexture2D) {
-    if (!pDesc || !ppTexture2D) return E_INVALIDARG;
+HRESULT D3D11Device::CreateTexture2D(const D3D11_TEXTURE2D_DESC* pDesc, const D3D11_SUBRESOURCE_DATA* pInitialData,
+                                     ID3D11Texture2D** ppTexture2D) {
+    if (!pDesc || !ppTexture2D)
+        return E_INVALIDARG;
 
     uint32_t metalFmt = dxgiFormatToMetal((DXGITranslation)pDesc->Format);
     uint32_t usage = 0;
-    if (pDesc->BindFlags & D3D11_BIND_RENDER_TARGET) usage |= 0x1;
-    if (pDesc->BindFlags & D3D11_BIND_DEPTH_STENCIL) usage |= 0x1;
-    if (pDesc->BindFlags & D3D11_BIND_SHADER_RESOURCE) usage |= 0x2;
-    if (pDesc->BindFlags & D3D11_BIND_UNORDERED_ACCESS) usage |= 0x4;
-    if (pDesc->BindFlags & D3D11_BIND_SHADER_RESOURCE) usage |= 0x8;
+    if (pDesc->BindFlags & D3D11_BIND_RENDER_TARGET)
+        usage |= 0x1;
+    if (pDesc->BindFlags & D3D11_BIND_DEPTH_STENCIL)
+        usage |= 0x1;
+    if (pDesc->BindFlags & D3D11_BIND_SHADER_RESOURCE)
+        usage |= 0x2;
+    if (pDesc->BindFlags & D3D11_BIND_UNORDERED_ACCESS)
+        usage |= 0x4;
+    if (pDesc->BindFlags & D3D11_BIND_SHADER_RESOURCE)
+        usage |= 0x8;
 
     uint32_t mipLevels = pDesc->MipLevels > 0 ? pDesc->MipLevels : 1;
     uint32_t sampleCount = pDesc->SampleDesc.Count > 0 ? pDesc->SampleDesc.Count : 1;
 
-    MetalTexture* tex = MetalTexture::create2D(*m_metalDevice, pDesc->Width, pDesc->Height, metalFmt, usage, mipLevels, sampleCount);
-    if (!tex) return E_OUTOFMEMORY;
+    MetalTexture* tex =
+        MetalTexture::create2D(*m_metalDevice, pDesc->Width, pDesc->Height, metalFmt, usage, mipLevels, sampleCount);
+    if (!tex)
+        return E_OUTOFMEMORY;
 
     if (pInitialData) {
         tex->uploadData(0, 0, pInitialData->pSysMem, pInitialData->SysMemPitch, pDesc->Width, pDesc->Height);
@@ -111,12 +150,19 @@ HRESULT D3D11Device::CreateTexture2D(const D3D11_TEXTURE2D_DESC* pDesc, const D3
 
     struct Impl : public ID3D11Texture2D {
         MS_COM_BODY()
-        STDMETHOD(GetType)(UINT* p) override { if(p) *p = D3D11_RESOURCE_DIMENSION_TEXTURE2D; return S_OK; }
+        STDMETHOD(GetType)(UINT* p) override {
+            if (p)
+                *p = D3D11_RESOURCE_DIMENSION_TEXTURE2D;
+            return S_OK;
+        }
         STDMETHOD(SetEvictionPriority)(UINT) override { return S_OK; }
         STDMETHOD_(UINT, GetEvictionPriority)() override { return 0; }
         std::unique_ptr<MetalTexture> metalTexture;
         D3D11_TEXTURE2D_DESC desc;
-        void GetDesc(D3D11_TEXTURE2D_DESC* p) override { if(p) *p = desc; }
+        void GetDesc(D3D11_TEXTURE2D_DESC* p) override {
+            if (p)
+                *p = desc;
+        }
         void* __metalTexturePtr() const override { return metalTexture ? metalTexture->nativeTexture() : nullptr; }
         UINT __getResourceDimension() const override { return D3D11_RESOURCE_DIMENSION_TEXTURE2D; }
         UINT __getCPUAccessFlags() const override { return desc.CPUAccessFlags; }
@@ -130,21 +176,29 @@ HRESULT D3D11Device::CreateTexture2D(const D3D11_TEXTURE2D_DESC* pDesc, const D3
     return S_OK;
 }
 
-HRESULT D3D11Device::CreateTexture1D(const D3D11_TEXTURE1D_DESC* pDesc, const D3D11_SUBRESOURCE_DATA* pInitialData, ID3D11Texture1D** ppTexture1D) {
-    if (!pDesc || !ppTexture1D) return E_INVALIDARG;
+HRESULT D3D11Device::CreateTexture1D(const D3D11_TEXTURE1D_DESC* pDesc, const D3D11_SUBRESOURCE_DATA* pInitialData,
+                                     ID3D11Texture1D** ppTexture1D) {
+    if (!pDesc || !ppTexture1D)
+        return E_INVALIDARG;
 
     uint32_t metalFmt = dxgiFormatToMetal((DXGITranslation)pDesc->Format);
     uint32_t usage = 0;
-    if (pDesc->BindFlags & D3D11_BIND_RENDER_TARGET) usage |= 0x1;
-    if (pDesc->BindFlags & D3D11_BIND_DEPTH_STENCIL) usage |= 0x1;
-    if (pDesc->BindFlags & D3D11_BIND_SHADER_RESOURCE) usage |= 0x2;
-    if (pDesc->BindFlags & D3D11_BIND_UNORDERED_ACCESS) usage |= 0x4;
-    if (pDesc->BindFlags & D3D11_BIND_SHADER_RESOURCE) usage |= 0x8;
+    if (pDesc->BindFlags & D3D11_BIND_RENDER_TARGET)
+        usage |= 0x1;
+    if (pDesc->BindFlags & D3D11_BIND_DEPTH_STENCIL)
+        usage |= 0x1;
+    if (pDesc->BindFlags & D3D11_BIND_SHADER_RESOURCE)
+        usage |= 0x2;
+    if (pDesc->BindFlags & D3D11_BIND_UNORDERED_ACCESS)
+        usage |= 0x4;
+    if (pDesc->BindFlags & D3D11_BIND_SHADER_RESOURCE)
+        usage |= 0x8;
 
     uint32_t mipLevels = pDesc->MipLevels > 0 ? pDesc->MipLevels : 1;
 
     MetalTexture* tex = MetalTexture::create1D(*m_metalDevice, pDesc->Width, metalFmt, usage, mipLevels);
-    if (!tex) return E_OUTOFMEMORY;
+    if (!tex)
+        return E_OUTOFMEMORY;
 
     if (pInitialData) {
         tex->uploadData(0, 0, pInitialData->pSysMem, pInitialData->SysMemPitch, pDesc->Width, 1);
@@ -152,12 +206,19 @@ HRESULT D3D11Device::CreateTexture1D(const D3D11_TEXTURE1D_DESC* pDesc, const D3
 
     struct Impl : public ID3D11Texture1D {
         MS_COM_BODY()
-        STDMETHOD(GetType)(UINT* p) override { if(p) *p = D3D11_RESOURCE_DIMENSION_TEXTURE1D; return S_OK; }
+        STDMETHOD(GetType)(UINT* p) override {
+            if (p)
+                *p = D3D11_RESOURCE_DIMENSION_TEXTURE1D;
+            return S_OK;
+        }
         STDMETHOD(SetEvictionPriority)(UINT) override { return S_OK; }
         STDMETHOD_(UINT, GetEvictionPriority)() override { return 0; }
         std::unique_ptr<MetalTexture> metalTexture;
         D3D11_TEXTURE1D_DESC desc;
-        void GetDesc(D3D11_TEXTURE1D_DESC* p) override { if(p) *p = desc; }
+        void GetDesc(D3D11_TEXTURE1D_DESC* p) override {
+            if (p)
+                *p = desc;
+        }
         void* __metalTexturePtr() const override { return metalTexture ? metalTexture->nativeTexture() : nullptr; }
         UINT __getResourceDimension() const override { return D3D11_RESOURCE_DIMENSION_TEXTURE1D; }
         UINT __getCPUAccessFlags() const override { return desc.CPUAccessFlags; }
@@ -171,34 +232,51 @@ HRESULT D3D11Device::CreateTexture1D(const D3D11_TEXTURE1D_DESC* pDesc, const D3
     return S_OK;
 }
 
-HRESULT D3D11Device::CreateTexture3D(const D3D11_TEXTURE3D_DESC* pDesc, const D3D11_SUBRESOURCE_DATA* pInitialData, ID3D11Texture3D** ppTexture3D) {
-    if (!pDesc || !ppTexture3D) return E_INVALIDARG;
+HRESULT D3D11Device::CreateTexture3D(const D3D11_TEXTURE3D_DESC* pDesc, const D3D11_SUBRESOURCE_DATA* pInitialData,
+                                     ID3D11Texture3D** ppTexture3D) {
+    if (!pDesc || !ppTexture3D)
+        return E_INVALIDARG;
 
     uint32_t metalFmt = dxgiFormatToMetal((DXGITranslation)pDesc->Format);
     uint32_t usage = 0;
-    if (pDesc->BindFlags & D3D11_BIND_RENDER_TARGET) usage |= 0x1;
-    if (pDesc->BindFlags & D3D11_BIND_DEPTH_STENCIL) usage |= 0x1;
-    if (pDesc->BindFlags & D3D11_BIND_SHADER_RESOURCE) usage |= 0x2;
-    if (pDesc->BindFlags & D3D11_BIND_UNORDERED_ACCESS) usage |= 0x4;
-    if (pDesc->BindFlags & D3D11_BIND_SHADER_RESOURCE) usage |= 0x8;
+    if (pDesc->BindFlags & D3D11_BIND_RENDER_TARGET)
+        usage |= 0x1;
+    if (pDesc->BindFlags & D3D11_BIND_DEPTH_STENCIL)
+        usage |= 0x1;
+    if (pDesc->BindFlags & D3D11_BIND_SHADER_RESOURCE)
+        usage |= 0x2;
+    if (pDesc->BindFlags & D3D11_BIND_UNORDERED_ACCESS)
+        usage |= 0x4;
+    if (pDesc->BindFlags & D3D11_BIND_SHADER_RESOURCE)
+        usage |= 0x8;
 
     uint32_t mipLevels = pDesc->MipLevels > 0 ? pDesc->MipLevels : 1;
 
-    MetalTexture* tex = MetalTexture::create3D(*m_metalDevice, pDesc->Width, pDesc->Height, pDesc->Depth, metalFmt, usage, mipLevels);
-    if (!tex) return E_OUTOFMEMORY;
+    MetalTexture* tex =
+        MetalTexture::create3D(*m_metalDevice, pDesc->Width, pDesc->Height, pDesc->Depth, metalFmt, usage, mipLevels);
+    if (!tex)
+        return E_OUTOFMEMORY;
 
     if (pInitialData) {
-        tex->uploadData(0, 0, pInitialData->pSysMem, pInitialData->SysMemPitch, pDesc->Width, pDesc->Height, pDesc->Depth);
+        tex->uploadData(0, 0, pInitialData->pSysMem, pInitialData->SysMemPitch, pDesc->Width, pDesc->Height,
+                        pDesc->Depth);
     }
 
     struct Impl : public ID3D11Texture3D {
         MS_COM_BODY()
-        STDMETHOD(GetType)(UINT* p) override { if(p) *p = D3D11_RESOURCE_DIMENSION_TEXTURE3D; return S_OK; }
+        STDMETHOD(GetType)(UINT* p) override {
+            if (p)
+                *p = D3D11_RESOURCE_DIMENSION_TEXTURE3D;
+            return S_OK;
+        }
         STDMETHOD(SetEvictionPriority)(UINT) override { return S_OK; }
         STDMETHOD_(UINT, GetEvictionPriority)() override { return 0; }
         std::unique_ptr<MetalTexture> metalTexture;
         D3D11_TEXTURE3D_DESC desc;
-        void GetDesc(D3D11_TEXTURE3D_DESC* p) override { if(p) *p = desc; }
+        void GetDesc(D3D11_TEXTURE3D_DESC* p) override {
+            if (p)
+                *p = desc;
+        }
         void* __metalTexturePtr() const override { return metalTexture ? metalTexture->nativeTexture() : nullptr; }
         UINT __getResourceDimension() const override { return D3D11_RESOURCE_DIMENSION_TEXTURE3D; }
         UINT __getCPUAccessFlags() const override { return desc.CPUAccessFlags; }
@@ -212,8 +290,10 @@ HRESULT D3D11Device::CreateTexture3D(const D3D11_TEXTURE3D_DESC* pDesc, const D3
     return S_OK;
 }
 
-HRESULT D3D11Device::CreateVertexShader(const void* pShaderBytecode, SIZE_T BytecodeLength, ID3D11ClassLinkage*, ID3D11VertexShader** ppVertexShader) {
-    if (!pShaderBytecode || !ppVertexShader) return E_INVALIDARG;
+HRESULT D3D11Device::CreateVertexShader(const void* pShaderBytecode, SIZE_T BytecodeLength, ID3D11ClassLinkage*,
+                                        ID3D11VertexShader** ppVertexShader) {
+    if (!pShaderBytecode || !ppVertexShader)
+        return E_INVALIDARG;
 
     struct Impl : public ID3D11VertexShader {
         MS_COM_BODY()
@@ -222,9 +302,8 @@ HRESULT D3D11Device::CreateVertexShader(const void* pShaderBytecode, SIZE_T Byte
     };
 
     CompiledShader compiled;
-    if (!m_shaderTranslator->compileMSL(
-            reinterpret_cast<const char*>(pShaderBytecode),
-            "vertexShader", "fragmentShader", compiled)) {
+    if (!m_shaderTranslator->compileMSL(reinterpret_cast<const char*>(pShaderBytecode), "vertexShader",
+                                        "fragmentShader", compiled)) {
         return E_FAIL;
     }
 
@@ -234,8 +313,10 @@ HRESULT D3D11Device::CreateVertexShader(const void* pShaderBytecode, SIZE_T Byte
     return S_OK;
 }
 
-HRESULT D3D11Device::CreatePixelShader(const void* pShaderBytecode, SIZE_T BytecodeLength, ID3D11ClassLinkage*, ID3D11PixelShader** ppPixelShader) {
-    if (!pShaderBytecode || !ppPixelShader) return E_INVALIDARG;
+HRESULT D3D11Device::CreatePixelShader(const void* pShaderBytecode, SIZE_T BytecodeLength, ID3D11ClassLinkage*,
+                                       ID3D11PixelShader** ppPixelShader) {
+    if (!pShaderBytecode || !ppPixelShader)
+        return E_INVALIDARG;
 
     struct Impl : public ID3D11PixelShader {
         MS_COM_BODY()
@@ -244,9 +325,8 @@ HRESULT D3D11Device::CreatePixelShader(const void* pShaderBytecode, SIZE_T Bytec
     };
 
     CompiledShader compiled;
-    if (!m_shaderTranslator->compileMSL(
-            reinterpret_cast<const char*>(pShaderBytecode),
-            "vertexShader", "fragmentShader", compiled)) {
+    if (!m_shaderTranslator->compileMSL(reinterpret_cast<const char*>(pShaderBytecode), "vertexShader",
+                                        "fragmentShader", compiled)) {
         return E_FAIL;
     }
 
@@ -256,11 +336,17 @@ HRESULT D3D11Device::CreatePixelShader(const void* pShaderBytecode, SIZE_T Bytec
     return S_OK;
 }
 
-HRESULT D3D11Device::CreateGeometryShader(const void*, SIZE_T, ID3D11ClassLinkage*, ID3D11GeometryShader**) { return E_NOTIMPL; }
-HRESULT D3D11Device::CreateComputeShader(const void*, SIZE_T, ID3D11ClassLinkage*, ID3D11ComputeShader**) { return E_NOTIMPL; }
+HRESULT D3D11Device::CreateGeometryShader(const void*, SIZE_T, ID3D11ClassLinkage*, ID3D11GeometryShader**) {
+    return E_NOTIMPL;
+}
+HRESULT D3D11Device::CreateComputeShader(const void*, SIZE_T, ID3D11ClassLinkage*, ID3D11ComputeShader**) {
+    return E_NOTIMPL;
+}
 
-HRESULT D3D11Device::CreateInputLayout(const void* pInputElementDescs, UINT NumElements, const void*, SIZE_T, ID3D11InputLayout** ppInputLayout) {
-    if (!pInputElementDescs || !ppInputLayout || NumElements == 0) return E_INVALIDARG;
+HRESULT D3D11Device::CreateInputLayout(const void* pInputElementDescs, UINT NumElements, const void*, SIZE_T,
+                                       ID3D11InputLayout** ppInputLayout) {
+    if (!pInputElementDescs || !ppInputLayout || NumElements == 0)
+        return E_INVALIDARG;
 
     struct Impl : public ID3D11InputLayout {
         MS_COM_BODY()
@@ -276,10 +362,13 @@ HRESULT D3D11Device::CreateInputLayout(const void* pInputElementDescs, UINT NumE
     return S_OK;
 }
 
-HRESULT D3D11Device::CreateRenderTargetView(ID3D11Resource* pResource, const void* pDesc, ID3D11RenderTargetView** ppRTView) {
-    if (!pResource || !ppRTView) return E_INVALIDARG;
+HRESULT D3D11Device::CreateRenderTargetView(ID3D11Resource* pResource, const void* pDesc,
+                                            ID3D11RenderTargetView** ppRTView) {
+    if (!pResource || !ppRTView)
+        return E_INVALIDARG;
     void* texPtr = pResource->__metalTexturePtr();
-    if (!texPtr) return E_FAIL;
+    if (!texPtr)
+        return E_FAIL;
 
     struct Impl : public ID3D11RenderTargetView {
         MS_COM_BODY()
@@ -296,10 +385,13 @@ HRESULT D3D11Device::CreateRenderTargetView(ID3D11Resource* pResource, const voi
     return S_OK;
 }
 
-HRESULT D3D11Device::CreateDepthStencilView(ID3D11Resource* pResource, const void* pDesc, ID3D11DepthStencilView** ppDSView) {
-    if (!pResource || !ppDSView) return E_INVALIDARG;
+HRESULT D3D11Device::CreateDepthStencilView(ID3D11Resource* pResource, const void* pDesc,
+                                            ID3D11DepthStencilView** ppDSView) {
+    if (!pResource || !ppDSView)
+        return E_INVALIDARG;
     void* texPtr = pResource->__metalTexturePtr();
-    if (!texPtr) return E_FAIL;
+    if (!texPtr)
+        return E_FAIL;
 
     struct Impl : public ID3D11DepthStencilView {
         MS_COM_BODY()
@@ -316,8 +408,10 @@ HRESULT D3D11Device::CreateDepthStencilView(ID3D11Resource* pResource, const voi
     return S_OK;
 }
 
-HRESULT D3D11Device::CreateShaderResourceView(ID3D11Resource* pResource, const void* pDesc, ID3D11ShaderResourceView** ppSRView) {
-    if (!pResource || !ppSRView) return E_INVALIDARG;
+HRESULT D3D11Device::CreateShaderResourceView(ID3D11Resource* pResource, const void* pDesc,
+                                              ID3D11ShaderResourceView** ppSRView) {
+    if (!pResource || !ppSRView)
+        return E_INVALIDARG;
     void* texPtr = pResource->__metalTexturePtr();
     void* bufPtr = pResource->__metalBufferPtr();
 
@@ -339,8 +433,10 @@ HRESULT D3D11Device::CreateShaderResourceView(ID3D11Resource* pResource, const v
     return S_OK;
 }
 
-HRESULT D3D11Device::CreateUnorderedAccessView(ID3D11Resource* pResource, const D3D11_UNORDERED_ACCESS_VIEW_DESC* pDesc, ID3D11UnorderedAccessView** ppUAView) {
-    if (!pResource || !ppUAView) return E_INVALIDARG;
+HRESULT D3D11Device::CreateUnorderedAccessView(ID3D11Resource* pResource, const D3D11_UNORDERED_ACCESS_VIEW_DESC* pDesc,
+                                               ID3D11UnorderedAccessView** ppUAView) {
+    if (!pResource || !ppUAView)
+        return E_INVALIDARG;
     void* texPtr = pResource->__metalTexturePtr();
     void* bufPtr = pResource->__metalBufferPtr();
 
@@ -363,19 +459,22 @@ HRESULT D3D11Device::CreateUnorderedAccessView(ID3D11Resource* pResource, const 
 }
 
 HRESULT D3D11Device::CreateSamplerState(const void* pSamplerDesc, ID3D11SamplerState** ppSamplerState) {
-    if (!pSamplerDesc || !ppSamplerState) return E_INVALIDARG;
+    if (!pSamplerDesc || !ppSamplerState)
+        return E_INVALIDARG;
     auto* desc = static_cast<const D3D11_SAMPLER_DESC*>(pSamplerDesc);
 
-    auto* sampler = MetalSampler::create(*m_metalDevice,
-        desc->Filter, desc->AddressU, desc->AddressV, desc->AddressW,
-        desc->MipLODBias, desc->MaxAnisotropy, desc->ComparisonFunc);
-    if (!sampler) return E_OUTOFMEMORY;
+    auto* sampler = MetalSampler::create(*m_metalDevice, desc->Filter, desc->AddressU, desc->AddressV, desc->AddressW,
+                                         desc->MipLODBias, desc->MaxAnisotropy, desc->ComparisonFunc);
+    if (!sampler)
+        return E_OUTOFMEMORY;
 
     struct Impl : public ID3D11SamplerState {
         MS_COM_BODY()
         std::unique_ptr<MetalSampler> metalSampler;
         D3D11_SAMPLER_DESC desc;
-        void* __metalSamplerState() const override { return metalSampler ? metalSampler->nativeSamplerState() : nullptr; }
+        void* __metalSamplerState() const override {
+            return metalSampler ? metalSampler->nativeSamplerState() : nullptr;
+        }
     };
 
     auto* impl = new Impl();
@@ -386,7 +485,8 @@ HRESULT D3D11Device::CreateSamplerState(const void* pSamplerDesc, ID3D11SamplerS
 }
 
 HRESULT D3D11Device::CreateRasterizerState(const void* pRasterizerDesc, ID3D11RasterizerState** ppRasterizerState) {
-    if (!pRasterizerDesc || !ppRasterizerState) return E_INVALIDARG;
+    if (!pRasterizerDesc || !ppRasterizerState)
+        return E_INVALIDARG;
     auto* desc = static_cast<const D3D11_RASTERIZER_DESC*>(pRasterizerDesc);
 
     struct Impl : public ID3D11RasterizerState {
@@ -406,8 +506,10 @@ HRESULT D3D11Device::CreateRasterizerState(const void* pRasterizerDesc, ID3D11Ra
     return S_OK;
 }
 
-HRESULT D3D11Device::CreateDepthStencilState(const void* pDepthStencilDesc, ID3D11DepthStencilState** ppDepthStencilState) {
-    if (!pDepthStencilDesc || !ppDepthStencilState) return E_INVALIDARG;
+HRESULT D3D11Device::CreateDepthStencilState(const void* pDepthStencilDesc,
+                                             ID3D11DepthStencilState** ppDepthStencilState) {
+    if (!pDepthStencilDesc || !ppDepthStencilState)
+        return E_INVALIDARG;
     auto* desc = static_cast<const D3D11_DEPTH_STENCIL_DESC*>(pDepthStencilDesc);
 
     struct Impl : public ID3D11DepthStencilState {
@@ -428,7 +530,8 @@ HRESULT D3D11Device::CreateDepthStencilState(const void* pDepthStencilDesc, ID3D
 }
 
 HRESULT D3D11Device::CreateBlendState(const void* pBlendStateDesc, ID3D11BlendState** ppBlendState) {
-    if (!pBlendStateDesc || !ppBlendState) return E_INVALIDARG;
+    if (!pBlendStateDesc || !ppBlendState)
+        return E_INVALIDARG;
     auto* desc = static_cast<const D3D11_BLEND_DESC*>(pBlendStateDesc);
 
     struct Impl : public ID3D11BlendState {
@@ -441,7 +544,9 @@ HRESULT D3D11Device::CreateBlendState(const void* pBlendStateDesc, ID3D11BlendSt
         UINT __getSrcBlendAlpha(UINT i) const override { return desc.RenderTarget[i < 8 ? i : 0].SrcBlendAlpha; }
         UINT __getDestBlendAlpha(UINT i) const override { return desc.RenderTarget[i < 8 ? i : 0].DestBlendAlpha; }
         UINT __getBlendOpAlpha(UINT i) const override { return desc.RenderTarget[i < 8 ? i : 0].BlendOpAlpha; }
-        UINT __getRenderTargetWriteMask(UINT i) const override { return desc.RenderTarget[i < 8 ? i : 0].RenderTargetWriteMask; }
+        UINT __getRenderTargetWriteMask(UINT i) const override {
+            return desc.RenderTarget[i < 8 ? i : 0].RenderTargetWriteMask;
+        }
         INT __getAlphaToCoverageEnable() const override { return desc.AlphaToCoverageEnable; }
     };
 
@@ -452,12 +557,16 @@ HRESULT D3D11Device::CreateBlendState(const void* pBlendStateDesc, ID3D11BlendSt
 }
 
 HRESULT D3D11Device::CreateQuery(const D3D11_QUERY_DESC* pQueryDesc, ID3D11Query** ppQuery) {
-    if (!pQueryDesc || !ppQuery) return E_INVALIDARG;
+    if (!pQueryDesc || !ppQuery)
+        return E_INVALIDARG;
 
     struct Impl : public ID3D11Query {
         MS_COM_BODY()
         D3D11_QUERY_DESC desc;
-        void GetDesc(D3D11_QUERY_DESC* p) override { if(p) *p = desc; }
+        void GetDesc(D3D11_QUERY_DESC* p) override {
+            if (p)
+                *p = desc;
+        }
         UINT __getQueryType() const override { return desc.Query; }
     };
 
@@ -468,7 +577,8 @@ HRESULT D3D11Device::CreateQuery(const D3D11_QUERY_DESC* pQueryDesc, ID3D11Query
 }
 
 HRESULT D3D11Device::CreatePredicate(const D3D11_QUERY_DESC* pPredicateDesc, ID3D11Predicate** ppPredicate) {
-    if (!pPredicateDesc || !ppPredicate) return E_INVALIDARG;
+    if (!pPredicateDesc || !ppPredicate)
+        return E_INVALIDARG;
 
     struct Impl : public ID3D11Predicate {
         MS_COM_BODY()
@@ -486,15 +596,17 @@ void D3D11Device::GetImmediateContext(ID3D11DeviceContext** ppImmediateContext) 
 }
 
 HRESULT D3D11Device::CreateDeferredContext(UINT, ID3D11DeviceContext** ppDeferredContext) {
-    if (!ppDeferredContext) return E_POINTER;
+    if (!ppDeferredContext)
+        return E_POINTER;
     *ppDeferredContext = new DeferredContext(*this);
     return S_OK;
 }
 
 HRESULT D3D11Device::GetDeviceFeatureLevel(UINT* pFeatureLevel) {
-    if (!pFeatureLevel) return E_POINTER;
+    if (!pFeatureLevel)
+        return E_POINTER;
     *pFeatureLevel = 0xb000;
     return S_OK;
 }
 
-}
+} // namespace metalsharp

--- a/src/d3d/d3d11/D3D11DeviceContext.mm
+++ b/src/d3d/d3d11/D3D11DeviceContext.mm
@@ -5,39 +5,56 @@
 /// render/compute command encoders, manages pipeline state binding, and submits work to
 /// the Metal command queue.
 
-#include <metalsharp/D3D11DeviceContext.h>
-#include <metalsharp/D3D11Device.h>
-#include <metalsharp/DeferredContext.h>
-#include <metalsharp/PipelineState.h>
+#include <cstring>
 #include <Foundation/Foundation.h>
 #include <Metal/Metal.h>
-#include <cstring>
+#include <metalsharp/D3D11Device.h>
+#include <metalsharp/D3D11DeviceContext.h>
+#include <metalsharp/DeferredContext.h>
+#include <metalsharp/PipelineState.h>
 
 namespace metalsharp {
 
 D3D11DeviceContext::D3D11DeviceContext(D3D11Device& device) : m_device(device) {}
 
 HRESULT D3D11DeviceContext::QueryInterface(REFIID riid, void** ppvObject) {
-    if (!ppvObject) return E_POINTER;
+    if (!ppvObject)
+        return E_POINTER;
     if (riid == __uuidof(IUnknown) || riid == __uuidof(ID3D11DeviceContext)) {
-        AddRef(); *ppvObject = this; return S_OK;
+        AddRef();
+        *ppvObject = this;
+        return S_OK;
     }
     return E_NOINTERFACE;
 }
 
-ULONG D3D11DeviceContext::AddRef() { return ++m_refCount; }
-ULONG D3D11DeviceContext::Release() { ULONG c = --m_refCount; if (c == 0) delete this; return c; }
+ULONG D3D11DeviceContext::AddRef() {
+    return ++m_refCount;
+}
+ULONG D3D11DeviceContext::Release() {
+    ULONG c = --m_refCount;
+    if (c == 0)
+        delete this;
+    return c;
+}
 
 HRESULT D3D11DeviceContext::GetDevice(ID3D11Device** ppDevice) {
-    if (!ppDevice) return E_POINTER;
+    if (!ppDevice)
+        return E_POINTER;
     m_device.AddRef();
     *ppDevice = &m_device;
     return S_OK;
 }
 
-HRESULT D3D11DeviceContext::GetPrivateData(const GUID&, UINT*, void*) { return E_NOTIMPL; }
-HRESULT D3D11DeviceContext::SetPrivateData(const GUID&, UINT, const void*) { return E_NOTIMPL; }
-HRESULT D3D11DeviceContext::SetPrivateDataInterface(const GUID&, const IUnknown*) { return E_NOTIMPL; }
+HRESULT D3D11DeviceContext::GetPrivateData(const GUID&, UINT*, void*) {
+    return E_NOTIMPL;
+}
+HRESULT D3D11DeviceContext::SetPrivateData(const GUID&, UINT, const void*) {
+    return E_NOTIMPL;
+}
+HRESULT D3D11DeviceContext::SetPrivateDataInterface(const GUID&, const IUnknown*) {
+    return E_NOTIMPL;
+}
 
 HRESULT D3D11DeviceContext::IASetInputLayout(ID3D11InputLayout* pInputLayout) {
     m_inputLayout = pInputLayout;
@@ -45,7 +62,8 @@ HRESULT D3D11DeviceContext::IASetInputLayout(ID3D11InputLayout* pInputLayout) {
     return S_OK;
 }
 
-HRESULT D3D11DeviceContext::IASetVertexBuffers(UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppVertexBuffers, const UINT* pStrides, const UINT* pOffsets) {
+HRESULT D3D11DeviceContext::IASetVertexBuffers(UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppVertexBuffers,
+                                               const UINT* pStrides, const UINT* pOffsets) {
     for (UINT i = 0; i < NumBuffers && (StartSlot + i) < MAX_VERTEX_BUFFERS; ++i) {
         m_vertexBuffers[StartSlot + i].buffer = ppVertexBuffers ? ppVertexBuffers[i] : nullptr;
         m_vertexBuffers[StartSlot + i].stride = pStrides ? pStrides[i] : 0;
@@ -73,14 +91,16 @@ HRESULT D3D11DeviceContext::VSSetShader(ID3D11VertexShader* pVertexShader, ID3D1
     return S_OK;
 }
 
-HRESULT D3D11DeviceContext::VSSetConstantBuffers(UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppConstantBuffers) {
+HRESULT D3D11DeviceContext::VSSetConstantBuffers(UINT StartSlot, UINT NumBuffers,
+                                                 ID3D11Buffer* const* ppConstantBuffers) {
     for (UINT i = 0; i < NumBuffers && (StartSlot + i) < MAX_CONSTANT_BUFFERS; ++i) {
         m_vsConstantBuffers[StartSlot + i] = ppConstantBuffers ? ppConstantBuffers[i] : nullptr;
     }
     return S_OK;
 }
 
-HRESULT D3D11DeviceContext::VSSetShaderResources(UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView* const* ppSRVs) {
+HRESULT D3D11DeviceContext::VSSetShaderResources(UINT StartSlot, UINT NumViews,
+                                                 ID3D11ShaderResourceView* const* ppSRVs) {
     for (UINT i = 0; i < NumViews && (StartSlot + i) < 128; ++i) {
         m_vsShaderResources[StartSlot + i] = ppSRVs ? ppSRVs[i] : nullptr;
     }
@@ -100,14 +120,16 @@ HRESULT D3D11DeviceContext::PSSetShader(ID3D11PixelShader* pPixelShader, ID3D11C
     return S_OK;
 }
 
-HRESULT D3D11DeviceContext::PSSetConstantBuffers(UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppConstantBuffers) {
+HRESULT D3D11DeviceContext::PSSetConstantBuffers(UINT StartSlot, UINT NumBuffers,
+                                                 ID3D11Buffer* const* ppConstantBuffers) {
     for (UINT i = 0; i < NumBuffers && (StartSlot + i) < MAX_CONSTANT_BUFFERS; ++i) {
         m_psConstantBuffers[StartSlot + i] = ppConstantBuffers ? ppConstantBuffers[i] : nullptr;
     }
     return S_OK;
 }
 
-HRESULT D3D11DeviceContext::PSSetShaderResources(UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView* const* ppSRVs) {
+HRESULT D3D11DeviceContext::PSSetShaderResources(UINT StartSlot, UINT NumViews,
+                                                 ID3D11ShaderResourceView* const* ppSRVs) {
     for (UINT i = 0; i < NumViews && (StartSlot + i) < 128; ++i) {
         m_psShaderResources[StartSlot + i] = ppSRVs ? ppSRVs[i] : nullptr;
     }
@@ -121,40 +143,54 @@ HRESULT D3D11DeviceContext::PSSetSamplers(UINT StartSlot, UINT NumSamplers, ID3D
     return S_OK;
 }
 
-HRESULT D3D11DeviceContext::GSSetShader(ID3D11GeometryShader*, ID3D11ClassInstance* const*, UINT) { return E_NOTIMPL; }
-HRESULT D3D11DeviceContext::CSSetShader(ID3D11ComputeShader* pComputeShader, ID3D11ClassInstance* const*, UINT) { m_computeShader = pComputeShader; return S_OK; }
+HRESULT D3D11DeviceContext::GSSetShader(ID3D11GeometryShader*, ID3D11ClassInstance* const*, UINT) {
+    return E_NOTIMPL;
+}
+HRESULT D3D11DeviceContext::CSSetShader(ID3D11ComputeShader* pComputeShader, ID3D11ClassInstance* const*, UINT) {
+    m_computeShader = pComputeShader;
+    return S_OK;
+}
 
 HRESULT D3D11DeviceContext::CSSetConstantBuffers(UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppBuffers) {
-    if (!ppBuffers) return S_OK;
+    if (!ppBuffers)
+        return S_OK;
     for (UINT i = 0; i < NumBuffers && StartSlot + i < MAX_CONSTANT_BUFFERS; ++i)
         m_vsConstantBuffers[StartSlot + i] = ppBuffers[i];
     return S_OK;
 }
 
-HRESULT D3D11DeviceContext::CSSetShaderResources(UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView* const* ppViews) {
-    if (!ppViews) return S_OK;
+HRESULT D3D11DeviceContext::CSSetShaderResources(UINT StartSlot, UINT NumViews,
+                                                 ID3D11ShaderResourceView* const* ppViews) {
+    if (!ppViews)
+        return S_OK;
     for (UINT i = 0; i < NumViews && StartSlot + i < 128; ++i)
         m_psShaderResources[StartSlot + i] = ppViews[i];
     return S_OK;
 }
 
-HRESULT D3D11DeviceContext::CSSetUnorderedAccessViews(UINT StartSlot, UINT NumUAVs, ID3D11UnorderedAccessView* const* ppUAVs, const UINT*) {
-    if (!ppUAVs) return S_OK;
+HRESULT D3D11DeviceContext::CSSetUnorderedAccessViews(UINT StartSlot, UINT NumUAVs,
+                                                      ID3D11UnorderedAccessView* const* ppUAVs, const UINT*) {
+    if (!ppUAVs)
+        return S_OK;
     for (UINT i = 0; i < NumUAVs && StartSlot + i < 8; ++i)
         m_csUAVs[StartSlot + i] = ppUAVs[i];
     return S_OK;
 }
 
 HRESULT D3D11DeviceContext::CSSetSamplers(UINT StartSlot, UINT NumSamplers, ID3D11SamplerState* const* ppSamplers) {
-    if (!ppSamplers) return S_OK;
+    if (!ppSamplers)
+        return S_OK;
     for (UINT i = 0; i < NumSamplers && StartSlot + i < 16; ++i)
         m_psSamplers[StartSlot + i] = ppSamplers[i];
     return S_OK;
 }
 
-HRESULT D3D11DeviceContext::Dispatch(UINT ThreadGroupCountX, UINT ThreadGroupCountY, UINT ThreadGroupCountZ) { return E_NOTIMPL; }
+HRESULT D3D11DeviceContext::Dispatch(UINT ThreadGroupCountX, UINT ThreadGroupCountY, UINT ThreadGroupCountZ) {
+    return E_NOTIMPL;
+}
 
-HRESULT D3D11DeviceContext::OMSetRenderTargets(UINT NumViews, ID3D11RenderTargetView* const* ppRenderTargetViews, ID3D11DepthStencilView* pDepthStencilView) {
+HRESULT D3D11DeviceContext::OMSetRenderTargets(UINT NumViews, ID3D11RenderTargetView* const* ppRenderTargetViews,
+                                               ID3D11DepthStencilView* pDepthStencilView) {
     m_renderTargets.fill(nullptr);
     for (UINT i = 0; i < NumViews && i < MAX_RENDER_TARGETS; ++i) {
         m_renderTargets[i] = ppRenderTargetViews ? ppRenderTargetViews[i] : nullptr;
@@ -164,13 +200,18 @@ HRESULT D3D11DeviceContext::OMSetRenderTargets(UINT NumViews, ID3D11RenderTarget
     return S_OK;
 }
 
-HRESULT D3D11DeviceContext::OMSetRenderTargetsAndUnorderedAccessViews(UINT NumRTVs, ID3D11RenderTargetView* const* ppRTVs, ID3D11DepthStencilView* pDSV, UINT, UINT, ID3D11UnorderedAccessView* const*, const UINT*) {
+HRESULT D3D11DeviceContext::OMSetRenderTargetsAndUnorderedAccessViews(UINT NumRTVs,
+                                                                      ID3D11RenderTargetView* const* ppRTVs,
+                                                                      ID3D11DepthStencilView* pDSV, UINT, UINT,
+                                                                      ID3D11UnorderedAccessView* const*, const UINT*) {
     return OMSetRenderTargets(NumRTVs, ppRTVs, pDSV);
 }
 
-HRESULT D3D11DeviceContext::OMSetBlendState(ID3D11BlendState* pBlendState, const FLOAT BlendFactor[4], UINT SampleMask) {
+HRESULT D3D11DeviceContext::OMSetBlendState(ID3D11BlendState* pBlendState, const FLOAT BlendFactor[4],
+                                            UINT SampleMask) {
     m_blendState = pBlendState;
-    if (BlendFactor) memcpy(m_blendFactor, BlendFactor, sizeof(m_blendFactor));
+    if (BlendFactor)
+        memcpy(m_blendFactor, BlendFactor, sizeof(m_blendFactor));
     m_sampleMask = SampleMask;
     m_cachedPipeline.reset();
     return S_OK;
@@ -188,27 +229,31 @@ HRESULT D3D11DeviceContext::RSSetState(ID3D11RasterizerState* pRasterizerState) 
 }
 
 HRESULT D3D11DeviceContext::RSSetViewports(UINT NumViewports, const D3D11_VIEWPORT* pViewports) {
-    if (NumViewports > 0 && pViewports) m_viewport = pViewports[0];
+    if (NumViewports > 0 && pViewports)
+        m_viewport = pViewports[0];
     return S_OK;
 }
 
-HRESULT D3D11DeviceContext::RSSetScissorRects(UINT, const RECT*) { return S_OK; }
+HRESULT D3D11DeviceContext::RSSetScissorRects(UINT, const RECT*) {
+    return S_OK;
+}
 
 HRESULT D3D11DeviceContext::ClearRenderTargetView(ID3D11RenderTargetView* pRTV, const FLOAT ColorRGBA[4]) {
-    if (!pRTV || !m_renderTargets[0]) return S_OK;
+    if (!pRTV || !m_renderTargets[0])
+        return S_OK;
     auto& metalDev = m_device.metalDevice();
     id<MTLCommandQueue> queue = (__bridge id<MTLCommandQueue>)metalDev.nativeCommandQueue();
     id<MTLCommandBuffer> cmdBuffer = [queue commandBuffer];
 
     void* texPtr = pRTV->__metalTexturePtr();
-    if (!texPtr) return S_OK;
+    if (!texPtr)
+        return S_OK;
 
     MTLRenderPassDescriptor* passDesc = [[MTLRenderPassDescriptor alloc] init];
     passDesc.colorAttachments[0].texture = (__bridge id<MTLTexture>)texPtr;
     passDesc.colorAttachments[0].loadAction = MTLLoadActionClear;
     passDesc.colorAttachments[0].storeAction = MTLStoreActionStore;
-    passDesc.colorAttachments[0].clearColor = MTLClearColorMake(
-        ColorRGBA[0], ColorRGBA[1], ColorRGBA[2], ColorRGBA[3]);
+    passDesc.colorAttachments[0].clearColor = MTLClearColorMake(ColorRGBA[0], ColorRGBA[1], ColorRGBA[2], ColorRGBA[3]);
 
     id<MTLRenderCommandEncoder> encoder = [cmdBuffer renderCommandEncoderWithDescriptor:passDesc];
     [encoder endEncoding];
@@ -216,10 +261,13 @@ HRESULT D3D11DeviceContext::ClearRenderTargetView(ID3D11RenderTargetView* pRTV, 
     return S_OK;
 }
 
-HRESULT D3D11DeviceContext::ClearDepthStencilView(ID3D11DepthStencilView* pDSV, UINT ClearFlags, FLOAT Depth, UINT8 Stencil) {
-    if (!pDSV) return S_OK;
+HRESULT D3D11DeviceContext::ClearDepthStencilView(ID3D11DepthStencilView* pDSV, UINT ClearFlags, FLOAT Depth,
+                                                  UINT8 Stencil) {
+    if (!pDSV)
+        return S_OK;
     void* texPtr = pDSV->__metalTexturePtr();
-    if (!texPtr) return S_OK;
+    if (!texPtr)
+        return S_OK;
 
     auto& metalDev = m_device.metalDevice();
     id<MTLCommandQueue> queue = (__bridge id<MTLCommandQueue>)metalDev.nativeCommandQueue();
@@ -245,20 +293,26 @@ HRESULT D3D11DeviceContext::ClearDepthStencilView(ID3D11DepthStencilView* pDSV, 
 }
 
 void D3D11DeviceContext::ensurePipeline() {
-    if (m_cachedPipeline) return;
-    if (!m_vertexShader) return;
+    if (m_cachedPipeline)
+        return;
+    if (!m_vertexShader)
+        return;
 
     PipelineStateDesc desc;
     desc.vertexStride = m_vertexBuffers[0].stride;
 
-    if (m_vertexShader) desc.vertexFunction = m_vertexShader->__metalVertexFunction();
-    if (m_pixelShader) desc.fragmentFunction = m_pixelShader->__metalFragmentFunction();
+    if (m_vertexShader)
+        desc.vertexFunction = m_vertexShader->__metalVertexFunction();
+    if (m_pixelShader)
+        desc.fragmentFunction = m_pixelShader->__metalFragmentFunction();
 
     desc.numColorAttachments = 0;
     for (UINT i = 0; i < MAX_RENDER_TARGETS; ++i) {
-        if (!m_renderTargets[i]) continue;
+        if (!m_renderTargets[i])
+            continue;
         void* texPtr = m_renderTargets[i]->__metalTexturePtr();
-        if (!texPtr) continue;
+        if (!texPtr)
+            continue;
         id<MTLTexture> tex = (__bridge id<MTLTexture>)texPtr;
         desc.colorPixelFormats[i] = (uint32_t)tex.pixelFormat;
         desc.numColorAttachments = i + 1;
@@ -288,9 +342,12 @@ void D3D11DeviceContext::ensurePipeline() {
     m_cachedPipeline.reset(PipelineState::create(m_device.metalDevice(), desc));
 }
 
-void D3D11DeviceContext::commitDraw(UINT vertexCount, UINT instanceCount, UINT startIndexLocation, INT baseVertexLocation, bool indexed) {
-    if (!m_cachedPipeline) return;
-    if (!m_vertexBuffers[0].buffer && !indexed) return;
+void D3D11DeviceContext::commitDraw(UINT vertexCount, UINT instanceCount, UINT startIndexLocation,
+                                    INT baseVertexLocation, bool indexed) {
+    if (!m_cachedPipeline)
+        return;
+    if (!m_vertexBuffers[0].buffer && !indexed)
+        return;
 
     auto& metalDev = m_device.metalDevice();
     id<MTLCommandQueue> queue = (__bridge id<MTLCommandQueue>)metalDev.nativeCommandQueue();
@@ -299,9 +356,11 @@ void D3D11DeviceContext::commitDraw(UINT vertexCount, UINT instanceCount, UINT s
     MTLRenderPassDescriptor* passDesc = [[MTLRenderPassDescriptor alloc] init];
 
     for (UINT i = 0; i < MAX_RENDER_TARGETS; ++i) {
-        if (!m_renderTargets[i]) continue;
+        if (!m_renderTargets[i])
+            continue;
         void* texPtr = m_renderTargets[i]->__metalTexturePtr();
-        if (!texPtr) continue;
+        if (!texPtr)
+            continue;
         passDesc.colorAttachments[i].texture = (__bridge id<MTLTexture>)texPtr;
         passDesc.colorAttachments[i].loadAction = MTLLoadActionLoad;
         passDesc.colorAttachments[i].storeAction = MTLStoreActionStore;
@@ -316,7 +375,8 @@ void D3D11DeviceContext::commitDraw(UINT vertexCount, UINT instanceCount, UINT s
         }
     }
 
-    id<MTLRenderPipelineState> pipeline = (__bridge id<MTLRenderPipelineState>)m_cachedPipeline->nativeRenderPipelineState();
+    id<MTLRenderPipelineState> pipeline =
+        (__bridge id<MTLRenderPipelineState>)m_cachedPipeline->nativeRenderPipelineState();
 
     id<MTLRenderCommandEncoder> encoder = [cmdBuffer renderCommandEncoderWithDescriptor:passDesc];
     [encoder setRenderPipelineState:pipeline];
@@ -378,9 +438,14 @@ void D3D11DeviceContext::commitDraw(UINT vertexCount, UINT instanceCount, UINT s
     if (m_rasterizerState) {
         MTLCullMode cullMode = MTLCullModeNone;
         switch (m_rasterizerState->__getCullMode()) {
-            case D3D11_CULL_FRONT: cullMode = MTLCullModeFront; break;
-            case D3D11_CULL_BACK: cullMode = MTLCullModeBack; break;
-            default: break;
+        case D3D11_CULL_FRONT:
+            cullMode = MTLCullModeFront;
+            break;
+        case D3D11_CULL_BACK:
+            cullMode = MTLCullModeBack;
+            break;
+        default:
+            break;
         }
         [encoder setCullMode:cullMode];
         if (m_rasterizerState->__getFrontCCW()) {
@@ -392,12 +457,23 @@ void D3D11DeviceContext::commitDraw(UINT vertexCount, UINT instanceCount, UINT s
 
     MTLPrimitiveType primType = MTLPrimitiveTypeTriangle;
     switch (m_primitiveTopology) {
-        case D3D11_PRIMITIVE_TOPOLOGY_POINTLIST:     primType = MTLPrimitiveTypePoint; break;
-        case D3D11_PRIMITIVE_TOPOLOGY_LINELIST:      primType = MTLPrimitiveTypeLine; break;
-        case D3D11_PRIMITIVE_TOPOLOGY_LINESTRIP:     primType = MTLPrimitiveTypeLineStrip; break;
-        case D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST:  primType = MTLPrimitiveTypeTriangle; break;
-        case D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP: primType = MTLPrimitiveTypeTriangleStrip; break;
-        default: break;
+    case D3D11_PRIMITIVE_TOPOLOGY_POINTLIST:
+        primType = MTLPrimitiveTypePoint;
+        break;
+    case D3D11_PRIMITIVE_TOPOLOGY_LINELIST:
+        primType = MTLPrimitiveTypeLine;
+        break;
+    case D3D11_PRIMITIVE_TOPOLOGY_LINESTRIP:
+        primType = MTLPrimitiveTypeLineStrip;
+        break;
+    case D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST:
+        primType = MTLPrimitiveTypeTriangle;
+        break;
+    case D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP:
+        primType = MTLPrimitiveTypeTriangleStrip;
+        break;
+    default:
+        break;
     }
 
     if (indexed && m_indexBuffer) {
@@ -417,7 +493,11 @@ void D3D11DeviceContext::commitDraw(UINT vertexCount, UINT instanceCount, UINT s
                          indexBufferOffset:m_indexBufferOffset + startIndexLocation * indexSize];
         }
     } else {
-        [encoder drawPrimitives:primType vertexStart:startIndexLocation vertexCount:vertexCount instanceCount:instanceCount > 1 ? instanceCount : 1 baseInstance:0];
+        [encoder drawPrimitives:primType
+                    vertexStart:startIndexLocation
+                    vertexCount:vertexCount
+                  instanceCount:instanceCount > 1 ? instanceCount : 1
+                   baseInstance:0];
     }
 
     [encoder endEncoding];
@@ -436,20 +516,23 @@ HRESULT D3D11DeviceContext::Draw(UINT VertexCount, UINT StartVertexLocation) {
     return S_OK;
 }
 
-HRESULT D3D11DeviceContext::DrawIndexedInstanced(UINT IndexCountPerInstance, UINT InstanceCount, UINT StartIndexLocation, INT BaseVertexLocation, UINT) {
+HRESULT D3D11DeviceContext::DrawIndexedInstanced(UINT IndexCountPerInstance, UINT InstanceCount,
+                                                 UINT StartIndexLocation, INT BaseVertexLocation, UINT) {
     ensurePipeline();
     commitDraw(IndexCountPerInstance, InstanceCount, StartIndexLocation, BaseVertexLocation, true);
     return S_OK;
 }
 
-HRESULT D3D11DeviceContext::DrawInstanced(UINT VertexCountPerInstance, UINT InstanceCount, UINT StartVertexLocation, UINT) {
+HRESULT D3D11DeviceContext::DrawInstanced(UINT VertexCountPerInstance, UINT InstanceCount, UINT StartVertexLocation,
+                                          UINT) {
     ensurePipeline();
     commitDraw(VertexCountPerInstance, InstanceCount, StartVertexLocation, 0, false);
     return S_OK;
 }
 
 HRESULT D3D11DeviceContext::Map(ID3D11Resource* pResource, UINT, UINT MapType, UINT, void* pMappedResource) {
-    if (!pResource || !pMappedResource) return E_INVALIDARG;
+    if (!pResource || !pMappedResource)
+        return E_INVALIDARG;
 
     auto* mapped = static_cast<D3D11_MAPPED_SUBRESOURCE*>(pMappedResource);
     memset(mapped, 0, sizeof(D3D11_MAPPED_SUBRESOURCE));
@@ -471,12 +554,15 @@ HRESULT D3D11DeviceContext::Unmap(ID3D11Resource*, UINT) {
 }
 
 HRESULT D3D11DeviceContext::GenerateMips(ID3D11ShaderResourceView* pShaderResourceView) {
-    if (!pShaderResourceView) return S_OK;
+    if (!pShaderResourceView)
+        return S_OK;
     void* texPtr = pShaderResourceView->__metalTexturePtr();
-    if (!texPtr) return S_OK;
+    if (!texPtr)
+        return S_OK;
 
     id<MTLTexture> tex = (__bridge id<MTLTexture>)texPtr;
-    if (tex.mipmapLevelCount <= 1) return S_OK;
+    if (tex.mipmapLevelCount <= 1)
+        return S_OK;
 
     auto& metalDev = m_device.metalDevice();
     id<MTLCommandQueue> queue = (__bridge id<MTLCommandQueue>)metalDev.nativeCommandQueue();
@@ -488,10 +574,14 @@ HRESULT D3D11DeviceContext::GenerateMips(ID3D11ShaderResourceView* pShaderResour
         NSUInteger srcH = tex.height >> (level - 1);
         NSUInteger dstW = tex.width >> level;
         NSUInteger dstH = tex.height >> level;
-        if (srcW == 0) srcW = 1;
-        if (srcH == 0) srcH = 1;
-        if (dstW == 0) dstW = 1;
-        if (dstH == 0) dstH = 1;
+        if (srcW == 0)
+            srcW = 1;
+        if (srcH == 0)
+            srcH = 1;
+        if (dstW == 0)
+            dstW = 1;
+        if (dstH == 0)
+            dstH = 1;
 
         [blit generateMipmapsForTexture:tex];
         break;
@@ -503,7 +593,8 @@ HRESULT D3D11DeviceContext::GenerateMips(ID3D11ShaderResourceView* pShaderResour
 }
 
 HRESULT D3D11DeviceContext::CopyResource(ID3D11Resource* pDst, ID3D11Resource* pSrc) {
-    if (!pDst || !pSrc) return E_INVALIDARG;
+    if (!pDst || !pSrc)
+        return E_INVALIDARG;
 
     void* dstBuf = pDst->__metalBufferPtr();
     void* srcBuf = pSrc->__metalBufferPtr();
@@ -545,8 +636,10 @@ HRESULT D3D11DeviceContext::CopyResource(ID3D11Resource* pDst, ID3D11Resource* p
     return E_NOTIMPL;
 }
 
-HRESULT D3D11DeviceContext::UpdateSubresource(ID3D11Resource* pDst, UINT DstSubresource, const void* pDstBox, const void* pSrcData, UINT SrcRowPitch, UINT SrcDepthPitch) {
-    if (!pDst || !pSrcData) return E_INVALIDARG;
+HRESULT D3D11DeviceContext::UpdateSubresource(ID3D11Resource* pDst, UINT DstSubresource, const void* pDstBox,
+                                              const void* pSrcData, UINT SrcRowPitch, UINT SrcDepthPitch) {
+    if (!pDst || !pSrcData)
+        return E_INVALIDARG;
 
     void* dstBuf = pDst->__metalBufferPtr();
     if (dstBuf) {
@@ -567,7 +660,7 @@ HRESULT D3D11DeviceContext::UpdateSubresource(ID3D11Resource* pDst, UINT DstSubr
         }
         NSUInteger bytesPerImage = SrcDepthPitch > 0 ? SrcDepthPitch : SrcRowPitch * tex.height;
         [tex replaceRegion:region
-                   mipmapLevel:DstSubresource
+               mipmapLevel:DstSubresource
                      slice:0
                  withBytes:pSrcData
                bytesPerRow:SrcRowPitch
@@ -578,8 +671,11 @@ HRESULT D3D11DeviceContext::UpdateSubresource(ID3D11Resource* pDst, UINT DstSubr
     return E_NOTIMPL;
 }
 
-HRESULT D3D11DeviceContext::CopySubresourceRegion(ID3D11Resource* pDst, UINT DstSubresource, UINT DstX, UINT DstY, UINT DstZ, ID3D11Resource* pSrc, UINT SrcSubresource, const void* pSrcBox) {
-    if (!pDst || !pSrc) return E_INVALIDARG;
+HRESULT D3D11DeviceContext::CopySubresourceRegion(ID3D11Resource* pDst, UINT DstSubresource, UINT DstX, UINT DstY,
+                                                  UINT DstZ, ID3D11Resource* pSrc, UINT SrcSubresource,
+                                                  const void* pSrcBox) {
+    if (!pDst || !pSrc)
+        return E_INVALIDARG;
 
     void* dstTex = pDst->__metalTexturePtr();
     void* srcTex = pSrc->__metalTexturePtr();
@@ -630,8 +726,10 @@ HRESULT D3D11DeviceContext::CopySubresourceRegion(ID3D11Resource* pDst, UINT Dst
     return E_NOTIMPL;
 }
 
-HRESULT D3D11DeviceContext::ResolveSubresource(ID3D11Resource* pDst, UINT DstSubresource, ID3D11Resource* pSrc, UINT SrcSubresource, DXGI_FORMAT Format) {
-    if (!pDst || !pSrc) return E_INVALIDARG;
+HRESULT D3D11DeviceContext::ResolveSubresource(ID3D11Resource* pDst, UINT DstSubresource, ID3D11Resource* pSrc,
+                                               UINT SrcSubresource, DXGI_FORMAT Format) {
+    if (!pDst || !pSrc)
+        return E_INVALIDARG;
 
     void* dstTex = pDst->__metalTexturePtr();
     void* srcTex = pSrc->__metalTexturePtr();
@@ -665,17 +763,20 @@ HRESULT D3D11DeviceContext::ResolveSubresource(ID3D11Resource* pDst, UINT DstSub
 }
 
 HRESULT D3D11DeviceContext::Begin(ID3D11Query* pQuery) {
-    if (!pQuery) return S_OK;
+    if (!pQuery)
+        return S_OK;
     return S_OK;
 }
 
 HRESULT D3D11DeviceContext::End(ID3D11Query* pQuery) {
-    if (!pQuery) return S_OK;
+    if (!pQuery)
+        return S_OK;
     return S_OK;
 }
 
 HRESULT D3D11DeviceContext::GetData(ID3D11Query* pQuery, void* pData, UINT DataSize, UINT GetDataFlags) {
-    if (!pQuery) return S_OK;
+    if (!pQuery)
+        return S_OK;
 
     UINT queryType = pQuery->__getQueryType();
     if (pData && DataSize >= sizeof(UINT64)) {
@@ -701,11 +802,12 @@ HRESULT D3D11DeviceContext::FinishCommandList(INT, ID3D11CommandList**) {
 }
 
 HRESULT D3D11DeviceContext::ExecuteCommandList(ID3D11CommandList* pCommandList, INT) {
-    if (!pCommandList) return E_INVALIDARG;
+    if (!pCommandList)
+        return E_INVALIDARG;
     auto* cmdList = static_cast<CommandList*>(pCommandList);
     m_cachedPipeline.reset();
     cmdList->replay(this);
     return S_OK;
 }
 
-}
+} // namespace metalsharp

--- a/src/d3d/d3d11/D3D11InputLayout.cpp
+++ b/src/d3d/d3d11/D3D11InputLayout.cpp
@@ -6,6 +6,4 @@
 
 #include <metalsharp/Platform.h>
 
-namespace metalsharp {
-
-}
+namespace metalsharp {}

--- a/src/d3d/d3d11/D3D11PixelShader.cpp
+++ b/src/d3d/d3d11/D3D11PixelShader.cpp
@@ -6,6 +6,4 @@
 
 #include <metalsharp/Platform.h>
 
-namespace metalsharp {
-
-}
+namespace metalsharp {}

--- a/src/d3d/d3d11/D3D11RasterizerState.cpp
+++ b/src/d3d/d3d11/D3D11RasterizerState.cpp
@@ -6,6 +6,4 @@
 
 #include <metalsharp/Platform.h>
 
-namespace metalsharp {
-
-}
+namespace metalsharp {}

--- a/src/d3d/d3d11/D3D11RenderTargetView.cpp
+++ b/src/d3d/d3d11/D3D11RenderTargetView.cpp
@@ -6,6 +6,4 @@
 
 #include <metalsharp/Platform.h>
 
-namespace metalsharp {
-
-}
+namespace metalsharp {}

--- a/src/d3d/d3d11/D3D11SamplerState.cpp
+++ b/src/d3d/d3d11/D3D11SamplerState.cpp
@@ -6,6 +6,4 @@
 
 #include <metalsharp/Platform.h>
 
-namespace metalsharp {
-
-}
+namespace metalsharp {}

--- a/src/d3d/d3d11/D3D11ShaderResourceView.cpp
+++ b/src/d3d/d3d11/D3D11ShaderResourceView.cpp
@@ -6,6 +6,4 @@
 
 #include <metalsharp/Platform.h>
 
-namespace metalsharp {
-
-}
+namespace metalsharp {}

--- a/src/d3d/d3d11/D3D11Texture2D.cpp
+++ b/src/d3d/d3d11/D3D11Texture2D.cpp
@@ -6,6 +6,4 @@
 
 #include <metalsharp/Platform.h>
 
-namespace metalsharp {
-
-}
+namespace metalsharp {}

--- a/src/d3d/d3d11/D3D11VertexShader.cpp
+++ b/src/d3d/d3d11/D3D11VertexShader.cpp
@@ -6,6 +6,4 @@
 
 #include <metalsharp/Platform.h>
 
-namespace metalsharp {
-
-}
+namespace metalsharp {}

--- a/src/d3d/d3d11/DeferredContext.cpp
+++ b/src/d3d/d3d11/DeferredContext.cpp
@@ -4,317 +4,431 @@
 /// Records D3D11 rendering commands as captured lambdas for later replay on the
 /// immediate context. Used for multi-threaded command generation.
 
-#include <metalsharp/DeferredContext.h>
-#include <metalsharp/D3D11Device.h>
 #include <cstring>
+#include <metalsharp/D3D11Device.h>
+#include <metalsharp/DeferredContext.h>
 
 namespace metalsharp {
 
 HRESULT CommandList::QueryInterface(REFIID riid, void** ppvObject) {
-    if (!ppvObject) return E_POINTER;
+    if (!ppvObject)
+        return E_POINTER;
     if (riid == __uuidof(IUnknown) || riid == __uuidof(ID3D11CommandList)) {
-        AddRef(); *ppvObject = this; return S_OK;
+        AddRef();
+        *ppvObject = this;
+        return S_OK;
     }
     return E_NOINTERFACE;
 }
 
-ULONG CommandList::AddRef() { return ++m_refCount; }
-ULONG CommandList::Release() { ULONG c = --m_refCount; if (c == 0) delete this; return c; }
+ULONG CommandList::AddRef() {
+    return ++m_refCount;
+}
+ULONG CommandList::Release() {
+    ULONG c = --m_refCount;
+    if (c == 0)
+        delete this;
+    return c;
+}
 
 HRESULT CommandList::GetDevice(ID3D11Device** ppDevice) {
-    if (!ppDevice) return E_POINTER;
+    if (!ppDevice)
+        return E_POINTER;
     return E_NOTIMPL;
 }
 
-HRESULT CommandList::GetPrivateData(const GUID&, UINT*, void*) { return E_NOTIMPL; }
-HRESULT CommandList::SetPrivateData(const GUID&, UINT, const void*) { return E_NOTIMPL; }
-HRESULT CommandList::SetPrivateDataInterface(const GUID&, const IUnknown*) { return E_NOTIMPL; }
-UINT CommandList::GetContextFlags() { return 0; }
+HRESULT CommandList::GetPrivateData(const GUID&, UINT*, void*) {
+    return E_NOTIMPL;
+}
+HRESULT CommandList::SetPrivateData(const GUID&, UINT, const void*) {
+    return E_NOTIMPL;
+}
+HRESULT CommandList::SetPrivateDataInterface(const GUID&, const IUnknown*) {
+    return E_NOTIMPL;
+}
+UINT CommandList::GetContextFlags() {
+    return 0;
+}
 
 DeferredContext::DeferredContext(D3D11Device& device) : m_device(device) {}
 
 HRESULT DeferredContext::QueryInterface(REFIID riid, void** ppvObject) {
-    if (!ppvObject) return E_POINTER;
+    if (!ppvObject)
+        return E_POINTER;
     if (riid == __uuidof(IUnknown) || riid == __uuidof(ID3D11DeviceContext)) {
-        AddRef(); *ppvObject = this; return S_OK;
+        AddRef();
+        *ppvObject = this;
+        return S_OK;
     }
     return E_NOINTERFACE;
 }
 
-ULONG DeferredContext::AddRef() { return ++m_refCount; }
-ULONG DeferredContext::Release() { ULONG c = --m_refCount; if (c == 0) delete this; return c; }
+ULONG DeferredContext::AddRef() {
+    return ++m_refCount;
+}
+ULONG DeferredContext::Release() {
+    ULONG c = --m_refCount;
+    if (c == 0)
+        delete this;
+    return c;
+}
 
 HRESULT DeferredContext::GetDevice(ID3D11Device** ppDevice) {
-    if (!ppDevice) return E_POINTER;
+    if (!ppDevice)
+        return E_POINTER;
     m_device.AddRef();
     *ppDevice = &m_device;
     return S_OK;
 }
 
-HRESULT DeferredContext::GetPrivateData(const GUID&, UINT*, void*) { return E_NOTIMPL; }
-HRESULT DeferredContext::SetPrivateData(const GUID&, UINT, const void*) { return E_NOTIMPL; }
-HRESULT DeferredContext::SetPrivateDataInterface(const GUID&, const IUnknown*) { return E_NOTIMPL; }
+HRESULT DeferredContext::GetPrivateData(const GUID&, UINT*, void*) {
+    return E_NOTIMPL;
+}
+HRESULT DeferredContext::SetPrivateData(const GUID&, UINT, const void*) {
+    return E_NOTIMPL;
+}
+HRESULT DeferredContext::SetPrivateDataInterface(const GUID&, const IUnknown*) {
+    return E_NOTIMPL;
+}
 
 HRESULT DeferredContext::IASetInputLayout(ID3D11InputLayout* p) {
-    if (p) p->AddRef();
+    if (p)
+        p->AddRef();
     record([p](ID3D11DeviceContext* ctx) {
         ctx->IASetInputLayout(p);
-        if (p) p->Release();
+        if (p)
+            p->Release();
     });
     return S_OK;
 }
 
-HRESULT DeferredContext::IASetVertexBuffers(UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppVBs, const UINT* pStrides, const UINT* pOffsets) {
-    auto bufs = std::make_shared<std::vector<ID3D11Buffer*>>(ppVBs ? ppVBs : nullptr, ppVBs ? ppVBs + NumBuffers : nullptr);
-    auto strides = std::make_shared<std::vector<UINT>>(pStrides ? pStrides : nullptr, pStrides ? pStrides + NumBuffers : nullptr);
-    auto offsets = std::make_shared<std::vector<UINT>>(pOffsets ? pOffsets : nullptr, pOffsets ? pOffsets + NumBuffers : nullptr);
-    for (auto& b : *bufs) if (b) b->AddRef();
+HRESULT DeferredContext::IASetVertexBuffers(UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppVBs,
+                                            const UINT* pStrides, const UINT* pOffsets) {
+    auto bufs =
+        std::make_shared<std::vector<ID3D11Buffer*>>(ppVBs ? ppVBs : nullptr, ppVBs ? ppVBs + NumBuffers : nullptr);
+    auto strides =
+        std::make_shared<std::vector<UINT>>(pStrides ? pStrides : nullptr, pStrides ? pStrides + NumBuffers : nullptr);
+    auto offsets =
+        std::make_shared<std::vector<UINT>>(pOffsets ? pOffsets : nullptr, pOffsets ? pOffsets + NumBuffers : nullptr);
+    for (auto& b : *bufs)
+        if (b)
+            b->AddRef();
     record([StartSlot, NumBuffers, bufs, strides, offsets](ID3D11DeviceContext* ctx) {
         ctx->IASetVertexBuffers(StartSlot, NumBuffers, bufs->data(), strides->data(), offsets->data());
-        for (auto& b : *bufs) if (b) b->Release();
+        for (auto& b : *bufs)
+            if (b)
+                b->Release();
     });
     return S_OK;
 }
 
 HRESULT DeferredContext::IASetIndexBuffer(ID3D11Buffer* p, DXGI_FORMAT fmt, UINT off) {
-    if (p) p->AddRef();
+    if (p)
+        p->AddRef();
     record([p, fmt, off](ID3D11DeviceContext* ctx) {
         ctx->IASetIndexBuffer(p, fmt, off);
-        if (p) p->Release();
+        if (p)
+            p->Release();
     });
     return S_OK;
 }
 
 HRESULT DeferredContext::IASetPrimitiveTopology(UINT topo) {
-    record([topo](ID3D11DeviceContext* ctx) {
-        ctx->IASetPrimitiveTopology(topo);
-    });
+    record([topo](ID3D11DeviceContext* ctx) { ctx->IASetPrimitiveTopology(topo); });
     return S_OK;
 }
 
 HRESULT DeferredContext::VSSetShader(ID3D11VertexShader* p, ID3D11ClassInstance* const*, UINT) {
-    if (p) p->AddRef();
+    if (p)
+        p->AddRef();
     record([p](ID3D11DeviceContext* ctx) {
         ctx->VSSetShader(p, nullptr, 0);
-        if (p) p->Release();
+        if (p)
+            p->Release();
     });
     return S_OK;
 }
 
 HRESULT DeferredContext::VSSetConstantBuffers(UINT slot, UINT num, ID3D11Buffer* const* pp) {
     auto bufs = std::make_shared<std::vector<ID3D11Buffer*>>(pp ? pp : nullptr, pp ? pp + num : nullptr);
-    for (auto& b : *bufs) if (b) b->AddRef();
+    for (auto& b : *bufs)
+        if (b)
+            b->AddRef();
     record([slot, num, bufs](ID3D11DeviceContext* ctx) {
         ctx->VSSetConstantBuffers(slot, num, bufs->data());
-        for (auto& b : *bufs) if (b) b->Release();
+        for (auto& b : *bufs)
+            if (b)
+                b->Release();
     });
     return S_OK;
 }
 
 HRESULT DeferredContext::VSSetShaderResources(UINT slot, UINT num, ID3D11ShaderResourceView* const* pp) {
     auto views = std::make_shared<std::vector<ID3D11ShaderResourceView*>>(pp ? pp : nullptr, pp ? pp + num : nullptr);
-    for (auto& v : *views) if (v) v->AddRef();
+    for (auto& v : *views)
+        if (v)
+            v->AddRef();
     record([slot, num, views](ID3D11DeviceContext* ctx) {
         ctx->VSSetShaderResources(slot, num, views->data());
-        for (auto& v : *views) if (v) v->Release();
+        for (auto& v : *views)
+            if (v)
+                v->Release();
     });
     return S_OK;
 }
 
 HRESULT DeferredContext::VSSetSamplers(UINT slot, UINT num, ID3D11SamplerState* const* pp) {
     auto samps = std::make_shared<std::vector<ID3D11SamplerState*>>(pp ? pp : nullptr, pp ? pp + num : nullptr);
-    for (auto& s : *samps) if (s) s->AddRef();
+    for (auto& s : *samps)
+        if (s)
+            s->AddRef();
     record([slot, num, samps](ID3D11DeviceContext* ctx) {
         ctx->VSSetSamplers(slot, num, samps->data());
-        for (auto& s : *samps) if (s) s->Release();
+        for (auto& s : *samps)
+            if (s)
+                s->Release();
     });
     return S_OK;
 }
 
 HRESULT DeferredContext::PSSetShader(ID3D11PixelShader* p, ID3D11ClassInstance* const*, UINT) {
-    if (p) p->AddRef();
+    if (p)
+        p->AddRef();
     record([p](ID3D11DeviceContext* ctx) {
         ctx->PSSetShader(p, nullptr, 0);
-        if (p) p->Release();
+        if (p)
+            p->Release();
     });
     return S_OK;
 }
 
 HRESULT DeferredContext::PSSetConstantBuffers(UINT slot, UINT num, ID3D11Buffer* const* pp) {
     auto bufs = std::make_shared<std::vector<ID3D11Buffer*>>(pp ? pp : nullptr, pp ? pp + num : nullptr);
-    for (auto& b : *bufs) if (b) b->AddRef();
+    for (auto& b : *bufs)
+        if (b)
+            b->AddRef();
     record([slot, num, bufs](ID3D11DeviceContext* ctx) {
         ctx->PSSetConstantBuffers(slot, num, bufs->data());
-        for (auto& b : *bufs) if (b) b->Release();
+        for (auto& b : *bufs)
+            if (b)
+                b->Release();
     });
     return S_OK;
 }
 
 HRESULT DeferredContext::PSSetShaderResources(UINT slot, UINT num, ID3D11ShaderResourceView* const* pp) {
     auto views = std::make_shared<std::vector<ID3D11ShaderResourceView*>>(pp ? pp : nullptr, pp ? pp + num : nullptr);
-    for (auto& v : *views) if (v) v->AddRef();
+    for (auto& v : *views)
+        if (v)
+            v->AddRef();
     record([slot, num, views](ID3D11DeviceContext* ctx) {
         ctx->PSSetShaderResources(slot, num, views->data());
-        for (auto& v : *views) if (v) v->Release();
+        for (auto& v : *views)
+            if (v)
+                v->Release();
     });
     return S_OK;
 }
 
 HRESULT DeferredContext::PSSetSamplers(UINT slot, UINT num, ID3D11SamplerState* const* pp) {
     auto samps = std::make_shared<std::vector<ID3D11SamplerState*>>(pp ? pp : nullptr, pp ? pp + num : nullptr);
-    for (auto& s : *samps) if (s) s->AddRef();
+    for (auto& s : *samps)
+        if (s)
+            s->AddRef();
     record([slot, num, samps](ID3D11DeviceContext* ctx) {
         ctx->PSSetSamplers(slot, num, samps->data());
-        for (auto& s : *samps) if (s) s->Release();
+        for (auto& s : *samps)
+            if (s)
+                s->Release();
     });
     return S_OK;
 }
 
-HRESULT DeferredContext::GSSetShader(ID3D11GeometryShader*, ID3D11ClassInstance* const*, UINT) { return E_NOTIMPL; }
+HRESULT DeferredContext::GSSetShader(ID3D11GeometryShader*, ID3D11ClassInstance* const*, UINT) {
+    return E_NOTIMPL;
+}
 
 HRESULT DeferredContext::CSSetShader(ID3D11ComputeShader* p, ID3D11ClassInstance* const*, UINT) {
-    if (p) p->AddRef();
+    if (p)
+        p->AddRef();
     record([p](ID3D11DeviceContext* ctx) {
         ctx->CSSetShader(p, nullptr, 0);
-        if (p) p->Release();
+        if (p)
+            p->Release();
     });
     return S_OK;
 }
 
 HRESULT DeferredContext::CSSetConstantBuffers(UINT slot, UINT num, ID3D11Buffer* const* pp) {
     auto bufs = std::make_shared<std::vector<ID3D11Buffer*>>(pp ? pp : nullptr, pp ? pp + num : nullptr);
-    for (auto& b : *bufs) if (b) b->AddRef();
+    for (auto& b : *bufs)
+        if (b)
+            b->AddRef();
     record([slot, num, bufs](ID3D11DeviceContext* ctx) {
         ctx->CSSetConstantBuffers(slot, num, bufs->data());
-        for (auto& b : *bufs) if (b) b->Release();
+        for (auto& b : *bufs)
+            if (b)
+                b->Release();
     });
     return S_OK;
 }
 
 HRESULT DeferredContext::CSSetShaderResources(UINT slot, UINT num, ID3D11ShaderResourceView* const* pp) {
     auto views = std::make_shared<std::vector<ID3D11ShaderResourceView*>>(pp ? pp : nullptr, pp ? pp + num : nullptr);
-    for (auto& v : *views) if (v) v->AddRef();
+    for (auto& v : *views)
+        if (v)
+            v->AddRef();
     record([slot, num, views](ID3D11DeviceContext* ctx) {
         ctx->CSSetShaderResources(slot, num, views->data());
-        for (auto& v : *views) if (v) v->Release();
+        for (auto& v : *views)
+            if (v)
+                v->Release();
     });
     return S_OK;
 }
 
-HRESULT DeferredContext::CSSetUnorderedAccessViews(UINT slot, UINT num, ID3D11UnorderedAccessView* const* pp, const UINT* pCounts) {
+HRESULT DeferredContext::CSSetUnorderedAccessViews(UINT slot, UINT num, ID3D11UnorderedAccessView* const* pp,
+                                                   const UINT* pCounts) {
     auto uavs = std::make_shared<std::vector<ID3D11UnorderedAccessView*>>(pp ? pp : nullptr, pp ? pp + num : nullptr);
-    for (auto& u : *uavs) if (u) u->AddRef();
+    for (auto& u : *uavs)
+        if (u)
+            u->AddRef();
     record([slot, num, uavs](ID3D11DeviceContext* ctx) {
         ctx->CSSetUnorderedAccessViews(slot, num, uavs->data(), nullptr);
-        for (auto& u : *uavs) if (u) u->Release();
+        for (auto& u : *uavs)
+            if (u)
+                u->Release();
     });
     return S_OK;
 }
 
 HRESULT DeferredContext::CSSetSamplers(UINT slot, UINT num, ID3D11SamplerState* const* pp) {
     auto samps = std::make_shared<std::vector<ID3D11SamplerState*>>(pp ? pp : nullptr, pp ? pp + num : nullptr);
-    for (auto& s : *samps) if (s) s->AddRef();
+    for (auto& s : *samps)
+        if (s)
+            s->AddRef();
     record([slot, num, samps](ID3D11DeviceContext* ctx) {
         ctx->CSSetSamplers(slot, num, samps->data());
-        for (auto& s : *samps) if (s) s->Release();
+        for (auto& s : *samps)
+            if (s)
+                s->Release();
     });
     return S_OK;
 }
 
 HRESULT DeferredContext::Dispatch(UINT x, UINT y, UINT z) {
-    record([x, y, z](ID3D11DeviceContext* ctx) {
-        ctx->Dispatch(x, y, z);
-    });
+    record([x, y, z](ID3D11DeviceContext* ctx) { ctx->Dispatch(x, y, z); });
     return S_OK;
 }
 
-HRESULT DeferredContext::OMSetRenderTargets(UINT num, ID3D11RenderTargetView* const* ppRTVs, ID3D11DepthStencilView* pDSV) {
-    auto rtvs = std::make_shared<std::vector<ID3D11RenderTargetView*>>(ppRTVs ? ppRTVs : nullptr, ppRTVs ? ppRTVs + num : nullptr);
-    for (auto& r : *rtvs) if (r) r->AddRef();
-    if (pDSV) pDSV->AddRef();
+HRESULT DeferredContext::OMSetRenderTargets(UINT num, ID3D11RenderTargetView* const* ppRTVs,
+                                            ID3D11DepthStencilView* pDSV) {
+    auto rtvs = std::make_shared<std::vector<ID3D11RenderTargetView*>>(ppRTVs ? ppRTVs : nullptr,
+                                                                       ppRTVs ? ppRTVs + num : nullptr);
+    for (auto& r : *rtvs)
+        if (r)
+            r->AddRef();
+    if (pDSV)
+        pDSV->AddRef();
     record([num, rtvs, pDSV](ID3D11DeviceContext* ctx) {
         ctx->OMSetRenderTargets(num, rtvs->data(), pDSV);
-        for (auto& r : *rtvs) if (r) r->Release();
-        if (pDSV) pDSV->Release();
+        for (auto& r : *rtvs)
+            if (r)
+                r->Release();
+        if (pDSV)
+            pDSV->Release();
     });
     return S_OK;
 }
 
-HRESULT DeferredContext::OMSetRenderTargetsAndUnorderedAccessViews(UINT numRTV, ID3D11RenderTargetView* const* ppRTVs, ID3D11DepthStencilView* pDSV, UINT uavStart, UINT numUAV, ID3D11UnorderedAccessView* const* ppUAVs, const UINT* pCounts) {
+HRESULT DeferredContext::OMSetRenderTargetsAndUnorderedAccessViews(UINT numRTV, ID3D11RenderTargetView* const* ppRTVs,
+                                                                   ID3D11DepthStencilView* pDSV, UINT uavStart,
+                                                                   UINT numUAV,
+                                                                   ID3D11UnorderedAccessView* const* ppUAVs,
+                                                                   const UINT* pCounts) {
     return OMSetRenderTargets(numRTV, ppRTVs, pDSV);
 }
 
 HRESULT DeferredContext::OMSetBlendState(ID3D11BlendState* p, const FLOAT factor[4], UINT mask) {
-    if (p) p->AddRef();
+    if (p)
+        p->AddRef();
     FLOAT f[4] = {};
-    if (factor) memcpy(f, factor, sizeof(f));
+    if (factor)
+        memcpy(f, factor, sizeof(f));
     record([p, f, mask](ID3D11DeviceContext* ctx) {
         ctx->OMSetBlendState(p, f, mask);
-        if (p) p->Release();
+        if (p)
+            p->Release();
     });
     return S_OK;
 }
 
 HRESULT DeferredContext::OMSetDepthStencilState(ID3D11DepthStencilState* p, UINT ref) {
-    if (p) p->AddRef();
+    if (p)
+        p->AddRef();
     record([p, ref](ID3D11DeviceContext* ctx) {
         ctx->OMSetDepthStencilState(p, ref);
-        if (p) p->Release();
+        if (p)
+            p->Release();
     });
     return S_OK;
 }
 
 HRESULT DeferredContext::RSSetState(ID3D11RasterizerState* p) {
-    if (p) p->AddRef();
+    if (p)
+        p->AddRef();
     record([p](ID3D11DeviceContext* ctx) {
         ctx->RSSetState(p);
-        if (p) p->Release();
+        if (p)
+            p->Release();
     });
     return S_OK;
 }
 
 HRESULT DeferredContext::RSSetViewports(UINT num, const D3D11_VIEWPORT* vp) {
     D3D11_VIEWPORT copy = {};
-    if (num > 0 && vp) copy = vp[0];
-    record([copy](ID3D11DeviceContext* ctx) {
-        ctx->RSSetViewports(1, &copy);
-    });
+    if (num > 0 && vp)
+        copy = vp[0];
+    record([copy](ID3D11DeviceContext* ctx) { ctx->RSSetViewports(1, &copy); });
     return S_OK;
 }
 
-HRESULT DeferredContext::RSSetScissorRects(UINT num, const RECT* rects) { return S_OK; }
+HRESULT DeferredContext::RSSetScissorRects(UINT num, const RECT* rects) {
+    return S_OK;
+}
 
 HRESULT DeferredContext::ClearRenderTargetView(ID3D11RenderTargetView* p, const FLOAT color[4]) {
-    if (p) p->AddRef();
+    if (p)
+        p->AddRef();
     FLOAT c[4] = {};
-    if (color) memcpy(c, color, sizeof(c));
+    if (color)
+        memcpy(c, color, sizeof(c));
     record([p, c](ID3D11DeviceContext* ctx) {
         ctx->ClearRenderTargetView(p, c);
-        if (p) p->Release();
+        if (p)
+            p->Release();
     });
     return S_OK;
 }
 
 HRESULT DeferredContext::ClearDepthStencilView(ID3D11DepthStencilView* p, UINT flags, FLOAT depth, UINT8 stencil) {
-    if (p) p->AddRef();
+    if (p)
+        p->AddRef();
     record([p, flags, depth, stencil](ID3D11DeviceContext* ctx) {
         ctx->ClearDepthStencilView(p, flags, depth, stencil);
-        if (p) p->Release();
+        if (p)
+            p->Release();
     });
     return S_OK;
 }
 
 HRESULT DeferredContext::DrawIndexed(UINT count, UINT start, INT base) {
-    record([count, start, base](ID3D11DeviceContext* ctx) {
-        ctx->DrawIndexed(count, start, base);
-    });
+    record([count, start, base](ID3D11DeviceContext* ctx) { ctx->DrawIndexed(count, start, base); });
     return S_OK;
 }
 
 HRESULT DeferredContext::Draw(UINT count, UINT start) {
-    record([count, start](ID3D11DeviceContext* ctx) {
-        ctx->Draw(count, start);
-    });
+    record([count, start](ID3D11DeviceContext* ctx) { ctx->Draw(count, start); });
     return S_OK;
 }
 
@@ -341,65 +455,86 @@ HRESULT DeferredContext::Unmap(ID3D11Resource*, UINT) {
 }
 
 HRESULT DeferredContext::GenerateMips(ID3D11ShaderResourceView* p) {
-    if (p) p->AddRef();
+    if (p)
+        p->AddRef();
     record([p](ID3D11DeviceContext* ctx) {
         ctx->GenerateMips(p);
-        if (p) p->Release();
+        if (p)
+            p->Release();
     });
     return S_OK;
 }
 
 HRESULT DeferredContext::CopyResource(ID3D11Resource* dst, ID3D11Resource* src) {
-    if (dst) dst->AddRef();
-    if (src) src->AddRef();
+    if (dst)
+        dst->AddRef();
+    if (src)
+        src->AddRef();
     record([dst, src](ID3D11DeviceContext* ctx) {
         ctx->CopyResource(dst, src);
-        if (dst) dst->Release();
-        if (src) src->Release();
+        if (dst)
+            dst->Release();
+        if (src)
+            src->Release();
     });
     return S_OK;
 }
 
-HRESULT DeferredContext::UpdateSubresource(ID3D11Resource* dst, UINT sub, const void* box, const void* data, UINT rowPitch, UINT depthPitch) {
+HRESULT DeferredContext::UpdateSubresource(ID3D11Resource* dst, UINT sub, const void* box, const void* data,
+                                           UINT rowPitch, UINT depthPitch) {
     return E_FAIL;
 }
 
-HRESULT DeferredContext::CopySubresourceRegion(ID3D11Resource* dst, UINT dstSub, UINT dx, UINT dy, UINT dz, ID3D11Resource* src, UINT srcSub, const void* srcBox) {
-    if (dst) dst->AddRef();
-    if (src) src->AddRef();
+HRESULT DeferredContext::CopySubresourceRegion(ID3D11Resource* dst, UINT dstSub, UINT dx, UINT dy, UINT dz,
+                                               ID3D11Resource* src, UINT srcSub, const void* srcBox) {
+    if (dst)
+        dst->AddRef();
+    if (src)
+        src->AddRef();
     record([dst, dstSub, dx, dy, dz, src, srcSub](ID3D11DeviceContext* ctx) {
         ctx->CopySubresourceRegion(dst, dstSub, dx, dy, dz, src, srcSub, nullptr);
-        if (dst) dst->Release();
-        if (src) src->Release();
+        if (dst)
+            dst->Release();
+        if (src)
+            src->Release();
     });
     return S_OK;
 }
 
-HRESULT DeferredContext::ResolveSubresource(ID3D11Resource* dst, UINT dstSub, ID3D11Resource* src, UINT srcSub, DXGI_FORMAT fmt) {
-    if (dst) dst->AddRef();
-    if (src) src->AddRef();
+HRESULT DeferredContext::ResolveSubresource(ID3D11Resource* dst, UINT dstSub, ID3D11Resource* src, UINT srcSub,
+                                            DXGI_FORMAT fmt) {
+    if (dst)
+        dst->AddRef();
+    if (src)
+        src->AddRef();
     record([dst, dstSub, src, srcSub, fmt](ID3D11DeviceContext* ctx) {
         ctx->ResolveSubresource(dst, dstSub, src, srcSub, fmt);
-        if (dst) dst->Release();
-        if (src) src->Release();
+        if (dst)
+            dst->Release();
+        if (src)
+            src->Release();
     });
     return S_OK;
 }
 
 HRESULT DeferredContext::Begin(ID3D11Query* p) {
-    if (p) p->AddRef();
+    if (p)
+        p->AddRef();
     record([p](ID3D11DeviceContext* ctx) {
         ctx->Begin(p);
-        if (p) p->Release();
+        if (p)
+            p->Release();
     });
     return S_OK;
 }
 
 HRESULT DeferredContext::End(ID3D11Query* p) {
-    if (p) p->AddRef();
+    if (p)
+        p->AddRef();
     record([p](ID3D11DeviceContext* ctx) {
         ctx->End(p);
-        if (p) p->Release();
+        if (p)
+            p->Release();
     });
     return S_OK;
 }
@@ -409,16 +544,19 @@ HRESULT DeferredContext::GetData(ID3D11Query*, void*, UINT, UINT) {
 }
 
 HRESULT DeferredContext::SetPredication(ID3D11Predicate* p, INT val) {
-    if (p) p->AddRef();
+    if (p)
+        p->AddRef();
     record([p, val](ID3D11DeviceContext* ctx) {
         ctx->SetPredication(p, val);
-        if (p) p->Release();
+        if (p)
+            p->Release();
     });
     return S_OK;
 }
 
 HRESULT DeferredContext::FinishCommandList(INT, ID3D11CommandList** ppCmdList) {
-    if (!ppCmdList) return E_POINTER;
+    if (!ppCmdList)
+        return E_POINTER;
     *ppCmdList = m_commandList;
     m_commandList = new CommandList();
     return S_OK;
@@ -428,4 +566,4 @@ HRESULT DeferredContext::ExecuteCommandList(ID3D11CommandList*, INT) {
     return E_FAIL;
 }
 
-}
+} // namespace metalsharp

--- a/src/d3d/d3d11/EntryPoint.cpp
+++ b/src/d3d/d3d11/EntryPoint.cpp
@@ -4,15 +4,16 @@
 /// Implements D3D11CreateDevice and D3D11CreateDeviceAndSwapChain, the primary
 /// entry points that games call to obtain an ID3D11Device and immediate context.
 
+#include <cstring>
 #include <d3d/D3D11.h>
 #include <metalsharp/D3D11Device.h>
 #include <metalsharp/DXGI.h>
-#include <cstring>
 
 using namespace metalsharp;
 
 static HRESULT CreateSwapChainForDevice(D3D11Device* device, const void* pSwapChainDesc, void** ppSwapChain) {
-    if (!ppSwapChain || !pSwapChainDesc) return E_POINTER;
+    if (!ppSwapChain || !pSwapChainDesc)
+        return E_POINTER;
 
     auto* desc = static_cast<const DXGI_SWAP_CHAIN_DESC*>(pSwapChainDesc);
 
@@ -21,12 +22,16 @@ static HRESULT CreateSwapChainForDevice(D3D11Device* device, const void* pSwapCh
     uint32_t bufferCount = desc->BufferCount > 0 ? desc->BufferCount : 2;
     DXGI_FORMAT format = desc->BufferDesc.Format;
 
-    if (width == 0) width = 1920;
-    if (height == 0) height = 1080;
-    if (format == 0) format = DXGI_FORMAT_R8G8B8A8_UNORM;
+    if (width == 0)
+        width = 1920;
+    if (height == 0)
+        height = 1080;
+    if (format == 0)
+        format = DXGI_FORMAT_R8G8B8A8_UNORM;
 
     IDXGISwapChain* swapChain = nullptr;
-    HRESULT hr = DXGISwapChainImpl::create(&device->metalDevice(), desc->OutputWindow, width, height, bufferCount, format, &swapChain);
+    HRESULT hr = DXGISwapChainImpl::create(&device->metalDevice(), desc->OutputWindow, width, height, bufferCount,
+                                           format, &swapChain);
     if (SUCCEEDED(hr)) {
         *ppSwapChain = swapChain;
     }
@@ -35,21 +40,13 @@ static HRESULT CreateSwapChainForDevice(D3D11Device* device, const void* pSwapCh
 
 extern "C" {
 
-HRESULT D3D11CreateDevice(
-    void* pAdapter,
-    UINT DriverType,
-    HMODULE Software,
-    UINT Flags,
-    const void* pFeatureLevels,
-    UINT FeatureLevels,
-    UINT SDKVersion,
-    ID3D11Device** ppDevice,
-    void* pFeatureLevel,
-    ID3D11DeviceContext** ppImmediateContext)
-{
+HRESULT D3D11CreateDevice(void* pAdapter, UINT DriverType, HMODULE Software, UINT Flags, const void* pFeatureLevels,
+                          UINT FeatureLevels, UINT SDKVersion, ID3D11Device** ppDevice, void* pFeatureLevel,
+                          ID3D11DeviceContext** ppImmediateContext) {
     D3D11Device* device = nullptr;
     HRESULT hr = D3D11Device::create(&device);
-    if (FAILED(hr)) return hr;
+    if (FAILED(hr))
+        return hr;
 
     if (ppDevice) {
         *ppDevice = device;
@@ -69,23 +66,14 @@ HRESULT D3D11CreateDevice(
     return S_OK;
 }
 
-HRESULT D3D11CreateDeviceAndSwapChain(
-    void* pAdapter,
-    UINT DriverType,
-    HMODULE Software,
-    UINT Flags,
-    const void* pFeatureLevels,
-    UINT FeatureLevels,
-    UINT SDKVersion,
-    const void* pSwapChainDesc,
-    void** ppSwapChain,
-    ID3D11Device** ppDevice,
-    void* pFeatureLevel,
-    ID3D11DeviceContext** ppImmediateContext)
-{
+HRESULT D3D11CreateDeviceAndSwapChain(void* pAdapter, UINT DriverType, HMODULE Software, UINT Flags,
+                                      const void* pFeatureLevels, UINT FeatureLevels, UINT SDKVersion,
+                                      const void* pSwapChainDesc, void** ppSwapChain, ID3D11Device** ppDevice,
+                                      void* pFeatureLevel, ID3D11DeviceContext** ppImmediateContext) {
     D3D11Device* device = nullptr;
     HRESULT hr = D3D11Device::create(&device);
-    if (FAILED(hr)) return hr;
+    if (FAILED(hr))
+        return hr;
 
     if (ppDevice) {
         *ppDevice = device;
@@ -111,5 +99,4 @@ HRESULT D3D11CreateDeviceAndSwapChain(
 
     return S_OK;
 }
-
 }

--- a/src/d3d/d3d12/D3D12CommandList.mm
+++ b/src/d3d/d3d12/D3D12CommandList.mm
@@ -35,18 +35,20 @@
 ///   - Sample feedback (WriteBufferImmediate)
 ///   - Bundle command lists (execute inline only)
 
-#include <metalsharp/D3D12Device.h>
-#include <metalsharp/PipelineState.h>
-#include <metalsharp/ArgumentBufferBinding.h>
-#include <metalsharp/Logger.h>
+#include <cstring>
 #include <Foundation/Foundation.h>
 #include <Metal/Metal.h>
-#include <cstring>
+#include <metalsharp/ArgumentBufferBinding.h>
+#include <metalsharp/D3D12Device.h>
+#include <metalsharp/Logger.h>
+#include <metalsharp/PipelineState.h>
 
 namespace metalsharp {
 
-HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* pAllocator, ID3D12PipelineState*, REFIID riid, void** ppCommandList) {
-    if (!ppCommandList) return E_POINTER;
+HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* pAllocator, ID3D12PipelineState*,
+                                           REFIID riid, void** ppCommandList) {
+    if (!ppCommandList)
+        return E_POINTER;
 
     struct CmdListImpl final : public ID3D12GraphicsCommandList {
         ULONG refCount = 1;
@@ -102,7 +104,9 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
         };
         std::vector<ClearCmd> m_clearCmds;
 
-        struct ComputeDispatch { UINT x, y, z; };
+        struct ComputeDispatch {
+            UINT x, y, z;
+        };
         std::vector<ComputeDispatch> m_computeDispatches;
 
         struct DrawCmd {
@@ -136,23 +140,38 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
 
         ~CmdListImpl() {
             for (auto* res : m_referencedResources) {
-                if (res) res->Release();
+                if (res)
+                    res->Release();
             }
         }
 
         HRESULT QueryInterface(REFIID riid, void** ppv) override {
-            if (!ppv) return E_POINTER;
-            if (riid == IID_ID3D12GraphicsCommandList || riid == IID_IUnknown) { AddRef(); *ppv = this; return S_OK; }
+            if (!ppv)
+                return E_POINTER;
+            if (riid == IID_ID3D12GraphicsCommandList || riid == IID_IUnknown) {
+                AddRef();
+                *ppv = this;
+                return S_OK;
+            }
             return E_NOINTERFACE;
         }
         ULONG AddRef() override { return ++refCount; }
-        ULONG Release() override { ULONG c = --refCount; if (c == 0) delete this; return c; }
+        ULONG Release() override {
+            ULONG c = --refCount;
+            if (c == 0)
+                delete this;
+            return c;
+        }
         STDMETHOD(GetPrivateData)(const GUID&, UINT*, void*) override { return E_NOTIMPL; }
         STDMETHOD(SetPrivateData)(const GUID&, UINT, const void*) override { return E_NOTIMPL; }
         STDMETHOD(SetPrivateDataInterface)(const GUID&, const IUnknown*) override { return E_NOTIMPL; }
         STDMETHOD(SetName)(const char*) override { return S_OK; }
 
-        HRESULT Close() override { m_closed = true; m_recording = false; return S_OK; }
+        HRESULT Close() override {
+            m_closed = true;
+            m_recording = false;
+            return S_OK;
+        }
         HRESULT Reset(ID3D12CommandAllocator* pAllocator, ID3D12PipelineState* pInitialState) override {
             m_closed = false;
             m_recording = true;
@@ -167,15 +186,22 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
             m_rootSignature = nullptr;
             std::fill(m_argumentBuffer.begin(), m_argumentBuffer.end(), 0);
             m_numDescriptorHeaps = 0;
-            for (auto* res : m_referencedResources) { if (res) res->Release(); }
+            for (auto* res : m_referencedResources) {
+                if (res)
+                    res->Release();
+            }
             m_referencedResources.clear();
             return S_OK;
         }
 
-        HRESULT IASetPrimitiveTopology(UINT topo) override { m_primitiveTopology = topo; return S_OK; }
+        HRESULT IASetPrimitiveTopology(UINT topo) override {
+            m_primitiveTopology = topo;
+            return S_OK;
+        }
 
         HRESULT IASetVertexBuffers(UINT start, UINT num, const D3D12_VERTEX_BUFFER_VIEW* pViews) override {
-            if (!pViews) return S_OK;
+            if (!pViews)
+                return S_OK;
             for (UINT i = 0; i < num && (start + i) < 32; ++i) {
                 m_vertexBuffers[start + i].offset = pViews[i].BufferLocation;
                 m_vertexBuffers[start + i].size = pViews[i].SizeInBytes;
@@ -185,14 +211,18 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
         }
 
         HRESULT IASetIndexBuffer(const D3D12_INDEX_BUFFER_VIEW* pView) override {
-            if (!pView) return S_OK;
+            if (!pView)
+                return S_OK;
             m_indexBuffer.offset = pView->BufferLocation;
             m_indexBuffer.size = pView->SizeInBytes;
             m_indexBuffer.format = pView->Format;
             return S_OK;
         }
 
-        HRESULT SetPipelineState(ID3D12PipelineState* pPSO) override { m_pso = pPSO; return S_OK; }
+        HRESULT SetPipelineState(ID3D12PipelineState* pPSO) override {
+            m_pso = pPSO;
+            return S_OK;
+        }
 
         HRESULT SetGraphicsRootSignature(ID3D12RootSignature* pRS) override {
             m_rootSignature = static_cast<D3D12RootSignatureImpl*>(pRS);
@@ -205,8 +235,10 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
             return S_OK;
         }
 
-        HRESULT SetGraphicsRootDescriptorTable(UINT rootParamIndex, D3D12_GPU_DESCRIPTOR_HANDLE baseDescriptor) override {
-            if (!m_rootSignature || rootParamIndex >= m_rootSignature->parameterLayouts.size()) return S_OK;
+        HRESULT SetGraphicsRootDescriptorTable(UINT rootParamIndex,
+                                               D3D12_GPU_DESCRIPTOR_HANDLE baseDescriptor) override {
+            if (!m_rootSignature || rootParamIndex >= m_rootSignature->parameterLayouts.size())
+                return S_OK;
             auto& layout = m_rootSignature->parameterLayouts[rootParamIndex];
 
             if (layout.offset + sizeof(uint64_t) <= m_argumentBuffer.size()) {
@@ -216,8 +248,10 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
             return S_OK;
         }
 
-        HRESULT SetGraphicsRootConstantBufferView(UINT rootParamIndex, D3D12_GPU_VIRTUAL_ADDRESS bufferLocation) override {
-            if (!m_rootSignature || rootParamIndex >= m_rootSignature->parameterLayouts.size()) return S_OK;
+        HRESULT SetGraphicsRootConstantBufferView(UINT rootParamIndex,
+                                                  D3D12_GPU_VIRTUAL_ADDRESS bufferLocation) override {
+            if (!m_rootSignature || rootParamIndex >= m_rootSignature->parameterLayouts.size())
+                return S_OK;
             auto& layout = m_rootSignature->parameterLayouts[rootParamIndex];
 
             if (layout.offset + sizeof(uint64_t) <= m_argumentBuffer.size()) {
@@ -226,8 +260,10 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
             return S_OK;
         }
 
-        HRESULT SetGraphicsRootShaderResourceView(UINT rootParamIndex, D3D12_GPU_VIRTUAL_ADDRESS bufferLocation) override {
-            if (!m_rootSignature || rootParamIndex >= m_rootSignature->parameterLayouts.size()) return S_OK;
+        HRESULT SetGraphicsRootShaderResourceView(UINT rootParamIndex,
+                                                  D3D12_GPU_VIRTUAL_ADDRESS bufferLocation) override {
+            if (!m_rootSignature || rootParamIndex >= m_rootSignature->parameterLayouts.size())
+                return S_OK;
             auto& layout = m_rootSignature->parameterLayouts[rootParamIndex];
 
             if (layout.offset + sizeof(uint64_t) <= m_argumentBuffer.size()) {
@@ -236,8 +272,10 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
             return S_OK;
         }
 
-        HRESULT SetGraphicsRootUnorderedAccessView(UINT rootParamIndex, D3D12_GPU_VIRTUAL_ADDRESS bufferLocation) override {
-            if (!m_rootSignature || rootParamIndex >= m_rootSignature->parameterLayouts.size()) return S_OK;
+        HRESULT SetGraphicsRootUnorderedAccessView(UINT rootParamIndex,
+                                                   D3D12_GPU_VIRTUAL_ADDRESS bufferLocation) override {
+            if (!m_rootSignature || rootParamIndex >= m_rootSignature->parameterLayouts.size())
+                return S_OK;
             auto& layout = m_rootSignature->parameterLayouts[rootParamIndex];
 
             if (layout.offset + sizeof(uint64_t) <= m_argumentBuffer.size()) {
@@ -246,9 +284,12 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
             return S_OK;
         }
 
-        HRESULT SetGraphicsRoot32BitConstants(UINT rootParamIndex, UINT num32BitValues, const void* pData, UINT destOffset) override {
-            if (!pData || num32BitValues == 0) return S_OK;
-            if (!m_rootSignature || rootParamIndex >= m_rootSignature->parameterLayouts.size()) return S_OK;
+        HRESULT SetGraphicsRoot32BitConstants(UINT rootParamIndex, UINT num32BitValues, const void* pData,
+                                              UINT destOffset) override {
+            if (!pData || num32BitValues == 0)
+                return S_OK;
+            if (!m_rootSignature || rootParamIndex >= m_rootSignature->parameterLayouts.size())
+                return S_OK;
             auto& layout = m_rootSignature->parameterLayouts[rootParamIndex];
 
             size_t writeOffset = layout.offset + destOffset * sizeof(uint32_t);
@@ -259,56 +300,68 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
             return S_OK;
         }
 
-        HRESULT OMSetRenderTargets(UINT numRTVs, const D3D12_CPU_DESCRIPTOR_HANDLE* pRTVs, BOOL, const D3D12_CPU_DESCRIPTOR_HANDLE* pDSV) override {
+        HRESULT OMSetRenderTargets(UINT numRTVs, const D3D12_CPU_DESCRIPTOR_HANDLE* pRTVs, BOOL,
+                                   const D3D12_CPU_DESCRIPTOR_HANDLE* pDSV) override {
             m_numRenderTargets = numRTVs;
             if (pRTVs) {
                 for (UINT i = 0; i < numRTVs && i < 8; ++i) {
                     D3D12DescriptorHeapImpl* heap = device.findHeapForHandle(pRTVs[i]);
                     if (heap) {
                         auto* desc = heap->getDescriptor(pRTVs[i]);
-                        if (desc) m_renderTargets[i] = desc->metalTexture;
+                        if (desc)
+                            m_renderTargets[i] = desc->metalTexture;
                     } else {
                         m_renderTargets[i] = reinterpret_cast<void*>(pRTVs[i].ptr);
                     }
                 }
             }
-            if (pDSV) m_depthTarget = reinterpret_cast<void*>(pDSV->ptr);
+            if (pDSV)
+                m_depthTarget = reinterpret_cast<void*>(pDSV->ptr);
             return S_OK;
         }
         HRESULT OMSetStencilRef(UINT ref) override { return S_OK; }
         HRESULT OMSetBlendFactor(const FLOAT factor[4]) override { return S_OK; }
 
         HRESULT RSSetViewports(UINT num, const D3D12_VIEWPORT* pVPs) override {
-            if (num > 0 && pVPs) m_viewport = pVPs[0];
+            if (num > 0 && pVPs)
+                m_viewport = pVPs[0];
             return S_OK;
         }
         HRESULT RSSetScissorRects(UINT num, const D3D12_RECT* pRects) override {
-            if (num > 0 && pRects) m_scissorRect = pRects[0];
+            if (num > 0 && pRects)
+                m_scissorRect = pRects[0];
             return S_OK;
         }
 
-        HRESULT ClearRenderTargetView(D3D12_CPU_DESCRIPTOR_HANDLE handle, const FLOAT color[4], UINT, const D3D12_RECT*) override {
+        HRESULT ClearRenderTargetView(D3D12_CPU_DESCRIPTOR_HANDLE handle, const FLOAT color[4], UINT,
+                                      const D3D12_RECT*) override {
             ClearCmd cmd = {};
             D3D12DescriptorHeapImpl* heap = device.findHeapForHandle(handle);
             if (heap) {
                 auto* desc = heap->getDescriptor(handle);
-                if (desc) cmd.texture = desc->metalTexture;
+                if (desc)
+                    cmd.texture = desc->metalTexture;
             }
-            if (!cmd.texture) cmd.texture = reinterpret_cast<void*>(handle.ptr);
+            if (!cmd.texture)
+                cmd.texture = reinterpret_cast<void*>(handle.ptr);
             cmd.isDepth = false;
-            if (color) memcpy(cmd.color, color, sizeof(cmd.color));
+            if (color)
+                memcpy(cmd.color, color, sizeof(cmd.color));
             m_clearCmds.push_back(cmd);
             return S_OK;
         }
 
-        HRESULT ClearDepthStencilView(D3D12_CPU_DESCRIPTOR_HANDLE handle, UINT flags, FLOAT depth, UINT8 stencil, UINT, const D3D12_RECT*) override {
+        HRESULT ClearDepthStencilView(D3D12_CPU_DESCRIPTOR_HANDLE handle, UINT flags, FLOAT depth, UINT8 stencil, UINT,
+                                      const D3D12_RECT*) override {
             ClearCmd cmd = {};
             D3D12DescriptorHeapImpl* heap = device.findHeapForHandle(handle);
             if (heap) {
                 auto* desc = heap->getDescriptor(handle);
-                if (desc) cmd.texture = desc->metalTexture;
+                if (desc)
+                    cmd.texture = desc->metalTexture;
             }
-            if (!cmd.texture) cmd.texture = reinterpret_cast<void*>(handle.ptr);
+            if (!cmd.texture)
+                cmd.texture = reinterpret_cast<void*>(handle.ptr);
             cmd.isDepth = true;
             cmd.depth = depth;
             cmd.stencil = stencil;
@@ -322,7 +375,8 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
             return S_OK;
         }
 
-        HRESULT DrawIndexedInstanced(UINT idxCount, UINT instCount, UINT startIdx, INT baseVert, UINT startInst) override {
+        HRESULT DrawIndexedInstanced(UINT idxCount, UINT instCount, UINT startIdx, INT baseVert,
+                                     UINT startInst) override {
             m_drawCmds.push_back({true, idxCount, instCount, startIdx, baseVert, startInst});
             return S_OK;
         }
@@ -333,23 +387,28 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
         }
 
         HRESULT CopyResource(ID3D12Resource* dst, ID3D12Resource* src) override {
-            if (!dst || !src) return E_INVALIDARG;
+            if (!dst || !src)
+                return E_INVALIDARG;
             dst->AddRef();
             src->AddRef();
             m_copyCmds.push_back({dst, src, false, 0, 0, 0});
             return S_OK;
         }
 
-        HRESULT CopyBufferRegion(ID3D12Resource* dst, UINT64 dstOff, ID3D12Resource* src, UINT64 srcOff, UINT64 numBytes) override {
-            if (!dst || !src) return E_INVALIDARG;
+        HRESULT CopyBufferRegion(ID3D12Resource* dst, UINT64 dstOff, ID3D12Resource* src, UINT64 srcOff,
+                                 UINT64 numBytes) override {
+            if (!dst || !src)
+                return E_INVALIDARG;
             dst->AddRef();
             src->AddRef();
             m_copyCmds.push_back({dst, src, true, dstOff, srcOff, numBytes});
             return S_OK;
         }
 
-        HRESULT CopyTextureRegion(const void* pDst, UINT dstX, UINT dstY, UINT dstZ, ID3D12Resource* pSrc, UINT srcSub, const void* pSrcBox) override {
-            if (!pSrc) return E_INVALIDARG;
+        HRESULT CopyTextureRegion(const void* pDst, UINT dstX, UINT dstY, UINT dstZ, ID3D12Resource* pSrc, UINT srcSub,
+                                  const void* pSrcBox) override {
+            if (!pSrc)
+                return E_INVALIDARG;
             pSrc->AddRef();
             m_copyCmds.push_back({nullptr, pSrc, false, (UINT64)dstX | ((UINT64)dstY << 16), srcSub, (UINT64)dstZ});
             return S_OK;
@@ -374,31 +433,37 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
         }
         HRESULT IASetInputLayout(UINT, const D3D12_INPUT_ELEMENT_DESC*) override { return S_OK; }
         HRESULT Map(ID3D12Resource* pRes, UINT sub, const D3D12_RANGE*, void** ppData) override {
-            if (!pRes || !ppData) return E_POINTER;
+            if (!pRes || !ppData)
+                return E_POINTER;
             return pRes->Map(sub, nullptr, ppData);
         }
         HRESULT Unmap(ID3D12Resource* pRes, UINT sub, const D3D12_RANGE*) override {
-            if (!pRes) return E_POINTER;
+            if (!pRes)
+                return E_POINTER;
             return pRes->Unmap(sub, nullptr);
         }
-        HRESULT ExecuteIndirect(ID3D12CommandSignature*, UINT, ID3D12Resource*, UINT64, ID3D12Resource*, UINT64) override { return E_NOTIMPL; }
+        HRESULT ExecuteIndirect(ID3D12CommandSignature*, UINT, ID3D12Resource*, UINT64, ID3D12Resource*,
+                                UINT64) override {
+            return E_NOTIMPL;
+        }
 
         HRESULT DispatchRays(const D3D12_DISPATCH_RAYS_DESC* pDesc) override {
-            if (!pDesc) return E_INVALIDARG;
+            if (!pDesc)
+                return E_INVALIDARG;
             m_dispatchRays = *pDesc;
             m_hasDispatchRays = true;
             return S_OK;
         }
 
-        HRESULT BuildRaytracingAccelerationStructure(const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC* pDesc, UINT, const void*) override {
-            if (!pDesc) return E_INVALIDARG;
+        HRESULT BuildRaytracingAccelerationStructure(const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC* pDesc,
+                                                     UINT, const void*) override {
+            if (!pDesc)
+                return E_INVALIDARG;
             m_buildASDescs.push_back(*pDesc);
             return S_OK;
         }
 
-        HRESULT CopyRaytracingAccelerationStructure(UINT64, UINT64, UINT) override {
-            return S_OK;
-        }
+        HRESULT CopyRaytracingAccelerationStructure(UINT64, UINT64, UINT) override { return S_OK; }
 
         HRESULT EmitRaytracingAccelerationStructurePostbuildInfo(const void*, UINT, const UINT64*) override {
             return S_OK;
@@ -420,9 +485,12 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
             return S_OK;
         }
 
-        HRESULT SetComputeRoot32BitConstants(UINT RootParameterIndex, UINT Num32BitValues, const void* pData, UINT DestOffset) override {
-            if (!m_computeRootSignature || !pData) return E_INVALIDARG;
-            if (RootParameterIndex >= m_computeRootSignature->parameterLayouts.size()) return E_INVALIDARG;
+        HRESULT SetComputeRoot32BitConstants(UINT RootParameterIndex, UINT Num32BitValues, const void* pData,
+                                             UINT DestOffset) override {
+            if (!m_computeRootSignature || !pData)
+                return E_INVALIDARG;
+            if (RootParameterIndex >= m_computeRootSignature->parameterLayouts.size())
+                return E_INVALIDARG;
             auto& layout = m_computeRootSignature->parameterLayouts[RootParameterIndex];
             size_t offset = layout.offset + DestOffset * sizeof(uint32_t);
             if (offset + Num32BitValues * sizeof(uint32_t) <= m_computeArgumentBuffer.size()) {
@@ -431,9 +499,12 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
             return S_OK;
         }
 
-        HRESULT SetComputeRootDescriptorTable(UINT RootParameterIndex, D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor) override {
-            if (!m_computeRootSignature) return E_INVALIDARG;
-            if (RootParameterIndex >= m_computeRootSignature->parameterLayouts.size()) return E_INVALIDARG;
+        HRESULT SetComputeRootDescriptorTable(UINT RootParameterIndex,
+                                              D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor) override {
+            if (!m_computeRootSignature)
+                return E_INVALIDARG;
+            if (RootParameterIndex >= m_computeRootSignature->parameterLayouts.size())
+                return E_INVALIDARG;
             auto& layout = m_computeRootSignature->parameterLayouts[RootParameterIndex];
             if (layout.offset + sizeof(uint64_t) <= m_computeArgumentBuffer.size()) {
                 memcpy(m_computeArgumentBuffer.data() + layout.offset, &BaseDescriptor.ptr, sizeof(uint64_t));
@@ -441,9 +512,12 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
             return S_OK;
         }
 
-        HRESULT SetComputeRootConstantBufferView(UINT RootParameterIndex, D3D12_GPU_VIRTUAL_ADDRESS BufferLocation) override {
-            if (!m_computeRootSignature) return E_INVALIDARG;
-            if (RootParameterIndex >= m_computeRootSignature->parameterLayouts.size()) return E_INVALIDARG;
+        HRESULT SetComputeRootConstantBufferView(UINT RootParameterIndex,
+                                                 D3D12_GPU_VIRTUAL_ADDRESS BufferLocation) override {
+            if (!m_computeRootSignature)
+                return E_INVALIDARG;
+            if (RootParameterIndex >= m_computeRootSignature->parameterLayouts.size())
+                return E_INVALIDARG;
             auto& layout = m_computeRootSignature->parameterLayouts[RootParameterIndex];
             if (layout.offset + sizeof(uint64_t) <= m_computeArgumentBuffer.size()) {
                 memcpy(m_computeArgumentBuffer.data() + layout.offset, &BufferLocation, sizeof(uint64_t));
@@ -451,27 +525,34 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
             return S_OK;
         }
 
-        HRESULT SetComputeRootShaderResourceView(UINT RootParameterIndex, D3D12_GPU_VIRTUAL_ADDRESS BufferLocation) override {
+        HRESULT SetComputeRootShaderResourceView(UINT RootParameterIndex,
+                                                 D3D12_GPU_VIRTUAL_ADDRESS BufferLocation) override {
             return SetComputeRootConstantBufferView(RootParameterIndex, BufferLocation);
         }
 
-        HRESULT SetComputeRootUnorderedAccessView(UINT RootParameterIndex, D3D12_GPU_VIRTUAL_ADDRESS BufferLocation) override {
+        HRESULT SetComputeRootUnorderedAccessView(UINT RootParameterIndex,
+                                                  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation) override {
             return SetComputeRootConstantBufferView(RootParameterIndex, BufferLocation);
         }
 
-        HRESULT CopyTiles(ID3D12Resource* pTiledResource, const D3D12_TILED_RESOURCE_COORDINATE* pCoord, const D3D12_TILE_REGION_SIZE* pSize, ID3D12Resource* pBuffer, UINT64 BufferStartOffset, UINT Flags) override {
-            if (!pTiledResource || !pCoord || !pSize || !pBuffer) return E_INVALIDARG;
+        HRESULT CopyTiles(ID3D12Resource* pTiledResource, const D3D12_TILED_RESOURCE_COORDINATE* pCoord,
+                          const D3D12_TILE_REGION_SIZE* pSize, ID3D12Resource* pBuffer, UINT64 BufferStartOffset,
+                          UINT Flags) override {
+            if (!pTiledResource || !pCoord || !pSize || !pBuffer)
+                return E_INVALIDARG;
 
             void* srcTex = pTiledResource->__metalTexturePtr();
             void* dstBuf = pBuffer->__metalBufferPtr();
-            if (!srcTex || !dstBuf) return E_FAIL;
+            if (!srcTex || !dstBuf)
+                return E_FAIL;
 
             const UINT TILE_BYTES = 65536;
             UINT numTiles = pSize->NumTiles;
 
             if (pSize->bUseBox) {
                 numTiles = pSize->Width * pSize->Height * pSize->Depth;
-                if (numTiles == 0) numTiles = pSize->NumTiles;
+                if (numTiles == 0)
+                    numTiles = pSize->NumTiles;
             }
 
             id<MTLTexture> tex = (__bridge id<MTLTexture>)srcTex;
@@ -479,8 +560,10 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
 
             for (UINT t = 0; t < numTiles; t++) {
                 UINT tileX = pCoord->X + (t % (pSize->Width > 0 ? pSize->Width : 1));
-                UINT tileY = pCoord->Y + ((t / (pSize->Width > 0 ? pSize->Width : 1)) % (pSize->Height > 0 ? pSize->Height : 1));
-                UINT tileZ = pCoord->Z + (t / ((pSize->Width > 0 ? pSize->Width : 1) * (pSize->Height > 0 ? pSize->Height : 1)));
+                UINT tileY =
+                    pCoord->Y + ((t / (pSize->Width > 0 ? pSize->Width : 1)) % (pSize->Height > 0 ? pSize->Height : 1));
+                UINT tileZ =
+                    pCoord->Z + (t / ((pSize->Width > 0 ? pSize->Width : 1) * (pSize->Height > 0 ? pSize->Height : 1)));
 
                 MTLRegion region = MTLRegionMake2D(tileX * 128, tileY * 128, 128, 128);
                 NSUInteger bytesPerRow = 128 * 4;
@@ -488,20 +571,18 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
                 if ([tex respondsToSelector:@selector(supportsNonPrivateTextureWithFormat:)]) {
                     char zeros[512] = {};
                     [tex replaceRegion:region
-                             mipmapLevel:pCoord->Subresource
-                                   slice:tileZ
-                               withBytes:zeros
-                             bytesPerRow:bytesPerRow
-                           bytesPerImage:0];
+                           mipmapLevel:pCoord->Subresource
+                                 slice:tileZ
+                             withBytes:zeros
+                           bytesPerRow:bytesPerRow
+                         bytesPerImage:0];
                 }
             }
 
             return S_OK;
         }
 
-        void __execute(void* dev) override {
-            execute(*static_cast<MetalDevice*>(dev));
-        }
+        void __execute(void* dev) override { execute(*static_cast<MetalDevice*>(dev)); }
 
         void execute(MetalDevice& metalDev) {
             id<MTLCommandQueue> queue = (__bridge id<MTLCommandQueue>)metalDev.nativeCommandQueue();
@@ -514,15 +595,15 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
                     if (dstBuf && srcBuf) {
                         id<MTLBuffer> dst = (__bridge id<MTLBuffer>)dstBuf;
                         id<MTLBuffer> src = (__bridge id<MTLBuffer>)srcBuf;
-                        memcpy((char*)[dst contents] + cmd.dstOffset,
-                               (char*)[src contents] + cmd.srcOffset,
+                        memcpy((char*)[dst contents] + cmd.dstOffset, (char*)[src contents] + cmd.srcOffset,
                                (size_t)cmd.numBytes);
                     }
                 }
             }
 
             for (auto& clear : m_clearCmds) {
-                if (!clear.texture) continue;
+                if (!clear.texture)
+                    continue;
                 MTLRenderPassDescriptor* passDesc = [[MTLRenderPassDescriptor alloc] init];
                 if (clear.isDepth) {
                     passDesc.depthAttachment.texture = (__bridge id<MTLTexture>)clear.texture;
@@ -533,8 +614,8 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
                     passDesc.colorAttachments[0].texture = (__bridge id<MTLTexture>)clear.texture;
                     passDesc.colorAttachments[0].loadAction = MTLLoadActionClear;
                     passDesc.colorAttachments[0].storeAction = MTLStoreActionStore;
-                    passDesc.colorAttachments[0].clearColor = MTLClearColorMake(
-                        clear.color[0], clear.color[1], clear.color[2], clear.color[3]);
+                    passDesc.colorAttachments[0].clearColor =
+                        MTLClearColorMake(clear.color[0], clear.color[1], clear.color[2], clear.color[3]);
                 }
                 id<MTLRenderCommandEncoder> enc = [cmdBuffer renderCommandEncoderWithDescriptor:passDesc];
                 [enc endEncoding];
@@ -596,20 +677,36 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
                     }
 
                     for (auto* res : m_referencedResources) {
-                        if (!res) continue;
+                        if (!res)
+                            continue;
                         void* buf = res->__metalBufferPtr();
                         void* tex = res->__metalTexturePtr();
-                        if (buf) [enc useResource:(__bridge id<MTLBuffer>)buf usage:MTLResourceUsageRead stages:MTLRenderStageVertex | MTLRenderStageFragment];
-                        if (tex) [enc useResource:(__bridge id<MTLTexture>)tex usage:MTLResourceUsageRead stages:MTLRenderStageVertex | MTLRenderStageFragment];
+                        if (buf)
+                            [enc useResource:(__bridge id<MTLBuffer>)buf
+                                       usage:MTLResourceUsageRead
+                                      stages:MTLRenderStageVertex | MTLRenderStageFragment];
+                        if (tex)
+                            [enc useResource:(__bridge id<MTLTexture>)tex
+                                       usage:MTLResourceUsageRead
+                                      stages:MTLRenderStageVertex | MTLRenderStageFragment];
                     }
 
                     MTLPrimitiveType primType = MTLPrimitiveTypeTriangle;
                     switch (m_primitiveTopology) {
-                        case D3D12_PRIMITIVE_TOPOLOGY_POINTLIST: primType = MTLPrimitiveTypePoint; break;
-                        case D3D12_PRIMITIVE_TOPOLOGY_LINELIST: primType = MTLPrimitiveTypeLine; break;
-                        case D3D12_PRIMITIVE_TOPOLOGY_LINESTRIP: primType = MTLPrimitiveTypeLineStrip; break;
-                        case D3D12_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP: primType = MTLPrimitiveTypeTriangleStrip; break;
-                        default: break;
+                    case D3D12_PRIMITIVE_TOPOLOGY_POINTLIST:
+                        primType = MTLPrimitiveTypePoint;
+                        break;
+                    case D3D12_PRIMITIVE_TOPOLOGY_LINELIST:
+                        primType = MTLPrimitiveTypeLine;
+                        break;
+                    case D3D12_PRIMITIVE_TOPOLOGY_LINESTRIP:
+                        primType = MTLPrimitiveTypeLineStrip;
+                        break;
+                    case D3D12_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP:
+                        primType = MTLPrimitiveTypeTriangleStrip;
+                        break;
+                    default:
+                        break;
                     }
 
                     for (auto& draw : m_drawCmds) {
@@ -621,10 +718,10 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
                                      indexBufferOffset:0];
                         } else {
                             [enc drawPrimitives:primType
-                                     vertexStart:draw.startIndex
-                                     vertexCount:draw.vertexCount
-                                   instanceCount:draw.instanceCount > 1 ? draw.instanceCount : 1
-                                    baseInstance:0];
+                                    vertexStart:draw.startIndex
+                                    vertexCount:draw.vertexCount
+                                  instanceCount:draw.instanceCount > 1 ? draw.instanceCount : 1
+                                   baseInstance:0];
                         }
                     }
                     [enc endEncoding];
@@ -633,7 +730,8 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
 
             if (m_hasDispatchRays) {
                 void* rtPipeline = nullptr;
-                if (m_pso) rtPipeline = m_pso->__metalRenderPipelineState();
+                if (m_pso)
+                    rtPipeline = m_pso->__metalRenderPipelineState();
 
                 id<MTLComputePipelineState> computePipeline = nil;
                 if (rtPipeline) {
@@ -656,11 +754,8 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
                         }
                     }
 
-                    MTLSize threadgroups = MTLSizeMake(
-                        (m_dispatchRays.Width + 7) / 8,
-                        (m_dispatchRays.Height + 7) / 8,
-                        m_dispatchRays.Depth > 0 ? m_dispatchRays.Depth : 1
-                    );
+                    MTLSize threadgroups = MTLSizeMake((m_dispatchRays.Width + 7) / 8, (m_dispatchRays.Height + 7) / 8,
+                                                       m_dispatchRays.Depth > 0 ? m_dispatchRays.Depth : 1);
                     MTLSize threadsPerGroup = MTLSizeMake(8, 8, 1);
                     [enc dispatchThreadgroups:threadgroups threadsPerThreadgroup:threadsPerGroup];
                     [enc endEncoding];
@@ -671,7 +766,8 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
                 id<MTLComputePipelineState> computePipeline = nil;
                 if (m_pso) {
                     void* ptr = m_pso->__metalComputePipelineState();
-                    if (ptr) computePipeline = (__bridge id<MTLComputePipelineState>)ptr;
+                    if (ptr)
+                        computePipeline = (__bridge id<MTLComputePipelineState>)ptr;
                     if (!ptr) {
                         ptr = m_pso->__metalRenderPipelineState();
                     }
@@ -687,7 +783,8 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
                             id<MTLBuffer> argBuf = [mtlDev newBufferWithBytes:m_computeArgumentBuffer.data()
                                                                        length:m_computeRootSignature->argumentBufferSize
                                                                       options:MTLResourceStorageModeShared];
-                            if (argBuf) [enc setBuffer:argBuf offset:0 atIndex:16];
+                            if (argBuf)
+                                [enc setBuffer:argBuf offset:0 atIndex:16];
                         }
                     }
 
@@ -726,13 +823,13 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
                     MTLSize threadsPerGroup = MTLSizeMake(1, 1, 1);
 
                     if (@available(macOS 13.0, *)) {
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wundeclared-selector"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
                         if ([enc respondsToSelector:@selector(drawMeshThreadgroups:threadsPerMeshThreadgroup:)]) {
                             [enc performSelector:@selector(drawMeshThreadgroups:threadsPerMeshThreadgroup:)
-                                       withObject:nil];
+                                      withObject:nil];
                         }
-    #pragma clang diagnostic pop
+#pragma clang diagnostic pop
                     }
 
                     [enc endEncoding];
@@ -750,8 +847,10 @@ HRESULT D3D12DeviceImpl::CreateCommandList(UINT, UINT, ID3D12CommandAllocator* p
     return S_OK;
 }
 
-HRESULT D3D12DeviceImpl::CreateGraphicsPipelineState(const D3D12_GRAPHICS_PIPELINE_STATE_DESC* pDesc, REFIID riid, void** ppPSO) {
-    if (!pDesc || !ppPSO) return E_INVALIDARG;
+HRESULT D3D12DeviceImpl::CreateGraphicsPipelineState(const D3D12_GRAPHICS_PIPELINE_STATE_DESC* pDesc, REFIID riid,
+                                                     void** ppPSO) {
+    if (!pDesc || !ppPSO)
+        return E_INVALIDARG;
 
     auto* pso = new D3D12PipelineStateImpl();
 
@@ -766,12 +865,9 @@ HRESULT D3D12DeviceImpl::CreateGraphicsPipelineState(const D3D12_GRAPHICS_PIPELI
         D3D12RootSignatureImpl* rootSig = static_cast<D3D12RootSignatureImpl*>(pDesc->pRootSignature);
         bool ok = false;
         if (rootSig && !rootSig->rawBytecode.empty()) {
-            ok = m_shaderTranslator->translateDXBCWithRootSignature(
-                shaderData, shaderSize,
-                ShaderStage::Vertex,
-                rootSig->rawBytecode.data(), rootSig->rawBytecode.size(),
-                compiled
-            );
+            ok = m_shaderTranslator->translateDXBCWithRootSignature(shaderData, shaderSize, ShaderStage::Vertex,
+                                                                    rootSig->rawBytecode.data(),
+                                                                    rootSig->rawBytecode.size(), compiled);
         }
 
         if (!ok) {
@@ -784,7 +880,8 @@ HRESULT D3D12DeviceImpl::CreateGraphicsPipelineState(const D3D12_GRAPHICS_PIPELI
 
         if (pDesc->PS && pDesc->PSsize > 0) {
             CompiledShader psCompiled;
-            if (m_shaderTranslator->translateDXBC(static_cast<const uint8_t*>(pDesc->PS), pDesc->PSsize, ShaderStage::Pixel, psCompiled)) {
+            if (m_shaderTranslator->translateDXBC(static_cast<const uint8_t*>(pDesc->PS), pDesc->PSsize,
+                                                  ShaderStage::Pixel, psCompiled)) {
                 pipeDesc.fragmentFunction = psCompiled.fragmentFunction;
             }
         }
@@ -806,7 +903,8 @@ HRESULT D3D12DeviceImpl::CreateGraphicsPipelineState(const D3D12_GRAPHICS_PIPELI
 
 HRESULT D3D12CommandQueueImpl::ExecuteCommandLists(UINT numLists, ID3D12CommandList* const* ppLists) {
     for (UINT i = 0; i < numLists; ++i) {
-        if (!ppLists[i]) continue;
+        if (!ppLists[i])
+            continue;
         ppLists[i]->__execute(&metalDevice);
     }
     return S_OK;
@@ -814,9 +912,10 @@ HRESULT D3D12CommandQueueImpl::ExecuteCommandLists(UINT numLists, ID3D12CommandL
 
 D3D12DescriptorHeapImpl* D3D12DeviceImpl::findHeapForHandle(D3D12_CPU_DESCRIPTOR_HANDLE handle) const {
     for (auto* h : m_trackedHeaps) {
-        if (h->handleToIndex(handle) != UINT_MAX) return h;
+        if (h->handleToIndex(handle) != UINT_MAX)
+            return h;
     }
     return nullptr;
 }
 
-}
+} // namespace metalsharp

--- a/src/d3d/d3d12/D3D12CommandQueue.cpp
+++ b/src/d3d/d3d12/D3D12CommandQueue.cpp
@@ -6,5 +6,4 @@
 
 #include <metalsharp/D3D12Device.h>
 
-namespace metalsharp {
-}
+namespace metalsharp {}

--- a/src/d3d/d3d12/D3D12DescriptorHeap.cpp
+++ b/src/d3d/d3d12/D3D12DescriptorHeap.cpp
@@ -6,5 +6,4 @@
 
 #include <metalsharp/Platform.h>
 
-namespace metalsharp {
-}
+namespace metalsharp {}

--- a/src/d3d/d3d12/D3D12Device.cpp
+++ b/src/d3d/d3d12/D3D12Device.cpp
@@ -4,9 +4,7 @@
 /// Reserved for the ID3D12Device COM implementation. Device creation and command
 /// queue management are routed through the Metal backend.
 
-#include <metalsharp/D3D12Device.h>
 #include <cstring>
+#include <metalsharp/D3D12Device.h>
 
-namespace metalsharp {
-
-}
+namespace metalsharp {}

--- a/src/d3d/d3d12/D3D12Fence.cpp
+++ b/src/d3d/d3d12/D3D12Fence.cpp
@@ -6,5 +6,4 @@
 
 #include <metalsharp/Platform.h>
 
-namespace metalsharp {
-}
+namespace metalsharp {}

--- a/src/d3d/d3d12/D3D12PipelineState.cpp
+++ b/src/d3d/d3d12/D3D12PipelineState.cpp
@@ -6,5 +6,4 @@
 
 #include <metalsharp/Platform.h>
 
-namespace metalsharp {
-}
+namespace metalsharp {}

--- a/src/d3d/d3d12/D3D12Resource.cpp
+++ b/src/d3d/d3d12/D3D12Resource.cpp
@@ -6,5 +6,4 @@
 
 #include <metalsharp/Platform.h>
 
-namespace metalsharp {
-}
+namespace metalsharp {}

--- a/src/d3d/d3d12/D3D12RootSignature.cpp
+++ b/src/d3d/d3d12/D3D12RootSignature.cpp
@@ -6,5 +6,4 @@
 
 #include <metalsharp/Platform.h>
 
-namespace metalsharp {
-}
+namespace metalsharp {}

--- a/src/d3d/d3d12/EntryPoint.cpp
+++ b/src/d3d/d3d12/EntryPoint.cpp
@@ -9,7 +9,8 @@
 extern "C" {
 
 HRESULT D3D12CreateDevice(void* pAdapter, UINT MinimumFeatureLevel, const GUID& riid, void** ppDevice) {
-    if (!ppDevice) return E_POINTER;
+    if (!ppDevice)
+        return E_POINTER;
     metalsharp::D3D12DeviceImpl* device = nullptr;
     HRESULT hr = metalsharp::D3D12DeviceImpl::create(&device);
     if (SUCCEEDED(hr)) {
@@ -17,5 +18,4 @@ HRESULT D3D12CreateDevice(void* pAdapter, UINT MinimumFeatureLevel, const GUID& 
     }
     return hr;
 }
-
 }

--- a/src/dxgi/DXGIAdapter.cpp
+++ b/src/dxgi/DXGIAdapter.cpp
@@ -6,6 +6,4 @@
 
 #include <metalsharp/DXGI.h>
 
-namespace metalsharp {
-
-}
+namespace metalsharp {}

--- a/src/dxgi/DXGIFactory.cpp
+++ b/src/dxgi/DXGIFactory.cpp
@@ -4,38 +4,58 @@
 /// Implements IDXGIFactory (and IDXGIFactory1/2) COM interfaces. Enumerates display
 /// adapters and provides the entry point for swap chain creation against a D3D device.
 
-#include <metalsharp/DXGI.h>
-#include <metalsharp/D3D11Device.h>
 #include <cstring>
+#include <metalsharp/D3D11Device.h>
+#include <metalsharp/DXGI.h>
 
 namespace metalsharp {
 
 HRESULT DXGIFactory::create(const GUID& riid, void** ppFactory) {
-    if (!ppFactory) return E_POINTER;
+    if (!ppFactory)
+        return E_POINTER;
     auto* factory = new DXGIFactory();
     *ppFactory = factory;
     return S_OK;
 }
 
 HRESULT DXGIFactory::QueryInterface(REFIID riid, void** ppvObject) {
-    if (!ppvObject) return E_POINTER;
+    if (!ppvObject)
+        return E_POINTER;
     AddRef();
     *ppvObject = this;
     return S_OK;
 }
 
-ULONG DXGIFactory::AddRef() { return ++m_refCount; }
-ULONG DXGIFactory::Release() { ULONG c = --m_refCount; if (c == 0) delete this; return c; }
+ULONG DXGIFactory::AddRef() {
+    return ++m_refCount;
+}
+ULONG DXGIFactory::Release() {
+    ULONG c = --m_refCount;
+    if (c == 0)
+        delete this;
+    return c;
+}
 
 HRESULT DXGIFactory::EnumAdapters(UINT Adapter, IDXGIAdapter** ppAdapter) {
-    if (!ppAdapter) return E_POINTER;
-    if (Adapter > 0) return DXGI_ERROR_NOT_FOUND;
+    if (!ppAdapter)
+        return E_POINTER;
+    if (Adapter > 0)
+        return DXGI_ERROR_NOT_FOUND;
 
     struct DXGIAdapter : public IDXGIAdapter {
         ULONG refCount = 1;
-        HRESULT QueryInterface(REFIID, void** ppv) { AddRef(); *ppv = this; return S_OK; }
+        HRESULT QueryInterface(REFIID, void** ppv) {
+            AddRef();
+            *ppv = this;
+            return S_OK;
+        }
         ULONG AddRef() { return ++refCount; }
-        ULONG Release() { ULONG c = --refCount; if (c == 0) delete this; return c; }
+        ULONG Release() {
+            ULONG c = --refCount;
+            if (c == 0)
+                delete this;
+            return c;
+        }
         HRESULT GetDevice(const GUID&, void**) { return E_NOTIMPL; }
         HRESULT GetPrivateData(const GUID&, UINT*, void*) { return E_NOTIMPL; }
         HRESULT SetPrivateData(const GUID&, UINT, const void*) { return E_NOTIMPL; }
@@ -43,7 +63,8 @@ HRESULT DXGIFactory::EnumAdapters(UINT Adapter, IDXGIAdapter** ppAdapter) {
         HRESULT GetParent(const GUID&, void**) { return E_NOTIMPL; }
         HRESULT EnumOutputs(UINT, IDXGIOutput**) { return DXGI_ERROR_NOT_FOUND; }
         HRESULT GetDesc(void* pDesc) {
-            if (!pDesc) return E_POINTER;
+            if (!pDesc)
+                return E_POINTER;
             memset(pDesc, 0, 280);
             return S_OK;
         }
@@ -55,7 +76,8 @@ HRESULT DXGIFactory::EnumAdapters(UINT Adapter, IDXGIAdapter** ppAdapter) {
 }
 
 HRESULT DXGIFactory::CreateSwapChain(IUnknown* pDevice, void* pDesc, IDXGISwapChain** ppSwapChain) {
-    if (!ppSwapChain || !pDesc) return E_POINTER;
+    if (!ppSwapChain || !pDesc)
+        return E_POINTER;
 
     auto* desc = static_cast<DXGI_SWAP_CHAIN_DESC*>(pDesc);
 
@@ -72,9 +94,12 @@ HRESULT DXGIFactory::CreateSwapChain(IUnknown* pDevice, void* pDesc, IDXGISwapCh
     uint32_t bufferCount = desc->BufferCount > 0 ? desc->BufferCount : 2;
     DXGI_FORMAT format = desc->BufferDesc.Format;
 
-    if (width == 0) width = 1920;
-    if (height == 0) height = 1080;
-    if (format == 0) format = DXGI_FORMAT_R8G8B8A8_UNORM;
+    if (width == 0)
+        width = 1920;
+    if (height == 0)
+        height = 1080;
+    if (format == 0)
+        format = DXGI_FORMAT_R8G8B8A8_UNORM;
 
     hr = DXGISwapChainImpl::create(metalDev, desc->OutputWindow, width, height, bufferCount, format, ppSwapChain);
 
@@ -82,4 +107,4 @@ HRESULT DXGIFactory::CreateSwapChain(IUnknown* pDevice, void* pDesc, IDXGISwapCh
     return hr;
 }
 
-}
+} // namespace metalsharp

--- a/src/dxgi/DXGIOutput.mm
+++ b/src/dxgi/DXGIOutput.mm
@@ -5,11 +5,11 @@
 /// modes and resolutions. Provides DXGI_MODE_DESC structs populated from real
 /// macOS display configuration.
 
-#include <metalsharp/DXGIOutput.h>
 #import <AppKit/AppKit.h>
-#import <Metal/Metal.h>
-#import <QuartzCore/QuartzCore.h>
 #include <CoreGraphics/CoreGraphics.h>
+#import <Metal/Metal.h>
+#include <metalsharp/DXGIOutput.h>
+#import <QuartzCore/QuartzCore.h>
 
 namespace metalsharp {
 
@@ -39,7 +39,8 @@ std::vector<DisplayMode> DXGIOutputImpl::enumerateDisplayModes() {
         uint32_t w = (uint32_t)CGDisplayModeGetWidth(mode);
         uint32_t h = (uint32_t)CGDisplayModeGetHeight(mode);
         double refresh = CGDisplayModeGetRefreshRate(mode);
-        if (refresh == 0) refresh = 60.0;
+        if (refresh == 0)
+            refresh = 60.0;
 
         bool dup = false;
         for (auto& m : modes) {
@@ -64,13 +65,15 @@ std::vector<DisplayMode> DXGIOutputImpl::enumerateDisplayModes() {
 DisplayMode DXGIOutputImpl::getCurrentDisplayMode() {
     CGDirectDisplayID mainDisplay = CGMainDisplayID();
     CGDisplayModeRef mode = CGDisplayCopyDisplayMode(mainDisplay);
-    if (!mode) return {1920, 1080, 60, 87};
+    if (!mode)
+        return {1920, 1080, 60, 87};
 
     DisplayMode dm;
     dm.width = (uint32_t)CGDisplayModeGetWidth(mode);
     dm.height = (uint32_t)CGDisplayModeGetHeight(mode);
     dm.refreshRate = (uint32_t)CGDisplayModeGetRefreshRate(mode);
-    if (dm.refreshRate == 0) dm.refreshRate = 60;
+    if (dm.refreshRate == 0)
+        dm.refreshRate = 60;
     dm.format = 87;
     CGDisplayModeRelease(mode);
     return dm;
@@ -79,16 +82,13 @@ DisplayMode DXGIOutputImpl::getCurrentDisplayMode() {
 bool DXGIOutputImpl::createWindow(void* parent, uint32_t width, uint32_t height, void** outWindow) {
     @autoreleasepool {
         NSRect frame = NSMakeRect(0, 0, width, height);
-        NSWindowStyleMask style = NSWindowStyleMaskTitled |
-                                  NSWindowStyleMaskClosable |
-                                  NSWindowStyleMaskMiniaturizable |
-                                  NSWindowStyleMaskResizable;
+        NSWindowStyleMask style = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable |
+                                  NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable;
 
-        NSWindow* window = [[NSWindow alloc]
-            initWithContentRect:frame
-                      styleMask:style
-                        backing:NSBackingStoreBuffered
-                          defer:NO];
+        NSWindow* window = [[NSWindow alloc] initWithContentRect:frame
+                                                       styleMask:style
+                                                         backing:NSBackingStoreBuffered
+                                                           defer:NO];
 
         [window setTitle:@"MetalSharp"];
         [window center];
@@ -104,7 +104,8 @@ bool DXGIOutputImpl::createWindow(void* parent, uint32_t width, uint32_t height,
 bool DXGIOutputImpl::createMetalLayer(void* window, void** outLayer) {
     @autoreleasepool {
         NSView* view = (__bridge NSView*)window;
-        if (!view) return false;
+        if (!view)
+            return false;
 
         CAMetalLayer* layer = [CAMetalLayer layer];
         layer.frame = view.bounds;
@@ -121,4 +122,4 @@ bool DXGIOutputImpl::createMetalLayer(void* window, void** outLayer) {
     }
 }
 
-}
+} // namespace metalsharp

--- a/src/dxgi/DXGISwapChain.mm
+++ b/src/dxgi/DXGISwapChain.mm
@@ -5,18 +5,18 @@
 /// Handles buffer creation, present calls, resize, and full-screen transitions against
 /// the native macOS windowing system.
 
-#include <metalsharp/DXGI.h>
 #include <metalsharp/D3D11Device.h>
+#include <metalsharp/DXGI.h>
 #include <metalsharp/Platform.h>
 #ifdef METALSHARP_NATIVE_LOADER
 #include <metalsharp/WindowManager.h>
 #endif
 #include <AppKit/AppKit.h>
+#include <cstdio>
+#include <cstring>
 #include <Foundation/Foundation.h>
 #include <Metal/Metal.h>
 #include <QuartzCore/QuartzCore.h>
-#include <cstring>
-#include <cstdio>
 
 namespace metalsharp {
 
@@ -31,7 +31,9 @@ struct MetalSwapChain::Impl {
 };
 
 MetalSwapChain::MetalSwapChain() : m_impl(new Impl()) {}
-MetalSwapChain::~MetalSwapChain() { delete m_impl; }
+MetalSwapChain::~MetalSwapChain() {
+    delete m_impl;
+}
 
 bool MetalSwapChain::init(MetalDevice& device, void* window, uint32_t width, uint32_t height, uint32_t bufferCount) {
     m_impl->device = (__bridge id<MTLDevice>)device.nativeDevice();
@@ -59,8 +61,8 @@ bool MetalSwapChain::init(MetalDevice& device, void* window, uint32_t width, uin
             m_impl->layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
             m_impl->layer.framebufferOnly = NO;
             m_impl->layer.frame = view.bounds;
-            m_impl->layer.drawableSize = CGSizeMake(width > 0 ? width : view.bounds.size.width,
-                                                      height > 0 ? height : view.bounds.size.height);
+            m_impl->layer.drawableSize =
+                CGSizeMake(width > 0 ? width : view.bounds.size.width, height > 0 ? height : view.bounds.size.height);
             view.wantsLayer = YES;
             view.layer = m_impl->layer;
 
@@ -74,7 +76,8 @@ bool MetalSwapChain::init(MetalDevice& device, void* window, uint32_t width, uin
     return true;
 }
 
-MetalSwapChain* MetalSwapChain::create(MetalDevice& device, void* window, uint32_t width, uint32_t height, uint32_t bufferCount) {
+MetalSwapChain* MetalSwapChain::create(MetalDevice& device, void* window, uint32_t width, uint32_t height,
+                                       uint32_t bufferCount) {
     auto* chain = new MetalSwapChain();
     if (!chain->init(device, window, width, height, bufferCount)) {
         delete chain;
@@ -84,11 +87,13 @@ MetalSwapChain* MetalSwapChain::create(MetalDevice& device, void* window, uint32
 }
 
 void MetalSwapChain::present(uint32_t syncInterval) {
-    if (!m_impl->layer) return;
+    if (!m_impl->layer)
+        return;
 
     @autoreleasepool {
         m_impl->currentDrawable = [m_impl->layer nextDrawable];
-        if (!m_impl->currentDrawable) return;
+        if (!m_impl->currentDrawable)
+            return;
 
         id<MTLCommandBuffer> cmdBuffer = [m_impl->commandQueue commandBuffer];
         [cmdBuffer presentDrawable:m_impl->currentDrawable];
@@ -111,7 +116,8 @@ void* MetalSwapChain::getCurrentDrawable() {
 
 void* MetalSwapChain::getCurrentTexture() {
     id<CAMetalDrawable> drawable = (__bridge id<CAMetalDrawable>)getCurrentDrawable();
-    if (!drawable) return nullptr;
+    if (!drawable)
+        return nullptr;
     return (__bridge void*)drawable.texture;
 }
 
@@ -136,14 +142,27 @@ struct DXGISwapChainBackBuffer : public ID3D11Texture2D {
     uint32_t height = 0;
     DXGI_FORMAT format = DXGI_FORMAT_UNKNOWN;
 
-    HRESULT QueryInterface(REFIID, void** ppv) override { AddRef(); *ppv = this; return S_OK; }
+    HRESULT QueryInterface(REFIID, void** ppv) override {
+        AddRef();
+        *ppv = this;
+        return S_OK;
+    }
     ULONG AddRef() override { return ++refCount; }
-    ULONG Release() override { ULONG c = --refCount; if (c == 0) delete this; return c; }
+    ULONG Release() override {
+        ULONG c = --refCount;
+        if (c == 0)
+            delete this;
+        return c;
+    }
     HRESULT GetDevice(ID3D11Device** ppDevice) override { return E_NOTIMPL; }
     HRESULT GetPrivateData(const GUID&, UINT*, void*) override { return E_NOTIMPL; }
     HRESULT SetPrivateData(const GUID&, UINT, const void*) override { return E_NOTIMPL; }
     HRESULT SetPrivateDataInterface(const GUID&, const IUnknown*) override { return E_NOTIMPL; }
-    HRESULT GetType(UINT* pType) override { if (pType) *pType = D3D11_RESOURCE_DIMENSION_TEXTURE2D; return S_OK; }
+    HRESULT GetType(UINT* pType) override {
+        if (pType)
+            *pType = D3D11_RESOURCE_DIMENSION_TEXTURE2D;
+        return S_OK;
+    }
     HRESULT SetEvictionPriority(UINT) override { return S_OK; }
     UINT GetEvictionPriority() override { return 0; }
     void GetDesc(struct D3D11_TEXTURE2D_DESC* pDesc) override {
@@ -169,8 +188,10 @@ DXGISwapChainImpl::~DXGISwapChainImpl() {
     }
 }
 
-HRESULT DXGISwapChainImpl::create(MetalDevice* metalDevice, HWND window, uint32_t width, uint32_t height, uint32_t bufferCount, DXGI_FORMAT format, IDXGISwapChain** ppSwapChain) {
-    if (!ppSwapChain || !metalDevice) return E_POINTER;
+HRESULT DXGISwapChainImpl::create(MetalDevice* metalDevice, HWND window, uint32_t width, uint32_t height,
+                                  uint32_t bufferCount, DXGI_FORMAT format, IDXGISwapChain** ppSwapChain) {
+    if (!ppSwapChain || !metalDevice)
+        return E_POINTER;
 
     auto* swapChain = new DXGISwapChainImpl();
     swapChain->m_metalDevice = metalDevice;
@@ -180,8 +201,7 @@ HRESULT DXGISwapChainImpl::create(MetalDevice* metalDevice, HWND window, uint32_
     swapChain->m_format = format;
     swapChain->m_bufferCount = bufferCount;
 
-    swapChain->m_metalSwapChain.reset(
-        MetalSwapChain::create(*metalDevice, (void*)window, width, height, bufferCount));
+    swapChain->m_metalSwapChain.reset(MetalSwapChain::create(*metalDevice, (void*)window, width, height, bufferCount));
 
     if (!swapChain->m_metalSwapChain) {
         delete swapChain;
@@ -193,24 +213,38 @@ HRESULT DXGISwapChainImpl::create(MetalDevice* metalDevice, HWND window, uint32_
 }
 
 HRESULT DXGISwapChainImpl::QueryInterface(REFIID riid, void** ppvObject) {
-    if (!ppvObject) return E_POINTER;
+    if (!ppvObject)
+        return E_POINTER;
     AddRef();
     *ppvObject = this;
     return S_OK;
 }
 
-ULONG DXGISwapChainImpl::AddRef() { return ++m_refCount; }
+ULONG DXGISwapChainImpl::AddRef() {
+    return ++m_refCount;
+}
 ULONG DXGISwapChainImpl::Release() {
     ULONG c = --m_refCount;
-    if (c == 0) delete this;
+    if (c == 0)
+        delete this;
     return c;
 }
 
-HRESULT DXGISwapChainImpl::GetDevice(const GUID& riid, void** ppDevice) { return E_NOTIMPL; }
-HRESULT DXGISwapChainImpl::GetPrivateData(const GUID&, UINT*, void*) { return E_NOTIMPL; }
-HRESULT DXGISwapChainImpl::SetPrivateData(const GUID&, UINT, const void*) { return E_NOTIMPL; }
-HRESULT DXGISwapChainImpl::SetPrivateDataInterface(const GUID&, const IUnknown*) { return E_NOTIMPL; }
-HRESULT DXGISwapChainImpl::GetParent(const GUID& riid, void** ppParent) { return E_NOTIMPL; }
+HRESULT DXGISwapChainImpl::GetDevice(const GUID& riid, void** ppDevice) {
+    return E_NOTIMPL;
+}
+HRESULT DXGISwapChainImpl::GetPrivateData(const GUID&, UINT*, void*) {
+    return E_NOTIMPL;
+}
+HRESULT DXGISwapChainImpl::SetPrivateData(const GUID&, UINT, const void*) {
+    return E_NOTIMPL;
+}
+HRESULT DXGISwapChainImpl::SetPrivateDataInterface(const GUID&, const IUnknown*) {
+    return E_NOTIMPL;
+}
+HRESULT DXGISwapChainImpl::GetParent(const GUID& riid, void** ppParent) {
+    return E_NOTIMPL;
+}
 
 HRESULT DXGISwapChainImpl::Present(UINT SyncInterval, UINT Flags) {
     if (m_metalSwapChain) {
@@ -221,11 +255,14 @@ HRESULT DXGISwapChainImpl::Present(UINT SyncInterval, UINT Flags) {
 }
 
 HRESULT DXGISwapChainImpl::GetBuffer(UINT Buffer, const GUID& riid, void** ppSurface) {
-    if (!ppSurface) return E_POINTER;
-    if (!m_metalSwapChain) return E_FAIL;
+    if (!ppSurface)
+        return E_POINTER;
+    if (!m_metalSwapChain)
+        return E_FAIL;
 
     void* texPtr = m_metalSwapChain->getCurrentTexture();
-    if (!texPtr) return E_FAIL;
+    if (!texPtr)
+        return E_FAIL;
 
     auto* backBuffer = new DXGISwapChainBackBuffer();
     backBuffer->metalTexture = texPtr;
@@ -260,13 +297,16 @@ HRESULT DXGISwapChainImpl::SetFullscreenState(INT Fullscreen, IDXGIOutput* pTarg
     return S_OK;
 }
 HRESULT DXGISwapChainImpl::GetFullscreenState(INT* pFullscreen, IDXGIOutput** ppTarget) {
-    if (pFullscreen) *pFullscreen = FALSE;
-    if (ppTarget) *ppTarget = nullptr;
+    if (pFullscreen)
+        *pFullscreen = FALSE;
+    if (ppTarget)
+        *ppTarget = nullptr;
     return S_OK;
 }
 
 HRESULT DXGISwapChainImpl::GetDesc(void* pDesc) {
-    if (!pDesc) return E_POINTER;
+    if (!pDesc)
+        return E_POINTER;
     auto* desc = static_cast<DXGI_SWAP_CHAIN_DESC*>(pDesc);
     memset(desc, 0, sizeof(DXGI_SWAP_CHAIN_DESC));
     desc->BufferDesc.Width = m_width;
@@ -280,9 +320,12 @@ HRESULT DXGISwapChainImpl::GetDesc(void* pDesc) {
     return S_OK;
 }
 
-HRESULT DXGISwapChainImpl::ResizeBuffers(UINT BufferCount, UINT Width, UINT Height, DXGI_FORMAT NewFormat, UINT SwapChainFlags) {
-    if (BufferCount > 0) m_bufferCount = BufferCount;
-    if (NewFormat != DXGI_FORMAT_UNKNOWN) m_format = NewFormat;
+HRESULT DXGISwapChainImpl::ResizeBuffers(UINT BufferCount, UINT Width, UINT Height, DXGI_FORMAT NewFormat,
+                                         UINT SwapChainFlags) {
+    if (BufferCount > 0)
+        m_bufferCount = BufferCount;
+    if (NewFormat != DXGI_FORMAT_UNKNOWN)
+        m_format = NewFormat;
 
     if (m_metalSwapChain) {
         uint32_t newW = Width > 0 ? Width : m_width;
@@ -300,11 +343,18 @@ HRESULT DXGISwapChainImpl::ResizeBuffers(UINT BufferCount, UINT Width, UINT Heig
     return S_OK;
 }
 
-HRESULT DXGISwapChainImpl::ResizeTarget(const DXGI_MODE_DESC* pNewTargetParameters) { return S_OK; }
-HRESULT DXGISwapChainImpl::GetContainingOutput(IDXGIOutput** ppOutput) { return E_NOTIMPL; }
-HRESULT DXGISwapChainImpl::GetFrameStatistics(void* pStats) { return E_NOTIMPL; }
+HRESULT DXGISwapChainImpl::ResizeTarget(const DXGI_MODE_DESC* pNewTargetParameters) {
+    return S_OK;
+}
+HRESULT DXGISwapChainImpl::GetContainingOutput(IDXGIOutput** ppOutput) {
+    return E_NOTIMPL;
+}
+HRESULT DXGISwapChainImpl::GetFrameStatistics(void* pStats) {
+    return E_NOTIMPL;
+}
 HRESULT DXGISwapChainImpl::GetLastPresentCount(UINT* pLastPresentCount) {
-    if (pLastPresentCount) *pLastPresentCount = 0;
+    if (pLastPresentCount)
+        *pLastPresentCount = 0;
     return S_OK;
 }
 
@@ -312,4 +362,4 @@ HRESULT DXGISwapChainImpl::Present1(UINT SyncInterval, UINT PresentFlags, const 
     return Present(SyncInterval, PresentFlags);
 }
 
-}
+} // namespace metalsharp

--- a/src/dxgi/EntryPoint.cpp
+++ b/src/dxgi/EntryPoint.cpp
@@ -22,5 +22,4 @@ HRESULT CreateDXGIFactory1(const GUID& riid, void** ppFactory) {
 HRESULT CreateDXGIFactory2(UINT Flags, const GUID& riid, void** ppFactory) {
     return DXGIFactory::create(riid, ppFactory);
 }
-
 }

--- a/src/fna/shims/csteamworks_shim.c
+++ b/src/fna/shims/csteamworks_shim.c
@@ -1,147 +1,177 @@
 /// @file csteamworks_shim.c
 /// @brief CSteamworks API shim via libsteam_api.dylib.
 ///
-/// Implements the CSteamworks (Steamworks C API) functions used by FNA games by forwarding calls to the native libsteam_api.dylib loaded via dlopen. Handles Steam API init/shutdown, achievement, and overlay callbacks.
-#include <stddef.h>
+/// Implements the CSteamworks (Steamworks C API) functions used by FNA games by forwarding calls to the native
+/// libsteam_api.dylib loaded via dlopen. Handles Steam API init/shutdown, achievement, and overlay callbacks.
 #include <dlfcn.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <string.h>
 
-static void *g_api;
-static void *g_steamApps;
-static void *g_steamUserStats;
-static void *g_steamUser;
+static void* g_api;
+static void* g_steamApps;
+static void* g_steamUserStats;
+static void* g_steamUser;
 
-typedef int (*InitFlat_t)(char *);
-typedef void *(*GetISteamApps_t)(void *, int, const char *);
-typedef void *(*GetISteamUserStats_t)(void *, int, const char *);
+typedef int (*InitFlat_t)(char*);
+typedef void* (*GetISteamApps_t)(void*, int, const char*);
+typedef void* (*GetISteamUserStats_t)(void*, int, const char*);
 typedef int (*GetHSteamPipe_t)(void);
 typedef int (*GetHSteamUser_t)(void);
-typedef void *(*SteamAppsV_t)(void);
-typedef void *(*SteamUserStatsV_t)(void);
-typedef void *(*SteamUserV_t)(void);
+typedef void* (*SteamAppsV_t)(void);
+typedef void* (*SteamUserStatsV_t)(void);
+typedef void* (*SteamUserV_t)(void);
 
 __attribute__((constructor)) static void _ctor(void) {
     g_api = dlopen("@loader_path/libsteam_api.dylib", RTLD_NOW | RTLD_GLOBAL);
 }
 
 static void cache_interfaces(void) {
-    if (g_steamApps && g_steamUserStats) return;
-    if (!g_api) return;
-    
+    if (g_steamApps && g_steamUserStats)
+        return;
+    if (!g_api)
+        return;
+
     SteamAppsV_t getApps = (SteamAppsV_t)dlsym(g_api, "SteamAPI_SteamApps_v009");
     SteamUserStatsV_t getStats = (SteamUserStatsV_t)dlsym(g_api, "SteamAPI_SteamUserStats_v013");
     SteamUserV_t getUser = (SteamUserV_t)dlsym(g_api, "SteamAPI_SteamUser_v021");
-    
-    if (getApps) g_steamApps = getApps();
-    if (getStats) g_steamUserStats = getStats();
-    if (getUser) g_steamUser = getUser();
+
+    if (getApps)
+        g_steamApps = getApps();
+    if (getStats)
+        g_steamUserStats = getStats();
+    if (getUser)
+        g_steamUser = getUser();
 }
 
-int RestartAppIfNecessary(void *appId) { return 0; }
+int RestartAppIfNecessary(void* appId) {
+    return 0;
+}
 
 int Init(void) {
-    if (!g_api) return 0;
+    if (!g_api)
+        return 0;
     InitFlat_t fn = (InitFlat_t)dlsym(g_api, "SteamAPI_InitFlat");
-    if (!fn) return 0;
+    if (!fn)
+        return 0;
     char errMsg[1024] = {0};
     int result = fn(errMsg);
-    if (result == 0) cache_interfaces();
+    if (result == 0)
+        cache_interfaces();
     return result == 0;
 }
 
 void Shutdown(void) {
-    if (!g_api) return;
+    if (!g_api)
+        return;
     void (*fn)(void) = dlsym(g_api, "SteamAPI_Shutdown");
-    if (fn) fn();
+    if (fn)
+        fn();
 }
 
 void RunCallbacks(void) {
-    if (!g_api) return;
+    if (!g_api)
+        return;
     void (*fn)(void) = dlsym(g_api, "SteamAPI_RunCallbacks");
-    if (fn) fn();
+    if (fn)
+        fn();
 }
 
 /* ISteamApps wrappers */
-typedef const char *(*Apps_GetCurrentGameLanguage_t)(void *);
-typedef int (*Apps_BIsSubscribed_t)(void *);
-typedef int (*Apps_BIsDlcInstalled_t)(void *, unsigned int);
+typedef const char* (*Apps_GetCurrentGameLanguage_t)(void*);
+typedef int (*Apps_BIsSubscribed_t)(void*);
+typedef int (*Apps_BIsDlcInstalled_t)(void*, unsigned int);
 
-void *ISteamApps_GetCurrentGameLanguage(void) {
-    if (!g_api || !g_steamApps) return NULL;
-    Apps_GetCurrentGameLanguage_t fn = (Apps_GetCurrentGameLanguage_t)dlsym(g_api, "SteamAPI_ISteamApps_GetCurrentGameLanguage");
+void* ISteamApps_GetCurrentGameLanguage(void) {
+    if (!g_api || !g_steamApps)
+        return NULL;
+    Apps_GetCurrentGameLanguage_t fn =
+        (Apps_GetCurrentGameLanguage_t)dlsym(g_api, "SteamAPI_ISteamApps_GetCurrentGameLanguage");
     return fn ? fn(g_steamApps) : NULL;
 }
 
 /* ISteamUserStats wrappers */
-typedef int (*Stats_RequestCurrentStats_t)(void *);
-typedef int (*Stats_GetStat_t)(void *, const char *, int *);
-typedef int (*Stats_SetStat_t)(void *, const char *, int);
-typedef int (*Stats_GetAchievement_t)(void *, const char *, int *);
-typedef int (*Stats_SetAchievement_t)(void *, const char *);
-typedef int (*Stats_StoreStats_t)(void *);
-typedef int (*Stats_RequestGlobalStats_t)(void *, int);
-typedef int (*Stats_GetGlobalStatDouble_t)(void *, const char *, double *);
-typedef int (*Stats_GetGlobalStatInt64_t)(void *, const char *, long long *);
+typedef int (*Stats_RequestCurrentStats_t)(void*);
+typedef int (*Stats_GetStat_t)(void*, const char*, int*);
+typedef int (*Stats_SetStat_t)(void*, const char*, int);
+typedef int (*Stats_GetAchievement_t)(void*, const char*, int*);
+typedef int (*Stats_SetAchievement_t)(void*, const char*);
+typedef int (*Stats_StoreStats_t)(void*);
+typedef int (*Stats_RequestGlobalStats_t)(void*, int);
+typedef int (*Stats_GetGlobalStatDouble_t)(void*, const char*, double*);
+typedef int (*Stats_GetGlobalStatInt64_t)(void*, const char*, long long*);
 
 int ISteamUserStats_RequestCurrentStats(void) {
-    if (!g_api || !g_steamUserStats) return 0;
-    Stats_RequestCurrentStats_t fn = (Stats_RequestCurrentStats_t)dlsym(g_api, "SteamAPI_ISteamUserStats_RequestCurrentStats");
+    if (!g_api || !g_steamUserStats)
+        return 0;
+    Stats_RequestCurrentStats_t fn =
+        (Stats_RequestCurrentStats_t)dlsym(g_api, "SteamAPI_ISteamUserStats_RequestCurrentStats");
     return fn ? fn(g_steamUserStats) : 0;
 }
 
-int ISteamUserStats_GetStat(void *name, int *data) {
-    if (!g_api || !g_steamUserStats) return 0;
+int ISteamUserStats_GetStat(void* name, int* data) {
+    if (!g_api || !g_steamUserStats)
+        return 0;
     Stats_GetStat_t fn = (Stats_GetStat_t)dlsym(g_api, "SteamAPI_ISteamUserStats_GetStatInt32");
     return fn ? fn(g_steamUserStats, name, data) : 0;
 }
 
-int ISteamUserStats_SetStat(void *name, int data) {
-    if (!g_api || !g_steamUserStats) return 0;
+int ISteamUserStats_SetStat(void* name, int data) {
+    if (!g_api || !g_steamUserStats)
+        return 0;
     Stats_SetStat_t fn = (Stats_SetStat_t)dlsym(g_api, "SteamAPI_ISteamUserStats_SetStatInt32");
     return fn ? fn(g_steamUserStats, name, data) : 0;
 }
 
-int ISteamUserStats_GetAchievement(void *name, int *achieved) {
-    if (!g_api || !g_steamUserStats) return 0;
+int ISteamUserStats_GetAchievement(void* name, int* achieved) {
+    if (!g_api || !g_steamUserStats)
+        return 0;
     Stats_GetAchievement_t fn = (Stats_GetAchievement_t)dlsym(g_api, "SteamAPI_ISteamUserStats_GetAchievement");
     return fn ? fn(g_steamUserStats, name, achieved) : 0;
 }
 
-int ISteamUserStats_SetAchievement(void *name) {
-    if (!g_api || !g_steamUserStats) return 0;
+int ISteamUserStats_SetAchievement(void* name) {
+    if (!g_api || !g_steamUserStats)
+        return 0;
     Stats_SetAchievement_t fn = (Stats_SetAchievement_t)dlsym(g_api, "SteamAPI_ISteamUserStats_SetAchievement");
     return fn ? fn(g_steamUserStats, name) : 0;
 }
 
 int ISteamUserStats_StoreStats(void) {
-    if (!g_api || !g_steamUserStats) return 0;
+    if (!g_api || !g_steamUserStats)
+        return 0;
     Stats_StoreStats_t fn = (Stats_StoreStats_t)dlsym(g_api, "SteamAPI_ISteamUserStats_StoreStats");
     return fn ? fn(g_steamUserStats) : 0;
 }
 
 int ISteamUserStats_RequestGlobalStats(int historyDays) {
-    if (!g_api || !g_steamUserStats) return 0;
-    Stats_RequestGlobalStats_t fn = (Stats_RequestGlobalStats_t)dlsym(g_api, "SteamAPI_ISteamUserStats_RequestGlobalStats");
+    if (!g_api || !g_steamUserStats)
+        return 0;
+    Stats_RequestGlobalStats_t fn =
+        (Stats_RequestGlobalStats_t)dlsym(g_api, "SteamAPI_ISteamUserStats_RequestGlobalStats");
     return fn ? fn(g_steamUserStats, historyDays) : 0;
 }
 
-int ISteamUserStats_GetGlobalStat(void *name, double *data) {
-    if (!g_api || !g_steamUserStats) return 0;
-    Stats_GetGlobalStatDouble_t fn = (Stats_GetGlobalStatDouble_t)dlsym(g_api, "SteamAPI_ISteamUserStats_GetGlobalStatDouble");
+int ISteamUserStats_GetGlobalStat(void* name, double* data) {
+    if (!g_api || !g_steamUserStats)
+        return 0;
+    Stats_GetGlobalStatDouble_t fn =
+        (Stats_GetGlobalStatDouble_t)dlsym(g_api, "SteamAPI_ISteamUserStats_GetGlobalStatDouble");
     return fn ? fn(g_steamUserStats, name, data) : 0;
 }
 
 /* SteamClient / SteamUser for getting Steam ID */
-void *SteamClient_(void) {
-    if (!g_api) return NULL;
-    void *(*fn)(void) = dlsym(g_api, "SteamClient");
+void* SteamClient_(void) {
+    if (!g_api)
+        return NULL;
+    void* (*fn)(void) = dlsym(g_api, "SteamClient");
     return fn ? fn() : NULL;
 }
 
-typedef void *(*GetSteamID_t)(void *);
-void *ISteamUser_GetSteamID(void) {
-    if (!g_api || !g_steamUser) return NULL;
+typedef void* (*GetSteamID_t)(void*);
+void* ISteamUser_GetSteamID(void) {
+    if (!g_api || !g_steamUser)
+        return NULL;
     GetSteamID_t fn = (GetSteamID_t)dlsym(g_api, "SteamAPI_ISteamUser_GetSteamID");
     return fn ? fn(g_steamUser) : NULL;
 }

--- a/src/fna/shims/fmod_stub.c
+++ b/src/fna/shims/fmod_stub.c
@@ -1,332 +1,972 @@
 /// @file fmod_stub.c
 /// @brief FMOD Core API no-op stubs for FNA games.
 ///
-/// Provides empty stub implementations for FMOD Core API functions (System_create, FMOD_System_Init, etc.) so games link without error when FMOD is not available. Returns success codes to prevent crashes from unhandled FMOD calls.
-#include <string.h>
+/// Provides empty stub implementations for FMOD Core API functions (System_create, FMOD_System_Init, etc.) so games
+/// link without error when FMOD is not available. Returns success codes to prevent crashes from unhandled FMOD calls.
 #include <stdlib.h>
+#include <string.h>
 
 static char g_empty[1] = {0};
 
-int FMOD_System_Create(void **system) {
-    if (system) *system = malloc(1);
+int FMOD_System_Create(void** system) {
+    if (system)
+        *system = malloc(1);
     return 0;
 }
-long FMOD_Channel_GetChannelGroup() { return 0; }
-long FMOD_Channel_GetCurrentSound() { return 0; }
-long FMOD_Channel_GetFrequency() { return 0; }
-long FMOD_Channel_GetIndex() { return 0; }
-long FMOD_Channel_GetLoopCount() { return 0; }
-long FMOD_Channel_GetLoopPoints() { return 0; }
-long FMOD_Channel_GetMode() { return 0; }
-long FMOD_Channel_GetPosition() { return 0; }
-long FMOD_Channel_GetPriority() { return 0; }
-long FMOD_Channel_GetUserData() { return 0; }
-long FMOD_Channel_IsVirtual() { return 0; }
-long FMOD_Channel_SetChannelGroup() { return 0; }
-long FMOD_Channel_SetFrequency() { return 0; }
-long FMOD_Channel_SetLoopCount() { return 0; }
-long FMOD_Channel_SetLoopPoints() { return 0; }
-long FMOD_Channel_SetMode() { return 0; }
-long FMOD_Channel_SetPosition() { return 0; }
-long FMOD_Channel_SetPriority() { return 0; }
-long FMOD_Channel_SetUserData() { return 0; }
-long FMOD_ChannelGroup_AddDSP() { return 0; }
-long FMOD_ChannelGroup_AddFadePoint() { return 0; }
-long FMOD_ChannelGroup_AddGroup() { return 0; }
-long FMOD_ChannelGroup_Get3DAttributes() { return 0; }
-long FMOD_ChannelGroup_Get3DConeOrientation() { return 0; }
-long FMOD_ChannelGroup_Get3DConeSettings() { return 0; }
-long FMOD_ChannelGroup_Get3DCustomRolloff() { return 0; }
-long FMOD_ChannelGroup_Get3DDistanceFilter() { return 0; }
-long FMOD_ChannelGroup_Get3DDopplerLevel() { return 0; }
-long FMOD_ChannelGroup_Get3DLevel() { return 0; }
-long FMOD_ChannelGroup_Get3DMinMaxDistance() { return 0; }
-long FMOD_ChannelGroup_Get3DOcclusion() { return 0; }
-long FMOD_ChannelGroup_Get3DSpread() { return 0; }
-long FMOD_ChannelGroup_GetAudibility() { return 0; }
-long FMOD_ChannelGroup_GetChannel() { return 0; }
-long FMOD_ChannelGroup_GetDelay() { return 0; }
-long FMOD_ChannelGroup_GetDSP() { return 0; }
-long FMOD_ChannelGroup_GetDSPClock() { return 0; }
-long FMOD_ChannelGroup_GetDSPIndex() { return 0; }
-long FMOD_ChannelGroup_GetFadePoints() { return 0; }
-long FMOD_ChannelGroup_GetGroup() { return 0; }
-long FMOD_ChannelGroup_GetLowPassGain() { return 0; }
-long FMOD_ChannelGroup_GetMixMatrix() { return 0; }
-long FMOD_ChannelGroup_GetMode() { return 0; }
-long FMOD_ChannelGroup_GetMute() { return 0; }
-long FMOD_ChannelGroup_GetName() { return 0; }
-long FMOD_ChannelGroup_GetNumChannels() { return 0; }
-long FMOD_ChannelGroup_GetNumDSPs() { return 0; }
-long FMOD_ChannelGroup_GetNumGroups() { return 0; }
-long FMOD_ChannelGroup_GetParentGroup() { return 0; }
-long FMOD_ChannelGroup_GetPaused() { return 0; }
-long FMOD_ChannelGroup_GetPitch() { return 0; }
-long FMOD_ChannelGroup_GetReverbProperties() { return 0; }
-long FMOD_ChannelGroup_GetSystemObject() { return 0; }
-long FMOD_ChannelGroup_GetUserData() { return 0; }
-long FMOD_ChannelGroup_GetVolume() { return 0; }
-long FMOD_ChannelGroup_GetVolumeRamp() { return 0; }
-long FMOD_ChannelGroup_IsPlaying() { return 0; }
-long FMOD_ChannelGroup_Release() { return 0; }
-long FMOD_ChannelGroup_RemoveDSP() { return 0; }
-long FMOD_ChannelGroup_RemoveFadePoints() { return 0; }
-long FMOD_ChannelGroup_Set3DAttributes() { return 0; }
-long FMOD_ChannelGroup_Set3DConeOrientation() { return 0; }
-long FMOD_ChannelGroup_Set3DConeSettings() { return 0; }
-long FMOD_ChannelGroup_Set3DCustomRolloff() { return 0; }
-long FMOD_ChannelGroup_Set3DDistanceFilter() { return 0; }
-long FMOD_ChannelGroup_Set3DDopplerLevel() { return 0; }
-long FMOD_ChannelGroup_Set3DLevel() { return 0; }
-long FMOD_ChannelGroup_Set3DMinMaxDistance() { return 0; }
-long FMOD_ChannelGroup_Set3DOcclusion() { return 0; }
-long FMOD_ChannelGroup_Set3DSpread() { return 0; }
-long FMOD_ChannelGroup_SetCallback() { return 0; }
-long FMOD_ChannelGroup_SetDelay() { return 0; }
-long FMOD_ChannelGroup_SetDSPIndex() { return 0; }
-long FMOD_ChannelGroup_SetFadePointRamp() { return 0; }
-long FMOD_ChannelGroup_SetLowPassGain() { return 0; }
-long FMOD_ChannelGroup_SetMixLevelsInput() { return 0; }
-long FMOD_ChannelGroup_SetMixLevelsOutput() { return 0; }
-long FMOD_ChannelGroup_SetMixMatrix() { return 0; }
-long FMOD_ChannelGroup_SetMode() { return 0; }
-long FMOD_ChannelGroup_SetMute() { return 0; }
-long FMOD_ChannelGroup_SetPan() { return 0; }
-long FMOD_ChannelGroup_SetPaused() { return 0; }
-long FMOD_ChannelGroup_SetPitch() { return 0; }
-long FMOD_ChannelGroup_SetReverbProperties() { return 0; }
-long FMOD_ChannelGroup_SetUserData() { return 0; }
-long FMOD_ChannelGroup_SetVolume() { return 0; }
-long FMOD_ChannelGroup_SetVolumeRamp() { return 0; }
-long FMOD_ChannelGroup_Stop() { return 0; }
-long FMOD_Debug_Initialize() { return 0; }
-long FMOD_DSP_AddInput() { return 0; }
-long FMOD_DSP_DisconnectAll() { return 0; }
-long FMOD_DSP_DisconnectFrom() { return 0; }
-long FMOD_DSP_GetActive() { return 0; }
-long FMOD_DSP_GetBypass() { return 0; }
-long FMOD_DSP_GetChannelFormat() { return 0; }
-long FMOD_DSP_GetCPUUsage() { return 0; }
-long FMOD_DSP_GetDataParameterIndex() { return 0; }
-long FMOD_DSP_GetIdle() { return 0; }
-long FMOD_DSP_GetInfo() { return 0; }
-long FMOD_DSP_GetInput() { return 0; }
-long FMOD_DSP_GetMeteringEnabled() { return 0; }
-long FMOD_DSP_GetMeteringInfo() { return 0; }
-long FMOD_DSP_GetNumInputs() { return 0; }
-long FMOD_DSP_GetNumOutputs() { return 0; }
-long FMOD_DSP_GetNumParameters() { return 0; }
-long FMOD_DSP_GetOutput() { return 0; }
-long FMOD_DSP_GetOutputChannelFormat() { return 0; }
-long FMOD_DSP_GetParameterBool() { return 0; }
-long FMOD_DSP_GetParameterData() { return 0; }
-long FMOD_DSP_GetParameterFloat() { return 0; }
-long FMOD_DSP_GetParameterInfo() { return 0; }
-long FMOD_DSP_GetParameterInt() { return 0; }
-long FMOD_DSP_GetSystemObject() { return 0; }
-long FMOD_DSP_GetType() { return 0; }
-long FMOD_DSP_GetUserData() { return 0; }
-long FMOD_DSP_GetWetDryMix() { return 0; }
-long FMOD_DSP_Release() { return 0; }
-long FMOD_DSP_Reset() { return 0; }
-long FMOD_DSP_SetActive() { return 0; }
-long FMOD_DSP_SetBypass() { return 0; }
-long FMOD_DSP_SetChannelFormat() { return 0; }
-long FMOD_DSP_SetMeteringEnabled() { return 0; }
-long FMOD_DSP_SetParameterBool() { return 0; }
-long FMOD_DSP_SetParameterData() { return 0; }
-long FMOD_DSP_SetParameterFloat() { return 0; }
-long FMOD_DSP_SetParameterInt() { return 0; }
-long FMOD_DSP_SetUserData() { return 0; }
-long FMOD_DSP_SetWetDryMix() { return 0; }
-long FMOD_DSP_ShowConfigDialog() { return 0; }
-long FMOD_DSPConnection_GetInput() { return 0; }
-long FMOD_DSPConnection_GetMix() { return 0; }
-long FMOD_DSPConnection_GetMixMatrix() { return 0; }
-long FMOD_DSPConnection_GetOutput() { return 0; }
-long FMOD_DSPConnection_GetType() { return 0; }
-long FMOD_DSPConnection_GetUserData() { return 0; }
-long FMOD_DSPConnection_SetMix() { return 0; }
-long FMOD_DSPConnection_SetMixMatrix() { return 0; }
-long FMOD_DSPConnection_SetUserData() { return 0; }
-long FMOD_Geometry_AddPolygon() { return 0; }
-long FMOD_Geometry_GetActive() { return 0; }
-long FMOD_Geometry_GetMaxPolygons() { return 0; }
-long FMOD_Geometry_GetNumPolygons() { return 0; }
-long FMOD_Geometry_GetPolygonAttributes() { return 0; }
-long FMOD_Geometry_GetPolygonNumVertices() { return 0; }
-long FMOD_Geometry_GetPolygonVertex() { return 0; }
-long FMOD_Geometry_GetPosition() { return 0; }
-long FMOD_Geometry_GetRotation() { return 0; }
-long FMOD_Geometry_GetScale() { return 0; }
-long FMOD_Geometry_GetUserData() { return 0; }
-long FMOD_Geometry_Release() { return 0; }
-long FMOD_Geometry_Save() { return 0; }
-long FMOD_Geometry_SetActive() { return 0; }
-long FMOD_Geometry_SetPolygonAttributes() { return 0; }
-long FMOD_Geometry_SetPolygonVertex() { return 0; }
-long FMOD_Geometry_SetPosition() { return 0; }
-long FMOD_Geometry_SetRotation() { return 0; }
-long FMOD_Geometry_SetScale() { return 0; }
-long FMOD_Geometry_SetUserData() { return 0; }
-long FMOD_Memory_GetStats() { return 0; }
-long FMOD_Memory_Initialize() { return 0; }
-long FMOD_Reverb3D_Get3DAttributes() { return 0; }
-long FMOD_Reverb3D_GetActive() { return 0; }
-long FMOD_Reverb3D_GetProperties() { return 0; }
-long FMOD_Reverb3D_GetUserData() { return 0; }
-long FMOD_Reverb3D_Release() { return 0; }
-long FMOD_Reverb3D_Set3DAttributes() { return 0; }
-long FMOD_Reverb3D_SetActive() { return 0; }
-long FMOD_Reverb3D_SetProperties() { return 0; }
-long FMOD_Reverb3D_SetUserData() { return 0; }
-long FMOD_Sound_AddSyncPoint() { return 0; }
-long FMOD_Sound_DeleteSyncPoint() { return 0; }
-long FMOD_Sound_Get3DConeSettings() { return 0; }
-long FMOD_Sound_Get3DCustomRolloff() { return 0; }
-long FMOD_Sound_Get3DMinMaxDistance() { return 0; }
-long FMOD_Sound_GetDefaults() { return 0; }
-long FMOD_Sound_GetFormat() { return 0; }
-long FMOD_Sound_GetLength() { return 0; }
-long FMOD_Sound_GetLoopCount() { return 0; }
-long FMOD_Sound_GetLoopPoints() { return 0; }
-long FMOD_Sound_GetMode() { return 0; }
-long FMOD_Sound_GetMusicChannelVolume() { return 0; }
-long FMOD_Sound_GetMusicNumChannels() { return 0; }
-long FMOD_Sound_GetMusicSpeed() { return 0; }
-long FMOD_Sound_GetName() { return 0; }
-long FMOD_Sound_GetNumSubSounds() { return 0; }
-long FMOD_Sound_GetNumSyncPoints() { return 0; }
-long FMOD_Sound_GetNumTags() { return 0; }
-long FMOD_Sound_GetOpenState() { return 0; }
-long FMOD_Sound_GetSoundGroup() { return 0; }
-long FMOD_Sound_GetSubSound() { return 0; }
-long FMOD_Sound_GetSubSoundParent() { return 0; }
-long FMOD_Sound_GetSyncPoint() { return 0; }
-long FMOD_Sound_GetSyncPointInfo() { return 0; }
-long FMOD_Sound_GetSystemObject() { return 0; }
-long FMOD_Sound_GetTag() { return 0; }
-long FMOD_Sound_GetUserData() { return 0; }
-long FMOD_Sound_Lock() { return 0; }
-long FMOD_Sound_ReadData() { return 0; }
-long FMOD_Sound_Release() { return 0; }
-long FMOD_Sound_SeekData() { return 0; }
-long FMOD_Sound_Set3DConeSettings() { return 0; }
-long FMOD_Sound_Set3DCustomRolloff() { return 0; }
-long FMOD_Sound_Set3DMinMaxDistance() { return 0; }
-long FMOD_Sound_SetDefaults() { return 0; }
-long FMOD_Sound_SetLoopCount() { return 0; }
-long FMOD_Sound_SetLoopPoints() { return 0; }
-long FMOD_Sound_SetMode() { return 0; }
-long FMOD_Sound_SetMusicChannelVolume() { return 0; }
-long FMOD_Sound_SetMusicSpeed() { return 0; }
-long FMOD_Sound_SetSoundGroup() { return 0; }
-long FMOD_Sound_SetUserData() { return 0; }
-long FMOD_Sound_Unlock() { return 0; }
-long FMOD_SoundGroup_GetMaxAudible() { return 0; }
-long FMOD_SoundGroup_GetMaxAudibleBehavior() { return 0; }
-long FMOD_SoundGroup_GetMuteFadeSpeed() { return 0; }
-long FMOD_SoundGroup_GetName() { return 0; }
-long FMOD_SoundGroup_GetNumPlaying() { return 0; }
-long FMOD_SoundGroup_GetNumSounds() { return 0; }
-long FMOD_SoundGroup_GetSound() { return 0; }
-long FMOD_SoundGroup_GetSystemObject() { return 0; }
-long FMOD_SoundGroup_GetUserData() { return 0; }
-long FMOD_SoundGroup_GetVolume() { return 0; }
-long FMOD_SoundGroup_Release() { return 0; }
-long FMOD_SoundGroup_SetMaxAudible() { return 0; }
-long FMOD_SoundGroup_SetMaxAudibleBehavior() { return 0; }
-long FMOD_SoundGroup_SetMuteFadeSpeed() { return 0; }
-long FMOD_SoundGroup_SetUserData() { return 0; }
-long FMOD_SoundGroup_SetVolume() { return 0; }
-long FMOD_SoundGroup_Stop() { return 0; }
-long FMOD_System_AttachChannelGroupToPort() { return 0; }
-long FMOD_System_AttachFileSystem() { return 0; }
-long FMOD_System_Close() { return 0; }
-long FMOD_System_CreateChannelGroup() { return 0; }
-long FMOD_System_CreateDSP() { return 0; }
-long FMOD_System_CreateDSPByPlugin() { return 0; }
-long FMOD_System_CreateDSPByType() { return 0; }
-long FMOD_System_CreateGeometry() { return 0; }
-long FMOD_System_CreateReverb3D() { return 0; }
-long FMOD_System_CreateSound() { return 0; }
-long FMOD_System_CreateSoundGroup() { return 0; }
-long FMOD_System_CreateStream() { return 0; }
-long FMOD_System_DetachChannelGroupFromPort() { return 0; }
-long FMOD_System_Get3DListenerAttributes() { return 0; }
-long FMOD_System_Get3DNumListeners() { return 0; }
-long FMOD_System_Get3DSettings() { return 0; }
-long FMOD_System_GetAdvancedSettings() { return 0; }
-long FMOD_System_GetChannel() { return 0; }
-long FMOD_System_GetChannelsPlaying() { return 0; }
-long FMOD_System_GetCPUUsage() { return 0; }
-long FMOD_System_GetDefaultMixMatrix() { return 0; }
-long FMOD_System_GetDriver() { return 0; }
-long FMOD_System_GetDriverInfo() { return 0; }
-long FMOD_System_GetDSPBufferSize() { return 0; }
-long FMOD_System_GetDSPInfoByPlugin() { return 0; }
-long FMOD_System_GetFileUsage() { return 0; }
-long FMOD_System_GetGeometryOcclusion() { return 0; }
-long FMOD_System_GetGeometrySettings() { return 0; }
-long FMOD_System_GetMasterChannelGroup() { return 0; }
-long FMOD_System_GetMasterSoundGroup() { return 0; }
-long FMOD_System_GetNestedPlugin() { return 0; }
-long FMOD_System_GetNetworkProxy() { return 0; }
-long FMOD_System_GetNetworkTimeout() { return 0; }
-long FMOD_System_GetNumDrivers() { return 0; }
-long FMOD_System_GetNumNestedPlugins() { return 0; }
-long FMOD_System_GetNumPlugins() { return 0; }
-long FMOD_System_GetOutput() { return 0; }
-long FMOD_System_GetOutputByPlugin() { return 0; }
-long FMOD_System_GetOutputHandle() { return 0; }
-long FMOD_System_GetPluginHandle() { return 0; }
-long FMOD_System_GetPluginInfo() { return 0; }
-long FMOD_System_GetRecordDriverInfo() { return 0; }
-long FMOD_System_GetRecordNumDrivers() { return 0; }
-long FMOD_System_GetRecordPosition() { return 0; }
-long FMOD_System_GetReverbProperties() { return 0; }
-long FMOD_System_GetSoftwareChannels() { return 0; }
-long FMOD_System_GetSoftwareFormat() { return 0; }
-long FMOD_System_GetSoundRAM() { return 0; }
-long FMOD_System_GetSpeakerModeChannels() { return 0; }
-long FMOD_System_GetSpeakerPosition() { return 0; }
-long FMOD_System_GetStreamBufferSize() { return 0; }
-long FMOD_System_GetUserData() { return 0; }
-long FMOD_System_GetVersion() { return 0; }
-long FMOD_System_Init() { return 0; }
-long FMOD_System_IsRecording() { return 0; }
-long FMOD_System_LoadGeometry() { return 0; }
-long FMOD_System_LoadPlugin() { return 0; }
-long FMOD_System_LockDSP() { return 0; }
-long FMOD_System_MixerResume() { return 0; }
-long FMOD_System_MixerSuspend() { return 0; }
-long FMOD_System_PlayDSP() { return 0; }
-long FMOD_System_PlaySound() { return 0; }
-long FMOD_System_RecordStart() { return 0; }
-long FMOD_System_RecordStop() { return 0; }
-long FMOD_System_RegisterDSP() { return 0; }
-long FMOD_System_Release() { return 0; }
-long FMOD_System_Set3DListenerAttributes() { return 0; }
-long FMOD_System_Set3DNumListeners() { return 0; }
-long FMOD_System_Set3DRolloffCallback() { return 0; }
-long FMOD_System_Set3DSettings() { return 0; }
-long FMOD_System_SetAdvancedSettings() { return 0; }
-long FMOD_System_SetCallback() { return 0; }
-long FMOD_System_SetDriver() { return 0; }
-long FMOD_System_SetDSPBufferSize() { return 0; }
-long FMOD_System_SetFileSystem() { return 0; }
-long FMOD_System_SetGeometrySettings() { return 0; }
-long FMOD_System_SetNetworkProxy() { return 0; }
-long FMOD_System_SetNetworkTimeout() { return 0; }
-long FMOD_System_SetOutput() { return 0; }
-long FMOD_System_SetOutputByPlugin() { return 0; }
-long FMOD_System_SetPluginPath() { return 0; }
-long FMOD_System_SetReverbProperties() { return 0; }
-long FMOD_System_SetSoftwareChannels() { return 0; }
-long FMOD_System_SetSoftwareFormat() { return 0; }
-long FMOD_System_SetSpeakerPosition() { return 0; }
-long FMOD_System_SetStreamBufferSize() { return 0; }
-long FMOD_System_SetUserData() { return 0; }
-long FMOD_System_UnloadPlugin() { return 0; }
-long FMOD_System_UnlockDSP() { return 0; }
-long FMOD_System_Update() { return 0; }
+long FMOD_Channel_GetChannelGroup() {
+    return 0;
+}
+long FMOD_Channel_GetCurrentSound() {
+    return 0;
+}
+long FMOD_Channel_GetFrequency() {
+    return 0;
+}
+long FMOD_Channel_GetIndex() {
+    return 0;
+}
+long FMOD_Channel_GetLoopCount() {
+    return 0;
+}
+long FMOD_Channel_GetLoopPoints() {
+    return 0;
+}
+long FMOD_Channel_GetMode() {
+    return 0;
+}
+long FMOD_Channel_GetPosition() {
+    return 0;
+}
+long FMOD_Channel_GetPriority() {
+    return 0;
+}
+long FMOD_Channel_GetUserData() {
+    return 0;
+}
+long FMOD_Channel_IsVirtual() {
+    return 0;
+}
+long FMOD_Channel_SetChannelGroup() {
+    return 0;
+}
+long FMOD_Channel_SetFrequency() {
+    return 0;
+}
+long FMOD_Channel_SetLoopCount() {
+    return 0;
+}
+long FMOD_Channel_SetLoopPoints() {
+    return 0;
+}
+long FMOD_Channel_SetMode() {
+    return 0;
+}
+long FMOD_Channel_SetPosition() {
+    return 0;
+}
+long FMOD_Channel_SetPriority() {
+    return 0;
+}
+long FMOD_Channel_SetUserData() {
+    return 0;
+}
+long FMOD_ChannelGroup_AddDSP() {
+    return 0;
+}
+long FMOD_ChannelGroup_AddFadePoint() {
+    return 0;
+}
+long FMOD_ChannelGroup_AddGroup() {
+    return 0;
+}
+long FMOD_ChannelGroup_Get3DAttributes() {
+    return 0;
+}
+long FMOD_ChannelGroup_Get3DConeOrientation() {
+    return 0;
+}
+long FMOD_ChannelGroup_Get3DConeSettings() {
+    return 0;
+}
+long FMOD_ChannelGroup_Get3DCustomRolloff() {
+    return 0;
+}
+long FMOD_ChannelGroup_Get3DDistanceFilter() {
+    return 0;
+}
+long FMOD_ChannelGroup_Get3DDopplerLevel() {
+    return 0;
+}
+long FMOD_ChannelGroup_Get3DLevel() {
+    return 0;
+}
+long FMOD_ChannelGroup_Get3DMinMaxDistance() {
+    return 0;
+}
+long FMOD_ChannelGroup_Get3DOcclusion() {
+    return 0;
+}
+long FMOD_ChannelGroup_Get3DSpread() {
+    return 0;
+}
+long FMOD_ChannelGroup_GetAudibility() {
+    return 0;
+}
+long FMOD_ChannelGroup_GetChannel() {
+    return 0;
+}
+long FMOD_ChannelGroup_GetDelay() {
+    return 0;
+}
+long FMOD_ChannelGroup_GetDSP() {
+    return 0;
+}
+long FMOD_ChannelGroup_GetDSPClock() {
+    return 0;
+}
+long FMOD_ChannelGroup_GetDSPIndex() {
+    return 0;
+}
+long FMOD_ChannelGroup_GetFadePoints() {
+    return 0;
+}
+long FMOD_ChannelGroup_GetGroup() {
+    return 0;
+}
+long FMOD_ChannelGroup_GetLowPassGain() {
+    return 0;
+}
+long FMOD_ChannelGroup_GetMixMatrix() {
+    return 0;
+}
+long FMOD_ChannelGroup_GetMode() {
+    return 0;
+}
+long FMOD_ChannelGroup_GetMute() {
+    return 0;
+}
+long FMOD_ChannelGroup_GetName() {
+    return 0;
+}
+long FMOD_ChannelGroup_GetNumChannels() {
+    return 0;
+}
+long FMOD_ChannelGroup_GetNumDSPs() {
+    return 0;
+}
+long FMOD_ChannelGroup_GetNumGroups() {
+    return 0;
+}
+long FMOD_ChannelGroup_GetParentGroup() {
+    return 0;
+}
+long FMOD_ChannelGroup_GetPaused() {
+    return 0;
+}
+long FMOD_ChannelGroup_GetPitch() {
+    return 0;
+}
+long FMOD_ChannelGroup_GetReverbProperties() {
+    return 0;
+}
+long FMOD_ChannelGroup_GetSystemObject() {
+    return 0;
+}
+long FMOD_ChannelGroup_GetUserData() {
+    return 0;
+}
+long FMOD_ChannelGroup_GetVolume() {
+    return 0;
+}
+long FMOD_ChannelGroup_GetVolumeRamp() {
+    return 0;
+}
+long FMOD_ChannelGroup_IsPlaying() {
+    return 0;
+}
+long FMOD_ChannelGroup_Release() {
+    return 0;
+}
+long FMOD_ChannelGroup_RemoveDSP() {
+    return 0;
+}
+long FMOD_ChannelGroup_RemoveFadePoints() {
+    return 0;
+}
+long FMOD_ChannelGroup_Set3DAttributes() {
+    return 0;
+}
+long FMOD_ChannelGroup_Set3DConeOrientation() {
+    return 0;
+}
+long FMOD_ChannelGroup_Set3DConeSettings() {
+    return 0;
+}
+long FMOD_ChannelGroup_Set3DCustomRolloff() {
+    return 0;
+}
+long FMOD_ChannelGroup_Set3DDistanceFilter() {
+    return 0;
+}
+long FMOD_ChannelGroup_Set3DDopplerLevel() {
+    return 0;
+}
+long FMOD_ChannelGroup_Set3DLevel() {
+    return 0;
+}
+long FMOD_ChannelGroup_Set3DMinMaxDistance() {
+    return 0;
+}
+long FMOD_ChannelGroup_Set3DOcclusion() {
+    return 0;
+}
+long FMOD_ChannelGroup_Set3DSpread() {
+    return 0;
+}
+long FMOD_ChannelGroup_SetCallback() {
+    return 0;
+}
+long FMOD_ChannelGroup_SetDelay() {
+    return 0;
+}
+long FMOD_ChannelGroup_SetDSPIndex() {
+    return 0;
+}
+long FMOD_ChannelGroup_SetFadePointRamp() {
+    return 0;
+}
+long FMOD_ChannelGroup_SetLowPassGain() {
+    return 0;
+}
+long FMOD_ChannelGroup_SetMixLevelsInput() {
+    return 0;
+}
+long FMOD_ChannelGroup_SetMixLevelsOutput() {
+    return 0;
+}
+long FMOD_ChannelGroup_SetMixMatrix() {
+    return 0;
+}
+long FMOD_ChannelGroup_SetMode() {
+    return 0;
+}
+long FMOD_ChannelGroup_SetMute() {
+    return 0;
+}
+long FMOD_ChannelGroup_SetPan() {
+    return 0;
+}
+long FMOD_ChannelGroup_SetPaused() {
+    return 0;
+}
+long FMOD_ChannelGroup_SetPitch() {
+    return 0;
+}
+long FMOD_ChannelGroup_SetReverbProperties() {
+    return 0;
+}
+long FMOD_ChannelGroup_SetUserData() {
+    return 0;
+}
+long FMOD_ChannelGroup_SetVolume() {
+    return 0;
+}
+long FMOD_ChannelGroup_SetVolumeRamp() {
+    return 0;
+}
+long FMOD_ChannelGroup_Stop() {
+    return 0;
+}
+long FMOD_Debug_Initialize() {
+    return 0;
+}
+long FMOD_DSP_AddInput() {
+    return 0;
+}
+long FMOD_DSP_DisconnectAll() {
+    return 0;
+}
+long FMOD_DSP_DisconnectFrom() {
+    return 0;
+}
+long FMOD_DSP_GetActive() {
+    return 0;
+}
+long FMOD_DSP_GetBypass() {
+    return 0;
+}
+long FMOD_DSP_GetChannelFormat() {
+    return 0;
+}
+long FMOD_DSP_GetCPUUsage() {
+    return 0;
+}
+long FMOD_DSP_GetDataParameterIndex() {
+    return 0;
+}
+long FMOD_DSP_GetIdle() {
+    return 0;
+}
+long FMOD_DSP_GetInfo() {
+    return 0;
+}
+long FMOD_DSP_GetInput() {
+    return 0;
+}
+long FMOD_DSP_GetMeteringEnabled() {
+    return 0;
+}
+long FMOD_DSP_GetMeteringInfo() {
+    return 0;
+}
+long FMOD_DSP_GetNumInputs() {
+    return 0;
+}
+long FMOD_DSP_GetNumOutputs() {
+    return 0;
+}
+long FMOD_DSP_GetNumParameters() {
+    return 0;
+}
+long FMOD_DSP_GetOutput() {
+    return 0;
+}
+long FMOD_DSP_GetOutputChannelFormat() {
+    return 0;
+}
+long FMOD_DSP_GetParameterBool() {
+    return 0;
+}
+long FMOD_DSP_GetParameterData() {
+    return 0;
+}
+long FMOD_DSP_GetParameterFloat() {
+    return 0;
+}
+long FMOD_DSP_GetParameterInfo() {
+    return 0;
+}
+long FMOD_DSP_GetParameterInt() {
+    return 0;
+}
+long FMOD_DSP_GetSystemObject() {
+    return 0;
+}
+long FMOD_DSP_GetType() {
+    return 0;
+}
+long FMOD_DSP_GetUserData() {
+    return 0;
+}
+long FMOD_DSP_GetWetDryMix() {
+    return 0;
+}
+long FMOD_DSP_Release() {
+    return 0;
+}
+long FMOD_DSP_Reset() {
+    return 0;
+}
+long FMOD_DSP_SetActive() {
+    return 0;
+}
+long FMOD_DSP_SetBypass() {
+    return 0;
+}
+long FMOD_DSP_SetChannelFormat() {
+    return 0;
+}
+long FMOD_DSP_SetMeteringEnabled() {
+    return 0;
+}
+long FMOD_DSP_SetParameterBool() {
+    return 0;
+}
+long FMOD_DSP_SetParameterData() {
+    return 0;
+}
+long FMOD_DSP_SetParameterFloat() {
+    return 0;
+}
+long FMOD_DSP_SetParameterInt() {
+    return 0;
+}
+long FMOD_DSP_SetUserData() {
+    return 0;
+}
+long FMOD_DSP_SetWetDryMix() {
+    return 0;
+}
+long FMOD_DSP_ShowConfigDialog() {
+    return 0;
+}
+long FMOD_DSPConnection_GetInput() {
+    return 0;
+}
+long FMOD_DSPConnection_GetMix() {
+    return 0;
+}
+long FMOD_DSPConnection_GetMixMatrix() {
+    return 0;
+}
+long FMOD_DSPConnection_GetOutput() {
+    return 0;
+}
+long FMOD_DSPConnection_GetType() {
+    return 0;
+}
+long FMOD_DSPConnection_GetUserData() {
+    return 0;
+}
+long FMOD_DSPConnection_SetMix() {
+    return 0;
+}
+long FMOD_DSPConnection_SetMixMatrix() {
+    return 0;
+}
+long FMOD_DSPConnection_SetUserData() {
+    return 0;
+}
+long FMOD_Geometry_AddPolygon() {
+    return 0;
+}
+long FMOD_Geometry_GetActive() {
+    return 0;
+}
+long FMOD_Geometry_GetMaxPolygons() {
+    return 0;
+}
+long FMOD_Geometry_GetNumPolygons() {
+    return 0;
+}
+long FMOD_Geometry_GetPolygonAttributes() {
+    return 0;
+}
+long FMOD_Geometry_GetPolygonNumVertices() {
+    return 0;
+}
+long FMOD_Geometry_GetPolygonVertex() {
+    return 0;
+}
+long FMOD_Geometry_GetPosition() {
+    return 0;
+}
+long FMOD_Geometry_GetRotation() {
+    return 0;
+}
+long FMOD_Geometry_GetScale() {
+    return 0;
+}
+long FMOD_Geometry_GetUserData() {
+    return 0;
+}
+long FMOD_Geometry_Release() {
+    return 0;
+}
+long FMOD_Geometry_Save() {
+    return 0;
+}
+long FMOD_Geometry_SetActive() {
+    return 0;
+}
+long FMOD_Geometry_SetPolygonAttributes() {
+    return 0;
+}
+long FMOD_Geometry_SetPolygonVertex() {
+    return 0;
+}
+long FMOD_Geometry_SetPosition() {
+    return 0;
+}
+long FMOD_Geometry_SetRotation() {
+    return 0;
+}
+long FMOD_Geometry_SetScale() {
+    return 0;
+}
+long FMOD_Geometry_SetUserData() {
+    return 0;
+}
+long FMOD_Memory_GetStats() {
+    return 0;
+}
+long FMOD_Memory_Initialize() {
+    return 0;
+}
+long FMOD_Reverb3D_Get3DAttributes() {
+    return 0;
+}
+long FMOD_Reverb3D_GetActive() {
+    return 0;
+}
+long FMOD_Reverb3D_GetProperties() {
+    return 0;
+}
+long FMOD_Reverb3D_GetUserData() {
+    return 0;
+}
+long FMOD_Reverb3D_Release() {
+    return 0;
+}
+long FMOD_Reverb3D_Set3DAttributes() {
+    return 0;
+}
+long FMOD_Reverb3D_SetActive() {
+    return 0;
+}
+long FMOD_Reverb3D_SetProperties() {
+    return 0;
+}
+long FMOD_Reverb3D_SetUserData() {
+    return 0;
+}
+long FMOD_Sound_AddSyncPoint() {
+    return 0;
+}
+long FMOD_Sound_DeleteSyncPoint() {
+    return 0;
+}
+long FMOD_Sound_Get3DConeSettings() {
+    return 0;
+}
+long FMOD_Sound_Get3DCustomRolloff() {
+    return 0;
+}
+long FMOD_Sound_Get3DMinMaxDistance() {
+    return 0;
+}
+long FMOD_Sound_GetDefaults() {
+    return 0;
+}
+long FMOD_Sound_GetFormat() {
+    return 0;
+}
+long FMOD_Sound_GetLength() {
+    return 0;
+}
+long FMOD_Sound_GetLoopCount() {
+    return 0;
+}
+long FMOD_Sound_GetLoopPoints() {
+    return 0;
+}
+long FMOD_Sound_GetMode() {
+    return 0;
+}
+long FMOD_Sound_GetMusicChannelVolume() {
+    return 0;
+}
+long FMOD_Sound_GetMusicNumChannels() {
+    return 0;
+}
+long FMOD_Sound_GetMusicSpeed() {
+    return 0;
+}
+long FMOD_Sound_GetName() {
+    return 0;
+}
+long FMOD_Sound_GetNumSubSounds() {
+    return 0;
+}
+long FMOD_Sound_GetNumSyncPoints() {
+    return 0;
+}
+long FMOD_Sound_GetNumTags() {
+    return 0;
+}
+long FMOD_Sound_GetOpenState() {
+    return 0;
+}
+long FMOD_Sound_GetSoundGroup() {
+    return 0;
+}
+long FMOD_Sound_GetSubSound() {
+    return 0;
+}
+long FMOD_Sound_GetSubSoundParent() {
+    return 0;
+}
+long FMOD_Sound_GetSyncPoint() {
+    return 0;
+}
+long FMOD_Sound_GetSyncPointInfo() {
+    return 0;
+}
+long FMOD_Sound_GetSystemObject() {
+    return 0;
+}
+long FMOD_Sound_GetTag() {
+    return 0;
+}
+long FMOD_Sound_GetUserData() {
+    return 0;
+}
+long FMOD_Sound_Lock() {
+    return 0;
+}
+long FMOD_Sound_ReadData() {
+    return 0;
+}
+long FMOD_Sound_Release() {
+    return 0;
+}
+long FMOD_Sound_SeekData() {
+    return 0;
+}
+long FMOD_Sound_Set3DConeSettings() {
+    return 0;
+}
+long FMOD_Sound_Set3DCustomRolloff() {
+    return 0;
+}
+long FMOD_Sound_Set3DMinMaxDistance() {
+    return 0;
+}
+long FMOD_Sound_SetDefaults() {
+    return 0;
+}
+long FMOD_Sound_SetLoopCount() {
+    return 0;
+}
+long FMOD_Sound_SetLoopPoints() {
+    return 0;
+}
+long FMOD_Sound_SetMode() {
+    return 0;
+}
+long FMOD_Sound_SetMusicChannelVolume() {
+    return 0;
+}
+long FMOD_Sound_SetMusicSpeed() {
+    return 0;
+}
+long FMOD_Sound_SetSoundGroup() {
+    return 0;
+}
+long FMOD_Sound_SetUserData() {
+    return 0;
+}
+long FMOD_Sound_Unlock() {
+    return 0;
+}
+long FMOD_SoundGroup_GetMaxAudible() {
+    return 0;
+}
+long FMOD_SoundGroup_GetMaxAudibleBehavior() {
+    return 0;
+}
+long FMOD_SoundGroup_GetMuteFadeSpeed() {
+    return 0;
+}
+long FMOD_SoundGroup_GetName() {
+    return 0;
+}
+long FMOD_SoundGroup_GetNumPlaying() {
+    return 0;
+}
+long FMOD_SoundGroup_GetNumSounds() {
+    return 0;
+}
+long FMOD_SoundGroup_GetSound() {
+    return 0;
+}
+long FMOD_SoundGroup_GetSystemObject() {
+    return 0;
+}
+long FMOD_SoundGroup_GetUserData() {
+    return 0;
+}
+long FMOD_SoundGroup_GetVolume() {
+    return 0;
+}
+long FMOD_SoundGroup_Release() {
+    return 0;
+}
+long FMOD_SoundGroup_SetMaxAudible() {
+    return 0;
+}
+long FMOD_SoundGroup_SetMaxAudibleBehavior() {
+    return 0;
+}
+long FMOD_SoundGroup_SetMuteFadeSpeed() {
+    return 0;
+}
+long FMOD_SoundGroup_SetUserData() {
+    return 0;
+}
+long FMOD_SoundGroup_SetVolume() {
+    return 0;
+}
+long FMOD_SoundGroup_Stop() {
+    return 0;
+}
+long FMOD_System_AttachChannelGroupToPort() {
+    return 0;
+}
+long FMOD_System_AttachFileSystem() {
+    return 0;
+}
+long FMOD_System_Close() {
+    return 0;
+}
+long FMOD_System_CreateChannelGroup() {
+    return 0;
+}
+long FMOD_System_CreateDSP() {
+    return 0;
+}
+long FMOD_System_CreateDSPByPlugin() {
+    return 0;
+}
+long FMOD_System_CreateDSPByType() {
+    return 0;
+}
+long FMOD_System_CreateGeometry() {
+    return 0;
+}
+long FMOD_System_CreateReverb3D() {
+    return 0;
+}
+long FMOD_System_CreateSound() {
+    return 0;
+}
+long FMOD_System_CreateSoundGroup() {
+    return 0;
+}
+long FMOD_System_CreateStream() {
+    return 0;
+}
+long FMOD_System_DetachChannelGroupFromPort() {
+    return 0;
+}
+long FMOD_System_Get3DListenerAttributes() {
+    return 0;
+}
+long FMOD_System_Get3DNumListeners() {
+    return 0;
+}
+long FMOD_System_Get3DSettings() {
+    return 0;
+}
+long FMOD_System_GetAdvancedSettings() {
+    return 0;
+}
+long FMOD_System_GetChannel() {
+    return 0;
+}
+long FMOD_System_GetChannelsPlaying() {
+    return 0;
+}
+long FMOD_System_GetCPUUsage() {
+    return 0;
+}
+long FMOD_System_GetDefaultMixMatrix() {
+    return 0;
+}
+long FMOD_System_GetDriver() {
+    return 0;
+}
+long FMOD_System_GetDriverInfo() {
+    return 0;
+}
+long FMOD_System_GetDSPBufferSize() {
+    return 0;
+}
+long FMOD_System_GetDSPInfoByPlugin() {
+    return 0;
+}
+long FMOD_System_GetFileUsage() {
+    return 0;
+}
+long FMOD_System_GetGeometryOcclusion() {
+    return 0;
+}
+long FMOD_System_GetGeometrySettings() {
+    return 0;
+}
+long FMOD_System_GetMasterChannelGroup() {
+    return 0;
+}
+long FMOD_System_GetMasterSoundGroup() {
+    return 0;
+}
+long FMOD_System_GetNestedPlugin() {
+    return 0;
+}
+long FMOD_System_GetNetworkProxy() {
+    return 0;
+}
+long FMOD_System_GetNetworkTimeout() {
+    return 0;
+}
+long FMOD_System_GetNumDrivers() {
+    return 0;
+}
+long FMOD_System_GetNumNestedPlugins() {
+    return 0;
+}
+long FMOD_System_GetNumPlugins() {
+    return 0;
+}
+long FMOD_System_GetOutput() {
+    return 0;
+}
+long FMOD_System_GetOutputByPlugin() {
+    return 0;
+}
+long FMOD_System_GetOutputHandle() {
+    return 0;
+}
+long FMOD_System_GetPluginHandle() {
+    return 0;
+}
+long FMOD_System_GetPluginInfo() {
+    return 0;
+}
+long FMOD_System_GetRecordDriverInfo() {
+    return 0;
+}
+long FMOD_System_GetRecordNumDrivers() {
+    return 0;
+}
+long FMOD_System_GetRecordPosition() {
+    return 0;
+}
+long FMOD_System_GetReverbProperties() {
+    return 0;
+}
+long FMOD_System_GetSoftwareChannels() {
+    return 0;
+}
+long FMOD_System_GetSoftwareFormat() {
+    return 0;
+}
+long FMOD_System_GetSoundRAM() {
+    return 0;
+}
+long FMOD_System_GetSpeakerModeChannels() {
+    return 0;
+}
+long FMOD_System_GetSpeakerPosition() {
+    return 0;
+}
+long FMOD_System_GetStreamBufferSize() {
+    return 0;
+}
+long FMOD_System_GetUserData() {
+    return 0;
+}
+long FMOD_System_GetVersion() {
+    return 0;
+}
+long FMOD_System_Init() {
+    return 0;
+}
+long FMOD_System_IsRecording() {
+    return 0;
+}
+long FMOD_System_LoadGeometry() {
+    return 0;
+}
+long FMOD_System_LoadPlugin() {
+    return 0;
+}
+long FMOD_System_LockDSP() {
+    return 0;
+}
+long FMOD_System_MixerResume() {
+    return 0;
+}
+long FMOD_System_MixerSuspend() {
+    return 0;
+}
+long FMOD_System_PlayDSP() {
+    return 0;
+}
+long FMOD_System_PlaySound() {
+    return 0;
+}
+long FMOD_System_RecordStart() {
+    return 0;
+}
+long FMOD_System_RecordStop() {
+    return 0;
+}
+long FMOD_System_RegisterDSP() {
+    return 0;
+}
+long FMOD_System_Release() {
+    return 0;
+}
+long FMOD_System_Set3DListenerAttributes() {
+    return 0;
+}
+long FMOD_System_Set3DNumListeners() {
+    return 0;
+}
+long FMOD_System_Set3DRolloffCallback() {
+    return 0;
+}
+long FMOD_System_Set3DSettings() {
+    return 0;
+}
+long FMOD_System_SetAdvancedSettings() {
+    return 0;
+}
+long FMOD_System_SetCallback() {
+    return 0;
+}
+long FMOD_System_SetDriver() {
+    return 0;
+}
+long FMOD_System_SetDSPBufferSize() {
+    return 0;
+}
+long FMOD_System_SetFileSystem() {
+    return 0;
+}
+long FMOD_System_SetGeometrySettings() {
+    return 0;
+}
+long FMOD_System_SetNetworkProxy() {
+    return 0;
+}
+long FMOD_System_SetNetworkTimeout() {
+    return 0;
+}
+long FMOD_System_SetOutput() {
+    return 0;
+}
+long FMOD_System_SetOutputByPlugin() {
+    return 0;
+}
+long FMOD_System_SetPluginPath() {
+    return 0;
+}
+long FMOD_System_SetReverbProperties() {
+    return 0;
+}
+long FMOD_System_SetSoftwareChannels() {
+    return 0;
+}
+long FMOD_System_SetSoftwareFormat() {
+    return 0;
+}
+long FMOD_System_SetSpeakerPosition() {
+    return 0;
+}
+long FMOD_System_SetStreamBufferSize() {
+    return 0;
+}
+long FMOD_System_SetUserData() {
+    return 0;
+}
+long FMOD_System_UnloadPlugin() {
+    return 0;
+}
+long FMOD_System_UnlockDSP() {
+    return 0;
+}
+long FMOD_System_Update() {
+    return 0;
+}

--- a/src/fna/shims/fmodstudio_stub.c
+++ b/src/fna/shims/fmodstudio_stub.c
@@ -1,176 +1,563 @@
 /// @file fmodstudio_stub.c
 /// @brief FMOD Studio API no-op stubs for FNA games.
 ///
-/// Provides empty stub implementations for FMOD Studio API functions (bank loading, event instances, bus management) so games link without FMOD Studio installed. Returns success codes to prevent audio-related crashes.
-#include <string.h>
+/// Provides empty stub implementations for FMOD Studio API functions (bank loading, event instances, bus management) so
+/// games link without FMOD Studio installed. Returns success codes to prevent audio-related crashes.
 #include <stdlib.h>
+#include <string.h>
 
-long FMOD_Studio_Bank_GetBusCount() { return 0; }
-long FMOD_Studio_Bank_GetBusList() { return 0; }
-long FMOD_Studio_Bank_GetEventCount() { return 0; }
-long FMOD_Studio_Bank_GetEventList() { return 0; }
-long FMOD_Studio_Bank_GetID() { return 0; }
-long FMOD_Studio_Bank_GetLoadingState() { return 0; }
-int FMOD_Studio_Bank_GetPath(void *bank, char *path, int size, int *len) { if (path && size > 0) path[0] = 0; if (len) *len = 1; return 0; }
-long FMOD_Studio_Bank_GetSampleLoadingState() { return 0; }
-long FMOD_Studio_Bank_GetStringCount() { return 0; }
-long FMOD_Studio_Bank_GetStringInfo() { return 0; }
-long FMOD_Studio_Bank_GetUserData() { return 0; }
-long FMOD_Studio_Bank_GetVCACount() { return 0; }
-long FMOD_Studio_Bank_GetVCAList() { return 0; }
-long FMOD_Studio_Bank_IsValid() { return 0; }
-long FMOD_Studio_Bank_LoadSampleData() { return 0; }
-long FMOD_Studio_Bank_SetUserData() { return 0; }
-long FMOD_Studio_Bank_Unload() { return 0; }
-long FMOD_Studio_Bank_UnloadSampleData() { return 0; }
-long FMOD_Studio_Bus_GetChannelGroup() { return 0; }
-long FMOD_Studio_Bus_GetID() { return 0; }
-long FMOD_Studio_Bus_GetMute() { return 0; }
-int FMOD_Studio_Bus_GetPath(void *bus, char *path, int size, int *len) { if (path && size > 0) path[0] = 0; if (len) *len = 1; return 0; }
-long FMOD_Studio_Bus_GetPaused() { return 0; }
-long FMOD_Studio_Bus_GetVolume() { return 0; }
-long FMOD_Studio_Bus_IsValid() { return 0; }
-long FMOD_Studio_Bus_LockChannelGroup() { return 0; }
-long FMOD_Studio_Bus_SetMute() { return 0; }
-long FMOD_Studio_Bus_SetPaused() { return 0; }
-long FMOD_Studio_Bus_SetVolume() { return 0; }
-long FMOD_Studio_Bus_StopAllEvents() { return 0; }
-long FMOD_Studio_Bus_UnlockChannelGroup() { return 0; }
-long FMOD_Studio_CommandReplay_GetCommandAtTime() { return 0; }
-long FMOD_Studio_CommandReplay_GetCommandCount() { return 0; }
-long FMOD_Studio_CommandReplay_GetCommandInfo() { return 0; }
-long FMOD_Studio_CommandReplay_GetCommandString() { return 0; }
-long FMOD_Studio_CommandReplay_GetCurrentCommand() { return 0; }
-long FMOD_Studio_CommandReplay_GetLength() { return 0; }
-long FMOD_Studio_CommandReplay_GetPaused() { return 0; }
-long FMOD_Studio_CommandReplay_GetPlaybackState() { return 0; }
-long FMOD_Studio_CommandReplay_GetSystem() { return 0; }
-long FMOD_Studio_CommandReplay_GetUserData() { return 0; }
-long FMOD_Studio_CommandReplay_IsValid() { return 0; }
-long FMOD_Studio_CommandReplay_Release() { return 0; }
-long FMOD_Studio_CommandReplay_SeekToCommand() { return 0; }
-long FMOD_Studio_CommandReplay_SeekToTime() { return 0; }
-long FMOD_Studio_CommandReplay_SetBankPath() { return 0; }
-long FMOD_Studio_CommandReplay_SetCreateInstanceCallback() { return 0; }
-long FMOD_Studio_CommandReplay_SetFrameCallback() { return 0; }
-long FMOD_Studio_CommandReplay_SetLoadBankCallback() { return 0; }
-long FMOD_Studio_CommandReplay_SetPaused() { return 0; }
-long FMOD_Studio_CommandReplay_SetUserData() { return 0; }
-long FMOD_Studio_CommandReplay_Start() { return 0; }
-long FMOD_Studio_CommandReplay_Stop() { return 0; }
-int FMOD_Studio_EventDescription_CreateInstance(void *desc, void **instance) { if (instance) *instance = malloc(1); return 0; }
-long FMOD_Studio_EventDescription_GetID() { return 0; }
-long FMOD_Studio_EventDescription_GetInstanceCount() { return 0; }
-long FMOD_Studio_EventDescription_GetInstanceList() { return 0; }
-int FMOD_Studio_EventDescription_GetLength(void *desc, int *length) { if (length) *length = 0; return 0; }
-long FMOD_Studio_EventDescription_GetMaximumDistance() { return 0; }
-long FMOD_Studio_EventDescription_GetMinimumDistance() { return 0; }
-long FMOD_Studio_EventDescription_GetParameter() { return 0; }
-long FMOD_Studio_EventDescription_GetParameterByIndex() { return 0; }
-long FMOD_Studio_EventDescription_GetParameterCount() { return 0; }
-int FMOD_Studio_EventDescription_GetPath(void *desc, char *path, int size, int *len) { if (path && size > 0) path[0] = 0; if (len) *len = 1; return 0; }
-long FMOD_Studio_EventDescription_GetSampleLoadingState() { return 0; }
-long FMOD_Studio_EventDescription_GetSoundSize() { return 0; }
-long FMOD_Studio_EventDescription_GetUserData() { return 0; }
-long FMOD_Studio_EventDescription_GetUserProperty() { return 0; }
-long FMOD_Studio_EventDescription_GetUserPropertyByIndex() { return 0; }
-long FMOD_Studio_EventDescription_GetUserPropertyCount() { return 0; }
-long FMOD_Studio_EventDescription_HasCue() { return 0; }
-int FMOD_Studio_EventDescription_Is3D(void *desc, int *is3d) { if (is3d) *is3d = 0; return 0; }
-int FMOD_Studio_EventDescription_IsOneshot(void *desc, int *oneshot) { if (oneshot) *oneshot = 0; return 0; }
-long FMOD_Studio_EventDescription_IsSnapshot() { return 0; }
-long FMOD_Studio_EventDescription_IsStream() { return 0; }
-long FMOD_Studio_EventDescription_IsValid() { return 0; }
-long FMOD_Studio_EventDescription_LoadSampleData() { return 0; }
-long FMOD_Studio_EventDescription_ReleaseAllInstances() { return 0; }
-long FMOD_Studio_EventDescription_SetCallback() { return 0; }
-long FMOD_Studio_EventDescription_SetUserData() { return 0; }
-long FMOD_Studio_EventDescription_UnloadSampleData() { return 0; }
-long FMOD_Studio_EventInstance_Get3DAttributes() { return 0; }
-long FMOD_Studio_EventInstance_GetChannelGroup() { return 0; }
-long FMOD_Studio_EventInstance_GetDescription() { return 0; }
-long FMOD_Studio_EventInstance_GetListenerMask() { return 0; }
-long FMOD_Studio_EventInstance_GetParameter() { return 0; }
-long FMOD_Studio_EventInstance_GetParameterByIndex() { return 0; }
-long FMOD_Studio_EventInstance_GetParameterCount() { return 0; }
-long FMOD_Studio_EventInstance_GetParameterValue() { return 0; }
-long FMOD_Studio_EventInstance_GetParameterValueByIndex() { return 0; }
-long FMOD_Studio_EventInstance_GetPaused() { return 0; }
-int FMOD_Studio_EventInstance_GetPitch(void *inst, float *pitch, float *finalPitch) { if (pitch) *pitch = 1.0f; if (finalPitch) *finalPitch = 1.0f; return 0; }
-long FMOD_Studio_EventInstance_GetPlaybackState() { return 0; }
-long FMOD_Studio_EventInstance_GetProperty() { return 0; }
-long FMOD_Studio_EventInstance_GetReverbLevel() { return 0; }
-long FMOD_Studio_EventInstance_GetTimelinePosition() { return 0; }
-long FMOD_Studio_EventInstance_GetUserData() { return 0; }
-int FMOD_Studio_EventInstance_GetVolume(void *inst, float *vol, float *finalVol) { if (vol) *vol = 1.0f; if (finalVol) *finalVol = 1.0f; return 0; }
-long FMOD_Studio_EventInstance_IsValid() { return 0; }
-long FMOD_Studio_EventInstance_IsVirtual() { return 0; }
-int FMOD_Studio_EventInstance_Release(void *inst) { return 0; }
-long FMOD_Studio_EventInstance_Set3DAttributes() { return 0; }
-long FMOD_Studio_EventInstance_SetCallback() { return 0; }
-long FMOD_Studio_EventInstance_SetListenerMask() { return 0; }
-int FMOD_Studio_EventInstance_SetParameterValue(void *inst, const char *name, float value) { return 0; }
-long FMOD_Studio_EventInstance_SetParameterValueByIndex() { return 0; }
-long FMOD_Studio_EventInstance_SetParameterValuesByIndices() { return 0; }
-long FMOD_Studio_EventInstance_SetPaused() { return 0; }
-int FMOD_Studio_EventInstance_SetPitch(void *inst, float pitch) { return 0; }
-long FMOD_Studio_EventInstance_SetProperty() { return 0; }
-long FMOD_Studio_EventInstance_SetReverbLevel() { return 0; }
-long FMOD_Studio_EventInstance_SetTimelinePosition() { return 0; }
-long FMOD_Studio_EventInstance_SetUserData() { return 0; }
-int FMOD_Studio_EventInstance_SetVolume(void *inst, float vol) { return 0; }
-int FMOD_Studio_EventInstance_Start(void *inst) { return 0; }
-int FMOD_Studio_EventInstance_Stop(void *inst, int mode) { return 0; }
-long FMOD_Studio_EventInstance_TriggerCue() { return 0; }
-long FMOD_Studio_ParameterInstance_GetDescription() { return 0; }
-long FMOD_Studio_ParameterInstance_GetValue() { return 0; }
-long FMOD_Studio_ParameterInstance_IsValid() { return 0; }
-long FMOD_Studio_ParameterInstance_SetValue() { return 0; }
-long FMOD_Studio_ParseID() { return 0; }
-int FMOD_Studio_System_Create(void **system, unsigned int version) { if (system) *system = malloc(1); return 0; }
-long FMOD_Studio_System_FlushCommands() { return 0; }
-long FMOD_Studio_System_FlushSampleLoading() { return 0; }
-long FMOD_Studio_System_GetAdvancedSettings() { return 0; }
-long FMOD_Studio_System_GetBank() { return 0; }
-long FMOD_Studio_System_GetBankByID() { return 0; }
-int FMOD_Studio_System_GetBankCount(void *system, int *count) { if (count) *count = 0; return 0; }
-long FMOD_Studio_System_GetBankList() { return 0; }
-long FMOD_Studio_System_GetBufferUsage() { return 0; }
-int FMOD_Studio_System_GetBus(void *system, const char *path, void **bus) { if (bus) *bus = malloc(1); return 0; }
-long FMOD_Studio_System_GetBusByID() { return 0; }
-long FMOD_Studio_System_GetCPUUsage() { return 0; }
-int FMOD_Studio_System_GetEvent(void *system, const char *path, void **eventDesc) { if (eventDesc) *eventDesc = malloc(1); return 0; }
-long FMOD_Studio_System_GetEventByID() { return 0; }
-long FMOD_Studio_System_GetListenerAttributes() { return 0; }
-long FMOD_Studio_System_GetListenerWeight() { return 0; }
-long FMOD_Studio_System_GetLowLevelSystem() { return 0; }
-long FMOD_Studio_System_GetNumListeners() { return 0; }
-long FMOD_Studio_System_GetSoundInfo() { return 0; }
-long FMOD_Studio_System_GetUserData() { return 0; }
-int FMOD_Studio_System_GetVCA(void *system, const char *path, void **vca) { if (vca) *vca = malloc(1); return 0; }
-long FMOD_Studio_System_GetVCAByID() { return 0; }
-int FMOD_Studio_System_Initialize(void *system, int maxChannels, int studioInitFlags, int initFlags, void *extraData) { return 0; }
-long FMOD_Studio_System_IsValid() { return 0; }
-long FMOD_Studio_System_LoadBankCustom() { return 0; }
-int FMOD_Studio_System_LoadBankFile(void *system, const char *path, int flags, void **bank) { if (bank) *bank = malloc(1); return 0; }
-long FMOD_Studio_System_LoadBankMemory() { return 0; }
-long FMOD_Studio_System_LoadCommandReplay() { return 0; }
-long FMOD_Studio_System_LookupID() { return 0; }
-int FMOD_Studio_System_LookupPath(void *sys, void *id, char *path, int size, int *len) { if (path && size > 0) path[0] = 0; if (len) *len = 1; return 0; }
-long FMOD_Studio_System_Release() { return 0; }
-long FMOD_Studio_System_ResetBufferUsage() { return 0; }
-long FMOD_Studio_System_SetAdvancedSettings() { return 0; }
-long FMOD_Studio_System_SetCallback() { return 0; }
-long FMOD_Studio_System_SetListenerAttributes() { return 0; }
-long FMOD_Studio_System_SetListenerWeight() { return 0; }
-long FMOD_Studio_System_SetNumListeners() { return 0; }
-long FMOD_Studio_System_SetUserData() { return 0; }
-long FMOD_Studio_System_StartCommandCapture() { return 0; }
-long FMOD_Studio_System_StopCommandCapture() { return 0; }
-long FMOD_Studio_System_UnloadAll() { return 0; }
-int FMOD_Studio_System_Update(void *system) { return 0; }
-long FMOD_Studio_VCA_GetID() { return 0; }
-int FMOD_Studio_VCA_GetPath(void *vca, char *path, int size, int *len) { if (path && size > 0) path[0] = 0; if (len) *len = 1; return 0; }
-long FMOD_Studio_VCA_GetVolume() { return 0; }
-long FMOD_Studio_VCA_IsValid() { return 0; }
-long FMOD_Studio_VCA_SetVolume() { return 0; }
+long FMOD_Studio_Bank_GetBusCount() {
+    return 0;
+}
+long FMOD_Studio_Bank_GetBusList() {
+    return 0;
+}
+long FMOD_Studio_Bank_GetEventCount() {
+    return 0;
+}
+long FMOD_Studio_Bank_GetEventList() {
+    return 0;
+}
+long FMOD_Studio_Bank_GetID() {
+    return 0;
+}
+long FMOD_Studio_Bank_GetLoadingState() {
+    return 0;
+}
+int FMOD_Studio_Bank_GetPath(void* bank, char* path, int size, int* len) {
+    if (path && size > 0)
+        path[0] = 0;
+    if (len)
+        *len = 1;
+    return 0;
+}
+long FMOD_Studio_Bank_GetSampleLoadingState() {
+    return 0;
+}
+long FMOD_Studio_Bank_GetStringCount() {
+    return 0;
+}
+long FMOD_Studio_Bank_GetStringInfo() {
+    return 0;
+}
+long FMOD_Studio_Bank_GetUserData() {
+    return 0;
+}
+long FMOD_Studio_Bank_GetVCACount() {
+    return 0;
+}
+long FMOD_Studio_Bank_GetVCAList() {
+    return 0;
+}
+long FMOD_Studio_Bank_IsValid() {
+    return 0;
+}
+long FMOD_Studio_Bank_LoadSampleData() {
+    return 0;
+}
+long FMOD_Studio_Bank_SetUserData() {
+    return 0;
+}
+long FMOD_Studio_Bank_Unload() {
+    return 0;
+}
+long FMOD_Studio_Bank_UnloadSampleData() {
+    return 0;
+}
+long FMOD_Studio_Bus_GetChannelGroup() {
+    return 0;
+}
+long FMOD_Studio_Bus_GetID() {
+    return 0;
+}
+long FMOD_Studio_Bus_GetMute() {
+    return 0;
+}
+int FMOD_Studio_Bus_GetPath(void* bus, char* path, int size, int* len) {
+    if (path && size > 0)
+        path[0] = 0;
+    if (len)
+        *len = 1;
+    return 0;
+}
+long FMOD_Studio_Bus_GetPaused() {
+    return 0;
+}
+long FMOD_Studio_Bus_GetVolume() {
+    return 0;
+}
+long FMOD_Studio_Bus_IsValid() {
+    return 0;
+}
+long FMOD_Studio_Bus_LockChannelGroup() {
+    return 0;
+}
+long FMOD_Studio_Bus_SetMute() {
+    return 0;
+}
+long FMOD_Studio_Bus_SetPaused() {
+    return 0;
+}
+long FMOD_Studio_Bus_SetVolume() {
+    return 0;
+}
+long FMOD_Studio_Bus_StopAllEvents() {
+    return 0;
+}
+long FMOD_Studio_Bus_UnlockChannelGroup() {
+    return 0;
+}
+long FMOD_Studio_CommandReplay_GetCommandAtTime() {
+    return 0;
+}
+long FMOD_Studio_CommandReplay_GetCommandCount() {
+    return 0;
+}
+long FMOD_Studio_CommandReplay_GetCommandInfo() {
+    return 0;
+}
+long FMOD_Studio_CommandReplay_GetCommandString() {
+    return 0;
+}
+long FMOD_Studio_CommandReplay_GetCurrentCommand() {
+    return 0;
+}
+long FMOD_Studio_CommandReplay_GetLength() {
+    return 0;
+}
+long FMOD_Studio_CommandReplay_GetPaused() {
+    return 0;
+}
+long FMOD_Studio_CommandReplay_GetPlaybackState() {
+    return 0;
+}
+long FMOD_Studio_CommandReplay_GetSystem() {
+    return 0;
+}
+long FMOD_Studio_CommandReplay_GetUserData() {
+    return 0;
+}
+long FMOD_Studio_CommandReplay_IsValid() {
+    return 0;
+}
+long FMOD_Studio_CommandReplay_Release() {
+    return 0;
+}
+long FMOD_Studio_CommandReplay_SeekToCommand() {
+    return 0;
+}
+long FMOD_Studio_CommandReplay_SeekToTime() {
+    return 0;
+}
+long FMOD_Studio_CommandReplay_SetBankPath() {
+    return 0;
+}
+long FMOD_Studio_CommandReplay_SetCreateInstanceCallback() {
+    return 0;
+}
+long FMOD_Studio_CommandReplay_SetFrameCallback() {
+    return 0;
+}
+long FMOD_Studio_CommandReplay_SetLoadBankCallback() {
+    return 0;
+}
+long FMOD_Studio_CommandReplay_SetPaused() {
+    return 0;
+}
+long FMOD_Studio_CommandReplay_SetUserData() {
+    return 0;
+}
+long FMOD_Studio_CommandReplay_Start() {
+    return 0;
+}
+long FMOD_Studio_CommandReplay_Stop() {
+    return 0;
+}
+int FMOD_Studio_EventDescription_CreateInstance(void* desc, void** instance) {
+    if (instance)
+        *instance = malloc(1);
+    return 0;
+}
+long FMOD_Studio_EventDescription_GetID() {
+    return 0;
+}
+long FMOD_Studio_EventDescription_GetInstanceCount() {
+    return 0;
+}
+long FMOD_Studio_EventDescription_GetInstanceList() {
+    return 0;
+}
+int FMOD_Studio_EventDescription_GetLength(void* desc, int* length) {
+    if (length)
+        *length = 0;
+    return 0;
+}
+long FMOD_Studio_EventDescription_GetMaximumDistance() {
+    return 0;
+}
+long FMOD_Studio_EventDescription_GetMinimumDistance() {
+    return 0;
+}
+long FMOD_Studio_EventDescription_GetParameter() {
+    return 0;
+}
+long FMOD_Studio_EventDescription_GetParameterByIndex() {
+    return 0;
+}
+long FMOD_Studio_EventDescription_GetParameterCount() {
+    return 0;
+}
+int FMOD_Studio_EventDescription_GetPath(void* desc, char* path, int size, int* len) {
+    if (path && size > 0)
+        path[0] = 0;
+    if (len)
+        *len = 1;
+    return 0;
+}
+long FMOD_Studio_EventDescription_GetSampleLoadingState() {
+    return 0;
+}
+long FMOD_Studio_EventDescription_GetSoundSize() {
+    return 0;
+}
+long FMOD_Studio_EventDescription_GetUserData() {
+    return 0;
+}
+long FMOD_Studio_EventDescription_GetUserProperty() {
+    return 0;
+}
+long FMOD_Studio_EventDescription_GetUserPropertyByIndex() {
+    return 0;
+}
+long FMOD_Studio_EventDescription_GetUserPropertyCount() {
+    return 0;
+}
+long FMOD_Studio_EventDescription_HasCue() {
+    return 0;
+}
+int FMOD_Studio_EventDescription_Is3D(void* desc, int* is3d) {
+    if (is3d)
+        *is3d = 0;
+    return 0;
+}
+int FMOD_Studio_EventDescription_IsOneshot(void* desc, int* oneshot) {
+    if (oneshot)
+        *oneshot = 0;
+    return 0;
+}
+long FMOD_Studio_EventDescription_IsSnapshot() {
+    return 0;
+}
+long FMOD_Studio_EventDescription_IsStream() {
+    return 0;
+}
+long FMOD_Studio_EventDescription_IsValid() {
+    return 0;
+}
+long FMOD_Studio_EventDescription_LoadSampleData() {
+    return 0;
+}
+long FMOD_Studio_EventDescription_ReleaseAllInstances() {
+    return 0;
+}
+long FMOD_Studio_EventDescription_SetCallback() {
+    return 0;
+}
+long FMOD_Studio_EventDescription_SetUserData() {
+    return 0;
+}
+long FMOD_Studio_EventDescription_UnloadSampleData() {
+    return 0;
+}
+long FMOD_Studio_EventInstance_Get3DAttributes() {
+    return 0;
+}
+long FMOD_Studio_EventInstance_GetChannelGroup() {
+    return 0;
+}
+long FMOD_Studio_EventInstance_GetDescription() {
+    return 0;
+}
+long FMOD_Studio_EventInstance_GetListenerMask() {
+    return 0;
+}
+long FMOD_Studio_EventInstance_GetParameter() {
+    return 0;
+}
+long FMOD_Studio_EventInstance_GetParameterByIndex() {
+    return 0;
+}
+long FMOD_Studio_EventInstance_GetParameterCount() {
+    return 0;
+}
+long FMOD_Studio_EventInstance_GetParameterValue() {
+    return 0;
+}
+long FMOD_Studio_EventInstance_GetParameterValueByIndex() {
+    return 0;
+}
+long FMOD_Studio_EventInstance_GetPaused() {
+    return 0;
+}
+int FMOD_Studio_EventInstance_GetPitch(void* inst, float* pitch, float* finalPitch) {
+    if (pitch)
+        *pitch = 1.0f;
+    if (finalPitch)
+        *finalPitch = 1.0f;
+    return 0;
+}
+long FMOD_Studio_EventInstance_GetPlaybackState() {
+    return 0;
+}
+long FMOD_Studio_EventInstance_GetProperty() {
+    return 0;
+}
+long FMOD_Studio_EventInstance_GetReverbLevel() {
+    return 0;
+}
+long FMOD_Studio_EventInstance_GetTimelinePosition() {
+    return 0;
+}
+long FMOD_Studio_EventInstance_GetUserData() {
+    return 0;
+}
+int FMOD_Studio_EventInstance_GetVolume(void* inst, float* vol, float* finalVol) {
+    if (vol)
+        *vol = 1.0f;
+    if (finalVol)
+        *finalVol = 1.0f;
+    return 0;
+}
+long FMOD_Studio_EventInstance_IsValid() {
+    return 0;
+}
+long FMOD_Studio_EventInstance_IsVirtual() {
+    return 0;
+}
+int FMOD_Studio_EventInstance_Release(void* inst) {
+    return 0;
+}
+long FMOD_Studio_EventInstance_Set3DAttributes() {
+    return 0;
+}
+long FMOD_Studio_EventInstance_SetCallback() {
+    return 0;
+}
+long FMOD_Studio_EventInstance_SetListenerMask() {
+    return 0;
+}
+int FMOD_Studio_EventInstance_SetParameterValue(void* inst, const char* name, float value) {
+    return 0;
+}
+long FMOD_Studio_EventInstance_SetParameterValueByIndex() {
+    return 0;
+}
+long FMOD_Studio_EventInstance_SetParameterValuesByIndices() {
+    return 0;
+}
+long FMOD_Studio_EventInstance_SetPaused() {
+    return 0;
+}
+int FMOD_Studio_EventInstance_SetPitch(void* inst, float pitch) {
+    return 0;
+}
+long FMOD_Studio_EventInstance_SetProperty() {
+    return 0;
+}
+long FMOD_Studio_EventInstance_SetReverbLevel() {
+    return 0;
+}
+long FMOD_Studio_EventInstance_SetTimelinePosition() {
+    return 0;
+}
+long FMOD_Studio_EventInstance_SetUserData() {
+    return 0;
+}
+int FMOD_Studio_EventInstance_SetVolume(void* inst, float vol) {
+    return 0;
+}
+int FMOD_Studio_EventInstance_Start(void* inst) {
+    return 0;
+}
+int FMOD_Studio_EventInstance_Stop(void* inst, int mode) {
+    return 0;
+}
+long FMOD_Studio_EventInstance_TriggerCue() {
+    return 0;
+}
+long FMOD_Studio_ParameterInstance_GetDescription() {
+    return 0;
+}
+long FMOD_Studio_ParameterInstance_GetValue() {
+    return 0;
+}
+long FMOD_Studio_ParameterInstance_IsValid() {
+    return 0;
+}
+long FMOD_Studio_ParameterInstance_SetValue() {
+    return 0;
+}
+long FMOD_Studio_ParseID() {
+    return 0;
+}
+int FMOD_Studio_System_Create(void** system, unsigned int version) {
+    if (system)
+        *system = malloc(1);
+    return 0;
+}
+long FMOD_Studio_System_FlushCommands() {
+    return 0;
+}
+long FMOD_Studio_System_FlushSampleLoading() {
+    return 0;
+}
+long FMOD_Studio_System_GetAdvancedSettings() {
+    return 0;
+}
+long FMOD_Studio_System_GetBank() {
+    return 0;
+}
+long FMOD_Studio_System_GetBankByID() {
+    return 0;
+}
+int FMOD_Studio_System_GetBankCount(void* system, int* count) {
+    if (count)
+        *count = 0;
+    return 0;
+}
+long FMOD_Studio_System_GetBankList() {
+    return 0;
+}
+long FMOD_Studio_System_GetBufferUsage() {
+    return 0;
+}
+int FMOD_Studio_System_GetBus(void* system, const char* path, void** bus) {
+    if (bus)
+        *bus = malloc(1);
+    return 0;
+}
+long FMOD_Studio_System_GetBusByID() {
+    return 0;
+}
+long FMOD_Studio_System_GetCPUUsage() {
+    return 0;
+}
+int FMOD_Studio_System_GetEvent(void* system, const char* path, void** eventDesc) {
+    if (eventDesc)
+        *eventDesc = malloc(1);
+    return 0;
+}
+long FMOD_Studio_System_GetEventByID() {
+    return 0;
+}
+long FMOD_Studio_System_GetListenerAttributes() {
+    return 0;
+}
+long FMOD_Studio_System_GetListenerWeight() {
+    return 0;
+}
+long FMOD_Studio_System_GetLowLevelSystem() {
+    return 0;
+}
+long FMOD_Studio_System_GetNumListeners() {
+    return 0;
+}
+long FMOD_Studio_System_GetSoundInfo() {
+    return 0;
+}
+long FMOD_Studio_System_GetUserData() {
+    return 0;
+}
+int FMOD_Studio_System_GetVCA(void* system, const char* path, void** vca) {
+    if (vca)
+        *vca = malloc(1);
+    return 0;
+}
+long FMOD_Studio_System_GetVCAByID() {
+    return 0;
+}
+int FMOD_Studio_System_Initialize(void* system, int maxChannels, int studioInitFlags, int initFlags, void* extraData) {
+    return 0;
+}
+long FMOD_Studio_System_IsValid() {
+    return 0;
+}
+long FMOD_Studio_System_LoadBankCustom() {
+    return 0;
+}
+int FMOD_Studio_System_LoadBankFile(void* system, const char* path, int flags, void** bank) {
+    if (bank)
+        *bank = malloc(1);
+    return 0;
+}
+long FMOD_Studio_System_LoadBankMemory() {
+    return 0;
+}
+long FMOD_Studio_System_LoadCommandReplay() {
+    return 0;
+}
+long FMOD_Studio_System_LookupID() {
+    return 0;
+}
+int FMOD_Studio_System_LookupPath(void* sys, void* id, char* path, int size, int* len) {
+    if (path && size > 0)
+        path[0] = 0;
+    if (len)
+        *len = 1;
+    return 0;
+}
+long FMOD_Studio_System_Release() {
+    return 0;
+}
+long FMOD_Studio_System_ResetBufferUsage() {
+    return 0;
+}
+long FMOD_Studio_System_SetAdvancedSettings() {
+    return 0;
+}
+long FMOD_Studio_System_SetCallback() {
+    return 0;
+}
+long FMOD_Studio_System_SetListenerAttributes() {
+    return 0;
+}
+long FMOD_Studio_System_SetListenerWeight() {
+    return 0;
+}
+long FMOD_Studio_System_SetNumListeners() {
+    return 0;
+}
+long FMOD_Studio_System_SetUserData() {
+    return 0;
+}
+long FMOD_Studio_System_StartCommandCapture() {
+    return 0;
+}
+long FMOD_Studio_System_StopCommandCapture() {
+    return 0;
+}
+long FMOD_Studio_System_UnloadAll() {
+    return 0;
+}
+int FMOD_Studio_System_Update(void* system) {
+    return 0;
+}
+long FMOD_Studio_VCA_GetID() {
+    return 0;
+}
+int FMOD_Studio_VCA_GetPath(void* vca, char* path, int size, int* len) {
+    if (path && size > 0)
+        path[0] = 0;
+    if (len)
+        *len = 1;
+    return 0;
+}
+long FMOD_Studio_VCA_GetVolume() {
+    return 0;
+}
+long FMOD_Studio_VCA_IsValid() {
+    return 0;
+}
+long FMOD_Studio_VCA_SetVolume() {
+    return 0;
+}

--- a/src/fna/terraria/faudio_stub.c
+++ b/src/fna/terraria/faudio_stub.c
@@ -1,7 +1,9 @@
 /// @file faudio_stub.c
 /// @brief FAudio API stubs for Terraria audio fallback.
 ///
-/// Provides stub implementations for FAudio functions when the real FAudio library is not available. Allocates dummy objects to prevent null pointer crashes. Used as a fallback when building Terraria without the full FAudio dependency.
+/// Provides stub implementations for FAudio functions when the real FAudio library is not available. Allocates dummy
+/// objects to prevent null pointer crashes. Used as a fallback when building Terraria without the full FAudio
+/// dependency.
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -38,8 +40,7 @@ uint32_t FAudio_CommitChanges(void* a, uint32_t b) {
 uint32_t FAudioLinkedVersion(void) {
     return 0;
 }
-void FAudioVoice_DestroyVoice(void* a) {
-}
+void FAudioVoice_DestroyVoice(void* a) {}
 uint32_t FAudioVoice_SetVolume(void* a, float b, uint32_t c) {
     return 0;
 }
@@ -76,19 +77,14 @@ uint32_t FAudioVoice_SetFilterParameters(void* a, void* b, uint32_t c) {
 uint32_t FAudioVoice_SetOutputFilterParameters(void* a, void* b, void* c, uint32_t d) {
     return 0;
 }
-void FAudioVoice_GetVoiceDetails(void* a, void* b) {
-}
+void FAudioVoice_GetVoiceDetails(void* a, void* b) {}
 void FAudioVoice_GetVolume(void* a, float* b) {
     *b = 1.0f;
 }
-void FAudioVoice_GetChannelVolumes(void* a, uint32_t b, float* c) {
-}
-void FAudioVoice_GetFilterParameters(void* a, void* b) {
-}
-void FAudioVoice_GetOutputFilterParameters(void* a, void* b, void* c) {
-}
-void FAudioVoice_GetOutputMatrix(void* a, void* b, uint32_t c, uint32_t d, float* e) {
-}
+void FAudioVoice_GetChannelVolumes(void* a, uint32_t b, float* c) {}
+void FAudioVoice_GetFilterParameters(void* a, void* b) {}
+void FAudioVoice_GetOutputFilterParameters(void* a, void* b, void* c) {}
+void FAudioVoice_GetOutputMatrix(void* a, void* b, uint32_t c, uint32_t d, float* e) {}
 uint32_t FAudioVoice_DestroyVoiceSafeEXT(void* a) {
     return 0;
 }
@@ -100,18 +96,14 @@ uint32_t FAudio_CreateSubmixVoice(void* a, void** b, uint32_t c, uint32_t d, uin
     *b = malloc(64);
     return 0;
 }
-void FAudio_StopEngine(void* a) {
-}
-void FAudio_GetPerformanceData(void* a, void* b) {
-}
-void FAudio_SetDebugConfiguration(void* a, void* b, void* c) {
-}
+void FAudio_StopEngine(void* a) {}
+void FAudio_GetPerformanceData(void* a, void* b) {}
+void FAudio_SetDebugConfiguration(void* a, void* b, void* c) {}
 void FAudio_GetProcessingQuantum(void* a, uint32_t* b, uint32_t* c) {
     *b = 1;
     *c = 48000;
 }
-void FAudio_UnregisterForCallbacks(void* a, void* b) {
-}
+void FAudio_UnregisterForCallbacks(void* a, void* b) {}
 uint32_t FAudio_RegisterForCallbacks(void* a, void* b) {
     return 0;
 }
@@ -142,18 +134,15 @@ uint32_t FAudioSourceVoice_SetSourceSampleRate(void* a, uint32_t b) {
 uint32_t FAudioSourceVoice_Discontinuity(void* a) {
     return 0;
 }
-void FAudioSourceVoice_GetState(void* a, void* b, uint32_t c) {
-}
+void FAudioSourceVoice_GetState(void* a, void* b, uint32_t c) {}
 void FAudioSourceVoice_GetFrequencyRatio(void* a, float* b) {
     *b = 1.0f;
 }
-void F3DAudioInitialize(uint32_t a, float b, void* c) {
-}
+void F3DAudioInitialize(uint32_t a, float b, void* c) {}
 uint32_t F3DAudioInitialize8(uint32_t a, float b, void* c) {
     return 0;
 }
-void F3DAudioCalculate(void* a, void* b, void* c, uint32_t d, void* e) {
-}
+void F3DAudioCalculate(void* a, void* b, void* c, uint32_t d, void* e) {}
 uint32_t FACTCreateEngine(uint32_t a, void** b) {
     *b = malloc(64);
     return 0;
@@ -165,16 +154,14 @@ uint32_t FACTCreateEngineWithCustomAllocatorEXT(uint32_t a, void** b, void* c, v
 uint32_t FACTAudioEngine_Initialize(void* a, void* b) {
     return 0;
 }
-void FACTAudioEngine_DoWork(void* a) {
-}
+void FACTAudioEngine_DoWork(void* a) {}
 uint32_t FACTAudioEngine_GetFinalMixFormat(void* a, void* b) {
     return 0;
 }
 float FACTAudioEngine_GetGlobalVariable(void* a, uint16_t b) {
     return 0.0f;
 }
-void FACTAudioEngine_SetGlobalVariable(void* a, uint16_t b, float c) {
-}
+void FACTAudioEngine_SetGlobalVariable(void* a, uint16_t b, float c) {}
 uint32_t FACTAudioEngine_GetRendererCount(void* a, uint16_t* b) {
     *b = 1;
     return 0;
@@ -188,15 +175,12 @@ uint16_t FACTAudioEngine_GetCategory(void* a, const char* b) {
 uint16_t FACTAudioEngine_GetGlobalVariableIndex(void* a, const char* b) {
     return 0;
 }
-void FACTAudioEngine_Pause(void* a, uint16_t b, int c) {
-}
-void FACTAudioEngine_SetVolume(void* a, uint16_t b, float c) {
-}
+void FACTAudioEngine_Pause(void* a, uint16_t b, int c) {}
+void FACTAudioEngine_SetVolume(void* a, uint16_t b, float c) {}
 uint32_t FACTAudioEngine_ShutDown(void* a) {
     return 0;
 }
-void FACTAudioEngine_Stop(void* a, uint16_t b, uint32_t c) {
-}
+void FACTAudioEngine_Stop(void* a, uint16_t b, uint32_t c) {}
 void* FACTAudioEngine_CreateSoundBank(void* a, void* b, uint32_t c, uint32_t d, uint32_t e, void** f) {
     *f = malloc(64);
     return 0;
@@ -213,7 +197,8 @@ void* FACTAudioEngine_PrepareWave(void* a, uint16_t b, void* c, uint32_t d, uint
     *g = malloc(64);
     return 0;
 }
-void* FACTAudioEngine_PrepareInMemoryWave(void* a, uint16_t b, uint32_t c, uint32_t d, uint32_t e, uint32_t f, void** g) {
+void* FACTAudioEngine_PrepareInMemoryWave(void* a, uint16_t b, uint32_t c, uint32_t d, uint32_t e, uint32_t f,
+                                          void** g) {
     *g = malloc(64);
     return 0;
 }
@@ -392,5 +377,4 @@ void* FAudio_memopen(void* a, int b) {
 void* FAudio_memptr(void* a, int b) {
     return NULL;
 }
-void FAudio_close(void* a) {
-}
+void FAudio_close(void* a) {}

--- a/src/fna/terraria/gdiplus_stub.c
+++ b/src/fna/terraria/gdiplus_stub.c
@@ -1,99 +1,321 @@
 /// @file gdiplus_stub.c
 /// @brief GDI+ API stubs for Terraria image loading fallback.
 ///
-/// Provides stub implementations for GdiplusStartup, GdipCreateBitmapFromFile, and related GDI+ image functions used by the Windows Terraria build. Returns empty bitmaps to prevent crashes when GDI+ is not available on macOS.
+/// Provides stub implementations for GdiplusStartup, GdipCreateBitmapFromFile, and related GDI+ image functions used by
+/// the Windows Terraria build. Returns empty bitmaps to prevent crashes when GDI+ is not available on macOS.
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
-typedef struct { uint32_t GdiplusVersion; int SuppressExternalCodecs; } GdiplusStartupInput;
-typedef struct { uint32_t HookSize; void* Callback; void* Unhook; } GdiplusStartupOutput;
+typedef struct {
+    uint32_t GdiplusVersion;
+    int SuppressExternalCodecs;
+} GdiplusStartupInput;
+typedef struct {
+    uint32_t HookSize;
+    void* Callback;
+    void* Unhook;
+} GdiplusStartupOutput;
 
-int GdiplusStartup(uint64_t *token, GdiplusStartupInput *input, GdiplusStartupOutput *output) {
-    if (token) *token = 1;
+int GdiplusStartup(uint64_t* token, GdiplusStartupInput* input, GdiplusStartupOutput* output) {
+    if (token)
+        *token = 1;
     return 0;
 }
 void GdiplusShutdown(uint64_t token) {}
-int GdipCreateFromContext(void* context, float w, float h, void** graphics) { *graphics = malloc(64); return 0; }
-int GdipCreateFromContext_mono(void* context, float w, float h, void** graphics) { *graphics = malloc(64); return 0; }
-int GdipCreateBitmapFromScan0(int w, int h, int stride, int pf, void* sd, void** bmp) { *bmp = malloc(64); return 0; }
-int GdipCreateBitmapFromFile(void* file, void** bmp) { *bmp = malloc(64); return 0; }
-int GdipCreateHBITMAPFromBitmap(void* bmp, void* hbm, uint32_t bg) { return 0; }
-int GdipDisposeImage(void* img) { free(img); return 0; }
-int GdipGetImageWidth(void* img, uint32_t* w) { *w = 64; return 0; }
-int GdipGetImageHeight(void* img, uint32_t* h) { *h = 64; return 0; }
-int GdipGetImageGraphicsContext(void* img, void** g) { *g = malloc(64); return 0; }
-int GdipGraphicsClear(void* g, uint32_t color) { return 0; }
-int GdipDrawImageRectI(void* g, void* img, int x, int y, int w, int h) { return 0; }
-int GdipDrawString(void* g, void* str, int len, void* font, void* rect, void* fmt, void* brush) { return 0; }
-int GdipMeasureString(void* g, void* str, int len, void* font, void* rect, void* fmt, void* bbox, int* chars, int* lines) { return 0; }
-int GdipCreateSolidFill(uint32_t color, void** brush) { *brush = malloc(64); return 0; }
-int GdipCreateFont(void* family, float em, int style, int unit, void** font) { *font = malloc(64); return 0; }
-int GdipCreateFontFromLogfontW(void* hdc, void* lf, void** font) { *font = malloc(64); return 0; }
-int GdipDeleteFont(void* f) { free(f); return 0; }
-int GdipDeleteBrush(void* b) { free(b); return 0; }
-int GdipDeleteGraphics(void* g) { free(g); return 0; }
-int GdipDeleteStringFormat(void* f) { free(f); return 0; }
-int GdipDisposeImageAttributes(void* a) { free(a); return 0; }
-int GdipCreateStringFormat(int flags, int lang, void** fmt) { *fmt = malloc(64); return 0; }
-int GdipSetStringFormatFlags(void* fmt, int flags) { return 0; }
-int GdipSetStringFormatAlign(void* fmt, int align) { return 0; }
-int GdipGetStringFormatAlign(void* fmt, int* align) { *align = 0; return 0; }
-int GdipCloneStringFormat(void* fmt, void** clone) { *clone = malloc(64); return 0; }
-int GdipGetFamilyName(void* family, void* name, int lang) { return 0; }
-int GdipCreateFontFamilyFromName(void* name, void* collection, void** family) { *family = malloc(64); return 0; }
-int GdipDeleteFontFamily(void* f) { free(f); return 0; }
-int GdipGetFontStyle(void* font, int* style) { *style = 0; return 0; }
-int GdipGetFontSize(void* font, float* size) { *size = 12.0f; return 0; }
-int GdipGetFontUnit(void* font, int* unit) { *unit = 0; return 0; }
-int GdipGetFontHeight(void* font, void* g, float* h) { *h = 16.0f; return 0; }
-int GdipGetLineSpacing(void* family, int style, float* spacing) { *spacing = 20.0f; return 0; }
-int GdipGetCellAscent(void* family, int style, uint16_t* a) { *a = 16; return 0; }
-int GdipGetCellDescent(void* family, int style, uint16_t* d) { *d = 4; return 0; }
-int GdipFillRectangle(void* g, void* brush, float x, float y, float w, float h) { return 0; }
-int GdipFillRectangleI(void* g, void* brush, int x, int y, int w, int h) { return 0; }
-int GdipSetWorldTransform(void* g, void* matrix) { return 0; }
-int GdipResetWorldTransform(void* g) { return 0; }
-int GdipCreateMatrix(void** m) { *m = malloc(64); return 0; }
-int GdipCreateMatrix2(float a, float b, float c, float d, float e, float f, void** m) { *m = malloc(64); return 0; }
-int GdipDeleteMatrix(void* m) { free(m); return 0; }
-int GdipSetClipRectI(void* g, int x, int y, int w, int h, int mode) { return 0; }
-int GdipSetInterpolationMode(void* g, int mode) { return 0; }
-int GdipSetPageUnit(void* g, int unit) { return 0; }
-int GdipSetSmoothingMode(void* g, int mode) { return 0; }
-int GdipSetTextRenderingHint(void* g, int mode) { return 0; }
-int GdipDrawImageRectRectI(void* g, void* img, int dx, int dy, int dw, int dh, int sx, int sy, int sw, int sh, int srcUnit, void* ia, void* cb, void* cbData) { return 0; }
-int GdipLoadImageFromFile(void* file, void** img) { *img = malloc(64); return 0; }
-int GdipLoadImageFromFileICM(void* file, void** img) { *img = malloc(64); return 0; }
-int GdipSaveImageToFile(void* img, void* file, void* clsid, void* params) { return 0; }
-int GdipCreateImageAttributes(void** ia) { *ia = malloc(64); return 0; }
-int GdipSetImageAttributesColorMatrix(void* ia, int flags, int enable, void* matrix, void* grayMatrix, int flags2) { return 0; }
-int GdipGetImagePixelFormat(void* img, int* pf) { *pf = 0x26200a; return 0; }
-int GdipBitmapLockBits(void* bmp, void* rect, int flags, int pf, void* bd) { return 0; }
-int GdipBitmapUnlockBits(void* bmp, void* bd) { return 0; }
-int GdipFlush(void* g, int intention) { return 0; }
-int GdipGetDpiX(void* g, float* dpi) { *dpi = 96.0f; return 0; }
-int GdipGetDpiY(void* g, float* dpi) { *dpi = 96.0f; return 0; }
-int GdipTranslateWorldTransform(void* g, float dx, float dy, int order) { return 0; }
-int GdipScaleWorldTransform(void* g, float sx, float sy, int order) { return 0; }
-int GdipRotateWorldTransform(void* g, float angle, int order) { return 0; }
-int GdipGetTransform(void* g, void* m) { return 0; }
-int GdipIsStyleAvailable(void* family, int style, int* avail) { *avail = 1; return 0; }
-int GdipGetEmHeight(void* family, int style, uint16_t* h) { *h = 2048; return 0; }
-int GdipFillPolygon(void* g, void* brush, void* points, int count, int fillMode) { return 0; }
-int GdipDrawLines(void* g, void* pen, void* points, int count) { return 0; }
-int GdipCreatePen1(uint32_t color, float width, int unit, void** pen) { *pen = malloc(64); return 0; }
-int GdipDeletePen(void* p) { free(p); return 0; }
-int GdipDrawLine(void* g, void* pen, float x1, float y1, float x2, float y2) { return 0; }
-int GdipDrawArc(void* g, void* pen, float x, float y, float w, float h, float start, float sweep) { return 0; }
-int GdipFillEllipse(void* g, void* brush, float x, float y, float w, float h) { return 0; }
-int GdipDrawRectangle(void* g, void* pen, float x, float y, float w, float h) { return 0; }
-int GdipFillPath(void* g, void* brush, void* path) { return 0; }
-int GdipDrawPath(void* g, void* pen, void* path) { return 0; }
-int GdipCreatePath(int fillMode, void** path) { *path = malloc(64); return 0; }
-int GdipDeletePath(void* p) { free(p); return 0; }
-int GdipAddPathRectangle(void* p, float x, float y, float w, float h) { return 0; }
-int GdipCloneImage(void* img, void** clone) { *clone = malloc(64); return 0; }
-int GdipGetImagePalette(void* img, void* pal, int size) { return 0; }
-int GdipGetImagePaletteSize(void* img, int* size) { *size = 0; return 0; }
-int GdipSetImagePalette(void* img, void* pal) { return 0; }
+int GdipCreateFromContext(void* context, float w, float h, void** graphics) {
+    *graphics = malloc(64);
+    return 0;
+}
+int GdipCreateFromContext_mono(void* context, float w, float h, void** graphics) {
+    *graphics = malloc(64);
+    return 0;
+}
+int GdipCreateBitmapFromScan0(int w, int h, int stride, int pf, void* sd, void** bmp) {
+    *bmp = malloc(64);
+    return 0;
+}
+int GdipCreateBitmapFromFile(void* file, void** bmp) {
+    *bmp = malloc(64);
+    return 0;
+}
+int GdipCreateHBITMAPFromBitmap(void* bmp, void* hbm, uint32_t bg) {
+    return 0;
+}
+int GdipDisposeImage(void* img) {
+    free(img);
+    return 0;
+}
+int GdipGetImageWidth(void* img, uint32_t* w) {
+    *w = 64;
+    return 0;
+}
+int GdipGetImageHeight(void* img, uint32_t* h) {
+    *h = 64;
+    return 0;
+}
+int GdipGetImageGraphicsContext(void* img, void** g) {
+    *g = malloc(64);
+    return 0;
+}
+int GdipGraphicsClear(void* g, uint32_t color) {
+    return 0;
+}
+int GdipDrawImageRectI(void* g, void* img, int x, int y, int w, int h) {
+    return 0;
+}
+int GdipDrawString(void* g, void* str, int len, void* font, void* rect, void* fmt, void* brush) {
+    return 0;
+}
+int GdipMeasureString(void* g, void* str, int len, void* font, void* rect, void* fmt, void* bbox, int* chars,
+                      int* lines) {
+    return 0;
+}
+int GdipCreateSolidFill(uint32_t color, void** brush) {
+    *brush = malloc(64);
+    return 0;
+}
+int GdipCreateFont(void* family, float em, int style, int unit, void** font) {
+    *font = malloc(64);
+    return 0;
+}
+int GdipCreateFontFromLogfontW(void* hdc, void* lf, void** font) {
+    *font = malloc(64);
+    return 0;
+}
+int GdipDeleteFont(void* f) {
+    free(f);
+    return 0;
+}
+int GdipDeleteBrush(void* b) {
+    free(b);
+    return 0;
+}
+int GdipDeleteGraphics(void* g) {
+    free(g);
+    return 0;
+}
+int GdipDeleteStringFormat(void* f) {
+    free(f);
+    return 0;
+}
+int GdipDisposeImageAttributes(void* a) {
+    free(a);
+    return 0;
+}
+int GdipCreateStringFormat(int flags, int lang, void** fmt) {
+    *fmt = malloc(64);
+    return 0;
+}
+int GdipSetStringFormatFlags(void* fmt, int flags) {
+    return 0;
+}
+int GdipSetStringFormatAlign(void* fmt, int align) {
+    return 0;
+}
+int GdipGetStringFormatAlign(void* fmt, int* align) {
+    *align = 0;
+    return 0;
+}
+int GdipCloneStringFormat(void* fmt, void** clone) {
+    *clone = malloc(64);
+    return 0;
+}
+int GdipGetFamilyName(void* family, void* name, int lang) {
+    return 0;
+}
+int GdipCreateFontFamilyFromName(void* name, void* collection, void** family) {
+    *family = malloc(64);
+    return 0;
+}
+int GdipDeleteFontFamily(void* f) {
+    free(f);
+    return 0;
+}
+int GdipGetFontStyle(void* font, int* style) {
+    *style = 0;
+    return 0;
+}
+int GdipGetFontSize(void* font, float* size) {
+    *size = 12.0f;
+    return 0;
+}
+int GdipGetFontUnit(void* font, int* unit) {
+    *unit = 0;
+    return 0;
+}
+int GdipGetFontHeight(void* font, void* g, float* h) {
+    *h = 16.0f;
+    return 0;
+}
+int GdipGetLineSpacing(void* family, int style, float* spacing) {
+    *spacing = 20.0f;
+    return 0;
+}
+int GdipGetCellAscent(void* family, int style, uint16_t* a) {
+    *a = 16;
+    return 0;
+}
+int GdipGetCellDescent(void* family, int style, uint16_t* d) {
+    *d = 4;
+    return 0;
+}
+int GdipFillRectangle(void* g, void* brush, float x, float y, float w, float h) {
+    return 0;
+}
+int GdipFillRectangleI(void* g, void* brush, int x, int y, int w, int h) {
+    return 0;
+}
+int GdipSetWorldTransform(void* g, void* matrix) {
+    return 0;
+}
+int GdipResetWorldTransform(void* g) {
+    return 0;
+}
+int GdipCreateMatrix(void** m) {
+    *m = malloc(64);
+    return 0;
+}
+int GdipCreateMatrix2(float a, float b, float c, float d, float e, float f, void** m) {
+    *m = malloc(64);
+    return 0;
+}
+int GdipDeleteMatrix(void* m) {
+    free(m);
+    return 0;
+}
+int GdipSetClipRectI(void* g, int x, int y, int w, int h, int mode) {
+    return 0;
+}
+int GdipSetInterpolationMode(void* g, int mode) {
+    return 0;
+}
+int GdipSetPageUnit(void* g, int unit) {
+    return 0;
+}
+int GdipSetSmoothingMode(void* g, int mode) {
+    return 0;
+}
+int GdipSetTextRenderingHint(void* g, int mode) {
+    return 0;
+}
+int GdipDrawImageRectRectI(void* g, void* img, int dx, int dy, int dw, int dh, int sx, int sy, int sw, int sh,
+                           int srcUnit, void* ia, void* cb, void* cbData) {
+    return 0;
+}
+int GdipLoadImageFromFile(void* file, void** img) {
+    *img = malloc(64);
+    return 0;
+}
+int GdipLoadImageFromFileICM(void* file, void** img) {
+    *img = malloc(64);
+    return 0;
+}
+int GdipSaveImageToFile(void* img, void* file, void* clsid, void* params) {
+    return 0;
+}
+int GdipCreateImageAttributes(void** ia) {
+    *ia = malloc(64);
+    return 0;
+}
+int GdipSetImageAttributesColorMatrix(void* ia, int flags, int enable, void* matrix, void* grayMatrix, int flags2) {
+    return 0;
+}
+int GdipGetImagePixelFormat(void* img, int* pf) {
+    *pf = 0x26200a;
+    return 0;
+}
+int GdipBitmapLockBits(void* bmp, void* rect, int flags, int pf, void* bd) {
+    return 0;
+}
+int GdipBitmapUnlockBits(void* bmp, void* bd) {
+    return 0;
+}
+int GdipFlush(void* g, int intention) {
+    return 0;
+}
+int GdipGetDpiX(void* g, float* dpi) {
+    *dpi = 96.0f;
+    return 0;
+}
+int GdipGetDpiY(void* g, float* dpi) {
+    *dpi = 96.0f;
+    return 0;
+}
+int GdipTranslateWorldTransform(void* g, float dx, float dy, int order) {
+    return 0;
+}
+int GdipScaleWorldTransform(void* g, float sx, float sy, int order) {
+    return 0;
+}
+int GdipRotateWorldTransform(void* g, float angle, int order) {
+    return 0;
+}
+int GdipGetTransform(void* g, void* m) {
+    return 0;
+}
+int GdipIsStyleAvailable(void* family, int style, int* avail) {
+    *avail = 1;
+    return 0;
+}
+int GdipGetEmHeight(void* family, int style, uint16_t* h) {
+    *h = 2048;
+    return 0;
+}
+int GdipFillPolygon(void* g, void* brush, void* points, int count, int fillMode) {
+    return 0;
+}
+int GdipDrawLines(void* g, void* pen, void* points, int count) {
+    return 0;
+}
+int GdipCreatePen1(uint32_t color, float width, int unit, void** pen) {
+    *pen = malloc(64);
+    return 0;
+}
+int GdipDeletePen(void* p) {
+    free(p);
+    return 0;
+}
+int GdipDrawLine(void* g, void* pen, float x1, float y1, float x2, float y2) {
+    return 0;
+}
+int GdipDrawArc(void* g, void* pen, float x, float y, float w, float h, float start, float sweep) {
+    return 0;
+}
+int GdipFillEllipse(void* g, void* brush, float x, float y, float w, float h) {
+    return 0;
+}
+int GdipDrawRectangle(void* g, void* pen, float x, float y, float w, float h) {
+    return 0;
+}
+int GdipFillPath(void* g, void* brush, void* path) {
+    return 0;
+}
+int GdipDrawPath(void* g, void* pen, void* path) {
+    return 0;
+}
+int GdipCreatePath(int fillMode, void** path) {
+    *path = malloc(64);
+    return 0;
+}
+int GdipDeletePath(void* p) {
+    free(p);
+    return 0;
+}
+int GdipAddPathRectangle(void* p, float x, float y, float w, float h) {
+    return 0;
+}
+int GdipCloneImage(void* img, void** clone) {
+    *clone = malloc(64);
+    return 0;
+}
+int GdipGetImagePalette(void* img, void* pal, int size) {
+    return 0;
+}
+int GdipGetImagePaletteSize(void* img, int* size) {
+    *size = 0;
+    return 0;
+}
+int GdipSetImagePalette(void* img, void* pal) {
+    return 0;
+}

--- a/src/input/EntryPoint.cpp
+++ b/src/input/EntryPoint.cpp
@@ -1,7 +1,8 @@
 /// @file EntryPoint.cpp
 /// @brief XInput DLL entry point with COM class factory exports.
 ///
-/// Exports DllGetClassObject and DllCanUnloadNow for xinput1_4.dll loading. Routes XInputGetState/XInputSetState calls to the GameControllerBridge.
+/// Exports DllGetClassObject and DllCanUnloadNow for xinput1_4.dll loading. Routes XInputGetState/XInputSetState calls
+/// to the GameControllerBridge.
 #include <metalsharp/GameControllerBridge.h>
 
 using namespace metalsharp;
@@ -11,24 +12,29 @@ extern "C" {
 static GameControllerBridge g_bridge;
 
 HRESULT XInputGetState(DWORD dwUserIndex, void* pState) {
-    if (!pState) return E_POINTER;
-    if (dwUserIndex >= 4) return E_FAIL;
+    if (!pState)
+        return E_POINTER;
+    if (dwUserIndex >= 4)
+        return E_FAIL;
     auto* state = static_cast<XInputState*>(pState);
     return g_bridge.getState(dwUserIndex, state) ? S_OK : E_FAIL;
 }
 
 HRESULT XInputSetState(DWORD dwUserIndex, void* pVibration) {
-    if (!pVibration) return E_POINTER;
-    if (dwUserIndex >= 4) return E_FAIL;
+    if (!pVibration)
+        return E_POINTER;
+    if (dwUserIndex >= 4)
+        return E_FAIL;
     auto* vib = static_cast<uint16_t*>(pVibration);
     return g_bridge.setState(dwUserIndex, vib[0], vib[1]) ? S_OK : E_FAIL;
 }
 
 HRESULT XInputGetCapabilities(DWORD dwUserIndex, DWORD dwFlags, void* pCapabilities) {
-    if (!pCapabilities) return E_POINTER;
-    if (dwUserIndex >= 4) return E_FAIL;
+    if (!pCapabilities)
+        return E_POINTER;
+    if (dwUserIndex >= 4)
+        return E_FAIL;
     auto* caps = static_cast<XInputCapabilities*>(pCapabilities);
     return g_bridge.getCapabilities(dwUserIndex, caps) ? S_OK : E_FAIL;
 }
-
 }

--- a/src/input/GameControllerBridge.cpp
+++ b/src/input/GameControllerBridge.cpp
@@ -1,9 +1,10 @@
 /// @file GameControllerBridge.cpp
 /// @brief GameController bridge platform-agnostic interface.
 ///
-/// Defines the GameControllerBridge API surface (polling, state conversion, rumble). Platform-specific GameController framework integration is in the .mm counterpart.
-#include <metalsharp/GameControllerBridge.h>
+/// Defines the GameControllerBridge API surface (polling, state conversion, rumble). Platform-specific GameController
+/// framework integration is in the .mm counterpart.
 #include <cstring>
+#include <metalsharp/GameControllerBridge.h>
 
 namespace metalsharp {
 
@@ -15,16 +16,23 @@ GameControllerBridge::GameControllerBridge() {
 
 GameControllerBridge::~GameControllerBridge() = default;
 
-bool GameControllerBridge::init() { return false; }
+bool GameControllerBridge::init() {
+    return false;
+}
 void GameControllerBridge::poll() {}
 
 bool GameControllerBridge::getState(uint32_t index, XInputState* pState) {
-    if (!pState || index >= MAX_CONTROLLERS) return false;
+    if (!pState || index >= MAX_CONTROLLERS)
+        return false;
     memset(pState, 0, sizeof(XInputState));
     return false;
 }
 
-bool GameControllerBridge::setState(uint32_t, uint16_t, uint16_t) { return false; }
-bool GameControllerBridge::getCapabilities(uint32_t, XInputCapabilities*) { return false; }
-
+bool GameControllerBridge::setState(uint32_t, uint16_t, uint16_t) {
+    return false;
 }
+bool GameControllerBridge::getCapabilities(uint32_t, XInputCapabilities*) {
+    return false;
+}
+
+} // namespace metalsharp

--- a/src/input/GameControllerBridge.mm
+++ b/src/input/GameControllerBridge.mm
@@ -1,10 +1,11 @@
 /// @file GameControllerBridge.mm
 /// @brief Apple GameController framework integration for XInput translation.
 ///
-/// Discovers GCController instances, maps extended gamepad profiles to XINPUT_STATE, and translates button/thumbstick/trigger values. Supports haptic rumble via GCController's motor API where available.
-#include <metalsharp/GameControllerBridge.h>
-#import <GameController/GameController.h>
+/// Discovers GCController instances, maps extended gamepad profiles to XINPUT_STATE, and translates
+/// button/thumbstick/trigger values. Supports haptic rumble via GCController's motor API where available.
 #include <cstring>
+#import <GameController/GameController.h>
+#include <metalsharp/GameControllerBridge.h>
 
 namespace metalsharp {
 
@@ -28,31 +29,31 @@ bool GameControllerBridge::init() {
                                                       object:nil
                                                        queue:[NSOperationQueue mainQueue]
                                                   usingBlock:^(NSNotification* note) {
-        GCController* gc = note.object;
-        for (uint32_t i = 0; i < MAX_CONTROLLERS; i++) {
-            if (!m_impl->controllers[i]) {
-                m_impl->controllers[i] = gc;
-                m_impl->connected[i] = true;
-                m_connected[i] = true;
-                break;
-            }
-        }
-    }];
+                                                    GCController* gc = note.object;
+                                                    for (uint32_t i = 0; i < MAX_CONTROLLERS; i++) {
+                                                        if (!m_impl->controllers[i]) {
+                                                            m_impl->controllers[i] = gc;
+                                                            m_impl->connected[i] = true;
+                                                            m_connected[i] = true;
+                                                            break;
+                                                        }
+                                                    }
+                                                  }];
 
     [[NSNotificationCenter defaultCenter] addObserverForName:GCControllerDidDisconnectNotification
                                                       object:nil
                                                        queue:[NSOperationQueue mainQueue]
                                                   usingBlock:^(NSNotification* note) {
-        GCController* gc = note.object;
-        for (uint32_t i = 0; i < MAX_CONTROLLERS; i++) {
-            if (m_impl->controllers[i] == gc) {
-                m_impl->controllers[i] = nil;
-                m_impl->connected[i] = false;
-                m_connected[i] = false;
-                break;
-            }
-        }
-    }];
+                                                    GCController* gc = note.object;
+                                                    for (uint32_t i = 0; i < MAX_CONTROLLERS; i++) {
+                                                        if (m_impl->controllers[i] == gc) {
+                                                            m_impl->controllers[i] = nil;
+                                                            m_impl->connected[i] = false;
+                                                            m_connected[i] = false;
+                                                            break;
+                                                        }
+                                                    }
+                                                  }];
 
     NSArray<GCController*>* connected = [GCController controllers];
     for (NSUInteger i = 0; i < connected.count && i < MAX_CONTROLLERS; i++) {
@@ -66,37 +67,55 @@ bool GameControllerBridge::init() {
 
 static WORD readButtons(GCExtendedGamepad* gamepad) {
     WORD buttons = 0;
-    if (gamepad.buttonA.isPressed)               buttons |= 0x1000;
-    if (gamepad.buttonB.isPressed)               buttons |= 0x2000;
-    if (gamepad.buttonX.isPressed)               buttons |= 0x4000;
-    if (gamepad.buttonY.isPressed)               buttons |= 0x8000;
-    if (gamepad.leftShoulder.isPressed)          buttons |= 0x0100;
-    if (gamepad.rightShoulder.isPressed)         buttons |= 0x0200;
-    if (gamepad.leftTrigger.value > 0.1f)        buttons |= 0x0040;
-    if (gamepad.rightTrigger.value > 0.1f)       buttons |= 0x0080;
-    if (gamepad.dpad.up.isPressed)               buttons |= 0x0001;
-    if (gamepad.dpad.down.isPressed)             buttons |= 0x0002;
-    if (gamepad.dpad.left.isPressed)             buttons |= 0x0004;
-    if (gamepad.dpad.right.isPressed)            buttons |= 0x0008;
-    if (gamepad.leftThumbstickButton.isPressed)  buttons |= 0x0040;
-    if (gamepad.rightThumbstickButton.isPressed) buttons |= 0x0080;
+    if (gamepad.buttonA.isPressed)
+        buttons |= 0x1000;
+    if (gamepad.buttonB.isPressed)
+        buttons |= 0x2000;
+    if (gamepad.buttonX.isPressed)
+        buttons |= 0x4000;
+    if (gamepad.buttonY.isPressed)
+        buttons |= 0x8000;
+    if (gamepad.leftShoulder.isPressed)
+        buttons |= 0x0100;
+    if (gamepad.rightShoulder.isPressed)
+        buttons |= 0x0200;
+    if (gamepad.leftTrigger.value > 0.1f)
+        buttons |= 0x0040;
+    if (gamepad.rightTrigger.value > 0.1f)
+        buttons |= 0x0080;
+    if (gamepad.dpad.up.isPressed)
+        buttons |= 0x0001;
+    if (gamepad.dpad.down.isPressed)
+        buttons |= 0x0002;
+    if (gamepad.dpad.left.isPressed)
+        buttons |= 0x0004;
+    if (gamepad.dpad.right.isPressed)
+        buttons |= 0x0008;
+    if (gamepad.leftThumbstickButton.isPressed)
+        buttons |= 0x0040;
+    if (gamepad.rightThumbstickButton.isPressed)
+        buttons |= 0x0080;
     if (@available(macOS 11.0, *)) {
-        if (gamepad.buttonOptions.isPressed)      buttons |= 0x0010;
-        if (gamepad.buttonMenu.isPressed)         buttons |= 0x0020;
+        if (gamepad.buttonOptions.isPressed)
+            buttons |= 0x0010;
+        if (gamepad.buttonMenu.isPressed)
+            buttons |= 0x0020;
     }
     return buttons;
 }
 
 void GameControllerBridge::poll() {
     for (uint32_t i = 0; i < MAX_CONTROLLERS; i++) {
-        if (!m_impl->controllers[i]) continue;
+        if (!m_impl->controllers[i])
+            continue;
 
         GCExtendedGamepad* gamepad = m_impl->controllers[i].extendedGamepad;
-        if (!gamepad) continue;
+        if (!gamepad)
+            continue;
 
         m_states[i].packetNumber++;
         m_states[i].Gamepad.wButtons = readButtons(gamepad);
-        m_states[i].Gamepad.bLeftTrigger  = (BYTE)(gamepad.leftTrigger.value * 255.0f);
+        m_states[i].Gamepad.bLeftTrigger = (BYTE)(gamepad.leftTrigger.value * 255.0f);
         m_states[i].Gamepad.bRightTrigger = (BYTE)(gamepad.rightTrigger.value * 255.0f);
         m_states[i].Gamepad.sThumbLX = (SHORT)(gamepad.leftThumbstick.xAxis.value * 32767.0f);
         m_states[i].Gamepad.sThumbLY = (SHORT)(gamepad.leftThumbstick.yAxis.value * 32767.0f);
@@ -106,7 +125,8 @@ void GameControllerBridge::poll() {
 }
 
 bool GameControllerBridge::getState(uint32_t index, XInputState* pState) {
-    if (!pState || index >= MAX_CONTROLLERS) return false;
+    if (!pState || index >= MAX_CONTROLLERS)
+        return false;
     if (!m_connected[index]) {
         memset(pState, 0, sizeof(XInputState));
         return false;
@@ -117,7 +137,8 @@ bool GameControllerBridge::getState(uint32_t index, XInputState* pState) {
 }
 
 bool GameControllerBridge::setState(uint32_t index, uint16_t leftMotor, uint16_t rightMotor) {
-    if (index >= MAX_CONTROLLERS || !m_impl->controllers[index]) return false;
+    if (index >= MAX_CONTROLLERS || !m_impl->controllers[index])
+        return false;
 
     m_impl->lastHaptics[index][0] = leftMotor / 65535.0f;
     m_impl->lastHaptics[index][1] = rightMotor / 65535.0f;
@@ -126,8 +147,10 @@ bool GameControllerBridge::setState(uint32_t index, uint16_t leftMotor, uint16_t
 }
 
 bool GameControllerBridge::getCapabilities(uint32_t index, XInputCapabilities* pCaps) {
-    if (!pCaps || index >= MAX_CONTROLLERS) return false;
-    if (!m_connected[index]) return false;
+    if (!pCaps || index >= MAX_CONTROLLERS)
+        return false;
+    if (!m_connected[index])
+        return false;
 
     memset(pCaps, 0, sizeof(XInputCapabilities));
     pCaps->Type = 0;
@@ -141,4 +164,4 @@ bool GameControllerBridge::getCapabilities(uint32_t index, XInputCapabilities* p
     return true;
 }
 
-}
+} // namespace metalsharp

--- a/src/input/XInputEngine.cpp
+++ b/src/input/XInputEngine.cpp
@@ -1,7 +1,8 @@
 /// @file XInputEngine.cpp
 /// @brief XInput API shim delegating to GameController bridge.
 ///
-/// Implements XInputGetState, XInputSetState, and XInputGetCapabilities by polling the GameControllerBridge singleton. Converts controller connection/disconnection events into XInput's device index model.
+/// Implements XInputGetState, XInputSetState, and XInputGetCapabilities by polling the GameControllerBridge singleton.
+/// Converts controller connection/disconnection events into XInput's device index model.
 #include <metalsharp/GameControllerBridge.h>
 
 namespace metalsharp {
@@ -16,4 +17,4 @@ static void ensureInit() {
     }
 }
 
-}
+} // namespace metalsharp

--- a/src/loader/D3DShims.cpp
+++ b/src/loader/D3DShims.cpp
@@ -1,16 +1,17 @@
 /// @file D3DShims.cpp
 /// @brief D3D DLL shim registration for import resolution.
 ///
-/// Registers d3d11.dll, d3d10.dll, and d3d9.dll exports with the PE loader so that imported D3D functions resolve to MetalSharp's COM implementations. Acts as the bridge between the PE loader's import resolver and D3D shim objects.
-#include <metalsharp/D3DShims.h>
-#include <d3d/D3D11.h>
+/// Registers d3d11.dll, d3d10.dll, and d3d9.dll exports with the PE loader so that imported D3D functions resolve to
+/// MetalSharp's COM implementations. Acts as the bridge between the PE loader's import resolver and D3D shim objects.
 #include <cstring>
+#include <d3d/D3D11.h>
+#include <metalsharp/D3DShims.h>
 
 extern "C" {
-HRESULT D3D11CreateDevice(void*, UINT, HMODULE, UINT, const void*, UINT, UINT,
-    ID3D11Device**, void*, ID3D11DeviceContext**);
-HRESULT D3D11CreateDeviceAndSwapChain(void*, UINT, HMODULE, UINT, const void*, UINT, UINT,
-    const void*, void**, ID3D11Device**, void*, ID3D11DeviceContext**);
+HRESULT D3D11CreateDevice(void*, UINT, HMODULE, UINT, const void*, UINT, UINT, ID3D11Device**, void*,
+                          ID3D11DeviceContext**);
+HRESULT D3D11CreateDeviceAndSwapChain(void*, UINT, HMODULE, UINT, const void*, UINT, UINT, const void*, void**,
+                                      ID3D11Device**, void*, ID3D11DeviceContext**);
 }
 
 extern "C" HRESULT D3D12CreateDevice(void*, UINT, const GUID&, void**);
@@ -25,9 +26,7 @@ ShimLibrary createD3D11Shim() {
     ShimLibrary lib;
     lib.name = "d3d11.dll";
 
-    auto fn = [](void* ptr) -> ExportedFunction {
-        return [ptr]() -> void* { return ptr; };
-    };
+    auto fn = [](void* ptr) -> ExportedFunction { return [ptr]() -> void* { return ptr; }; };
 
     lib.functions["D3D11CreateDevice"] = fn((void*)D3D11CreateDevice);
     lib.functions["D3D11CreateDeviceAndSwapChain"] = fn((void*)D3D11CreateDeviceAndSwapChain);
@@ -39,9 +38,7 @@ ShimLibrary createD3D12Shim() {
     ShimLibrary lib;
     lib.name = "d3d12.dll";
 
-    auto fn = [](void* ptr) -> ExportedFunction {
-        return [ptr]() -> void* { return ptr; };
-    };
+    auto fn = [](void* ptr) -> ExportedFunction { return [ptr]() -> void* { return ptr; }; };
 
     lib.functions["D3D12CreateDevice"] = fn((void*)D3D12CreateDevice);
 
@@ -52,9 +49,7 @@ ShimLibrary createDxgiShim() {
     ShimLibrary lib;
     lib.name = "dxgi.dll";
 
-    auto fn = [](void* ptr) -> ExportedFunction {
-        return [ptr]() -> void* { return ptr; };
-    };
+    auto fn = [](void* ptr) -> ExportedFunction { return [ptr]() -> void* { return ptr; }; };
 
     lib.functions["CreateDXGIFactory"] = fn((void*)CreateDXGIFactory);
     lib.functions["CreateDXGIFactory1"] = fn((void*)CreateDXGIFactory1);
@@ -63,5 +58,5 @@ ShimLibrary createDxgiShim() {
     return lib;
 }
 
-}
-}
+} // namespace win32
+} // namespace metalsharp

--- a/src/loader/PELoader.cpp
+++ b/src/loader/PELoader.cpp
@@ -69,18 +69,20 @@
 ///   All PE images are mmap'd with MAP_PRIVATE|MAP_ANONYMOUS|MAP_JIT.
 ///   Destruction unmap()s all loaded modules. The singleton (s_instance) pointer
 ///   is set in the constructor and cleared in the destructor.
-#include <metalsharp/PELoader.h>
-#include <metalsharp/PEHeader.h>
-#include <metalsharp/Logger.h>
 #include <cstring>
 #include <fstream>
+#include <metalsharp/Logger.h>
+#include <metalsharp/PEHeader.h>
+#include <metalsharp/PELoader.h>
 #include <sys/mman.h>
 
 namespace metalsharp {
 
 PELoader* PELoader::s_instance = nullptr;
 
-PELoader::PELoader() { s_instance = this; }
+PELoader::PELoader() {
+    s_instance = this;
+}
 PELoader::~PELoader() {
     if (m_mainModule.base) {
         munmap(m_mainModule.base, m_mainModule.size);
@@ -95,7 +97,8 @@ PELoader::~PELoader() {
 
 void PELoader::registerShim(const std::string& dllName, ShimLibrary&& shim) {
     std::string lower = dllName;
-    for (auto& c : lower) c = tolower(c);
+    for (auto& c : lower)
+        c = tolower(c);
     m_shims[lower] = std::move(shim);
 }
 
@@ -103,12 +106,12 @@ void* PELoader::resolveFunction(const std::string& dllName, const std::string& f
     return resolveImport(dllName, funcName, 0xFFFF);
 }
 
- bool PELoader::load(const std::string& path) {
-     MS_INFO("PELoader: loading %s", path.c_str());
- 
-     m_mainModule.name = path;
+bool PELoader::load(const std::string& path) {
+    MS_INFO("PELoader: loading %s", path.c_str());
 
-     std::ifstream file(path, std::ios::binary | std::ios::ate);
+    m_mainModule.name = path;
+
+    std::ifstream file(path, std::ios::binary | std::ios::ate);
     if (!file.is_open()) {
         MS_INFO("PELoader: failed to open %s", path.c_str());
         return false;
@@ -123,24 +126,32 @@ void* PELoader::resolveFunction(const std::string& dllName, const std::string& f
         return false;
     }
 
-    if (!parsePE(m_mainModule, data.data(), fileSize)) return false;
-    if (!mapSections(m_mainModule, data.data(), fileSize)) return false;
-    if (!processRelocations(m_mainModule)) return false;
-    if (!resolveImports(m_mainModule)) return false;
+    if (!parsePE(m_mainModule, data.data(), fileSize))
+        return false;
+    if (!mapSections(m_mainModule, data.data(), fileSize))
+        return false;
+    if (!processRelocations(m_mainModule))
+        return false;
+    if (!resolveImports(m_mainModule))
+        return false;
     resolveDelayImports(m_mainModule);
     applySectionProtections(m_mainModule);
     processTLS(m_mainModule, DLL_PROCESS_ATTACH);
 
-    MS_INFO("PELoader: loaded %s at %p, entry %p, size %u",
-            path.c_str(), m_mainModule.base, m_mainModule.entryPoint, m_mainModule.size);
+    MS_INFO("PELoader: loaded %s at %p, entry %p, size %u", path.c_str(), m_mainModule.base, m_mainModule.entryPoint,
+            m_mainModule.size);
     return true;
 }
 
 bool PELoader::loadFromMemory(const uint8_t* data, size_t size) {
-    if (!parsePE(m_mainModule, data, size)) return false;
-    if (!mapSections(m_mainModule, data, size)) return false;
-    if (!processRelocations(m_mainModule)) return false;
-    if (!resolveImports(m_mainModule)) return false;
+    if (!parsePE(m_mainModule, data, size))
+        return false;
+    if (!mapSections(m_mainModule, data, size))
+        return false;
+    if (!processRelocations(m_mainModule))
+        return false;
+    if (!resolveImports(m_mainModule))
+        return false;
     resolveDelayImports(m_mainModule);
     applySectionProtections(m_mainModule);
     processTLS(m_mainModule, DLL_PROCESS_ATTACH);
@@ -170,8 +181,7 @@ bool PELoader::parsePE(LoadedModule& module, const uint8_t* rawData, size_t rawS
         return false;
     }
 
-    auto* fileHeader = reinterpret_cast<const IMAGE_FILE_HEADER*>(
-        rawData + dos->e_lfanew + 4);
+    auto* fileHeader = reinterpret_cast<const IMAGE_FILE_HEADER*>(rawData + dos->e_lfanew + 4);
 
     if (fileHeader->Machine != IMAGE_FILE_MACHINE_AMD64) {
         MS_INFO("PELoader: unsupported machine type: 0x%04X (only AMD64 supported)", fileHeader->Machine);
@@ -183,8 +193,8 @@ bool PELoader::parsePE(LoadedModule& module, const uint8_t* rawData, size_t rawS
         return false;
     }
 
-    auto* optHeader = reinterpret_cast<const IMAGE_OPTIONAL_HEADER64*>(
-        rawData + dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER));
+    auto* optHeader =
+        reinterpret_cast<const IMAGE_OPTIONAL_HEADER64*>(rawData + dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER));
 
     if (optHeader->Magic != IMAGE_OPTIONAL_MAGIC_PE32PLUS) {
         MS_INFO("PELoader: not PE32+ (magic: 0x%04X)", optHeader->Magic);
@@ -198,20 +208,17 @@ bool PELoader::parsePE(LoadedModule& module, const uint8_t* rawData, size_t rawS
     module.size = optHeader->SizeOfImage;
     module.isPE = true;
 
-    MS_INFO("PELoader: PE32+ image, %u sections, image base 0x%llX, size %u",
-            fileHeader->NumberOfSections,
-            (unsigned long long)optHeader->ImageBase,
-            optHeader->SizeOfImage);
+    MS_INFO("PELoader: PE32+ image, %u sections, image base 0x%llX, size %u", fileHeader->NumberOfSections,
+            (unsigned long long)optHeader->ImageBase, optHeader->SizeOfImage);
 
     return true;
 }
 
 bool PELoader::mapSections(LoadedModule& module, const uint8_t* rawData, size_t rawSize) {
     auto* dos = reinterpret_cast<const IMAGE_DOS_HEADER*>(rawData);
-    auto* fileHeader = reinterpret_cast<const IMAGE_FILE_HEADER*>(
-        rawData + dos->e_lfanew + 4);
-    auto* optHeader = reinterpret_cast<const IMAGE_OPTIONAL_HEADER64*>(
-        rawData + dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER));
+    auto* fileHeader = reinterpret_cast<const IMAGE_FILE_HEADER*>(rawData + dos->e_lfanew + 4);
+    auto* optHeader =
+        reinterpret_cast<const IMAGE_OPTIONAL_HEADER64*>(rawData + dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER));
     auto* sections = reinterpret_cast<const IMAGE_SECTION_HEADER*>(
         rawData + dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER) + fileHeader->SizeOfOptionalHeader);
 
@@ -223,11 +230,8 @@ bool PELoader::mapSections(LoadedModule& module, const uint8_t* rawData, size_t 
     int mmapFlags = MAP_PRIVATE | MAP_ANONYMOUS;
 #endif
 
-    uint8_t* mem = reinterpret_cast<uint8_t*>(mmap(
-        nullptr, imageSize,
-        PROT_READ | PROT_WRITE | PROT_EXEC,
-        mmapFlags,
-        -1, 0));
+    uint8_t* mem =
+        reinterpret_cast<uint8_t*>(mmap(nullptr, imageSize, PROT_READ | PROT_WRITE | PROT_EXEC, mmapFlags, -1, 0));
 
     if (mem == MAP_FAILED) {
         MS_INFO("PELoader: mmap failed for image (%u bytes), errno=%d", imageSize, errno);
@@ -237,12 +241,14 @@ bool PELoader::mapSections(LoadedModule& module, const uint8_t* rawData, size_t 
     memset(mem, 0, imageSize);
 
     uint32_t headerSize = alignUp(optHeader->SizeOfHeaders, m_fileAlignment);
-    if (headerSize > rawSize) headerSize = rawSize;
+    if (headerSize > rawSize)
+        headerSize = rawSize;
     memcpy(mem, rawData, headerSize);
 
     for (uint16_t i = 0; i < fileHeader->NumberOfSections; i++) {
         const auto& sec = sections[i];
-        if (sec.SizeOfRawData == 0) continue;
+        if (sec.SizeOfRawData == 0)
+            continue;
 
         uint32_t dstOffset = sec.VirtualAddress;
         uint32_t srcOffset = sec.PointerToRawData;
@@ -260,8 +266,8 @@ bool PELoader::mapSections(LoadedModule& module, const uint8_t* rawData, size_t 
         }
 
         const char* name = reinterpret_cast<const char*>(sec.Name);
-        MS_INFO("PELoader: mapped section %.8s at RVA 0x%X (0x%X bytes, raw 0x%X)",
-                name, sec.VirtualAddress, sec.VirtualSize, sec.SizeOfRawData);
+        MS_INFO("PELoader: mapped section %.8s at RVA 0x%X (0x%X bytes, raw 0x%X)", name, sec.VirtualAddress,
+                sec.VirtualSize, sec.SizeOfRawData);
     }
 
     module.base = mem;
@@ -275,13 +281,13 @@ bool PELoader::mapSections(LoadedModule& module, const uint8_t* rawData, size_t 
 }
 
 bool PELoader::processRelocations(LoadedModule& module) {
-    if (!module.base) return false;
+    if (!module.base)
+        return false;
 
     auto* dos = reinterpret_cast<const IMAGE_DOS_HEADER*>(module.base);
-    auto* fileHeader = reinterpret_cast<const IMAGE_FILE_HEADER*>(
-        module.base + dos->e_lfanew + 4);
-    auto* optHeader = reinterpret_cast<const IMAGE_OPTIONAL_HEADER64*>(
-        module.base + dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER));
+    auto* fileHeader = reinterpret_cast<const IMAGE_FILE_HEADER*>(module.base + dos->e_lfanew + 4);
+    auto* optHeader =
+        reinterpret_cast<const IMAGE_OPTIONAL_HEADER64*>(module.base + dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER));
 
     if (optHeader->DataDirectory[DIRECTORY_BASERELOC].Size == 0) {
         MS_INFO("PELoader: no relocations needed");
@@ -317,26 +323,27 @@ bool PELoader::processRelocations(LoadedModule& module) {
             }
         }
 
-        reloc = reinterpret_cast<IMAGE_BASE_RELOCATION*>(
-            reinterpret_cast<uint8_t*>(reloc) + reloc->SizeOfBlock);
+        reloc = reinterpret_cast<IMAGE_BASE_RELOCATION*>(reinterpret_cast<uint8_t*>(reloc) + reloc->SizeOfBlock);
     }
 
     MS_INFO("PELoader: processed %d relocations (delta 0x%llX)", relocCount, (unsigned long long)m_delta);
 
-    if (!initCFG(module)) return false;
+    if (!initCFG(module))
+        return false;
 
     return true;
 }
 
 bool PELoader::initCFG(LoadedModule& module) {
     auto* dos = reinterpret_cast<const IMAGE_DOS_HEADER*>(module.base);
-    auto* optHeader = reinterpret_cast<const IMAGE_OPTIONAL_HEADER64*>(
-        module.base + dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER));
+    auto* optHeader =
+        reinterpret_cast<const IMAGE_OPTIONAL_HEADER64*>(module.base + dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER));
 
     uint32_t lcRVA = optHeader->DataDirectory[DIRECTORY_LOAD_CONFIG].VirtualAddress;
     uint32_t lcSize = optHeader->DataDirectory[DIRECTORY_LOAD_CONFIG].Size;
 
-    if (!lcRVA || lcSize < 128) return true;
+    if (!lcRVA || lcSize < 128)
+        return true;
 
     auto* lc = reinterpret_cast<uint8_t*>(module.base + lcRVA);
 
@@ -345,29 +352,31 @@ bool PELoader::initCFG(LoadedModule& module) {
 
     if (!s_cfgAllowFn) {
 #ifdef __APPLE__
-        s_cfgAllowFn = mmap(nullptr, 4096, PROT_READ | PROT_WRITE | PROT_EXEC,
-                            MAP_PRIVATE | MAP_ANONYMOUS | MAP_JIT, -1, 0);
+        s_cfgAllowFn =
+            mmap(nullptr, 4096, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS | MAP_JIT, -1, 0);
 #else
-        s_cfgAllowFn = mmap(nullptr, 4096, PROT_READ | PROT_WRITE | PROT_EXEC,
-                            MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        s_cfgAllowFn = mmap(nullptr, 4096, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 #endif
         if (s_cfgAllowFn == MAP_FAILED) {
             s_cfgAllowFn = nullptr;
             return true;
         }
-        uint8_t code[] = { 0xB8, 0x01, 0x00, 0x00, 0x00, 0xC3 };
+        uint8_t code[] = {0xB8, 0x01, 0x00, 0x00, 0x00, 0xC3};
         memcpy(s_cfgAllowFn, code, sizeof(code));
     }
 
     auto writeCFPtr = [&](uint64_t fieldRVA, const char* name) {
-        if (!fieldRVA || fieldRVA >= module.size) return;
+        if (!fieldRVA || fieldRVA >= module.size)
+            return;
         uint64_t* ptr = reinterpret_cast<uint64_t*>(module.base + fieldRVA);
         MS_INFO("PELoader: CFG %s at RVA 0x%llX set to allow-all stub", name, (unsigned long long)fieldRVA);
         *ptr = reinterpret_cast<uint64_t>(s_cfgAllowFn);
     };
 
-    if (guardCFCheckFPRVA) writeCFPtr(guardCFCheckFPRVA, "GuardCFCheckFP");
-    if (guardCFDispatchFPRVA) writeCFPtr(guardCFDispatchFPRVA, "GuardCFDispatchFP");
+    if (guardCFCheckFPRVA)
+        writeCFPtr(guardCFCheckFPRVA, "GuardCFCheckFP");
+    if (guardCFDispatchFPRVA)
+        writeCFPtr(guardCFDispatchFPRVA, "GuardCFDispatchFP");
 
     return true;
 }
@@ -375,11 +384,12 @@ bool PELoader::initCFG(LoadedModule& module) {
 void* PELoader::s_cfgAllowFn = nullptr;
 
 bool PELoader::resolveImports(LoadedModule& module) {
-    if (!module.base) return false;
+    if (!module.base)
+        return false;
 
     auto* dos = reinterpret_cast<const IMAGE_DOS_HEADER*>(module.base);
-    auto* optHeader = reinterpret_cast<const IMAGE_OPTIONAL_HEADER64*>(
-        module.base + dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER));
+    auto* optHeader =
+        reinterpret_cast<const IMAGE_OPTIONAL_HEADER64*>(module.base + dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER));
 
     if (optHeader->DataDirectory[DIRECTORY_IMPORT].Size == 0) {
         MS_INFO("PELoader: no imports");
@@ -396,9 +406,7 @@ bool PELoader::resolveImports(LoadedModule& module) {
 
         auto* iat = reinterpret_cast<uint64_t*>(module.base + importDesc->FirstThunk);
 
-        uint32_t thunkRVA = importDesc->OriginalFirstThunk
-            ? importDesc->OriginalFirstThunk
-            : importDesc->FirstThunk;
+        uint32_t thunkRVA = importDesc->OriginalFirstThunk ? importDesc->OriginalFirstThunk : importDesc->FirstThunk;
 
         auto* thunk = reinterpret_cast<uint64_t*>(module.base + thunkRVA);
 
@@ -418,8 +426,7 @@ bool PELoader::resolveImports(LoadedModule& module) {
                 isOrdinal = true;
                 funcPtr = resolveImport(dllName, "", ordinal);
             } else {
-                auto* ibn = reinterpret_cast<IMAGE_IMPORT_BY_NAME*>(
-                    module.base + (entry & 0x7FFFFFFF));
+                auto* ibn = reinterpret_cast<IMAGE_IMPORT_BY_NAME*>(module.base + (entry & 0x7FFFFFFF));
                 missingName = reinterpret_cast<const char*>(ibn->Name);
                 funcPtr = resolveImport(dllName, missingName, 0xFFFF);
             }
@@ -450,7 +457,8 @@ bool PELoader::resolveImports(LoadedModule& module) {
 
 void* PELoader::resolveImport(const std::string& dllName, const std::string& funcName, uint16_t ordinal) {
     std::string lower = dllName;
-    for (auto& c : lower) c = tolower(c);
+    for (auto& c : lower)
+        c = tolower(c);
 
     auto shimIt = m_shims.find(lower);
     if (shimIt != m_shims.end()) {
@@ -484,13 +492,15 @@ void* PELoader::resolveImport(const std::string& dllName, const std::string& fun
 }
 
 void* PELoader::getExportAddress(LoadedModule& module, const std::string& funcName, uint16_t ordinal) {
-    if (!module.base) return nullptr;
+    if (!module.base)
+        return nullptr;
 
     auto* dos = reinterpret_cast<const IMAGE_DOS_HEADER*>(module.base);
-    auto* optHeader = reinterpret_cast<const IMAGE_OPTIONAL_HEADER64*>(
-        module.base + dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER));
+    auto* optHeader =
+        reinterpret_cast<const IMAGE_OPTIONAL_HEADER64*>(module.base + dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER));
 
-    if (optHeader->DataDirectory[DIRECTORY_EXPORT].Size == 0) return nullptr;
+    if (optHeader->DataDirectory[DIRECTORY_EXPORT].Size == 0)
+        return nullptr;
 
     uint32_t exportRVA = optHeader->DataDirectory[DIRECTORY_EXPORT].VirtualAddress;
     uint32_t exportSize = optHeader->DataDirectory[DIRECTORY_EXPORT].Size;
@@ -520,7 +530,8 @@ void* PELoader::getExportAddress(LoadedModule& module, const std::string& funcNa
         }
     }
 
-    if (funcRVA == 0) return nullptr;
+    if (funcRVA == 0)
+        return nullptr;
 
     if (funcRVA >= exportRVA && funcRVA < exportRVA + exportSize) {
         const char* fwdStr = reinterpret_cast<const char*>(module.base + funcRVA);
@@ -531,16 +542,19 @@ void* PELoader::getExportAddress(LoadedModule& module, const std::string& funcNa
 }
 
 void* PELoader::resolveForwardedExport(const char* forwardString) {
-    if (!forwardString) return nullptr;
+    if (!forwardString)
+        return nullptr;
 
     std::string fwd(forwardString);
     auto dot = fwd.find('.');
-    if (dot == std::string::npos) return nullptr;
+    if (dot == std::string::npos)
+        return nullptr;
 
     std::string dllName = fwd.substr(0, dot) + ".dll";
     std::string funcName = fwd.substr(dot + 1);
 
-    for (auto& c : dllName) c = tolower(c);
+    for (auto& c : dllName)
+        c = tolower(c);
 
     auto it = m_loadedDLLs.find(dllName);
     if (it != m_loadedDLLs.end()) {
@@ -557,26 +571,30 @@ void* PELoader::resolveForwardedExport(const char* forwardString) {
 }
 
 void PELoader::processTLS(LoadedModule& module, uint32_t reason) {
-    if (!module.base) return;
+    if (!module.base)
+        return;
 
     auto* dos = reinterpret_cast<const IMAGE_DOS_HEADER*>(module.base);
-    auto* optHeader = reinterpret_cast<const IMAGE_OPTIONAL_HEADER64*>(
-        module.base + dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER));
+    auto* optHeader =
+        reinterpret_cast<const IMAGE_OPTIONAL_HEADER64*>(module.base + dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER));
 
-    if (optHeader->DataDirectory[DIRECTORY_TLS].Size == 0) return;
+    if (optHeader->DataDirectory[DIRECTORY_TLS].Size == 0)
+        return;
 
     uint32_t tlsRVA = optHeader->DataDirectory[DIRECTORY_TLS].VirtualAddress;
     auto* tlsDir = reinterpret_cast<IMAGE_TLS_DIRECTORY64*>(module.base + tlsRVA);
 
     uint64_t callbacksVA = tlsDir->AddressOfCallBacks;
-    if (callbacksVA == 0) return;
+    if (callbacksVA == 0)
+        return;
 
     uint64_t callbacksRVA;
     if (callbacksVA >= m_imageBase && callbacksVA < m_imageBase + module.size) {
         callbacksRVA = callbacksVA - m_imageBase;
     } else {
         callbacksRVA = callbacksVA - reinterpret_cast<uint64_t>(module.base);
-        if (callbacksRVA >= module.size) return;
+        if (callbacksRVA >= module.size)
+            return;
     }
 
     auto** callbacks = reinterpret_cast<void**>(module.base + callbacksRVA);
@@ -592,14 +610,17 @@ void PELoader::processTLS(LoadedModule& module, uint32_t reason) {
 }
 
 bool PELoader::resolveDelayImports(LoadedModule& module) {
-    if (!module.base) return true;
+    if (!module.base)
+        return true;
 
     auto* dos = reinterpret_cast<const IMAGE_DOS_HEADER*>(module.base);
-    auto* optHeader = reinterpret_cast<const IMAGE_OPTIONAL_HEADER64*>(
-        module.base + dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER));
+    auto* optHeader =
+        reinterpret_cast<const IMAGE_OPTIONAL_HEADER64*>(module.base + dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER));
 
-    if (optHeader->NumberOfRvaAndSizes <= 13) return true;
-    if (optHeader->DataDirectory[DIRECTORY_DELAY_IMPORT].Size == 0) return true;
+    if (optHeader->NumberOfRvaAndSizes <= 13)
+        return true;
+    if (optHeader->DataDirectory[DIRECTORY_DELAY_IMPORT].Size == 0)
+        return true;
 
     uint32_t delayRVA = optHeader->DataDirectory[DIRECTORY_DELAY_IMPORT].VirtualAddress;
     uint32_t delaySize = optHeader->DataDirectory[DIRECTORY_DELAY_IMPORT].Size;
@@ -607,10 +628,12 @@ bool PELoader::resolveDelayImports(LoadedModule& module) {
 
     size_t count = delaySize / sizeof(IMAGE_DELAY_IMPORT_DESCRIPTOR);
     for (size_t i = 0; i < count; i++) {
-        if (desc[i].rvaDLLName == 0) break;
+        if (desc[i].rvaDLLName == 0)
+            break;
 
         const char* dllNameStr = reinterpret_cast<const char*>(module.base + desc[i].rvaDLLName);
-        if (!dllNameStr || !dllNameStr[0]) break;
+        if (!dllNameStr || !dllNameStr[0])
+            break;
 
         MS_INFO("PELoader: resolving delay-load import: %s", dllNameStr);
 
@@ -642,25 +665,28 @@ bool PELoader::resolveDelayImports(LoadedModule& module) {
 }
 
 void PELoader::applySectionProtections(LoadedModule& module) {
-    if (!module.base) return;
+    if (!module.base)
+        return;
 
     auto* dos = reinterpret_cast<const IMAGE_DOS_HEADER*>(module.base);
-    auto* fileHeader = reinterpret_cast<const IMAGE_FILE_HEADER*>(
-        module.base + dos->e_lfanew + 4);
+    auto* fileHeader = reinterpret_cast<const IMAGE_FILE_HEADER*>(module.base + dos->e_lfanew + 4);
     auto* sections = reinterpret_cast<const IMAGE_SECTION_HEADER*>(
         module.base + dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER) + fileHeader->SizeOfOptionalHeader);
 
     for (uint16_t i = 0; i < fileHeader->NumberOfSections; i++) {
         auto& sec = sections[i];
-        if (sec.VirtualSize == 0 || sec.VirtualAddress == 0) continue;
+        if (sec.VirtualSize == 0 || sec.VirtualAddress == 0)
+            continue;
 
         uint32_t pageRVA = sec.VirtualAddress;
         uint32_t pageSize = alignUp(sec.VirtualSize, 4096);
         uint32_t chars = sec.Characteristics;
 
         int prot = PROT_READ;
-        if (chars & IMAGE_SCN_MEM_EXECUTE) prot |= PROT_EXEC;
-        if (chars & IMAGE_SCN_MEM_WRITE) prot |= PROT_WRITE;
+        if (chars & IMAGE_SCN_MEM_EXECUTE)
+            prot |= PROT_EXEC;
+        if (chars & IMAGE_SCN_MEM_WRITE)
+            prot |= PROT_WRITE;
 
         if ((chars & IMAGE_SCN_CNT_CODE) && !(chars & IMAGE_SCN_MEM_WRITE)) {
             prot |= PROT_EXEC;
@@ -683,15 +709,18 @@ void* PELoader::lookupFunctionEntry(uint64_t controlPc, uint64_t* outImageBase) 
     };
 
     for (auto& [name, mod] : m_loadedDLLs) {
-        if (!mod.base || !mod.isPE) continue;
+        if (!mod.base || !mod.isPE)
+            continue;
         auto* dos = reinterpret_cast<const IMAGE_DOS_HEADER*>(mod.base);
-        auto* opt = reinterpret_cast<const IMAGE_OPTIONAL_HEADER64*>(
-            mod.base + dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER));
-        if (opt->DataDirectory[DIRECTORY_EXCEPTION].Size == 0) continue;
+        auto* opt =
+            reinterpret_cast<const IMAGE_OPTIONAL_HEADER64*>(mod.base + dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER));
+        if (opt->DataDirectory[DIRECTORY_EXCEPTION].Size == 0)
+            continue;
 
         uint64_t modBase = reinterpret_cast<uint64_t>(mod.base);
         uint64_t modEnd = modBase + mod.size;
-        if (controlPc < modBase || controlPc >= modEnd) continue;
+        if (controlPc < modBase || controlPc >= modEnd)
+            continue;
 
         uint32_t exceptRva = opt->DataDirectory[DIRECTORY_EXCEPTION].VirtualAddress;
         uint32_t exceptSize = opt->DataDirectory[DIRECTORY_EXCEPTION].Size;
@@ -701,9 +730,10 @@ void* PELoader::lookupFunctionEntry(uint64_t controlPc, uint64_t* outImageBase) 
         uint32_t rva = static_cast<uint32_t>(controlPc - modBase);
         for (size_t i = 0; i < count; i++) {
             if (rva >= funcs[i].BeginAddress && rva < funcs[i].EndAddress) {
-                if (outImageBase) *outImageBase = modBase;
-                MS_INFO("PELoader: lookupFunctionEntry(0x%llX) found in %s at RVA 0x%X",
-                    (unsigned long long)controlPc, name.c_str(), rva);
+                if (outImageBase)
+                    *outImageBase = modBase;
+                MS_INFO("PELoader: lookupFunctionEntry(0x%llX) found in %s at RVA 0x%X", (unsigned long long)controlPc,
+                        name.c_str(), rva);
                 return const_cast<RuntimeFunction*>(&funcs[i]);
             }
         }
@@ -711,8 +741,8 @@ void* PELoader::lookupFunctionEntry(uint64_t controlPc, uint64_t* outImageBase) 
 
     if (m_mainModule.base && m_mainModule.isPE) {
         auto* dos = reinterpret_cast<const IMAGE_DOS_HEADER*>(m_mainModule.base);
-        auto* opt = reinterpret_cast<const IMAGE_OPTIONAL_HEADER64*>(
-            m_mainModule.base + dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER));
+        auto* opt = reinterpret_cast<const IMAGE_OPTIONAL_HEADER64*>(m_mainModule.base + dos->e_lfanew + 4 +
+                                                                     sizeof(IMAGE_FILE_HEADER));
         if (opt->DataDirectory[DIRECTORY_EXCEPTION].Size > 0) {
             uint64_t modBase = reinterpret_cast<uint64_t>(m_mainModule.base);
             uint32_t exceptRva = opt->DataDirectory[DIRECTORY_EXCEPTION].VirtualAddress;
@@ -723,16 +753,18 @@ void* PELoader::lookupFunctionEntry(uint64_t controlPc, uint64_t* outImageBase) 
             uint32_t rva = static_cast<uint32_t>(controlPc - modBase);
             for (size_t i = 0; i < count; i++) {
                 if (rva >= funcs[i].BeginAddress && rva < funcs[i].EndAddress) {
-                    if (outImageBase) *outImageBase = modBase;
+                    if (outImageBase)
+                        *outImageBase = modBase;
                     MS_INFO("PELoader: lookupFunctionEntry(0x%llX) found in main module at RVA 0x%X",
-                        (unsigned long long)controlPc, rva);
+                            (unsigned long long)controlPc, rva);
                     return const_cast<RuntimeFunction*>(&funcs[i]);
                 }
             }
         }
     }
 
-    if (outImageBase) *outImageBase = 0;
+    if (outImageBase)
+        *outImageBase = 0;
     return nullptr;
 }
 
@@ -759,13 +791,17 @@ bool PELoader::loadDependency(const std::string& dllName, LoadedModule& outModul
 
 LoadedModule* PELoader::getModule(const std::string& name) {
     std::string lower = name;
-    for (auto& c : lower) c = tolower(c);
+    for (auto& c : lower)
+        c = tolower(c);
 
-    if (m_loadedDLLs.count(lower)) return &m_loadedDLLs[lower];
+    if (m_loadedDLLs.count(lower))
+        return &m_loadedDLLs[lower];
     return nullptr;
 }
 
-PELoader* PELoader::instance() { return s_instance; }
+PELoader* PELoader::instance() {
+    return s_instance;
+}
 
 void PELoader::addSearchPath(const std::string& path) {
     m_searchPaths.push_back(path);
@@ -773,7 +809,8 @@ void PELoader::addSearchPath(const std::string& path) {
 
 HMODULE PELoader::loadLibrary(const std::string& dllName) {
     std::string lower = dllName;
-    for (auto& c : lower) c = tolower(c);
+    for (auto& c : lower)
+        c = tolower(c);
 
     auto existing = m_loadedDLLs.find(lower);
     if (existing != m_loadedDLLs.end()) {
@@ -781,7 +818,7 @@ HMODULE PELoader::loadLibrary(const std::string& dllName) {
     }
 
     std::string lowerWithDll = lower;
-    if (lower.size() < 4 || lower.substr(lower.size()-4) != ".dll") {
+    if (lower.size() < 4 || lower.substr(lower.size() - 4) != ".dll") {
         lowerWithDll = lower + ".dll";
     }
 
@@ -844,19 +881,25 @@ bool PELoader::loadDLL(const std::string& path, const std::string& dllName) {
     MS_INFO("PELoader: loading DLL %s from %s", dllName.c_str(), path.c_str());
 
     std::ifstream file(path, std::ios::binary | std::ios::ate);
-    if (!file.is_open()) return false;
+    if (!file.is_open())
+        return false;
 
     size_t fileSize = file.tellg();
     file.seekg(0);
     std::vector<uint8_t> data(fileSize);
-    if (!file.read(reinterpret_cast<char*>(data.data()), fileSize)) return false;
+    if (!file.read(reinterpret_cast<char*>(data.data()), fileSize))
+        return false;
 
     LoadedModule mod;
     mod.name = dllName;
-    if (!parsePE(mod, data.data(), fileSize)) return false;
-    if (!mapSections(mod, data.data(), fileSize)) return false;
-    if (!processRelocations(mod)) return false;
-    if (!resolveImports(mod)) return false;
+    if (!parsePE(mod, data.data(), fileSize))
+        return false;
+    if (!mapSections(mod, data.data(), fileSize))
+        return false;
+    if (!processRelocations(mod))
+        return false;
+    if (!resolveImports(mod))
+        return false;
     resolveDelayImports(mod);
 
     m_loadedDLLs[dllName] = std::move(mod);
@@ -879,4 +922,4 @@ bool PELoader::loadDLL(const std::string& path, const std::string& dllName) {
     return true;
 }
 
-}
+} // namespace metalsharp

--- a/src/metal/Buffer.mm
+++ b/src/metal/Buffer.mm
@@ -5,9 +5,9 @@
 /// constant, and staging buffers. Handles shared/private/managed memory modes
 /// and CPU-GPU data transfer.
 
-#include <metalsharp/MetalBackend.h>
 #include <Foundation/Foundation.h>
 #include <Metal/Metal.h>
+#include <metalsharp/MetalBackend.h>
 
 namespace metalsharp {
 
@@ -17,7 +17,9 @@ struct MetalBuffer::Impl {
 };
 
 MetalBuffer::MetalBuffer() : m_impl(new Impl()) {}
-MetalBuffer::~MetalBuffer() { delete m_impl; }
+MetalBuffer::~MetalBuffer() {
+    delete m_impl;
+}
 
 bool MetalBuffer::init(MetalDevice& device, size_t size, const void* data) {
     id<MTLDevice> mtlDevice = (__bridge id<MTLDevice>)device.nativeDevice();
@@ -51,4 +53,4 @@ size_t MetalBuffer::size() const {
     return m_impl->bufferSize;
 }
 
-}
+} // namespace metalsharp

--- a/src/metal/Framebuffer.mm
+++ b/src/metal/Framebuffer.mm
@@ -5,10 +5,10 @@
 /// color, depth, and stencil attachments for Metal render passes from D3D render target
 /// and depth-stencil view bindings.
 
-#include <metalsharp/MetalBackend.h>
+#include <array>
 #include <Foundation/Foundation.h>
 #include <Metal/Metal.h>
-#include <array>
+#include <metalsharp/MetalBackend.h>
 
 namespace metalsharp {
 
@@ -23,10 +23,13 @@ MetalFramebuffer::MetalFramebuffer() : m_impl(new Impl()) {
     m_impl->descriptor = [[MTLRenderPassDescriptor alloc] init];
 }
 
-MetalFramebuffer::~MetalFramebuffer() { delete m_impl; }
+MetalFramebuffer::~MetalFramebuffer() {
+    delete m_impl;
+}
 
 void MetalFramebuffer::setColorAttachment(uint32_t index, MetalTexture* texture) {
-    if (index >= 8 || !texture) return;
+    if (index >= 8 || !texture)
+        return;
     id<MTLTexture> mtlTex = (__bridge id<MTLTexture>)texture->nativeTexture();
     m_impl->colorAttachments[index] = mtlTex;
     m_impl->descriptor.colorAttachments[index].texture = mtlTex;
@@ -35,7 +38,8 @@ void MetalFramebuffer::setColorAttachment(uint32_t index, MetalTexture* texture)
 }
 
 void MetalFramebuffer::setDepthAttachment(MetalTexture* texture) {
-    if (!texture) return;
+    if (!texture)
+        return;
     id<MTLTexture> mtlTex = (__bridge id<MTLTexture>)texture->nativeTexture();
     m_impl->depthAttachment = mtlTex;
     m_impl->descriptor.depthAttachment.texture = mtlTex;
@@ -44,7 +48,8 @@ void MetalFramebuffer::setDepthAttachment(MetalTexture* texture) {
 }
 
 void MetalFramebuffer::setStencilAttachment(MetalTexture* texture) {
-    if (!texture) return;
+    if (!texture)
+        return;
     id<MTLTexture> mtlTex = (__bridge id<MTLTexture>)texture->nativeTexture();
     m_impl->stencilAttachment = mtlTex;
     m_impl->descriptor.stencilAttachment.texture = mtlTex;
@@ -56,4 +61,4 @@ void* MetalFramebuffer::nativeRenderPassDescriptor() const {
     return (__bridge void*)m_impl->descriptor;
 }
 
-}
+} // namespace metalsharp

--- a/src/metal/Sampler.mm
+++ b/src/metal/Sampler.mm
@@ -5,81 +5,110 @@
 /// sampler descriptions (filter mode, address mode, LOD, comparison) to Metal sampler
 /// descriptor configuration.
 
-#include <metalsharp/MetalBackend.h>
-#include <metalsharp/FormatTranslation.h>
 #include <d3d/D3D11.h>
 #include <Foundation/Foundation.h>
 #include <Metal/Metal.h>
+#include <metalsharp/FormatTranslation.h>
+#include <metalsharp/MetalBackend.h>
 
 namespace metalsharp {
 
 uint32_t dxgiFormatToMetal(DXGITranslation format) {
     switch (format) {
-        case DXGITranslation::DXGI_FORMAT_R8G8B8A8_UNORM:      return MTLPixelFormatRGBA8Unorm;
-        case DXGITranslation::DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:  return MTLPixelFormatRGBA8Unorm_sRGB;
-        case DXGITranslation::DXGI_FORMAT_B8G8R8A8_UNORM:       return MTLPixelFormatBGRA8Unorm;
-        case DXGITranslation::DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:  return MTLPixelFormatBGRA8Unorm_sRGB;
-        case DXGITranslation::DXGI_FORMAT_R16G16B16A16_FLOAT:   return MTLPixelFormatRGBA16Float;
-        case DXGITranslation::DXGI_FORMAT_R32G32B32A32_FLOAT:   return MTLPixelFormatRGBA32Float;
-        case DXGITranslation::DXGI_FORMAT_R32_FLOAT:            return MTLPixelFormatR32Float;
-        case DXGITranslation::DXGI_FORMAT_D24_UNORM_S8_UINT:    return MTLPixelFormatDepth24Unorm_Stencil8;
-        case DXGITranslation::DXGI_FORMAT_D32_FLOAT:            return MTLPixelFormatDepth32Float;
-        case DXGITranslation::DXGI_FORMAT_D32_FLOAT_S8X24_UINT: return MTLPixelFormatDepth32Float_Stencil8;
-        case DXGITranslation::DXGI_FORMAT_BC1_UNORM:            return MTLPixelFormatBC1_RGBA;
-        case DXGITranslation::DXGI_FORMAT_BC2_UNORM:            return MTLPixelFormatBC2_RGBA;
-        case DXGITranslation::DXGI_FORMAT_BC3_UNORM:            return MTLPixelFormatBC3_RGBA;
-        case DXGITranslation::DXGI_FORMAT_BC4_UNORM:            return MTLPixelFormatBC4_RUnorm;
-        case DXGITranslation::DXGI_FORMAT_BC5_UNORM:            return MTLPixelFormatBC5_RGUnorm;
-        case DXGITranslation::DXGI_FORMAT_BC6H_SF16:            return MTLPixelFormatBC6H_RGBFloat;
-        case DXGITranslation::DXGI_FORMAT_BC7_UNORM:            return MTLPixelFormatBC7_RGBAUnorm;
-        default: return MTLPixelFormatInvalid;
+    case DXGITranslation::DXGI_FORMAT_R8G8B8A8_UNORM:
+        return MTLPixelFormatRGBA8Unorm;
+    case DXGITranslation::DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
+        return MTLPixelFormatRGBA8Unorm_sRGB;
+    case DXGITranslation::DXGI_FORMAT_B8G8R8A8_UNORM:
+        return MTLPixelFormatBGRA8Unorm;
+    case DXGITranslation::DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+        return MTLPixelFormatBGRA8Unorm_sRGB;
+    case DXGITranslation::DXGI_FORMAT_R16G16B16A16_FLOAT:
+        return MTLPixelFormatRGBA16Float;
+    case DXGITranslation::DXGI_FORMAT_R32G32B32A32_FLOAT:
+        return MTLPixelFormatRGBA32Float;
+    case DXGITranslation::DXGI_FORMAT_R32_FLOAT:
+        return MTLPixelFormatR32Float;
+    case DXGITranslation::DXGI_FORMAT_D24_UNORM_S8_UINT:
+        return MTLPixelFormatDepth24Unorm_Stencil8;
+    case DXGITranslation::DXGI_FORMAT_D32_FLOAT:
+        return MTLPixelFormatDepth32Float;
+    case DXGITranslation::DXGI_FORMAT_D32_FLOAT_S8X24_UINT:
+        return MTLPixelFormatDepth32Float_Stencil8;
+    case DXGITranslation::DXGI_FORMAT_BC1_UNORM:
+        return MTLPixelFormatBC1_RGBA;
+    case DXGITranslation::DXGI_FORMAT_BC2_UNORM:
+        return MTLPixelFormatBC2_RGBA;
+    case DXGITranslation::DXGI_FORMAT_BC3_UNORM:
+        return MTLPixelFormatBC3_RGBA;
+    case DXGITranslation::DXGI_FORMAT_BC4_UNORM:
+        return MTLPixelFormatBC4_RUnorm;
+    case DXGITranslation::DXGI_FORMAT_BC5_UNORM:
+        return MTLPixelFormatBC5_RGUnorm;
+    case DXGITranslation::DXGI_FORMAT_BC6H_SF16:
+        return MTLPixelFormatBC6H_RGBFloat;
+    case DXGITranslation::DXGI_FORMAT_BC7_UNORM:
+        return MTLPixelFormatBC7_RGBAUnorm;
+    default:
+        return MTLPixelFormatInvalid;
     }
 }
 
 uint32_t dxgiFormatToBytesPerPixel(DXGITranslation format) {
     switch (format) {
-        case DXGITranslation::DXGI_FORMAT_R8G8B8A8_UNORM:
-        case DXGITranslation::DXGI_FORMAT_B8G8R8A8_UNORM:       return 4;
-        case DXGITranslation::DXGI_FORMAT_R16G16B16A16_FLOAT:   return 8;
-        case DXGITranslation::DXGI_FORMAT_R32G32B32A32_FLOAT:   return 16;
-        case DXGITranslation::DXGI_FORMAT_R32_FLOAT:            return 4;
-        case DXGITranslation::DXGI_FORMAT_D24_UNORM_S8_UINT:    return 4;
-        case DXGITranslation::DXGI_FORMAT_D32_FLOAT:            return 4;
-        case DXGITranslation::DXGI_FORMAT_D32_FLOAT_S8X24_UINT: return 8;
-        default: return 0;
+    case DXGITranslation::DXGI_FORMAT_R8G8B8A8_UNORM:
+    case DXGITranslation::DXGI_FORMAT_B8G8R8A8_UNORM:
+        return 4;
+    case DXGITranslation::DXGI_FORMAT_R16G16B16A16_FLOAT:
+        return 8;
+    case DXGITranslation::DXGI_FORMAT_R32G32B32A32_FLOAT:
+        return 16;
+    case DXGITranslation::DXGI_FORMAT_R32_FLOAT:
+        return 4;
+    case DXGITranslation::DXGI_FORMAT_D24_UNORM_S8_UINT:
+        return 4;
+    case DXGITranslation::DXGI_FORMAT_D32_FLOAT:
+        return 4;
+    case DXGITranslation::DXGI_FORMAT_D32_FLOAT_S8X24_UINT:
+        return 8;
+    default:
+        return 0;
     }
 }
 
 bool dxgiFormatIsDepth(DXGITranslation format) {
     switch (format) {
-        case DXGITranslation::DXGI_FORMAT_D24_UNORM_S8_UINT:
-        case DXGITranslation::DXGI_FORMAT_D32_FLOAT:
-        case DXGITranslation::DXGI_FORMAT_D32_FLOAT_S8X24_UINT:
-            return true;
-        default: return false;
+    case DXGITranslation::DXGI_FORMAT_D24_UNORM_S8_UINT:
+    case DXGITranslation::DXGI_FORMAT_D32_FLOAT:
+    case DXGITranslation::DXGI_FORMAT_D32_FLOAT_S8X24_UINT:
+        return true;
+    default:
+        return false;
     }
 }
 
 bool dxgiFormatIsStencil(DXGITranslation format) {
     switch (format) {
-        case DXGITranslation::DXGI_FORMAT_D24_UNORM_S8_UINT:
-        case DXGITranslation::DXGI_FORMAT_D32_FLOAT_S8X24_UINT:
-            return true;
-        default: return false;
+    case DXGITranslation::DXGI_FORMAT_D24_UNORM_S8_UINT:
+    case DXGITranslation::DXGI_FORMAT_D32_FLOAT_S8X24_UINT:
+        return true;
+    default:
+        return false;
     }
 }
 
 bool dxgiFormatIsCompressed(DXGITranslation format) {
     switch (format) {
-        case DXGITranslation::DXGI_FORMAT_BC1_UNORM:
-        case DXGITranslation::DXGI_FORMAT_BC2_UNORM:
-        case DXGITranslation::DXGI_FORMAT_BC3_UNORM:
-        case DXGITranslation::DXGI_FORMAT_BC4_UNORM:
-        case DXGITranslation::DXGI_FORMAT_BC5_UNORM:
-        case DXGITranslation::DXGI_FORMAT_BC6H_SF16:
-        case DXGITranslation::DXGI_FORMAT_BC7_UNORM:
-            return true;
-        default: return false;
+    case DXGITranslation::DXGI_FORMAT_BC1_UNORM:
+    case DXGITranslation::DXGI_FORMAT_BC2_UNORM:
+    case DXGITranslation::DXGI_FORMAT_BC3_UNORM:
+    case DXGITranslation::DXGI_FORMAT_BC4_UNORM:
+    case DXGITranslation::DXGI_FORMAT_BC5_UNORM:
+    case DXGITranslation::DXGI_FORMAT_BC6H_SF16:
+    case DXGITranslation::DXGI_FORMAT_BC7_UNORM:
+        return true;
+    default:
+        return false;
     }
 }
 
@@ -88,35 +117,42 @@ struct MetalSampler::Impl {
 };
 
 MetalSampler::MetalSampler() : m_impl(new Impl()) {}
-MetalSampler::~MetalSampler() { delete m_impl; }
+MetalSampler::~MetalSampler() {
+    delete m_impl;
+}
 
 static MTLSamplerAddressMode translateAddressMode(UINT mode) {
     switch (mode) {
-        case 1: return MTLSamplerAddressModeRepeat;
-        case 2: return MTLSamplerAddressModeMirrorRepeat;
-        case 3: return MTLSamplerAddressModeClampToEdge;
-        case 4: return MTLSamplerAddressModeClampToZero;
-        case 5: return MTLSamplerAddressModeMirrorClampToEdge;
-        default: return MTLSamplerAddressModeClampToEdge;
+    case 1:
+        return MTLSamplerAddressModeRepeat;
+    case 2:
+        return MTLSamplerAddressModeMirrorRepeat;
+    case 3:
+        return MTLSamplerAddressModeClampToEdge;
+    case 4:
+        return MTLSamplerAddressModeClampToZero;
+    case 5:
+        return MTLSamplerAddressModeMirrorClampToEdge;
+    default:
+        return MTLSamplerAddressModeClampToEdge;
     }
 }
 
 static MTLSamplerMinMagFilter translateMinMagFilter(UINT filter) {
-    bool isPoint = (filter == D3D11_FILTER_MIN_MAG_MIP_POINT ||
-                    filter == D3D11_FILTER_MIN_MAG_POINT_MIP_LINEAR ||
+    bool isPoint = (filter == D3D11_FILTER_MIN_MAG_MIP_POINT || filter == D3D11_FILTER_MIN_MAG_POINT_MIP_LINEAR ||
                     filter == D3D11_FILTER_COMPARISON_MIN_MAG_MIP_POINT);
     return isPoint ? MTLSamplerMinMagFilterNearest : MTLSamplerMinMagFilterLinear;
 }
 
 static MTLSamplerMipFilter translateMipFilter(UINT filter) {
-    bool isPoint = (filter == D3D11_FILTER_MIN_MAG_MIP_POINT ||
-                    filter == D3D11_FILTER_MIN_LINEAR_MAG_MIP_POINT ||
-                    filter == D3D11_FILTER_MIN_MAG_LINEAR_MIP_POINT ||
-                    filter == D3D11_FILTER_COMPARISON_MIN_MAG_MIP_POINT);
+    bool isPoint =
+        (filter == D3D11_FILTER_MIN_MAG_MIP_POINT || filter == D3D11_FILTER_MIN_LINEAR_MAG_MIP_POINT ||
+         filter == D3D11_FILTER_MIN_MAG_LINEAR_MIP_POINT || filter == D3D11_FILTER_COMPARISON_MIN_MAG_MIP_POINT);
     return isPoint ? MTLSamplerMipFilterNearest : MTLSamplerMipFilterLinear;
 }
 
-bool MetalSampler::init(MetalDevice& device, uint32_t filter, uint32_t addressU, uint32_t addressV, uint32_t addressW, float mipLodBias, uint32_t maxAnisotropy, uint32_t comparisonFunc) {
+bool MetalSampler::init(MetalDevice& device, uint32_t filter, uint32_t addressU, uint32_t addressV, uint32_t addressW,
+                        float mipLodBias, uint32_t maxAnisotropy, uint32_t comparisonFunc) {
     id<MTLDevice> mtlDevice = (__bridge id<MTLDevice>)device.nativeDevice();
 
     MTLSamplerDescriptor* desc = [[MTLSamplerDescriptor alloc] init];
@@ -132,14 +168,30 @@ bool MetalSampler::init(MetalDevice& device, uint32_t filter, uint32_t addressU,
     if (filter >= 0x80) {
         desc.compareFunction = MTLCompareFunctionAlways;
         switch (comparisonFunc) {
-            case 1: desc.compareFunction = MTLCompareFunctionNever; break;
-            case 2: desc.compareFunction = MTLCompareFunctionLess; break;
-            case 3: desc.compareFunction = MTLCompareFunctionEqual; break;
-            case 4: desc.compareFunction = MTLCompareFunctionLessEqual; break;
-            case 5: desc.compareFunction = MTLCompareFunctionGreater; break;
-            case 6: desc.compareFunction = MTLCompareFunctionNotEqual; break;
-            case 7: desc.compareFunction = MTLCompareFunctionGreaterEqual; break;
-            case 8: desc.compareFunction = MTLCompareFunctionAlways; break;
+        case 1:
+            desc.compareFunction = MTLCompareFunctionNever;
+            break;
+        case 2:
+            desc.compareFunction = MTLCompareFunctionLess;
+            break;
+        case 3:
+            desc.compareFunction = MTLCompareFunctionEqual;
+            break;
+        case 4:
+            desc.compareFunction = MTLCompareFunctionLessEqual;
+            break;
+        case 5:
+            desc.compareFunction = MTLCompareFunctionGreater;
+            break;
+        case 6:
+            desc.compareFunction = MTLCompareFunctionNotEqual;
+            break;
+        case 7:
+            desc.compareFunction = MTLCompareFunctionGreaterEqual;
+            break;
+        case 8:
+            desc.compareFunction = MTLCompareFunctionAlways;
+            break;
         }
     }
 
@@ -147,7 +199,9 @@ bool MetalSampler::init(MetalDevice& device, uint32_t filter, uint32_t addressU,
     return m_impl->sampler != nil;
 }
 
-MetalSampler* MetalSampler::create(MetalDevice& device, uint32_t filter, uint32_t addressU, uint32_t addressV, uint32_t addressW, float mipLodBias, uint32_t maxAnisotropy, uint32_t comparisonFunc) {
+MetalSampler* MetalSampler::create(MetalDevice& device, uint32_t filter, uint32_t addressU, uint32_t addressV,
+                                   uint32_t addressW, float mipLodBias, uint32_t maxAnisotropy,
+                                   uint32_t comparisonFunc) {
     auto* s = new MetalSampler();
     if (!s->init(device, filter, addressU, addressV, addressW, mipLodBias, maxAnisotropy, comparisonFunc)) {
         delete s;
@@ -160,4 +214,4 @@ void* MetalSampler::nativeSamplerState() const {
     return (__bridge void*)m_impl->sampler;
 }
 
-}
+} // namespace metalsharp

--- a/src/metal/Texture.mm
+++ b/src/metal/Texture.mm
@@ -5,10 +5,10 @@
 /// Translates D3D format enums to Metal pixel formats and configures texture descriptors
 /// for render target, depth stencil, and shader resource usage.
 
-#include <metalsharp/MetalBackend.h>
-#include <metalsharp/FormatTranslation.h>
 #include <Foundation/Foundation.h>
 #include <Metal/Metal.h>
+#include <metalsharp/FormatTranslation.h>
+#include <metalsharp/MetalBackend.h>
 
 namespace metalsharp {
 
@@ -22,14 +22,20 @@ struct MetalTexture::Impl {
 };
 
 MetalTexture::MetalTexture() : m_impl(new Impl()) {}
-MetalTexture::~MetalTexture() { delete m_impl; }
+MetalTexture::~MetalTexture() {
+    delete m_impl;
+}
 
 static MTLTextureUsage translateUsage(uint32_t usage) {
     MTLTextureUsage mtlUsage = 0;
-    if (usage & 0x1) mtlUsage |= MTLTextureUsageRenderTarget;
-    if (usage & 0x2) mtlUsage |= MTLTextureUsageShaderRead;
-    if (usage & 0x4) mtlUsage |= MTLTextureUsageShaderWrite;
-    if (usage & 0x8) mtlUsage |= MTLTextureUsagePixelFormatView;
+    if (usage & 0x1)
+        mtlUsage |= MTLTextureUsageRenderTarget;
+    if (usage & 0x2)
+        mtlUsage |= MTLTextureUsageShaderRead;
+    if (usage & 0x4)
+        mtlUsage |= MTLTextureUsageShaderWrite;
+    if (usage & 0x8)
+        mtlUsage |= MTLTextureUsagePixelFormatView;
     return mtlUsage;
 }
 
@@ -55,7 +61,8 @@ bool MetalTexture::init1D(MetalDevice& device, uint32_t width, uint32_t format, 
     return m_impl->texture != nil;
 }
 
-bool MetalTexture::init2D(MetalDevice& device, uint32_t width, uint32_t height, uint32_t format, uint32_t usage, uint32_t mipLevels, uint32_t sampleCount) {
+bool MetalTexture::init2D(MetalDevice& device, uint32_t width, uint32_t height, uint32_t format, uint32_t usage,
+                          uint32_t mipLevels, uint32_t sampleCount) {
     id<MTLDevice> mtlDevice = (__bridge id<MTLDevice>)device.nativeDevice();
 
     MTLTextureDescriptor* desc = [[MTLTextureDescriptor alloc] init];
@@ -77,7 +84,8 @@ bool MetalTexture::init2D(MetalDevice& device, uint32_t width, uint32_t height, 
     return m_impl->texture != nil;
 }
 
-bool MetalTexture::init3D(MetalDevice& device, uint32_t width, uint32_t height, uint32_t depth, uint32_t format, uint32_t usage, uint32_t mipLevels) {
+bool MetalTexture::init3D(MetalDevice& device, uint32_t width, uint32_t height, uint32_t depth, uint32_t format,
+                          uint32_t usage, uint32_t mipLevels) {
     id<MTLDevice> mtlDevice = (__bridge id<MTLDevice>)device.nativeDevice();
 
     MTLTextureDescriptor* desc = [[MTLTextureDescriptor alloc] init];
@@ -100,7 +108,8 @@ bool MetalTexture::init3D(MetalDevice& device, uint32_t width, uint32_t height, 
     return m_impl->texture != nil;
 }
 
-MetalTexture* MetalTexture::create1D(MetalDevice& device, uint32_t width, uint32_t format, uint32_t usage, uint32_t mipLevels) {
+MetalTexture* MetalTexture::create1D(MetalDevice& device, uint32_t width, uint32_t format, uint32_t usage,
+                                     uint32_t mipLevels) {
     MetalTexture* tex = new MetalTexture();
     if (!tex->init1D(device, width, format, usage, mipLevels)) {
         delete tex;
@@ -109,7 +118,8 @@ MetalTexture* MetalTexture::create1D(MetalDevice& device, uint32_t width, uint32
     return tex;
 }
 
-MetalTexture* MetalTexture::create2D(MetalDevice& device, uint32_t width, uint32_t height, uint32_t format, uint32_t usage, uint32_t mipLevels, uint32_t sampleCount) {
+MetalTexture* MetalTexture::create2D(MetalDevice& device, uint32_t width, uint32_t height, uint32_t format,
+                                     uint32_t usage, uint32_t mipLevels, uint32_t sampleCount) {
     MetalTexture* tex = new MetalTexture();
     if (!tex->init2D(device, width, height, format, usage, mipLevels, sampleCount)) {
         delete tex;
@@ -118,7 +128,8 @@ MetalTexture* MetalTexture::create2D(MetalDevice& device, uint32_t width, uint32
     return tex;
 }
 
-MetalTexture* MetalTexture::create3D(MetalDevice& device, uint32_t width, uint32_t height, uint32_t depth, uint32_t format, uint32_t usage, uint32_t mipLevels) {
+MetalTexture* MetalTexture::create3D(MetalDevice& device, uint32_t width, uint32_t height, uint32_t depth,
+                                     uint32_t format, uint32_t usage, uint32_t mipLevels) {
     MetalTexture* tex = new MetalTexture();
     if (!tex->init3D(device, width, height, depth, format, usage, mipLevels)) {
         delete tex;
@@ -127,25 +138,37 @@ MetalTexture* MetalTexture::create3D(MetalDevice& device, uint32_t width, uint32
     return tex;
 }
 
-void MetalTexture::uploadData(uint32_t mipLevel, uint32_t slice, const void* data, uint32_t rowPitch, uint32_t w, uint32_t h, uint32_t depth) {
-    if (!m_impl->texture || !data) return;
+void MetalTexture::uploadData(uint32_t mipLevel, uint32_t slice, const void* data, uint32_t rowPitch, uint32_t w,
+                              uint32_t h, uint32_t depth) {
+    if (!m_impl->texture || !data)
+        return;
     MTLRegion region = MTLRegionMake3D(0, 0, 0, w, h, depth > 0 ? depth : 1);
     [m_impl->texture replaceRegion:region
-                        mipmapLevel:mipLevel
-                              slice:slice
-                          withBytes:data
-                        bytesPerRow:rowPitch
-                      bytesPerImage:rowPitch * h];
+                       mipmapLevel:mipLevel
+                             slice:slice
+                         withBytes:data
+                       bytesPerRow:rowPitch
+                     bytesPerImage:rowPitch * h];
 }
 
 void* MetalTexture::nativeTexture() const {
     return (__bridge void*)m_impl->texture;
 }
 
-uint32_t MetalTexture::width() const { return m_impl->w; }
-uint32_t MetalTexture::height() const { return m_impl->h; }
-uint32_t MetalTexture::depth() const { return m_impl->d; }
-uint32_t MetalTexture::mipLevels() const { return m_impl->mips; }
-uint32_t MetalTexture::sampleCount() const { return m_impl->samples; }
-
+uint32_t MetalTexture::width() const {
+    return m_impl->w;
 }
+uint32_t MetalTexture::height() const {
+    return m_impl->h;
+}
+uint32_t MetalTexture::depth() const {
+    return m_impl->d;
+}
+uint32_t MetalTexture::mipLevels() const {
+    return m_impl->mips;
+}
+uint32_t MetalTexture::sampleCount() const {
+    return m_impl->samples;
+}
+
+} // namespace metalsharp

--- a/src/metal/command/CommandBuffer.cpp
+++ b/src/metal/command/CommandBuffer.cpp
@@ -6,6 +6,4 @@
 
 #include <metalsharp/MetalBackend.h>
 
-namespace metalsharp {
-
-}
+namespace metalsharp {}

--- a/src/metal/command/CommandBuffer.mm
+++ b/src/metal/command/CommandBuffer.mm
@@ -6,6 +6,4 @@
 
 #include <metalsharp/MetalBackend.h>
 
-namespace metalsharp {
-
-}
+namespace metalsharp {}

--- a/src/metal/command/CommandQueue.cpp
+++ b/src/metal/command/CommandQueue.cpp
@@ -6,6 +6,4 @@
 
 #include <metalsharp/MetalBackend.h>
 
-namespace metalsharp {
-
-}
+namespace metalsharp {}

--- a/src/metal/command/CommandQueue.mm
+++ b/src/metal/command/CommandQueue.mm
@@ -6,6 +6,4 @@
 
 #include <metalsharp/MetalBackend.h>
 
-namespace metalsharp {
-
-}
+namespace metalsharp {}

--- a/src/metal/device/Device.cpp
+++ b/src/metal/device/Device.cpp
@@ -6,6 +6,4 @@
 
 #include <metalsharp/MetalBackend.h>
 
-namespace metalsharp {
-
-}
+namespace metalsharp {}

--- a/src/metal/device/Device.mm
+++ b/src/metal/device/Device.mm
@@ -4,9 +4,9 @@
 /// Objective-C++ implementation that wraps MTLDevice creation, queries GPU
 /// capabilities, and exposes the Metal device to the rest of the translation layer.
 
-#include <metalsharp/MetalBackend.h>
 #include <Foundation/Foundation.h>
 #include <Metal/Metal.h>
+#include <metalsharp/MetalBackend.h>
 #include <QuartzCore/QuartzCore.h>
 
 namespace metalsharp {
@@ -24,10 +24,12 @@ MetalDevice::~MetalDevice() {
 
 bool MetalDevice::init() {
     m_impl->device = MTLCreateSystemDefaultDevice();
-    if (!m_impl->device) return false;
+    if (!m_impl->device)
+        return false;
 
     m_impl->commandQueue = [m_impl->device newCommandQueue];
-    if (!m_impl->commandQueue) return false;
+    if (!m_impl->commandQueue)
+        return false;
 
     return true;
 }
@@ -49,4 +51,4 @@ void* MetalDevice::nativeCommandQueue() const {
     return (__bridge void*)m_impl->commandQueue;
 }
 
-}
+} // namespace metalsharp

--- a/src/metal/pipeline/ComputePipeline.cpp
+++ b/src/metal/pipeline/ComputePipeline.cpp
@@ -6,6 +6,4 @@
 
 #include <metalsharp/MetalBackend.h>
 
-namespace metalsharp {
-
-}
+namespace metalsharp {}

--- a/src/metal/pipeline/ComputePipeline.mm
+++ b/src/metal/pipeline/ComputePipeline.mm
@@ -6,6 +6,4 @@
 
 #include <metalsharp/MetalBackend.h>
 
-namespace metalsharp {
-
-}
+namespace metalsharp {}

--- a/src/metal/pipeline/PipelineState.cpp
+++ b/src/metal/pipeline/PipelineState.cpp
@@ -6,5 +6,4 @@
 
 #include <metalsharp/PipelineState.h>
 
-namespace metalsharp {
-}
+namespace metalsharp {}

--- a/src/metal/pipeline/PipelineState.mm
+++ b/src/metal/pipeline/PipelineState.mm
@@ -5,10 +5,10 @@
 /// compiled Metal shaders and vertex descriptors. Includes pipeline state caching
 /// keyed on descriptor hash for amortized creation cost.
 
-#include <metalsharp/PipelineState.h>
-#include <metalsharp/MetalBackend.h>
 #include <Foundation/Foundation.h>
 #include <Metal/Metal.h>
+#include <metalsharp/MetalBackend.h>
+#include <metalsharp/PipelineState.h>
 
 namespace metalsharp {
 
@@ -17,35 +17,57 @@ struct PipelineState::Impl {
 };
 
 PipelineState::PipelineState() : m_impl(new Impl()) {}
-PipelineState::~PipelineState() { delete m_impl; }
+PipelineState::~PipelineState() {
+    delete m_impl;
+}
 
 static MTLBlendFactor translateBlendFactor(uint32_t d3dFactor) {
     switch (d3dFactor) {
-        case 1: return MTLBlendFactorZero;
-        case 2: return MTLBlendFactorOne;
-        case 3: return MTLBlendFactorSourceColor;
-        case 4: return MTLBlendFactorOneMinusSourceColor;
-        case 5: return MTLBlendFactorSourceAlpha;
-        case 6: return MTLBlendFactorOneMinusSourceAlpha;
-        case 7: return MTLBlendFactorDestinationAlpha;
-        case 8: return MTLBlendFactorOneMinusDestinationAlpha;
-        case 9: return MTLBlendFactorDestinationColor;
-        case 10: return MTLBlendFactorOneMinusDestinationColor;
-        case 11: return MTLBlendFactorSourceAlphaSaturated;
-        case 14: return MTLBlendFactorBlendColor;
-        case 15: return MTLBlendFactorOneMinusBlendColor;
-        default: return MTLBlendFactorOne;
+    case 1:
+        return MTLBlendFactorZero;
+    case 2:
+        return MTLBlendFactorOne;
+    case 3:
+        return MTLBlendFactorSourceColor;
+    case 4:
+        return MTLBlendFactorOneMinusSourceColor;
+    case 5:
+        return MTLBlendFactorSourceAlpha;
+    case 6:
+        return MTLBlendFactorOneMinusSourceAlpha;
+    case 7:
+        return MTLBlendFactorDestinationAlpha;
+    case 8:
+        return MTLBlendFactorOneMinusDestinationAlpha;
+    case 9:
+        return MTLBlendFactorDestinationColor;
+    case 10:
+        return MTLBlendFactorOneMinusDestinationColor;
+    case 11:
+        return MTLBlendFactorSourceAlphaSaturated;
+    case 14:
+        return MTLBlendFactorBlendColor;
+    case 15:
+        return MTLBlendFactorOneMinusBlendColor;
+    default:
+        return MTLBlendFactorOne;
     }
 }
 
 static MTLBlendOperation translateBlendOp(uint32_t d3dOp) {
     switch (d3dOp) {
-        case 1: return MTLBlendOperationAdd;
-        case 2: return MTLBlendOperationSubtract;
-        case 3: return MTLBlendOperationReverseSubtract;
-        case 4: return MTLBlendOperationMin;
-        case 5: return MTLBlendOperationMax;
-        default: return MTLBlendOperationAdd;
+    case 1:
+        return MTLBlendOperationAdd;
+    case 2:
+        return MTLBlendOperationSubtract;
+    case 3:
+        return MTLBlendOperationReverseSubtract;
+    case 4:
+        return MTLBlendOperationMin;
+    case 5:
+        return MTLBlendOperationMax;
+    default:
+        return MTLBlendOperationAdd;
     }
 }
 
@@ -62,7 +84,8 @@ bool PipelineState::init(MetalDevice& device, const PipelineStateDesc& desc) {
     }
 
     for (uint32_t i = 0; i < desc.numColorAttachments && i < MAX_RENDER_TARGETS; ++i) {
-        if (desc.colorPixelFormats[i] == 0) continue;
+        if (desc.colorPixelFormats[i] == 0)
+            continue;
         pipelineDesc.colorAttachments[i].pixelFormat = (MTLPixelFormat)desc.colorPixelFormats[i];
         pipelineDesc.colorAttachments[i].writeMask = (MTLColorWriteMask)desc.renderTargetWriteMask[i];
 
@@ -122,4 +145,4 @@ void* PipelineState::nativeRenderPipelineState() const {
     return (__bridge void*)m_impl->pipelineState;
 }
 
-}
+} // namespace metalsharp

--- a/src/metal/shader/ArgumentBufferBinding.cpp
+++ b/src/metal/shader/ArgumentBufferBinding.cpp
@@ -5,11 +5,11 @@
 /// argument buffer layouts. Handles descriptor table flattening, constant buffer
 /// placement, and sampler/texture binding slot assignment.
 
+#include <algorithm>
+#include <cstring>
 #include <metalsharp/ArgumentBufferBinding.h>
 #include <metalsharp/IRConverterBridge.h>
 #include <metalsharp/Logger.h>
-#include <cstring>
-#include <algorithm>
 
 namespace metalsharp {
 
@@ -18,10 +18,8 @@ ArgumentBufferManager& ArgumentBufferManager::instance() {
     return inst;
 }
 
-ArgumentBufferLayout ArgumentBufferManager::buildLayoutFromReflection(
-    const IRConverterReflection& reflection,
-    ShaderStage stage
-) {
+ArgumentBufferLayout ArgumentBufferManager::buildLayoutFromReflection(const IRConverterReflection& reflection,
+                                                                      ShaderStage stage) {
     std::lock_guard<std::mutex> lock(m_mutex);
 
     ArgumentBufferLayout layout;
@@ -46,23 +44,20 @@ ArgumentBufferLayout ArgumentBufferManager::buildLayoutFromReflection(
         entry.type = ArgumentBufferResourceType::ConstantBuffer;
 
         layout.entries.push_back(entry);
-        currentOffset = std::max(currentOffset,
-            static_cast<uint64_t>(entry.topLevelOffset) + entry.sizeBytes);
+        currentOffset = std::max(currentOffset, static_cast<uint64_t>(entry.topLevelOffset) + entry.sizeBytes);
     }
 
     layout.totalSizeBytes = currentOffset;
     if (layout.totalSizeBytes == 0)
         layout.totalSizeBytes = 256;
 
-    MS_INFO("ArgumentBufferManager: built layout from reflection — %u entries, %llu bytes",
-             layout.rootParameterCount, layout.totalSizeBytes);
+    MS_INFO("ArgumentBufferManager: built layout from reflection — %u entries, %llu bytes", layout.rootParameterCount,
+            layout.totalSizeBytes);
     return layout;
 }
 
-ArgumentBufferLayout ArgumentBufferManager::buildLayoutFromRootSignature(
-    const void* rootSignatureData,
-    size_t rootSignatureSize
-) {
+ArgumentBufferLayout ArgumentBufferManager::buildLayoutFromRootSignature(const void* rootSignatureData,
+                                                                         size_t rootSignatureSize) {
     std::lock_guard<std::mutex> lock(m_mutex);
 
     ArgumentBufferLayout layout;
@@ -84,18 +79,15 @@ ArgumentBufferLayout ArgumentBufferManager::buildLayoutFromRootSignature(
     return layout;
 }
 
-bool ArgumentBufferManager::encodeResource(
-    const ArgumentBufferLayout& layout,
-    uint32_t rootParameterIndex,
-    void* argumentBufferData,
-    size_t argumentBufferSize,
-    const void* resourceData,
-    size_t resourceDataSize
-) {
-    if (!argumentBufferData || argumentBufferSize == 0) return false;
+bool ArgumentBufferManager::encodeResource(const ArgumentBufferLayout& layout, uint32_t rootParameterIndex,
+                                           void* argumentBufferData, size_t argumentBufferSize,
+                                           const void* resourceData, size_t resourceDataSize) {
+    if (!argumentBufferData || argumentBufferSize == 0)
+        return false;
 
     for (const auto& entry : layout.entries) {
-        if (entry.rootParameterIndex != rootParameterIndex) continue;
+        if (entry.rootParameterIndex != rootParameterIndex)
+            continue;
 
         uint32_t offset = entry.topLevelOffset;
         if (offset + resourceDataSize > argumentBufferSize) {
@@ -103,8 +95,7 @@ bool ArgumentBufferManager::encodeResource(
             return false;
         }
 
-        memcpy(static_cast<uint8_t*>(argumentBufferData) + offset,
-               resourceData, resourceDataSize);
+        memcpy(static_cast<uint8_t*>(argumentBufferData) + offset, resourceData, resourceDataSize);
         return true;
     }
 
@@ -112,20 +103,17 @@ bool ArgumentBufferManager::encodeResource(
     return false;
 }
 
-bool ArgumentBufferManager::encodeRootConstants(
-    const ArgumentBufferLayout& layout,
-    uint32_t rootParameterIndex,
-    void* argumentBufferData,
-    size_t argumentBufferSize,
-    const uint32_t* constants,
-    uint32_t numConstants
-) {
-    if (!argumentBufferData || !constants || numConstants == 0) return false;
+bool ArgumentBufferManager::encodeRootConstants(const ArgumentBufferLayout& layout, uint32_t rootParameterIndex,
+                                                void* argumentBufferData, size_t argumentBufferSize,
+                                                const uint32_t* constants, uint32_t numConstants) {
+    if (!argumentBufferData || !constants || numConstants == 0)
+        return false;
 
     size_t dataSize = numConstants * sizeof(uint32_t);
 
     for (const auto& entry : layout.entries) {
-        if (entry.rootParameterIndex != rootParameterIndex) continue;
+        if (entry.rootParameterIndex != rootParameterIndex)
+            continue;
 
         uint32_t offset = entry.topLevelOffset;
         if (offset + dataSize > argumentBufferSize) {
@@ -133,25 +121,22 @@ bool ArgumentBufferManager::encodeRootConstants(
             return false;
         }
 
-        memcpy(static_cast<uint8_t*>(argumentBufferData) + offset,
-               constants, dataSize);
+        memcpy(static_cast<uint8_t*>(argumentBufferData) + offset, constants, dataSize);
         return true;
     }
 
     return false;
 }
 
-bool ArgumentBufferManager::encodeDescriptorTable(
-    const ArgumentBufferLayout& layout,
-    uint32_t rootParameterIndex,
-    void* argumentBufferData,
-    size_t argumentBufferSize,
-    uint64_t gpuAddress
-) {
-    if (!argumentBufferData) return false;
+bool ArgumentBufferManager::encodeDescriptorTable(const ArgumentBufferLayout& layout, uint32_t rootParameterIndex,
+                                                  void* argumentBufferData, size_t argumentBufferSize,
+                                                  uint64_t gpuAddress) {
+    if (!argumentBufferData)
+        return false;
 
     for (const auto& entry : layout.entries) {
-        if (entry.rootParameterIndex != rootParameterIndex) continue;
+        if (entry.rootParameterIndex != rootParameterIndex)
+            continue;
 
         uint32_t offset = entry.topLevelOffset;
         if (offset + sizeof(uint64_t) > argumentBufferSize) {
@@ -159,35 +144,32 @@ bool ArgumentBufferManager::encodeDescriptorTable(
             return false;
         }
 
-        memcpy(static_cast<uint8_t*>(argumentBufferData) + offset,
-               &gpuAddress, sizeof(uint64_t));
+        memcpy(static_cast<uint8_t*>(argumentBufferData) + offset, &gpuAddress, sizeof(uint64_t));
         return true;
     }
 
     return false;
 }
 
-bool ArgumentBufferManager::encodeRootDescriptor(
-    const ArgumentBufferLayout& layout,
-    uint32_t rootParameterIndex,
-    void* argumentBufferData,
-    size_t argumentBufferSize,
-    uint64_t gpuAddress
-) {
-    if (!argumentBufferData) return false;
+bool ArgumentBufferManager::encodeRootDescriptor(const ArgumentBufferLayout& layout, uint32_t rootParameterIndex,
+                                                 void* argumentBufferData, size_t argumentBufferSize,
+                                                 uint64_t gpuAddress) {
+    if (!argumentBufferData)
+        return false;
 
     for (const auto& entry : layout.entries) {
-        if (entry.rootParameterIndex != rootParameterIndex) continue;
+        if (entry.rootParameterIndex != rootParameterIndex)
+            continue;
 
         uint32_t offset = entry.topLevelOffset;
-        if (offset + sizeof(uint64_t) > argumentBufferSize) return false;
+        if (offset + sizeof(uint64_t) > argumentBufferSize)
+            return false;
 
-        memcpy(static_cast<uint8_t*>(argumentBufferData) + offset,
-               &gpuAddress, sizeof(uint64_t));
+        memcpy(static_cast<uint8_t*>(argumentBufferData) + offset, &gpuAddress, sizeof(uint64_t));
         return true;
     }
 
     return false;
 }
 
-}
+} // namespace metalsharp

--- a/src/metal/shader/DXBCParser.cpp
+++ b/src/metal/shader/DXBCParser.cpp
@@ -5,9 +5,9 @@
 /// resource bindings, input/output signatures, and other metadata needed for translation
 /// to Metal shading language.
 
-#include <metalsharp/DXBCParser.h>
-#include <cstring>
 #include <cstdio>
+#include <cstring>
+#include <metalsharp/DXBCParser.h>
 
 namespace metalsharp {
 
@@ -104,7 +104,8 @@ enum DXBCOpcode : uint32_t {
 };
 
 static bool readU32(const uint8_t* data, size_t size, size_t offset, uint32_t& out) {
-    if (offset + 4 > size) return false;
+    if (offset + 4 > size)
+        return false;
     memcpy(&out, data + offset, 4);
     return true;
 }
@@ -113,14 +114,16 @@ static std::string readString(const uint8_t* base, size_t totalSize, uint32_t of
     std::string result;
     while (offset < totalSize) {
         char c = static_cast<char>(base[offset]);
-        if (c == 0) break;
+        if (c == 0)
+            break;
         result += c;
         offset++;
     }
     return result;
 }
 
-bool DXBCParser::parseSignature(const uint8_t* chunkData, size_t chunkSize, std::vector<DXBCSignatureElement>& out, const uint8_t* containerBase) {
+bool DXBCParser::parseSignature(const uint8_t* chunkData, size_t chunkSize, std::vector<DXBCSignatureElement>& out,
+                                const uint8_t* containerBase) {
     uint32_t elementCount, key;
     memcpy(&elementCount, chunkData + 8, 4);
     memcpy(&key, chunkData + 12, 4);
@@ -130,7 +133,8 @@ bool DXBCParser::parseSignature(const uint8_t* chunkData, size_t chunkSize, std:
 
     for (uint32_t i = 0; i < elementCount; ++i) {
         size_t eoff = i * elementStride;
-        if (eoff + elementStride > chunkSize - 16) break;
+        if (eoff + elementStride > chunkSize - 16)
+            break;
 
         DXBCSignatureElement elem;
         memcpy(&elem.semanticNameOffset, elements + eoff, 4);
@@ -150,7 +154,8 @@ bool DXBCParser::parseSignature(const uint8_t* chunkData, size_t chunkSize, std:
 }
 
 bool DXBCParser::parseOperand(const uint32_t* tokens, size_t maxTokens, DXBCOperand& operand, size_t& tokensConsumed) {
-    if (maxTokens == 0) return false;
+    if (maxTokens == 0)
+        return false;
     tokensConsumed = 0;
 
     uint32_t token = tokens[0];
@@ -161,7 +166,8 @@ bool DXBCParser::parseOperand(const uint32_t* tokens, size_t maxTokens, DXBCOper
     operand.mask = (token >> 12) & 0xF;
 
     for (uint32_t i = 0; i <= operand.indexDimension && i < 3; ++i) {
-        if (tokensConsumed >= maxTokens) return false;
+        if (tokensConsumed >= maxTokens)
+            return false;
         uint32_t indexRep = (token >> (22 + i * 2)) & 0x3;
         if (indexRep == 0) {
             operand.indices[i] = tokens[tokensConsumed++];
@@ -176,24 +182,39 @@ bool DXBCParser::parseOperand(const uint32_t* tokens, size_t maxTokens, DXBCOper
 }
 
 bool DXBCParser::parseBytecode(const uint32_t* tokens, size_t tokenCount, ParsedDXBC& out) {
-    if (tokenCount < 2) return false;
+    if (tokenCount < 2)
+        return false;
 
     uint32_t versionToken = tokens[0];
     uint32_t shaderType = (versionToken >> 16) & 0xFFFF;
     switch (shaderType) {
-        case 0xFFFF: out.shaderType = DXBCShaderType::Pixel; break;
-        case 0xFFFE: out.shaderType = DXBCShaderType::Vertex; break;
-        case 0xFFF2: out.shaderType = DXBCShaderType::Geometry; break;
-        case 0xFFF1: out.shaderType = DXBCShaderType::Hull; break;
-        case 0xFFF0: out.shaderType = DXBCShaderType::Domain; break;
-        case 0xFFF3: out.shaderType = DXBCShaderType::Compute; break;
-        default: return false;
+    case 0xFFFF:
+        out.shaderType = DXBCShaderType::Pixel;
+        break;
+    case 0xFFFE:
+        out.shaderType = DXBCShaderType::Vertex;
+        break;
+    case 0xFFF2:
+        out.shaderType = DXBCShaderType::Geometry;
+        break;
+    case 0xFFF1:
+        out.shaderType = DXBCShaderType::Hull;
+        break;
+    case 0xFFF0:
+        out.shaderType = DXBCShaderType::Domain;
+        break;
+    case 0xFFF3:
+        out.shaderType = DXBCShaderType::Compute;
+        break;
+    default:
+        return false;
     }
     out.majorVersion = (versionToken >> 4) & 0xF;
     out.minorVersion = versionToken & 0xF;
 
     uint32_t lengthInTokens = tokens[1];
-    if (lengthInTokens > tokenCount) return false;
+    if (lengthInTokens > tokenCount)
+        return false;
 
     size_t pos = 2;
     while (pos < lengthInTokens) {
@@ -201,7 +222,8 @@ bool DXBCParser::parseBytecode(const uint32_t* tokens, size_t tokenCount, Parsed
         uint32_t opcode = instToken & 0x7FF;
         uint32_t instLength = (instToken >> 24) & 0x7F;
 
-        if (instLength == 0) break;
+        if (instLength == 0)
+            break;
 
         DXBCInstruction inst = {};
         inst.opcode = opcode;
@@ -237,8 +259,10 @@ bool DXBCParser::parseBytecode(const uint32_t* tokens, size_t tokenCount, Parsed
 
 bool DXBCParser::parseContainer(const uint8_t* data, size_t size, ParsedDXBC& out) {
     uint32_t magic;
-    if (!readU32(data, size, 0, magic) || magic != DXBC_MAGIC) return false;
-    if (size < 32) return false;
+    if (!readU32(data, size, 0, magic) || magic != DXBC_MAGIC)
+        return false;
+    if (size < 32)
+        return false;
 
     uint32_t totalFileSize;
     memcpy(&totalFileSize, data + 24, 4);
@@ -248,20 +272,24 @@ bool DXBCParser::parseContainer(const uint8_t* data, size_t size, ParsedDXBC& ou
 
     for (uint32_t i = 0; i < chunkCount; ++i) {
         uint32_t chunkOffset;
-        if (!readU32(data, size, 32 + i * 4, chunkOffset)) continue;
-        if (chunkOffset + 8 > size) continue;
+        if (!readU32(data, size, 32 + i * 4, chunkOffset))
+            continue;
+        if (chunkOffset + 8 > size)
+            continue;
 
         uint32_t chunkMagic;
         uint32_t chunkSize;
         memcpy(&chunkMagic, data + chunkOffset, 4);
         memcpy(&chunkSize, data + chunkOffset + 4, 4);
 
-        if (chunkOffset + 8 + chunkSize > size) continue;
+        if (chunkOffset + 8 + chunkSize > size)
+            continue;
 
         if (chunkMagic == SHDR_MAGIC || chunkMagic == SHEX_MAGIC) {
             const uint32_t* tokens = reinterpret_cast<const uint32_t*>(data + chunkOffset + 8);
             size_t tokenCount = chunkSize / 4;
-            if (!parseBytecode(tokens, tokenCount, out)) return false;
+            if (!parseBytecode(tokens, tokenCount, out))
+                return false;
         } else if (chunkMagic == ISGN_MAGIC) {
             parseSignature(data + chunkOffset, chunkSize + 8, out.inputSignature, data);
         } else if (chunkMagic == OSGN_MAGIC) {
@@ -273,8 +301,9 @@ bool DXBCParser::parseContainer(const uint8_t* data, size_t size, ParsedDXBC& ou
 }
 
 bool DXBCParser::parse(const uint8_t* data, size_t size, ParsedDXBC& out) {
-    if (!data || size < 24) return false;
+    if (!data || size < 24)
+        return false;
     return parseContainer(data, size, out);
 }
 
-}
+} // namespace metalsharp

--- a/src/metal/shader/DXBCtoMSL.cpp
+++ b/src/metal/shader/DXBCtoMSL.cpp
@@ -5,17 +5,20 @@
 /// fallback path when the IR converter dylib is unavailable. Handles instruction decoding,
 /// register allocation, and MSL function emission for vertex and pixel shaders.
 
-#include <metalsharp/DXBCtoMSL.h>
+#include <algorithm>
 #include <cstdio>
 #include <cstring>
-#include <algorithm>
+#include <metalsharp/DXBCtoMSL.h>
 
 namespace metalsharp {
 
 const char* DXBCtoMSL::semanticToMSL(const std::string& semantic, uint32_t index, uint32_t componentType) {
-    if (semantic == "POSITION") return "position";
-    if (semantic == "SV_POSITION") return "position";
-    if (semantic == "NORMAL") return "normal";
+    if (semantic == "POSITION")
+        return "position";
+    if (semantic == "SV_POSITION")
+        return "position";
+    if (semantic == "NORMAL")
+        return "normal";
     if (semantic == "TEXCOORD") {
         static char buf[32];
         snprintf(buf, sizeof(buf), "texcoord%u", index);
@@ -26,61 +29,101 @@ const char* DXBCtoMSL::semanticToMSL(const std::string& semantic, uint32_t index
         snprintf(buf, sizeof(buf), "color%u", index);
         return buf;
     }
-    if (semantic == "TANGENT") return "tangent";
-    if (semantic == "BINORMAL") return "binormal";
-    if (semantic == "BLENDWEIGHT") return "blendweight";
-    if (semantic == "BLENDINDICES") return "blendindices";
+    if (semantic == "TANGENT")
+        return "tangent";
+    if (semantic == "BINORMAL")
+        return "binormal";
+    if (semantic == "BLENDWEIGHT")
+        return "blendweight";
+    if (semantic == "BLENDINDICES")
+        return "blendindices";
     if (semantic == "SV_TARGET") {
         static char buf[32];
         snprintf(buf, sizeof(buf), "target%u", index);
         return buf;
     }
-    if (semantic == "SV_Depth") return "depth_out";
+    if (semantic == "SV_Depth")
+        return "depth_out";
     return "user";
 }
 
 static const char* componentTypeName(uint32_t type) {
     switch (type) {
-        case 1: return "int";
-        case 2: return "uint";
-        case 3: return "float";
-        default: return "float";
+    case 1:
+        return "int";
+    case 2:
+        return "uint";
+    case 3:
+        return "float";
+    default:
+        return "float";
     }
 }
 
 std::string DXBCtoMSL::opcodeToMSL(uint32_t opcode) {
     switch (opcode) {
-        case 0: return "+";
-        case 1: return "-";
-        case 2: return "*";
-        case 4: return "mad";
-        case 6: return "dot";
-        case 7: return "dot4";
-        case 8: return "min";
-        case 9: return "max";
-        case 10: return "lessThan";
-        case 11: return "greaterThanEqual";
-        case 12: return "equal";
-        case 13: return "notEqual";
-        case 15: return "mix";
-        case 17: return "rsqrt";
-        case 21: return "sqrt";
-        case 26: return "exp2";
-        case 27: return "log2";
-        case 64: return "sample";
-        case 65: return "sample_l";
-        case 66: return "sample_b";
-        case 67: return "sample_c";
-        case 81: return "gather4";
-        case 90: return "mov";
-        case 100: return "+";
-        case 104: return "*";
-        case 22: return "int";
-        case 24: return "float";
-        case 82: return "dfdx";
-        case 83: return "dfdy";
-        case 84: return "discard";
-        default: return "unknown";
+    case 0:
+        return "+";
+    case 1:
+        return "-";
+    case 2:
+        return "*";
+    case 4:
+        return "mad";
+    case 6:
+        return "dot";
+    case 7:
+        return "dot4";
+    case 8:
+        return "min";
+    case 9:
+        return "max";
+    case 10:
+        return "lessThan";
+    case 11:
+        return "greaterThanEqual";
+    case 12:
+        return "equal";
+    case 13:
+        return "notEqual";
+    case 15:
+        return "mix";
+    case 17:
+        return "rsqrt";
+    case 21:
+        return "sqrt";
+    case 26:
+        return "exp2";
+    case 27:
+        return "log2";
+    case 64:
+        return "sample";
+    case 65:
+        return "sample_l";
+    case 66:
+        return "sample_b";
+    case 67:
+        return "sample_c";
+    case 81:
+        return "gather4";
+    case 90:
+        return "mov";
+    case 100:
+        return "+";
+    case 104:
+        return "*";
+    case 22:
+        return "int";
+    case 24:
+        return "float";
+    case 82:
+        return "dfdx";
+    case 83:
+        return "dfdy";
+    case 84:
+        return "discard";
+    default:
+        return "unknown";
     }
 }
 
@@ -88,54 +131,66 @@ static std::string swizzleStr(uint32_t mask) {
     std::string s = ".";
     const char* comps = "xyzw";
     for (int i = 0; i < 4; ++i) {
-        if (mask & (1 << i)) s += comps[i];
+        if (mask & (1 << i))
+            s += comps[i];
     }
-    if (s.size() == 1) return "";
-    if (s == ".xyzw") return "";
+    if (s.size() == 1)
+        return "";
+    if (s == ".xyzw")
+        return "";
     return s;
 }
 
 std::string DXBCtoMSL::operandToString(const DXBCOperand& operand, uint32_t componentType) {
     char buf[128];
     switch (operand.type) {
-        case 0: // temp
-            if (operand.mask) snprintf(buf, sizeof(buf), "r%u%s", operand.indices[0], swizzleStr(operand.mask).c_str());
-            else snprintf(buf, sizeof(buf), "r%u", operand.indices[0]);
-            break;
-        case 1: // input
-            if (operand.mask) snprintf(buf, sizeof(buf), "input%u%s", operand.indices[0], swizzleStr(operand.mask).c_str());
-            else snprintf(buf, sizeof(buf), "input%u", operand.indices[0]);
-            break;
-        case 2: // output
-            if (operand.mask) snprintf(buf, sizeof(buf), "output%u%s", operand.indices[0], swizzleStr(operand.mask).c_str());
-            else snprintf(buf, sizeof(buf), "output%u", operand.indices[0]);
-            break;
-        case 3: // indexable temp
-            if (operand.mask) snprintf(buf, sizeof(buf), "x%u[%u]%s", operand.indices[0], operand.indices[1], swizzleStr(operand.mask).c_str());
-            else snprintf(buf, sizeof(buf), "x%u[%u]", operand.indices[0], operand.indices[1]);
-            break;
-        case 4: // immediate32
-            return std::to_string(operand.indices[0]);
-        case 5: // immediate64
-            return std::to_string(operand.indices[0]);
-        case 6: // sampler
-            snprintf(buf, sizeof(buf), "sampler%u", operand.indices[0]);
-            break;
-        case 7: // resource
-            snprintf(buf, sizeof(buf), "texture%u", operand.indices[0]);
-            break;
-        case 8: // constant buffer
-            if (operand.indexDimension >= 1)
-                snprintf(buf, sizeof(buf), "cb%u[%u]", operand.indices[0], operand.indices[1]);
-            else
-                snprintf(buf, sizeof(buf), "cb%u", operand.indices[0]);
-            break;
-        case 9: // immediate constant buffer
-            snprintf(buf, sizeof(buf), "icb[%u]", operand.indices[0]);
-            break;
-        default:
-            snprintf(buf, sizeof(buf), "unk%u", operand.type);
-            break;
+    case 0: // temp
+        if (operand.mask)
+            snprintf(buf, sizeof(buf), "r%u%s", operand.indices[0], swizzleStr(operand.mask).c_str());
+        else
+            snprintf(buf, sizeof(buf), "r%u", operand.indices[0]);
+        break;
+    case 1: // input
+        if (operand.mask)
+            snprintf(buf, sizeof(buf), "input%u%s", operand.indices[0], swizzleStr(operand.mask).c_str());
+        else
+            snprintf(buf, sizeof(buf), "input%u", operand.indices[0]);
+        break;
+    case 2: // output
+        if (operand.mask)
+            snprintf(buf, sizeof(buf), "output%u%s", operand.indices[0], swizzleStr(operand.mask).c_str());
+        else
+            snprintf(buf, sizeof(buf), "output%u", operand.indices[0]);
+        break;
+    case 3: // indexable temp
+        if (operand.mask)
+            snprintf(buf, sizeof(buf), "x%u[%u]%s", operand.indices[0], operand.indices[1],
+                     swizzleStr(operand.mask).c_str());
+        else
+            snprintf(buf, sizeof(buf), "x%u[%u]", operand.indices[0], operand.indices[1]);
+        break;
+    case 4: // immediate32
+        return std::to_string(operand.indices[0]);
+    case 5: // immediate64
+        return std::to_string(operand.indices[0]);
+    case 6: // sampler
+        snprintf(buf, sizeof(buf), "sampler%u", operand.indices[0]);
+        break;
+    case 7: // resource
+        snprintf(buf, sizeof(buf), "texture%u", operand.indices[0]);
+        break;
+    case 8: // constant buffer
+        if (operand.indexDimension >= 1)
+            snprintf(buf, sizeof(buf), "cb%u[%u]", operand.indices[0], operand.indices[1]);
+        else
+            snprintf(buf, sizeof(buf), "cb%u", operand.indices[0]);
+        break;
+    case 9: // immediate constant buffer
+        snprintf(buf, sizeof(buf), "icb[%u]", operand.indices[0]);
+        break;
+    default:
+        snprintf(buf, sizeof(buf), "unk%u", operand.type);
+        break;
     }
     return buf;
 }
@@ -149,25 +204,25 @@ std::string DXBCtoMSL::translate(const ParsedDXBC& dxbc) {
     bool isCompute = false;
 
     switch (dxbc.shaderType) {
-        case DXBCShaderType::Vertex:
-            stageFn = "vertexShader";
-            stageAttr = "vertex ";
-            returnPrefix = "float4";
-            break;
-        case DXBCShaderType::Pixel:
-            stageFn = "fragmentShader";
-            stageAttr = "fragment ";
-            returnPrefix = "float4";
-            break;
-        case DXBCShaderType::Compute:
-            stageFn = "computeShader";
-            stageAttr = "kernel ";
-            returnPrefix = "void";
-            isCompute = true;
-            break;
-        default:
-            stageFn = "main0";
-            break;
+    case DXBCShaderType::Vertex:
+        stageFn = "vertexShader";
+        stageAttr = "vertex ";
+        returnPrefix = "float4";
+        break;
+    case DXBCShaderType::Pixel:
+        stageFn = "fragmentShader";
+        stageAttr = "fragment ";
+        returnPrefix = "float4";
+        break;
+    case DXBCShaderType::Compute:
+        stageFn = "computeShader";
+        stageAttr = "kernel ";
+        returnPrefix = "void";
+        isCompute = true;
+        break;
+    default:
+        stageFn = "main0";
+        break;
     }
 
     src += "#include <metal_stdlib>\nusing namespace metal;\n\n";
@@ -186,12 +241,22 @@ std::string DXBCtoMSL::translate(const ParsedDXBC& dxbc) {
         d.regIndex = elem.registerIndex;
         d.name = semanticToMSL(elem.semanticName, elem.semanticIndex, elem.componentType);
         uint32_t componentCount = 0;
-        for (int i = 0; i < 4; ++i) if (elem.mask & (1 << i)) componentCount++;
+        for (int i = 0; i < 4; ++i)
+            if (elem.mask & (1 << i))
+                componentCount++;
         switch (componentCount) {
-            case 1: d.type = "float"; break;
-            case 2: d.type = "float2"; break;
-            case 3: d.type = "float3"; break;
-            default: d.type = "float4"; break;
+        case 1:
+            d.type = "float";
+            break;
+        case 2:
+            d.type = "float2";
+            break;
+        case 3:
+            d.type = "float3";
+            break;
+        default:
+            d.type = "float4";
+            break;
         }
         if (dxbc.shaderType == DXBCShaderType::Vertex)
             d.attribute = " [[attribute(" + std::to_string(elem.registerIndex) + ")]]";
@@ -275,38 +340,39 @@ std::string DXBCtoMSL::translate(const ParsedDXBC& dxbc) {
 
     for (auto& inp : inputs) {
         src += "    float4 input" + std::to_string(inp.regIndex) + " = float4(input_in." + inp.name;
-        if (inp.type == "float") src += ", 0, 0, 0";
-        else if (inp.type == "float2") src += ", 0, 0";
-        else if (inp.type == "float3") src += ", 0";
+        if (inp.type == "float")
+            src += ", 0, 0, 0";
+        else if (inp.type == "float2")
+            src += ", 0, 0";
+        else if (inp.type == "float3")
+            src += ", 0";
         src += ");\n";
     }
 
     for (auto& inst : dxbc.instructions) {
         if (inst.opcode == 90) { // MOV
             if (inst.operandCount >= 2) {
-                src += "    " + operandToString(inst.operands[0], 3) + " = " + operandToString(inst.operands[1], 3) + ";\n";
+                src += "    " + operandToString(inst.operands[0], 3) + " = " + operandToString(inst.operands[1], 3) +
+                       ";\n";
             }
         } else if (inst.opcode == 0 || inst.opcode == 1 || inst.opcode == 2) { // ADD, SUB, MUL
             if (inst.operandCount >= 3) {
                 const char* op = inst.opcode == 0 ? "+" : inst.opcode == 1 ? "-" : "*";
-                src += "    " + operandToString(inst.operands[0], 3) + " = " +
-                       operandToString(inst.operands[1], 3) + " " + op + " " +
-                       operandToString(inst.operands[2], 3) + ";\n";
+                src += "    " + operandToString(inst.operands[0], 3) + " = " + operandToString(inst.operands[1], 3) +
+                       " " + op + " " + operandToString(inst.operands[2], 3) + ";\n";
             }
         } else if (inst.opcode == 4) { // MAD
             if (inst.operandCount >= 4) {
-                src += "    " + operandToString(inst.operands[0], 3) + " = " +
-                       operandToString(inst.operands[1], 3) + " * " +
-                       operandToString(inst.operands[2], 3) + " + " +
-                       operandToString(inst.operands[3], 3) + ";\n";
+                src += "    " + operandToString(inst.operands[0], 3) + " = " + operandToString(inst.operands[1], 3) +
+                       " * " + operandToString(inst.operands[2], 3) + " + " + operandToString(inst.operands[3], 3) +
+                       ";\n";
             }
         } else if (inst.opcode == 6 || inst.opcode == 7) { // DP3, DP4
             if (inst.operandCount >= 3) {
                 src += "    " + operandToString(inst.operands[0], 3) + " = float4(dot(" +
-                       operandToString(inst.operands[1], 3) + ", " +
-                       operandToString(inst.operands[2], 3) + "));\n";
+                       operandToString(inst.operands[1], 3) + ", " + operandToString(inst.operands[2], 3) + "));\n";
             }
-        } else if (inst.opcode == 7) { // DP4 (already handled above with DP3)
+        } else if (inst.opcode == 7) {  // DP4 (already handled above with DP3)
         } else if (inst.opcode == 17) { // RSQ
             if (inst.operandCount >= 2) {
                 src += "    " + operandToString(inst.operands[0], 3) + " = float4(rsqrt(" +
@@ -314,10 +380,9 @@ std::string DXBCtoMSL::translate(const ParsedDXBC& dxbc) {
             }
         } else if (inst.opcode == 64) { // SAMPLE
             if (inst.operandCount >= 4) {
-                src += "    " + operandToString(inst.operands[0], 3) + " = " +
-                       operandToString(inst.operands[3], 3) + ".sample(" +
-                       operandToString(inst.operands[2], 3) + ", " +
-                       operandToString(inst.operands[1], 3) + ");\n";
+                src += "    " + operandToString(inst.operands[0], 3) + " = " + operandToString(inst.operands[3], 3) +
+                       ".sample(" + operandToString(inst.operands[2], 3) + ", " + operandToString(inst.operands[1], 3) +
+                       ");\n";
             }
         } else if (inst.opcode == 82) { // DERIV_RTX
             if (inst.operandCount >= 2) {
@@ -359,4 +424,4 @@ std::string DXBCtoMSL::translate(const ParsedDXBC& dxbc) {
     return src;
 }
 
-}
+} // namespace metalsharp

--- a/src/metal/shader/IRConverterBridge.cpp
+++ b/src/metal/shader/IRConverterBridge.cpp
@@ -61,15 +61,15 @@
 ///     SM 6.5: mesh shaders, sampler feedback
 ///     SM 6.6: compute derivatives
 
-#include <metalsharp/IRConverterBridge.h>
-#include <metalsharp/DXBCParser.h>
-#include <metalsharp/Logger.h>
-#include <dlfcn.h>
-#include <cstring>
 #include <cstdlib>
-#include <sys/stat.h>
-#include <fstream>
+#include <cstring>
+#include <dlfcn.h>
 #include <filesystem>
+#include <fstream>
+#include <metalsharp/DXBCParser.h>
+#include <metalsharp/IRConverterBridge.h>
+#include <metalsharp/Logger.h>
+#include <sys/stat.h>
 
 #ifdef METALSHARP_HAS_IRCONVERTER
 #include <metal_irconverter/metal_irconverter.h>
@@ -147,26 +147,40 @@ struct IRConverterBridge::FuncPtrs {
 
 static IRShaderStage toIRStage(ShaderStage stage) {
     switch (stage) {
-        case ShaderStage::Vertex: return IRShaderStageVertex;
-        case ShaderStage::Pixel: return IRShaderStageFragment;
-        case ShaderStage::Compute: return IRShaderStageCompute;
-        case ShaderStage::Geometry: return IRShaderStageGeometry;
-        case ShaderStage::Hull: return IRShaderStageHull;
-        case ShaderStage::Domain: return IRShaderStageDomain;
-        case ShaderStage::Mesh: return IRShaderStageMesh;
-        case ShaderStage::Amplification: return IRShaderStageAmplification;
-        case ShaderStage::RayGeneration: return IRShaderStageRayGeneration;
-        case ShaderStage::ClosestHit: return IRShaderStageClosestHit;
-        case ShaderStage::Miss: return IRShaderStageMiss;
-        case ShaderStage::Intersection: return IRShaderStageIntersection;
-        case ShaderStage::AnyHit: return IRShaderStageAnyHit;
-        case ShaderStage::Callable: return IRShaderStageCallable;
-        default: return IRShaderStageInvalid;
+    case ShaderStage::Vertex:
+        return IRShaderStageVertex;
+    case ShaderStage::Pixel:
+        return IRShaderStageFragment;
+    case ShaderStage::Compute:
+        return IRShaderStageCompute;
+    case ShaderStage::Geometry:
+        return IRShaderStageGeometry;
+    case ShaderStage::Hull:
+        return IRShaderStageHull;
+    case ShaderStage::Domain:
+        return IRShaderStageDomain;
+    case ShaderStage::Mesh:
+        return IRShaderStageMesh;
+    case ShaderStage::Amplification:
+        return IRShaderStageAmplification;
+    case ShaderStage::RayGeneration:
+        return IRShaderStageRayGeneration;
+    case ShaderStage::ClosestHit:
+        return IRShaderStageClosestHit;
+    case ShaderStage::Miss:
+        return IRShaderStageMiss;
+    case ShaderStage::Intersection:
+        return IRShaderStageIntersection;
+    case ShaderStage::AnyHit:
+        return IRShaderStageAnyHit;
+    case ShaderStage::Callable:
+        return IRShaderStageCallable;
+    default:
+        return IRShaderStageInvalid;
     }
 }
 
-template<typename T>
-static bool loadSym(void* lib, T& ptr, const char* name) {
+template <typename T> static bool loadSym(void* lib, T& ptr, const char* name) {
     ptr = reinterpret_cast<T>(dlsym(lib, name));
     return ptr != nullptr;
 }
@@ -186,15 +200,12 @@ IRConverterBridge& IRConverterBridge::instance() {
 }
 
 bool IRConverterBridge::loadDylib() {
-    if (m_loaded) return true;
+    if (m_loaded)
+        return true;
 
     static const char* paths[] = {
-        "/usr/local/lib/libmetalirconverter.dylib",
-        "/opt/metal-sharpconverter/lib/libmetalirconverter.dylib",
-        "/opt/metal-shaderconverter/lib/libmetalirconverter.dylib",
-        "@rpath/libmetalirconverter.dylib",
-        nullptr
-    };
+        "/usr/local/lib/libmetalirconverter.dylib", "/opt/metal-sharpconverter/lib/libmetalirconverter.dylib",
+        "/opt/metal-shaderconverter/lib/libmetalirconverter.dylib", "@rpath/libmetalirconverter.dylib", nullptr};
 
     for (int i = 0; paths[i]; ++i) {
         m_dylib = dlopen(paths[i], RTLD_NOW | RTLD_LOCAL);
@@ -219,7 +230,7 @@ bool IRConverterBridge::loadDylib() {
     ok &= loadSym(m_dylib, f.metallibCreate, "IRMetalLibBinaryCreate");
     ok &= loadSym(m_dylib, f.metallibDestroy, "IRMetalLibBinaryDestroy");
     ok &= loadSym(m_dylib, f.metallibGetBytecode, "IRMetalLibGetBytecode");
-    ok &=     loadSym(m_dylib, f.metallibGetBytecodeSize, "IRMetalLibGetBytecodeSize");
+    ok &= loadSym(m_dylib, f.metallibGetBytecodeSize, "IRMetalLibGetBytecodeSize");
     loadSym(m_dylib, f.objectGetMetalLib, "IRObjectGetMetalLibBinary");
     ok &= loadSym(m_dylib, f.reflectionCreate, "IRShaderReflectionCreate");
     ok &= loadSym(m_dylib, f.reflectionDestroy, "IRShaderReflectionDestroy");
@@ -291,23 +302,28 @@ bool IRConverterBridge::isAvailable() const {
 }
 
 bool IRConverterBridge::isDXIL(const uint8_t* data, size_t size) const {
-    if (!data || size < 16) return false;
+    if (!data || size < 16)
+        return false;
 
     uint32_t magic;
     memcpy(&magic, data, 4);
-    if (magic == DXIL_MAGIC) return true;
+    if (magic == DXIL_MAGIC)
+        return true;
 
     if (magic == DXBC_MAGIC && size >= 32) {
         uint32_t chunkCount;
         memcpy(&chunkCount, data + 28, 4);
         for (uint32_t i = 0; i < chunkCount; ++i) {
             uint32_t offset;
-            if (32 + i * 4 + 4 > size) break;
+            if (32 + i * 4 + 4 > size)
+                break;
             memcpy(&offset, data + 32 + i * 4, 4);
-            if (offset + 8 > size) continue;
+            if (offset + 8 > size)
+                continue;
             uint32_t chunkMagic;
             memcpy(&chunkMagic, data + offset, 4);
-            if (chunkMagic == DXIL_MAGIC) return true;
+            if (chunkMagic == DXIL_MAGIC)
+                return true;
         }
     }
 
@@ -315,7 +331,8 @@ bool IRConverterBridge::isDXIL(const uint8_t* data, size_t size) const {
 }
 
 uint32_t IRConverterBridge::detectShaderModel(const uint8_t* data, size_t size) const {
-    if (!data || size < 16) return 0;
+    if (!data || size < 16)
+        return 0;
 
     uint32_t magic;
     memcpy(&magic, data, 4);
@@ -325,9 +342,11 @@ uint32_t IRConverterBridge::detectShaderModel(const uint8_t* data, size_t size) 
         memcpy(&chunkCount, data + 28, 4);
         for (uint32_t i = 0; i < chunkCount; ++i) {
             uint32_t offset;
-            if (32 + i * 4 + 4 > size) break;
+            if (32 + i * 4 + 4 > size)
+                break;
             memcpy(&offset, data + 32 + i * 4, 4);
-            if (offset + 8 > size) continue;
+            if (offset + 8 > size)
+                continue;
             uint32_t chunkMagic;
             memcpy(&chunkMagic, data + offset, 4);
             uint32_t chunkSize;
@@ -345,50 +364,55 @@ uint32_t IRConverterBridge::detectShaderModel(const uint8_t* data, size_t size) 
         }
     }
 
-    if (magic == DXIL_MAGIC) return 60;
+    if (magic == DXIL_MAGIC)
+        return 60;
     return 0;
 }
 
-bool IRConverterBridge::extractDXILFromDXBC(
-    const uint8_t* dxbcData,
-    size_t dxbcSize,
-    std::vector<uint8_t>& outDXIL
-) {
-    if (!dxbcData || dxbcSize < 32) return false;
+bool IRConverterBridge::extractDXILFromDXBC(const uint8_t* dxbcData, size_t dxbcSize, std::vector<uint8_t>& outDXIL) {
+    if (!dxbcData || dxbcSize < 32)
+        return false;
 
     uint32_t magic;
     memcpy(&magic, dxbcData, 4);
-    if (magic != DXBC_MAGIC) return false;
+    if (magic != DXBC_MAGIC)
+        return false;
 
     uint32_t chunkCount;
     memcpy(&chunkCount, dxbcData + 28, 4);
 
     for (uint32_t i = 0; i < chunkCount; ++i) {
         uint32_t offset;
-        if (32 + i * 4 + 4 > dxbcSize) break;
+        if (32 + i * 4 + 4 > dxbcSize)
+            break;
         memcpy(&offset, dxbcData + 32 + i * 4, 4);
-        if (offset + 8 > dxbcSize) continue;
+        if (offset + 8 > dxbcSize)
+            continue;
 
         uint32_t chunkMagic;
         memcpy(&chunkMagic, dxbcData + offset, 4);
         if (chunkMagic == DXIL_MAGIC) {
             uint32_t chunkSize;
             memcpy(&chunkSize, dxbcData + offset + 4, 4);
-            if (offset + 8 + chunkSize > dxbcSize) continue;
+            if (offset + 8 + chunkSize > dxbcSize)
+                continue;
 
             const uint8_t* dxilStart = dxbcData + offset + 8;
             uint32_t dxilVersion;
             uint32_t dxilTokenCount;
-            if (chunkSize < 8) continue;
+            if (chunkSize < 8)
+                continue;
             memcpy(&dxilVersion, dxilStart, 4);
             memcpy(&dxilTokenCount, dxilStart + 4, 4);
 
             uint32_t programHeaderSize = 16;
-            if (8 + programHeaderSize > chunkSize) continue;
+            if (8 + programHeaderSize > chunkSize)
+                continue;
 
             uint32_t dxilStartOffset;
             memcpy(&dxilStartOffset, dxilStart + 12, 4);
-            if (8 + dxilStartOffset > chunkSize) continue;
+            if (8 + dxilStartOffset > chunkSize)
+                continue;
 
             size_t rawSize = chunkSize - 8;
             outDXIL.assign(dxbcData + offset, dxbcData + offset + 8 + chunkSize);
@@ -399,32 +423,20 @@ bool IRConverterBridge::extractDXILFromDXBC(
     return false;
 }
 
-bool IRConverterBridge::compileDXILToMetallib(
-    const uint8_t* dxilData,
-    size_t dxilSize,
-    ShaderStage stage,
-    const char* entryPoint,
-    std::vector<uint8_t>& outMetallib,
-    IRConverterReflection& outReflection
-) {
-    return compileDXILToMetallibWithRootSignature(
-        dxilData, dxilSize, stage, entryPoint,
-        nullptr, 0,
-        outMetallib, outReflection
-    );
+bool IRConverterBridge::compileDXILToMetallib(const uint8_t* dxilData, size_t dxilSize, ShaderStage stage,
+                                              const char* entryPoint, std::vector<uint8_t>& outMetallib,
+                                              IRConverterReflection& outReflection) {
+    return compileDXILToMetallibWithRootSignature(dxilData, dxilSize, stage, entryPoint, nullptr, 0, outMetallib,
+                                                  outReflection);
 }
 
-bool IRConverterBridge::compileDXILToMetallibWithRootSignature(
-    const uint8_t* dxilData,
-    size_t dxilSize,
-    ShaderStage stage,
-    const char* entryPoint,
-    const void* rootSignatureData,
-    size_t rootSignatureSize,
-    std::vector<uint8_t>& outMetallib,
-    IRConverterReflection& outReflection
-) {
-    if (!m_loaded || !dxilData || dxilSize == 0) return false;
+bool IRConverterBridge::compileDXILToMetallibWithRootSignature(const uint8_t* dxilData, size_t dxilSize,
+                                                               ShaderStage stage, const char* entryPoint,
+                                                               const void* rootSignatureData, size_t rootSignatureSize,
+                                                               std::vector<uint8_t>& outMetallib,
+                                                               IRConverterReflection& outReflection) {
+    if (!m_loaded || !dxilData || dxilSize == 0)
+        return false;
 
     std::lock_guard<std::mutex> lock(m_compileMutex);
 
@@ -443,16 +455,15 @@ bool IRConverterBridge::compileDXILToMetallibWithRootSignature(
     if (rootSignatureData && rootSignatureSize > 0 && f.rootSigDescFromBlob && f.rootSigCreateFromDesc) {
         IRError* rsError = nullptr;
         IRVersionedRootSignatureDescriptor* rsDesc = f.rootSigDescFromBlob(
-            static_cast<const uint8_t*>(rootSignatureData),
-            static_cast<uint32_t>(rootSignatureSize),
-            &rsError
-        );
-        if (rsError) f.errorDestroy(rsError);
+            static_cast<const uint8_t*>(rootSignatureData), static_cast<uint32_t>(rootSignatureSize), &rsError);
+        if (rsError)
+            f.errorDestroy(rsError);
 
         if (rsDesc) {
             IRError* createError = nullptr;
             IRRootSignature* rootSig = f.rootSigCreateFromDesc(rsDesc, &createError);
-            if (createError) f.errorDestroy(createError);
+            if (createError)
+                f.errorDestroy(createError);
             f.rootSigDescRelease(rsDesc);
 
             if (rootSig) {
@@ -506,7 +517,8 @@ bool IRConverterBridge::compileDXILToMetallibWithRootSignature(
     IRMetalLibBinary* metallib = f.metallibCreate();
     if (!metallib) {
         f.objectDestroy(compiled);
-        if (compileError) f.errorDestroy(compileError);
+        if (compileError)
+            f.errorDestroy(compileError);
         return false;
     }
 
@@ -514,13 +526,10 @@ bool IRConverterBridge::compileDXILToMetallibWithRootSignature(
     if (!gotBinary) {
         MS_WARN("IRConverterBridge: no metallib for stage, trying all stages");
         static const IRShaderStage stages[] = {
-            IRShaderStageVertex, IRShaderStageFragment, IRShaderStageCompute,
-            IRShaderStageGeometry, IRShaderStageHull, IRShaderStageDomain,
-            IRShaderStageMesh, IRShaderStageAmplification,
-            IRShaderStageRayGeneration, IRShaderStageClosestHit,
-            IRShaderStageMiss, IRShaderStageIntersection,
-            IRShaderStageAnyHit, IRShaderStageCallable
-        };
+            IRShaderStageVertex,        IRShaderStageFragment,   IRShaderStageCompute, IRShaderStageGeometry,
+            IRShaderStageHull,          IRShaderStageDomain,     IRShaderStageMesh,    IRShaderStageAmplification,
+            IRShaderStageRayGeneration, IRShaderStageClosestHit, IRShaderStageMiss,    IRShaderStageIntersection,
+            IRShaderStageAnyHit,        IRShaderStageCallable};
         for (auto s : stages) {
             if (f.objectGetMetalLib(compiled, s, metallib)) {
                 gotBinary = true;
@@ -533,7 +542,8 @@ bool IRConverterBridge::compileDXILToMetallibWithRootSignature(
         MS_ERROR("IRConverterBridge: no metallib binary produced");
         f.metallibDestroy(metallib);
         f.objectDestroy(compiled);
-        if (compileError) f.errorDestroy(compileError);
+        if (compileError)
+            f.errorDestroy(compileError);
         return false;
     }
 
@@ -541,7 +551,8 @@ bool IRConverterBridge::compileDXILToMetallibWithRootSignature(
     if (bytecodeSize == 0) {
         f.metallibDestroy(metallib);
         f.objectDestroy(compiled);
-        if (compileError) f.errorDestroy(compileError);
+        if (compileError)
+            f.errorDestroy(compileError);
         return false;
     }
 
@@ -624,29 +635,26 @@ bool IRConverterBridge::compileDXILToMetallibWithRootSignature(
 
     f.metallibDestroy(metallib);
     f.objectDestroy(compiled);
-    if (compileError) f.errorDestroy(compileError);
+    if (compileError)
+        f.errorDestroy(compileError);
 
     MS_INFO("IRConverterBridge: compiled DXIL → metallib (%zu bytes, stage %d)", bytecodeSize, (int)stage);
     return true;
 }
 
-bool IRConverterBridge::compileRayTracingShader(
-    const uint8_t* dxilData,
-    size_t dxilSize,
-    ShaderStage stage,
-    const char* entryPoint,
-    uint32_t maxRecursionDepth,
-    uint32_t maxAttributeSize,
-    std::vector<uint8_t>& outMetallib,
-    IRConverterReflection& outReflection
-) {
-    if (!m_loaded || !dxilData || dxilSize == 0) return false;
+bool IRConverterBridge::compileRayTracingShader(const uint8_t* dxilData, size_t dxilSize, ShaderStage stage,
+                                                const char* entryPoint, uint32_t maxRecursionDepth,
+                                                uint32_t maxAttributeSize, std::vector<uint8_t>& outMetallib,
+                                                IRConverterReflection& outReflection) {
+    if (!m_loaded || !dxilData || dxilSize == 0)
+        return false;
 
     std::lock_guard<std::mutex> lock(m_compileMutex);
     auto& f = *m_fn;
 
     IRCompiler* compiler = f.compilerCreate();
-    if (!compiler) return false;
+    if (!compiler)
+        return false;
     auto compilerCleanup = [&](IRCompiler*) { f.compilerDestroy(compiler); };
     std::unique_ptr<IRCompiler, decltype(compilerCleanup)> compilerGuard(compiler, compilerCleanup);
 
@@ -655,7 +663,10 @@ bool IRConverterBridge::compileRayTracingShader(
     if (f.rtPipelineConfigCreate && f.compilerSetRTPipeline) {
         IRRayTracingPipelineConfiguration* rtConfig = f.rtPipelineConfigCreate();
         if (rtConfig) {
-            auto rtCleanup = [&](IRRayTracingPipelineConfiguration*) { if (f.rtPipelineConfigDestroy) f.rtPipelineConfigDestroy(rtConfig); };
+            auto rtCleanup = [&](IRRayTracingPipelineConfiguration*) {
+                if (f.rtPipelineConfigDestroy)
+                    f.rtPipelineConfigDestroy(rtConfig);
+            };
             std::unique_ptr<IRRayTracingPipelineConfiguration, decltype(rtCleanup)> rtGuard(rtConfig, rtCleanup);
 
             if (f.rtSetMaxRecursion)
@@ -668,37 +679,47 @@ bool IRConverterBridge::compileRayTracingShader(
     }
 
     IRObject* irObject = f.objectCreateFromDXIL(dxilData, dxilSize, IRBytecodeOwnershipCopy);
-    if (!irObject) return false;
+    if (!irObject)
+        return false;
 
     IRError* compileError = nullptr;
     IRObject* compiled = f.compileAndLink(compiler, entryPoint, irObject, &compileError);
     f.objectDestroy(irObject);
 
     if (!compiled) {
-        if (compileError) { f.errorDestroy(compileError); }
+        if (compileError) {
+            f.errorDestroy(compileError);
+        }
         return false;
     }
 
     IRShaderStage irStage = toIRStage(stage);
     IRMetalLibBinary* metallib = f.metallibCreate();
-    if (!metallib) { f.objectDestroy(compiled); if (compileError) f.errorDestroy(compileError); return false; }
+    if (!metallib) {
+        f.objectDestroy(compiled);
+        if (compileError)
+            f.errorDestroy(compileError);
+        return false;
+    }
 
     bool gotBinary = f.objectGetMetalLib(compiled, irStage, metallib);
     if (!gotBinary) {
-        static const IRShaderStage rtStages[] = {
-            IRShaderStageRayGeneration, IRShaderStageClosestHit,
-            IRShaderStageMiss, IRShaderStageIntersection,
-            IRShaderStageAnyHit, IRShaderStageCallable
-        };
+        static const IRShaderStage rtStages[] = {IRShaderStageRayGeneration, IRShaderStageClosestHit,
+                                                 IRShaderStageMiss,          IRShaderStageIntersection,
+                                                 IRShaderStageAnyHit,        IRShaderStageCallable};
         for (auto s : rtStages) {
-            if (f.objectGetMetalLib(compiled, s, metallib)) { gotBinary = true; break; }
+            if (f.objectGetMetalLib(compiled, s, metallib)) {
+                gotBinary = true;
+                break;
+            }
         }
     }
 
     if (!gotBinary) {
         f.metallibDestroy(metallib);
         f.objectDestroy(compiled);
-        if (compileError) f.errorDestroy(compileError);
+        if (compileError)
+            f.errorDestroy(compileError);
         return false;
     }
 
@@ -706,7 +727,8 @@ bool IRConverterBridge::compileRayTracingShader(
     if (bytecodeSize == 0) {
         f.metallibDestroy(metallib);
         f.objectDestroy(compiled);
-        if (compileError) f.errorDestroy(compileError);
+        if (compileError)
+            f.errorDestroy(compileError);
         return false;
     }
 
@@ -715,9 +737,11 @@ bool IRConverterBridge::compileRayTracingShader(
 
     f.metallibDestroy(metallib);
     f.objectDestroy(compiled);
-    if (compileError) f.errorDestroy(compileError);
+    if (compileError)
+        f.errorDestroy(compileError);
 
-    MS_INFO("IRConverterBridge: compiled RT shader → metallib (%zu bytes, stage %d, maxRecursion=%u)", bytecodeSize, (int)stage, maxRecursionDepth);
+    MS_INFO("IRConverterBridge: compiled RT shader → metallib (%zu bytes, stage %d, maxRecursion=%u)", bytecodeSize,
+            (int)stage, maxRecursionDepth);
     return true;
 }
 
@@ -754,7 +778,8 @@ ShaderCompileService::~ShaderCompileService() {
 }
 
 bool ShaderCompileService::init(uint32_t numThreads) {
-    if (m_running.load()) return true;
+    if (m_running.load())
+        return true;
 
     if (numThreads == 0)
         numThreads = std::max(1u, std::thread::hardware_concurrency() / 2);
@@ -775,11 +800,13 @@ bool ShaderCompileService::init(uint32_t numThreads) {
 }
 
 void ShaderCompileService::shutdown() {
-    if (!m_running.load()) return;
+    if (!m_running.load())
+        return;
     m_running.store(false);
     m_queueCV.notify_all();
     for (auto& w : m_workers) {
-        if (w.joinable()) w.join();
+        if (w.joinable())
+            w.join();
     }
     m_workers.clear();
 }
@@ -816,11 +843,12 @@ void ShaderCompileService::workerLoop() {
         std::pair<ShaderCompileRequest, std::promise<ShaderCompileResult>> work;
         {
             std::unique_lock<std::mutex> lock(m_queueMutex);
-            m_queueCV.wait_for(lock, std::chrono::milliseconds(100), [this] {
-                return !m_queue.empty() || !m_running.load();
-            });
-            if (!m_running.load() && m_queue.empty()) return;
-            if (m_queue.empty()) continue;
+            m_queueCV.wait_for(lock, std::chrono::milliseconds(100),
+                               [this] { return !m_queue.empty() || !m_running.load(); });
+            if (!m_running.load() && m_queue.empty())
+                return;
+            if (m_queue.empty())
+                continue;
             work = std::move(m_queue.front());
             m_queue.pop();
         }
@@ -850,27 +878,21 @@ void ShaderCompileService::workerLoop() {
         bool ok;
         if (!work.first.rootSignatureData.empty()) {
             ok = bridge.compileDXILToMetallibWithRootSignature(
-                dxil.data(), dxil.size(),
-                work.first.stage,
+                dxil.data(), dxil.size(), work.first.stage,
                 work.first.entryPoint.empty() ? nullptr : work.first.entryPoint.c_str(),
-                work.first.rootSignatureData.data(),
-                work.first.rootSignatureData.size(),
-                result.metallib,
-                result.reflection
-            );
+                work.first.rootSignatureData.data(), work.first.rootSignatureData.size(), result.metallib,
+                result.reflection);
         } else {
-            ok = bridge.compileDXILToMetallib(
-                dxil.data(), dxil.size(),
-                work.first.stage,
-                work.first.entryPoint.empty() ? nullptr : work.first.entryPoint.c_str(),
-                result.metallib,
-                result.reflection
-            );
+            ok = bridge.compileDXILToMetallib(dxil.data(), dxil.size(), work.first.stage,
+                                              work.first.entryPoint.empty() ? nullptr : work.first.entryPoint.c_str(),
+                                              result.metallib, result.reflection);
         }
 
         result.success = ok;
-        if (!ok) result.error = "libmetalirconverter compilation failed";
-        if (ok) m_compiledCount.fetch_add(1);
+        if (!ok)
+            result.error = "libmetalirconverter compilation failed";
+        if (ok)
+            m_compiledCount.fetch_add(1);
 
         if (ok && !m_cacheDir.empty()) {
             storeDiskCache(work.first.hash, result);
@@ -881,11 +903,13 @@ void ShaderCompileService::workerLoop() {
 }
 
 bool ShaderCompileService::checkDiskCache(uint64_t hash, ShaderCompileResult& out) {
-    if (m_cacheDir.empty()) return false;
+    if (m_cacheDir.empty())
+        return false;
 
     std::string path = m_cacheDir + "/metallib_cache/" + std::to_string(hash) + ".metallib";
     std::ifstream file(path, std::ios::binary);
-    if (!file.is_open()) return false;
+    if (!file.is_open())
+        return false;
 
     out.hash = hash;
     out.success = true;
@@ -894,9 +918,8 @@ bool ShaderCompileService::checkDiskCache(uint64_t hash, ShaderCompileResult& ou
     std::string jsonPath = m_cacheDir + "/metallib_cache/" + std::to_string(hash) + ".json";
     std::ifstream jsonFile(jsonPath);
     if (jsonFile.is_open()) {
-        out.reflection.reflectionJSON.assign(
-            std::istreambuf_iterator<char>(jsonFile), std::istreambuf_iterator<char>()
-        );
+        out.reflection.reflectionJSON.assign(std::istreambuf_iterator<char>(jsonFile),
+                                             std::istreambuf_iterator<char>());
     }
 
     return true;
@@ -926,44 +949,73 @@ IRConverterBridge& IRConverterBridge::instance() {
     static IRConverterBridge inst;
     return inst;
 }
-bool IRConverterBridge::loadDylib() { return false; }
+bool IRConverterBridge::loadDylib() {
+    return false;
+}
 void IRConverterBridge::unloadDylib() {}
-bool IRConverterBridge::isAvailable() const { return false; }
+bool IRConverterBridge::isAvailable() const {
+    return false;
+}
 
 bool IRConverterBridge::isDXIL(const uint8_t* data, size_t size) const {
-    if (!data || size < 16) return false;
+    if (!data || size < 16)
+        return false;
     uint32_t magic;
     memcpy(&magic, data, 4);
-    if (magic == DXIL_MAGIC) return true;
+    if (magic == DXIL_MAGIC)
+        return true;
     if (magic == DXBC_MAGIC && size >= 32) {
         uint32_t chunkCount;
         memcpy(&chunkCount, data + 28, 4);
         for (uint32_t i = 0; i < chunkCount; ++i) {
             uint32_t offset;
-            if (32 + i * 4 + 4 > size) break;
+            if (32 + i * 4 + 4 > size)
+                break;
             memcpy(&offset, data + 32 + i * 4, 4);
-            if (offset + 8 > size) continue;
+            if (offset + 8 > size)
+                continue;
             uint32_t chunkMagic;
             memcpy(&chunkMagic, data + offset, 4);
-            if (chunkMagic == DXIL_MAGIC) return true;
+            if (chunkMagic == DXIL_MAGIC)
+                return true;
         }
     }
     return false;
 }
 
-uint32_t IRConverterBridge::detectShaderModel(const uint8_t* data, size_t size) const { return 0; }
-bool IRConverterBridge::extractDXILFromDXBC(const uint8_t*, size_t, std::vector<uint8_t>&) { return false; }
-bool IRConverterBridge::compileDXILToMetallib(const uint8_t*, size_t, ShaderStage, const char*, std::vector<uint8_t>&, IRConverterReflection&) { return false; }
-bool IRConverterBridge::compileDXILToMetallibWithRootSignature(const uint8_t*, size_t, ShaderStage, const char*, const void*, size_t, std::vector<uint8_t>&, IRConverterReflection&) { return false; }
-bool IRConverterBridge::compileRayTracingShader(const uint8_t*, size_t, ShaderStage, const char*, uint32_t, uint32_t, std::vector<uint8_t>&, IRConverterReflection&) { return false; }
-IRConverterBridge::ShaderModelCapabilities IRConverterBridge::getShaderModelCapabilities(uint32_t) const { return {}; }
+uint32_t IRConverterBridge::detectShaderModel(const uint8_t* data, size_t size) const {
+    return 0;
+}
+bool IRConverterBridge::extractDXILFromDXBC(const uint8_t*, size_t, std::vector<uint8_t>&) {
+    return false;
+}
+bool IRConverterBridge::compileDXILToMetallib(const uint8_t*, size_t, ShaderStage, const char*, std::vector<uint8_t>&,
+                                              IRConverterReflection&) {
+    return false;
+}
+bool IRConverterBridge::compileDXILToMetallibWithRootSignature(const uint8_t*, size_t, ShaderStage, const char*,
+                                                               const void*, size_t, std::vector<uint8_t>&,
+                                                               IRConverterReflection&) {
+    return false;
+}
+bool IRConverterBridge::compileRayTracingShader(const uint8_t*, size_t, ShaderStage, const char*, uint32_t, uint32_t,
+                                                std::vector<uint8_t>&, IRConverterReflection&) {
+    return false;
+}
+IRConverterBridge::ShaderModelCapabilities IRConverterBridge::getShaderModelCapabilities(uint32_t) const {
+    return {};
+}
 
 ShaderCompileService& ShaderCompileService::instance() {
     static ShaderCompileService inst;
     return inst;
 }
-ShaderCompileService::~ShaderCompileService() { shutdown(); }
-bool ShaderCompileService::init(uint32_t) { return false; }
+ShaderCompileService::~ShaderCompileService() {
+    shutdown();
+}
+bool ShaderCompileService::init(uint32_t) {
+    return false;
+}
 void ShaderCompileService::shutdown() {}
 void ShaderCompileService::setCacheDir(const std::string&) {}
 std::future<ShaderCompileResult> ShaderCompileService::submit(const ShaderCompileRequest&) {
@@ -975,9 +1027,11 @@ std::future<ShaderCompileResult> ShaderCompileService::submit(const ShaderCompil
     return p.get_future();
 }
 void ShaderCompileService::workerLoop() {}
-bool ShaderCompileService::checkDiskCache(uint64_t, ShaderCompileResult&) { return false; }
+bool ShaderCompileService::checkDiskCache(uint64_t, ShaderCompileResult&) {
+    return false;
+}
 void ShaderCompileService::storeDiskCache(uint64_t, const ShaderCompileResult&) {}
 
 #endif // METALSHARP_HAS_IRCONVERTER
 
-}
+} // namespace metalsharp

--- a/src/metal/shader/IRConverterBridge.mm
+++ b/src/metal/shader/IRConverterBridge.mm
@@ -5,23 +5,25 @@
 /// objects for shader function extraction. Bridges the dylib converter results
 /// into the Metal Objective-C API surface.
 
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
 #include <metalsharp/IRConverterBridge.h>
 #include <metalsharp/Logger.h>
-#import <Metal/Metal.h>
-#import <Foundation/Foundation.h>
 
 namespace metalsharp {
 
 void* createMTLLibraryFromMetallib(const uint8_t* data, size_t size) {
-    if (!data || size == 0) return nullptr;
+    if (!data || size == 0)
+        return nullptr;
 
     id<MTLDevice> device = MTLCreateSystemDefaultDevice();
-    if (!device) return nullptr;
+    if (!device)
+        return nullptr;
 
-    dispatch_data_t dispatchData = dispatch_data_create(
-        data, size, dispatch_get_main_queue(), DISPATCH_DATA_DESTRUCTOR_DEFAULT
-    );
-    if (!dispatchData) return nullptr;
+    dispatch_data_t dispatchData =
+        dispatch_data_create(data, size, dispatch_get_main_queue(), DISPATCH_DATA_DESTRUCTOR_DEFAULT);
+    if (!dispatchData)
+        return nullptr;
 
     NSError* error = nil;
     id<MTLLibrary> library = [device newLibraryWithData:dispatchData error:&error];
@@ -37,7 +39,8 @@ void* createMTLLibraryFromMetallib(const uint8_t* data, size_t size) {
 }
 
 void* getFunctionFromLibrary(void* libraryPtr, const char* name) {
-    if (!libraryPtr || !name) return nullptr;
+    if (!libraryPtr || !name)
+        return nullptr;
 
     id<MTLLibrary> library = (__bridge id<MTLLibrary>)libraryPtr;
     NSString* nsName = [NSString stringWithUTF8String:name];
@@ -47,9 +50,10 @@ void* getFunctionFromLibrary(void* libraryPtr, const char* name) {
 }
 
 void releaseMTLObject(void* obj) {
-    if (!obj) return;
+    if (!obj)
+        return;
     id nsObj = (__bridge_transfer id)obj;
     (void)nsObj;
 }
 
-}
+} // namespace metalsharp

--- a/src/metal/shader/ShaderTranslator.mm
+++ b/src/metal/shader/ShaderTranslator.mm
@@ -5,13 +5,13 @@
 /// DXIL bytecode via the IR converter bridge or DXBC-to-MSL fallback, and produces
 /// Metal shader functions ready for pipeline state creation.
 
-#include <metalsharp/ShaderTranslator.h>
-#include <metalsharp/MetalBackend.h>
+#include <Foundation/Foundation.h>
+#include <Metal/Metal.h>
 #include <metalsharp/DXBCParser.h>
 #include <metalsharp/DXBCtoMSL.h>
 #include <metalsharp/Logger.h>
-#include <Foundation/Foundation.h>
-#include <Metal/Metal.h>
+#include <metalsharp/MetalBackend.h>
+#include <metalsharp/ShaderTranslator.h>
 
 namespace metalsharp {
 
@@ -27,10 +27,14 @@ ShaderTranslator::ShaderTranslator() : m_impl(new Impl()) {
     m_impl->device = MTLCreateSystemDefaultDevice();
 }
 
-ShaderTranslator::~ShaderTranslator() { delete m_impl; }
+ShaderTranslator::~ShaderTranslator() {
+    delete m_impl;
+}
 
-bool ShaderTranslator::compileMSL(const char* source, const char* vertexEntry, const char* fragmentEntry, CompiledShader& out) {
-    if (!m_impl->device || !source) return false;
+bool ShaderTranslator::compileMSL(const char* source, const char* vertexEntry, const char* fragmentEntry,
+                                  CompiledShader& out) {
+    if (!m_impl->device || !source)
+        return false;
 
     NSString* sourceNS = [NSString stringWithUTF8String:source];
     NSError* error = nil;
@@ -56,33 +60,26 @@ bool ShaderTranslator::compileMSL(const char* source, const char* vertexEntry, c
     return true;
 }
 
-bool ShaderTranslator::translateViaIRConverter(
-    const uint8_t* dxilData, size_t dxilSize,
-    ShaderStage stage, const char* entryPoint,
-    const void* rootSigData, size_t rootSigSize,
-    CompiledShader& out
-) {
+bool ShaderTranslator::translateViaIRConverter(const uint8_t* dxilData, size_t dxilSize, ShaderStage stage,
+                                               const char* entryPoint, const void* rootSigData, size_t rootSigSize,
+                                               CompiledShader& out) {
     auto& bridge = IRConverterBridge::instance();
-    if (!bridge.isAvailable()) return false;
+    if (!bridge.isAvailable())
+        return false;
 
     std::vector<uint8_t> metallib;
     IRConverterReflection reflection;
 
     bool ok;
     if (rootSigData && rootSigSize > 0) {
-        ok = bridge.compileDXILToMetallibWithRootSignature(
-            dxilData, dxilSize, stage, entryPoint,
-            rootSigData, rootSigSize,
-            metallib, reflection
-        );
+        ok = bridge.compileDXILToMetallibWithRootSignature(dxilData, dxilSize, stage, entryPoint, rootSigData,
+                                                           rootSigSize, metallib, reflection);
     } else {
-        ok = bridge.compileDXILToMetallib(
-            dxilData, dxilSize, stage, entryPoint,
-            metallib, reflection
-        );
+        ok = bridge.compileDXILToMetallib(dxilData, dxilSize, stage, entryPoint, metallib, reflection);
     }
 
-    if (!ok || metallib.empty()) return false;
+    if (!ok || metallib.empty())
+        return false;
 
     void* lib = createMTLLibraryFromMetallib(metallib.data(), metallib.size());
     if (!lib) {
@@ -91,7 +88,8 @@ bool ShaderTranslator::translateViaIRConverter(
     }
 
     const char* funcName = reflection.entryPointName.empty() ? entryPoint : reflection.entryPointName.c_str();
-    if (!funcName) funcName = "main0";
+    if (!funcName)
+        funcName = "main0";
 
     void* func = getFunctionFromLibrary(lib, funcName);
 
@@ -103,32 +101,50 @@ bool ShaderTranslator::translateViaIRConverter(
     out.entryPointName = funcName;
 
     switch (stage) {
-        case ShaderStage::Vertex: out.vertexFunction = func; break;
-        case ShaderStage::Pixel: out.fragmentFunction = func; break;
-        case ShaderStage::Compute: out.computeFunction = func; break;
-        default: break;
+    case ShaderStage::Vertex:
+        out.vertexFunction = func;
+        break;
+    case ShaderStage::Pixel:
+        out.fragmentFunction = func;
+        break;
+    case ShaderStage::Compute:
+        out.computeFunction = func;
+        break;
+    default:
+        break;
     }
 
     MS_INFO("ShaderTranslator: compiled via IRConverter (stage=%d, entry=%s)", (int)stage, funcName);
     return true;
 }
 
-bool ShaderTranslator::translateViaFallbackDXBC(const uint8_t* data, size_t size, ShaderStage stage, CompiledShader& out) {
+bool ShaderTranslator::translateViaFallbackDXBC(const uint8_t* data, size_t size, ShaderStage stage,
+                                                CompiledShader& out) {
     ParsedDXBC parsed;
-    if (!DXBCParser::parse(data, size, parsed)) return false;
+    if (!DXBCParser::parse(data, size, parsed))
+        return false;
 
     std::string mslSource = DXBCtoMSL::translate(parsed);
-    if (mslSource.empty()) return false;
+    if (mslSource.empty())
+        return false;
 
     const char* entryName = "main0";
     switch (stage) {
-        case ShaderStage::Vertex: entryName = "vertexShader"; break;
-        case ShaderStage::Pixel: entryName = "fragmentShader"; break;
-        case ShaderStage::Compute: entryName = "computeShader"; break;
-        default: break;
+    case ShaderStage::Vertex:
+        entryName = "vertexShader";
+        break;
+    case ShaderStage::Pixel:
+        entryName = "fragmentShader";
+        break;
+    case ShaderStage::Compute:
+        entryName = "computeShader";
+        break;
+    default:
+        break;
     }
 
-    if (!m_impl->device) return false;
+    if (!m_impl->device)
+        return false;
 
     NSString* sourceNS = [NSString stringWithUTF8String:mslSource.c_str()];
     NSError* error = nil;
@@ -150,16 +166,17 @@ bool ShaderTranslator::translateViaFallbackDXBC(const uint8_t* data, size_t size
     out.computeFunction = nullptr;
 
     switch (stage) {
-        case ShaderStage::Vertex:
-            out.vertexFunction = func ? (__bridge_retained void*)func : nullptr;
-            break;
-        case ShaderStage::Pixel:
-            out.fragmentFunction = func ? (__bridge_retained void*)func : nullptr;
-            break;
-        case ShaderStage::Compute:
-            out.computeFunction = func ? (__bridge_retained void*)func : nullptr;
-            break;
-        default: break;
+    case ShaderStage::Vertex:
+        out.vertexFunction = func ? (__bridge_retained void*)func : nullptr;
+        break;
+    case ShaderStage::Pixel:
+        out.fragmentFunction = func ? (__bridge_retained void*)func : nullptr;
+        break;
+    case ShaderStage::Compute:
+        out.computeFunction = func ? (__bridge_retained void*)func : nullptr;
+        break;
+    default:
+        break;
     }
 
     MS_INFO("ShaderTranslator: compiled via DXBC->MSL fallback (stage=%d)", (int)stage);
@@ -167,7 +184,8 @@ bool ShaderTranslator::translateViaFallbackDXBC(const uint8_t* data, size_t size
 }
 
 bool ShaderTranslator::translateDXIL(const uint8_t* data, size_t size, ShaderStage stage, CompiledShader& out) {
-    if (!data || size == 0) return false;
+    if (!data || size == 0)
+        return false;
     return translateViaIRConverter(data, size, stage, nullptr, nullptr, 0, out);
 }
 
@@ -175,13 +193,11 @@ bool ShaderTranslator::translateDXBC(const uint8_t* data, size_t size, ShaderSta
     return translateDXBCWithRootSignature(data, size, stage, nullptr, 0, out);
 }
 
-bool ShaderTranslator::translateDXBCWithRootSignature(
-    const uint8_t* data, size_t size,
-    ShaderStage stage,
-    const void* rootSigData, size_t rootSigSize,
-    CompiledShader& out
-) {
-    if (!data || size == 0) return false;
+bool ShaderTranslator::translateDXBCWithRootSignature(const uint8_t* data, size_t size, ShaderStage stage,
+                                                      const void* rootSigData, size_t rootSigSize,
+                                                      CompiledShader& out) {
+    if (!data || size == 0)
+        return false;
 
     auto& bridge = IRConverterBridge::instance();
 
@@ -194,17 +210,14 @@ bool ShaderTranslator::translateDXBCWithRootSignature(
             bool extracted = bridge.extractDXILFromDXBC(data, size, dxil);
             if (!extracted) {
                 uint32_t sm = bridge.detectShaderModel(data, size);
-                MS_INFO("ShaderTranslator: DXBC SM %u.%u — no DXIL chunk, using MSL fallback",
-                         sm / 10, sm % 10);
+                MS_INFO("ShaderTranslator: DXBC SM %u.%u — no DXIL chunk, using MSL fallback", sm / 10, sm % 10);
                 return translateViaFallbackDXBC(data, size, stage, out);
             }
         }
 
-        bool ok = translateViaIRConverter(
-            dxil.data(), dxil.size(), stage, nullptr,
-            rootSigData, rootSigSize, out
-        );
-        if (ok) return true;
+        bool ok = translateViaIRConverter(dxil.data(), dxil.size(), stage, nullptr, rootSigData, rootSigSize, out);
+        if (ok)
+            return true;
 
         MS_WARN("ShaderTranslator: IRConverter failed, falling back to DXBC->MSL");
     }
@@ -212,4 +225,4 @@ bool ShaderTranslator::translateDXBCWithRootSignature(
     return translateViaFallbackDXBC(data, size, stage, out);
 }
 
-}
+} // namespace metalsharp

--- a/src/perf/BufferPool.mm
+++ b/src/perf/BufferPool.mm
@@ -1,11 +1,13 @@
 /// @file BufferPool.mm
 /// @brief MTLBuffer allocation pool with size-class recycling.
 ///
-/// Recycles MTLBuffer allocations by size class to avoid repeated GPU heap allocation. Tracks buffer lifetimes via Metal shareable event fences and returns completed buffers to the free list for reuse. Reduces allocation latency for dynamic vertex/index buffers.
+/// Recycles MTLBuffer allocations by size class to avoid repeated GPU heap allocation. Tracks buffer lifetimes via
+/// Metal shareable event fences and returns completed buffers to the free list for reuse. Reduces allocation latency
+/// for dynamic vertex/index buffers.
+#include <algorithm>
+#include <cstring>
 #include <metalsharp/BufferPool.h>
 #include <metalsharp/Logger.h>
-#include <cstring>
-#include <algorithm>
 
 #import <Metal/Metal.h>
 
@@ -36,10 +38,12 @@ void BufferPool::shutdown() {
 
 void* BufferPool::allocate(size_t size) {
     std::lock_guard<std::mutex> lock(m_mutex);
-    if (!m_initialized || !m_device) return nullptr;
+    if (!m_initialized || !m_device)
+        return nullptr;
 
     size_t searchMax = size * 2;
-    if (searchMax < size) searchMax = size;
+    if (searchMax < size)
+        searchMax = size;
 
     void* reused = findFree(size, searchMax);
     if (reused) {
@@ -56,7 +60,8 @@ void* BufferPool::allocate(size_t size) {
 
 void BufferPool::release(void* buffer) {
     std::lock_guard<std::mutex> lock(m_mutex);
-    if (!buffer) return;
+    if (!buffer)
+        return;
 
     for (auto& entry : m_entries) {
         if (entry.buffer == buffer) {
@@ -69,7 +74,8 @@ void BufferPool::release(void* buffer) {
 void* BufferPool::createBuffer(size_t size) {
     id<MTLDevice> device = (__bridge id<MTLDevice>)m_device;
     id<MTLBuffer> buffer = [device newBufferWithLength:size options:MTLResourceStorageModeShared];
-    if (!buffer) return nullptr;
+    if (!buffer)
+        return nullptr;
 
     BufferPoolEntry entry;
     entry.buffer = (__bridge_retained void*)buffer;
@@ -92,7 +98,8 @@ void* BufferPool::findFree(size_t minSize, size_t maxSize) {
 uint64_t BufferPool::activeBuffers() const {
     uint64_t count = 0;
     for (auto& entry : m_entries) {
-        if (entry.inUse) count++;
+        if (entry.inUse)
+            count++;
     }
     return count;
 }
@@ -100,9 +107,10 @@ uint64_t BufferPool::activeBuffers() const {
 uint64_t BufferPool::pooledBuffers() const {
     uint64_t count = 0;
     for (auto& entry : m_entries) {
-        if (!entry.inUse) count++;
+        if (!entry.inUse)
+            count++;
     }
     return count;
 }
 
-}
+} // namespace metalsharp

--- a/src/perf/CommandBatcher.cpp
+++ b/src/perf/CommandBatcher.cpp
@@ -1,7 +1,8 @@
 /// @file CommandBatcher.cpp
 /// @brief Metal command buffer batching for reduced submit overhead.
 ///
-/// Groups multiple D3D11 draw calls into fewer Metal command buffers to reduce commit overhead. Tracks render pass boundaries and automatically flushes when the batch size limit or resource hazard is detected.
+/// Groups multiple D3D11 draw calls into fewer Metal command buffers to reduce commit overhead. Tracks render pass
+/// boundaries and automatically flushes when the batch size limit or resource hazard is detected.
 #include <metalsharp/CommandBatcher.h>
 #include <metalsharp/Logger.h>
 
@@ -32,7 +33,8 @@ void CommandBatcher::endFrame() {
 }
 
 void CommandBatcher::enqueue(const BatchedCommand& cmd) {
-    if (!m_initialized) return;
+    if (!m_initialized)
+        return;
 
     m_batch.push_back(cmd);
     m_totalBatches++;
@@ -43,7 +45,8 @@ void CommandBatcher::enqueue(const BatchedCommand& cmd) {
 }
 
 void CommandBatcher::flush() {
-    if (m_batch.empty()) return;
+    if (m_batch.empty())
+        return;
     if (!m_execute) {
         m_batch.clear();
         return;
@@ -61,4 +64,4 @@ void CommandBatcher::setExecuteFunction(ExecuteFn fn) {
     m_execute = fn;
 }
 
-}
+} // namespace metalsharp

--- a/src/perf/FramePacer.cpp
+++ b/src/perf/FramePacer.cpp
@@ -1,13 +1,14 @@
 /// @file FramePacer.cpp
 /// @brief Display-linked frame pacing with adaptive rate control.
 ///
-/// Regulates frame presentation timing to match the display's refresh rate, preventing tearing and stutter. Uses sleep/spin-wait hybrid for precise V-sync-like pacing without relying on Metal's built-in presentWithin handler.
+/// Regulates frame presentation timing to match the display's refresh rate, preventing tearing and stutter. Uses
+/// sleep/spin-wait hybrid for precise V-sync-like pacing without relying on Metal's built-in presentWithin handler.
+#include <algorithm>
+#include <chrono>
+#include <cmath>
 #include <metalsharp/FramePacer.h>
 #include <metalsharp/Logger.h>
-#include <chrono>
 #include <thread>
-#include <cmath>
-#include <algorithm>
 
 namespace metalsharp {
 
@@ -26,11 +27,12 @@ void FramePacer::init(double targetFPS) {
     m_frameTimeAccum = 0;
     m_currentFPS = 0;
     m_frameTimeHistory.resize(120, 0);
-    MS_INFO("FramePacer initialized: target %.1f FPS (%.2f ms), present mode: %s",
-            targetFPS, m_targetFrameTime * 1000.0,
-            m_presentMode == PresentMode::VSync ? "VSync" :
-            m_presentMode == PresentMode::Immediate ? "Immediate" :
-            m_presentMode == PresentMode::HalfRateVSync ? "HalfRateVSync" : "Adaptive");
+    MS_INFO("FramePacer initialized: target %.1f FPS (%.2f ms), present mode: %s", targetFPS,
+            m_targetFrameTime * 1000.0,
+            m_presentMode == PresentMode::VSync           ? "VSync"
+            : m_presentMode == PresentMode::Immediate     ? "Immediate"
+            : m_presentMode == PresentMode::HalfRateVSync ? "HalfRateVSync"
+                                                          : "Adaptive");
 }
 
 void FramePacer::shutdown() {
@@ -38,7 +40,8 @@ void FramePacer::shutdown() {
 }
 
 void FramePacer::beginFrame() {
-    if (!m_initialized || !m_enabled) return;
+    if (!m_initialized || !m_enabled)
+        return;
 
     auto now = std::chrono::high_resolution_clock::now();
     auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch());
@@ -46,7 +49,8 @@ void FramePacer::beginFrame() {
 }
 
 void FramePacer::endFrame() {
-    if (!m_initialized || !m_enabled) return;
+    if (!m_initialized || !m_enabled)
+        return;
 
     auto now = std::chrono::high_resolution_clock::now();
     auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch());
@@ -78,8 +82,10 @@ void FramePacer::endFrame() {
 }
 
 void FramePacer::waitForVSync() {
-    if (!m_initialized || !m_enabled) return;
-    if (m_presentMode == PresentMode::Immediate) return;
+    if (!m_initialized || !m_enabled)
+        return;
+    if (m_presentMode == PresentMode::Immediate)
+        return;
 
     double elapsed = m_lastFrameEnd - m_lastFrameStart;
     double remaining = m_targetFrameTime - elapsed;
@@ -95,7 +101,8 @@ void FramePacer::waitForVSync() {
 }
 
 double FramePacer::computePresentTime() const {
-    if (m_presentMode == PresentMode::Immediate) return 0;
+    if (m_presentMode == PresentMode::Immediate)
+        return 0;
 
     double target = m_targetFrameTime;
     if (m_presentMode == PresentMode::HalfRateVSync) {
@@ -135,7 +142,8 @@ void FramePacer::setPresentMode(PresentMode mode) {
 }
 
 double FramePacer::getFrameTimePercentile(double percentile) const {
-    if (m_frameTimeHistory.empty()) return 0;
+    if (m_frameTimeHistory.empty())
+        return 0;
 
     std::vector<double> sorted = m_frameTimeHistory;
     std::sort(sorted.begin(), sorted.end());
@@ -144,4 +152,4 @@ double FramePacer::getFrameTimePercentile(double percentile) const {
     return sorted[idx];
 }
 
-}
+} // namespace metalsharp

--- a/src/perf/GPUProfiler.mm
+++ b/src/perf/GPUProfiler.mm
@@ -1,13 +1,14 @@
 /// @file GPUProfiler.mm
 /// @brief Metal GPU timing profiler with frame-level metrics.
 ///
-/// Uses MTLCounterSampleBuffer and Metal timestamp queries to measure GPU execution time per frame and per render pass. Aggregates min/max/average frame times and reports bottlenecks for D3D11 draw call batches.
+/// Uses MTLCounterSampleBuffer and Metal timestamp queries to measure GPU execution time per frame and per render pass.
+/// Aggregates min/max/average frame times and reports bottlenecks for D3D11 draw call batches.
+#include <algorithm>
+#include <chrono>
+#include <cstring>
+#import <Metal/Metal.h>
 #include <metalsharp/GPUProfiler.h>
 #include <metalsharp/Logger.h>
-#import <Metal/Metal.h>
-#include <chrono>
-#include <algorithm>
-#include <cstring>
 
 namespace metalsharp {
 
@@ -30,7 +31,8 @@ void GPUProfiler::shutdown() {
 }
 
 void GPUProfiler::beginFrame() {
-    if (!m_initialized || !m_enabled) return;
+    if (!m_initialized || !m_enabled)
+        return;
 
     auto now = std::chrono::high_resolution_clock::now();
     auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch());
@@ -42,7 +44,8 @@ void GPUProfiler::beginFrame() {
 }
 
 void GPUProfiler::endFrame() {
-    if (!m_initialized || !m_enabled) return;
+    if (!m_initialized || !m_enabled)
+        return;
 
     auto now = std::chrono::high_resolution_clock::now();
     auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch());
@@ -65,7 +68,8 @@ void GPUProfiler::endFrame() {
 }
 
 void GPUProfiler::beginPass(const std::string& name) {
-    if (!m_initialized || !m_enabled) return;
+    if (!m_initialized || !m_enabled)
+        return;
 
     auto now = std::chrono::high_resolution_clock::now();
     auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch());
@@ -79,7 +83,8 @@ void GPUProfiler::beginPass(const std::string& name) {
 }
 
 void GPUProfiler::endPass(const std::string& name) {
-    if (!m_initialized || !m_enabled) return;
+    if (!m_initialized || !m_enabled)
+        return;
 
     auto now = std::chrono::high_resolution_clock::now();
     auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch());
@@ -94,10 +99,12 @@ void GPUProfiler::endPass(const std::string& name) {
 }
 
 void GPUProfiler::recordGPUTiming(void* commandBuffer) {
-    if (!m_initialized || !m_enabled) return;
+    if (!m_initialized || !m_enabled)
+        return;
 
     id<MTLCommandBuffer> cmdBuf = (__bridge id<MTLCommandBuffer>)commandBuffer;
-    if (!cmdBuf) return;
+    if (!cmdBuf)
+        return;
 
     double gpuStart = [cmdBuf GPUStartTime];
     double gpuEnd = [cmdBuf GPUEndTime];
@@ -118,7 +125,8 @@ void GPUProfiler::recordGPUTiming(void* commandBuffer) {
 }
 
 void GPUProfiler::recordDraw(const std::string& passName, uint32_t vertexCount, uint32_t instanceCount) {
-    if (!m_initialized || !m_enabled) return;
+    if (!m_initialized || !m_enabled)
+        return;
 
     for (auto* pass : m_activePasses) {
         if (pass->name == passName) {
@@ -130,7 +138,8 @@ void GPUProfiler::recordDraw(const std::string& passName, uint32_t vertexCount, 
 }
 
 void GPUProfiler::recordCompute(const std::string& passName, uint32_t tgX, uint32_t tgY, uint32_t tgZ) {
-    if (!m_initialized || !m_enabled) return;
+    if (!m_initialized || !m_enabled)
+        return;
 
     for (auto* pass : m_activePasses) {
         if (pass->name == passName) {
@@ -149,7 +158,8 @@ GPUProfiler::FrameStats GPUProfiler::getLastFrameStats() const {
     stats.triangles = 0;
     stats.frameIndex = 0;
 
-    if (m_history.empty()) return stats;
+    if (m_history.empty())
+        return stats;
 
     const auto& frame = m_history.back();
     stats.frameTime = frame.endTime - frame.startTime;
@@ -176,7 +186,8 @@ GPUProfiler::FrameStats GPUProfiler::getAverageStats(uint32_t numFrames) const {
     avg.frameIndex = 0;
 
     uint32_t count = std::min(numFrames, static_cast<uint32_t>(m_history.size()));
-    if (count == 0) return avg;
+    if (count == 0)
+        return avg;
 
     auto start = m_history.end() - count;
     for (auto it = start; it != m_history.end(); ++it) {
@@ -202,4 +213,4 @@ void GPUProfiler::setStatsCallback(StatsCallback callback) {
     m_callback = callback;
 }
 
-}
+} // namespace metalsharp

--- a/src/perf/MetalFXUpscaler.mm
+++ b/src/perf/MetalFXUpscaler.mm
@@ -1,10 +1,12 @@
 /// @file MetalFXUpscaler.mm
 /// @brief MetalFX spatial/temporal upscaling integration.
 ///
-/// Wraps Apple's MetalFX framework (MTLFXSpatialScaler / MTLFXTemporalScaler) to provide DLSS-style upscaling from lower-resolution render targets. Supports dynamic resolution scaling with configurable quality presets (quality, balanced, performance).
-#include <metalsharp/MetalFXUpscaler.h>
-#include <metalsharp/Logger.h>
+/// Wraps Apple's MetalFX framework (MTLFXSpatialScaler / MTLFXTemporalScaler) to provide DLSS-style upscaling from
+/// lower-resolution render targets. Supports dynamic resolution scaling with configurable quality presets (quality,
+/// balanced, performance).
 #include <dlfcn.h>
+#include <metalsharp/Logger.h>
+#include <metalsharp/MetalFXUpscaler.h>
 
 #import <Metal/Metal.h>
 
@@ -42,10 +44,10 @@ MetalFXUpscaler::~MetalFXUpscaler() {
     shutdown();
 }
 
-bool MetalFXUpscaler::init(uint32_t inputWidth, uint32_t inputHeight,
-                           uint32_t outputWidth, uint32_t outputHeight,
+bool MetalFXUpscaler::init(uint32_t inputWidth, uint32_t inputHeight, uint32_t outputWidth, uint32_t outputHeight,
                            uint32_t format) {
-    if (!m_available) return false;
+    if (!m_available)
+        return false;
 
     m_inputWidth = inputWidth;
     m_inputHeight = inputHeight;
@@ -53,8 +55,7 @@ bool MetalFXUpscaler::init(uint32_t inputWidth, uint32_t inputHeight,
     m_outputHeight = outputHeight;
     m_initialized = true;
 
-    MS_INFO("MetalFX spatial upscaler: %ux%u -> %ux%u",
-            inputWidth, inputHeight, outputWidth, outputHeight);
+    MS_INFO("MetalFX spatial upscaler: %ux%u -> %ux%u", inputWidth, inputHeight, outputWidth, outputHeight);
     return true;
 }
 
@@ -62,20 +63,19 @@ void MetalFXUpscaler::shutdown() {
     m_initialized = false;
 }
 
-bool MetalFXUpscaler::process(void* inputTexture, void* outputTexture,
-                               void* depthTexture, void* motionTexture,
-                               float jitterX, float jitterY,
-                               float motionScaleX, float motionScaleY) {
-    if (!m_available || !m_initialized) return false;
+bool MetalFXUpscaler::process(void* inputTexture, void* outputTexture, void* depthTexture, void* motionTexture,
+                              float jitterX, float jitterY, float motionScaleX, float motionScaleY) {
+    if (!m_available || !m_initialized)
+        return false;
 
-    if (!inputTexture || !outputTexture) return false;
+    if (!inputTexture || !outputTexture)
+        return false;
 
     id<MTLTexture> input = (__bridge id<MTLTexture>)inputTexture;
     id<MTLTexture> output = (__bridge id<MTLTexture>)outputTexture;
 
-    MS_TRACE("MetalFX spatial upscale: input %dx%d -> output %dx%d, sharpness=%.2f",
-             (int)input.width, (int)input.height,
-             (int)output.width, (int)output.height, m_sharpness);
+    MS_TRACE("MetalFX spatial upscale: input %dx%d -> output %dx%d, sharpness=%.2f", (int)input.width,
+             (int)input.height, (int)output.width, (int)output.height, m_sharpness);
 
     return true;
 }
@@ -101,7 +101,8 @@ MetalFXInterpolator::~MetalFXInterpolator() {
 }
 
 bool MetalFXInterpolator::init(uint32_t width, uint32_t height, uint32_t format) {
-    if (!m_available) return false;
+    if (!m_available)
+        return false;
     m_initialized = true;
     return true;
 }
@@ -110,11 +111,11 @@ void MetalFXInterpolator::shutdown() {
     m_initialized = false;
 }
 
-bool MetalFXInterpolator::process(void* outputTexture,
-                                   void* depthTexture, void* motionTexture,
-                                   float jitterX, float jitterY) {
-    if (!m_available || !m_initialized) return false;
+bool MetalFXInterpolator::process(void* outputTexture, void* depthTexture, void* motionTexture, float jitterX,
+                                  float jitterY) {
+    if (!m_available || !m_initialized)
+        return false;
     return true;
 }
 
-}
+} // namespace metalsharp

--- a/src/perf/PipelineCache.cpp
+++ b/src/perf/PipelineCache.cpp
@@ -1,13 +1,15 @@
 /// @file PipelineCache.cpp
 /// @brief Render pipeline state cache with LRU eviction.
 ///
-/// Caches compiled MTLRenderPipelineState objects keyed by a hash of their descriptor (shader functions, blend state, vertex layout, pixel format). Persists cache entries to disk for warm-start across runs. Uses LRU eviction to bound memory usage.
-#include <metalsharp/PipelineCache.h>
-#include <metalsharp/Logger.h>
+/// Caches compiled MTLRenderPipelineState objects keyed by a hash of their descriptor (shader functions, blend state,
+/// vertex layout, pixel format). Persists cache entries to disk for warm-start across runs. Uses LRU eviction to bound
+/// memory usage.
+#include <algorithm>
 #include <cstring>
 #include <fstream>
+#include <metalsharp/Logger.h>
+#include <metalsharp/PipelineCache.h>
 #include <sys/stat.h>
-#include <algorithm>
 
 namespace metalsharp {
 
@@ -41,7 +43,8 @@ void PipelineCache::shutdown() {
 
 void* PipelineCache::lookup(uint64_t hash) {
     std::lock_guard<std::mutex> lock(m_mutex);
-    if (!m_initialized) return nullptr;
+    if (!m_initialized)
+        return nullptr;
 
     auto it = m_entries.find(hash);
     if (it != m_entries.end()) {
@@ -57,7 +60,8 @@ void* PipelineCache::lookup(uint64_t hash) {
 
 void PipelineCache::store(uint64_t hash, void* pipelineState, const std::string& label) {
     std::lock_guard<std::mutex> lock(m_mutex);
-    if (!m_initialized) return;
+    if (!m_initialized)
+        return;
 
     auto& entry = m_entries[hash];
     entry.hash = hash;
@@ -74,7 +78,8 @@ void PipelineCache::store(uint64_t hash, void* pipelineState, const std::string&
 
 void PipelineCache::storeDescriptor(uint64_t hash, const void* desc, size_t descSize, const std::string& label) {
     std::lock_guard<std::mutex> lock(m_mutex);
-    if (!m_initialized) return;
+    if (!m_initialized)
+        return;
 
     auto& entry = m_entries[hash];
     entry.hash = hash;
@@ -82,9 +87,8 @@ void PipelineCache::storeDescriptor(uint64_t hash, const void* desc, size_t desc
     entry.lastAccess = std::chrono::steady_clock::now();
 
     if (desc && descSize > 0) {
-        entry.serializedDescriptor.assign(
-            static_cast<const uint8_t*>(desc),
-            static_cast<const uint8_t*>(desc) + descSize);
+        entry.serializedDescriptor.assign(static_cast<const uint8_t*>(desc),
+                                          static_cast<const uint8_t*>(desc) + descSize);
     }
 
     if (std::find(m_lruOrder.begin(), m_lruOrder.end(), hash) == m_lruOrder.end()) {
@@ -96,10 +100,12 @@ void PipelineCache::storeDescriptor(uint64_t hash, const void* desc, size_t desc
 
 bool PipelineCache::getDescriptor(uint64_t hash, std::vector<uint8_t>& outDesc, std::string& outLabel) {
     std::lock_guard<std::mutex> lock(m_mutex);
-    if (!m_initialized) return false;
+    if (!m_initialized)
+        return false;
 
     auto it = m_entries.find(hash);
-    if (it == m_entries.end() || it->second.serializedDescriptor.empty()) return false;
+    if (it == m_entries.end() || it->second.serializedDescriptor.empty())
+        return false;
 
     outDesc = it->second.serializedDescriptor;
     outLabel = it->second.label;
@@ -141,11 +147,13 @@ void PipelineCache::clear() {
 }
 
 bool PipelineCache::saveToDisk() {
-    if (m_cacheDir.empty()) return false;
+    if (m_cacheDir.empty())
+        return false;
 
     std::string indexPath = m_cacheDir + "/pipeline_cache.bin";
     std::ofstream idx(indexPath, std::ios::binary);
-    if (!idx.is_open()) return false;
+    if (!idx.is_open())
+        return false;
 
     uint32_t count = static_cast<uint32_t>(m_entries.size());
     idx.write(reinterpret_cast<const char*>(&count), 4);
@@ -154,11 +162,13 @@ bool PipelineCache::saveToDisk() {
         idx.write(reinterpret_cast<const char*>(&hash), 8);
         uint32_t labelLen = static_cast<uint32_t>(entry.label.size());
         idx.write(reinterpret_cast<const char*>(&labelLen), 4);
-        if (labelLen > 0) idx.write(entry.label.data(), labelLen);
+        if (labelLen > 0)
+            idx.write(entry.label.data(), labelLen);
 
         uint32_t descSize = static_cast<uint32_t>(entry.serializedDescriptor.size());
         idx.write(reinterpret_cast<const char*>(&descSize), 4);
-        if (descSize > 0) idx.write(reinterpret_cast<const char*>(entry.serializedDescriptor.data()), descSize);
+        if (descSize > 0)
+            idx.write(reinterpret_cast<const char*>(entry.serializedDescriptor.data()), descSize);
     }
 
     MS_INFO("PipelineCache: saved %u entries to %s", count, indexPath.c_str());
@@ -166,15 +176,18 @@ bool PipelineCache::saveToDisk() {
 }
 
 bool PipelineCache::loadFromDisk() {
-    if (m_cacheDir.empty()) return false;
+    if (m_cacheDir.empty())
+        return false;
 
     std::string indexPath = m_cacheDir + "/pipeline_cache.bin";
     std::ifstream idx(indexPath, std::ios::binary);
-    if (!idx.is_open()) return false;
+    if (!idx.is_open())
+        return false;
 
     uint32_t count = 0;
     idx.read(reinterpret_cast<char*>(&count), 4);
-    if (count > m_maxEntries) return false;
+    if (count > m_maxEntries)
+        return false;
 
     for (uint32_t i = 0; i < count; i++) {
         uint64_t hash = 0;
@@ -210,4 +223,4 @@ bool PipelineCache::loadFromDisk() {
     return true;
 }
 
-}
+} // namespace metalsharp

--- a/src/perf/RenderThreadPool.cpp
+++ b/src/perf/RenderThreadPool.cpp
@@ -1,10 +1,11 @@
 /// @file RenderThreadPool.cpp
 /// @brief Thread pool for parallel command buffer encoding.
 ///
-/// Manages a pool of worker threads that encode Metal command buffers in parallel, splitting draw call batches across threads. Uses work-stealing queues and fence-based synchronization to preserve D3D11 submission order.
-#include <metalsharp/RenderThreadPool.h>
-#include <metalsharp/Logger.h>
+/// Manages a pool of worker threads that encode Metal command buffers in parallel, splitting draw call batches across
+/// threads. Uses work-stealing queues and fence-based synchronization to preserve D3D11 submission order.
 #include <algorithm>
+#include <metalsharp/Logger.h>
+#include <metalsharp/RenderThreadPool.h>
 
 namespace metalsharp {
 
@@ -14,7 +15,8 @@ RenderThreadPool& RenderThreadPool::instance() {
 }
 
 void RenderThreadPool::init(uint32_t threadCount) {
-    if (m_initialized) return;
+    if (m_initialized)
+        return;
 
     if (threadCount == 0) {
         threadCount = std::max(1u, std::thread::hardware_concurrency() / 2);
@@ -34,7 +36,8 @@ void RenderThreadPool::init(uint32_t threadCount) {
 }
 
 void RenderThreadPool::shutdown() {
-    if (!m_initialized) return;
+    if (!m_initialized)
+        return;
 
     {
         std::lock_guard<std::mutex> lock(m_queueMutex);
@@ -43,7 +46,8 @@ void RenderThreadPool::shutdown() {
     m_queueCV.notify_all();
 
     for (auto& t : m_threads) {
-        if (t.joinable()) t.join();
+        if (t.joinable())
+            t.join();
     }
     m_threads.clear();
     m_queue.clear();
@@ -51,7 +55,8 @@ void RenderThreadPool::shutdown() {
 }
 
 uint64_t RenderThreadPool::submit(std::function<void()> task) {
-    if (!m_initialized || !m_running) return 0;
+    if (!m_initialized || !m_running)
+        return 0;
 
     RenderTask rt;
     rt.work = std::move(task);
@@ -68,7 +73,8 @@ uint64_t RenderThreadPool::submit(std::function<void()> task) {
 }
 
 void RenderThreadPool::submitBarrier() {
-    if (!m_initialized || !m_running) return;
+    if (!m_initialized || !m_running)
+        return;
 
     RenderTask barrier;
     barrier.isBarrier = true;
@@ -83,9 +89,7 @@ void RenderThreadPool::submitBarrier() {
 
 void RenderThreadPool::waitIdle() {
     std::unique_lock<std::mutex> lock(m_queueMutex);
-    m_completionCV.wait(lock, [this] {
-        return m_queue.empty() && m_tasksCompleted >= m_tasksSubmitted;
-    });
+    m_completionCV.wait(lock, [this] { return m_queue.empty() && m_tasksCompleted >= m_tasksSubmitted; });
 }
 
 void RenderThreadPool::workerLoop() {
@@ -93,11 +97,10 @@ void RenderThreadPool::workerLoop() {
         RenderTask task;
         {
             std::unique_lock<std::mutex> lock(m_queueMutex);
-            m_queueCV.wait(lock, [this] {
-                return !m_queue.empty() || !m_running;
-            });
+            m_queueCV.wait(lock, [this] { return !m_queue.empty() || !m_running; });
 
-            if (!m_running && m_queue.empty()) return;
+            if (!m_running && m_queue.empty())
+                return;
 
             task = std::move(m_queue.front());
             m_queue.pop_front();
@@ -140,7 +143,8 @@ void CommandBufferPool::shutdown() {
 
 void* CommandBufferPool::acquire() {
     std::lock_guard<std::mutex> lock(m_mutex);
-    if (!m_initialized || !m_commandQueue) return nullptr;
+    if (!m_initialized || !m_commandQueue)
+        return nullptr;
 
     for (auto& entry : m_pool) {
         if (!entry.inUse) {
@@ -154,7 +158,8 @@ void* CommandBufferPool::acquire() {
 
 void CommandBufferPool::release(void* buffer) {
     std::lock_guard<std::mutex> lock(m_mutex);
-    if (!buffer) return;
+    if (!buffer)
+        return;
 
     for (auto& entry : m_pool) {
         if (entry.buffer == buffer) {
@@ -172,7 +177,8 @@ void CommandBufferPool::release(void* buffer) {
 uint64_t CommandBufferPool::activeCount() const {
     uint64_t count = 0;
     for (const auto& entry : m_pool) {
-        if (entry.inUse) count++;
+        if (entry.inUse)
+            count++;
     }
     return count;
 }
@@ -180,9 +186,10 @@ uint64_t CommandBufferPool::activeCount() const {
 uint64_t CommandBufferPool::pooledCount() const {
     uint64_t count = 0;
     for (const auto& entry : m_pool) {
-        if (!entry.inUse) count++;
+        if (!entry.inUse)
+            count++;
     }
     return count;
 }
 
-}
+} // namespace metalsharp

--- a/src/perf/ShaderCache.cpp
+++ b/src/perf/ShaderCache.cpp
@@ -1,15 +1,16 @@
 /// @file ShaderCache.cpp
 /// @brief DXBC-to-MSL shader compilation cache (platform-agnostic logic).
 ///
-/// Manages the on-disk shader cache that maps DXBC bytecode hashes to compiled MSL source. Handles cache lookup, insertion, serialization, and stale entry cleanup. Metal-specific compilation lives in the .mm counterpart.
-#include <metalsharp/ShaderCache.h>
-#include <metalsharp/Logger.h>
-#include <fstream>
-#include <cstring>
-#include <cstdlib>
-#include <sys/stat.h>
-#include <dirent.h>
+/// Manages the on-disk shader cache that maps DXBC bytecode hashes to compiled MSL source. Handles cache lookup,
+/// insertion, serialization, and stale entry cleanup. Metal-specific compilation lives in the .mm counterpart.
 #include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <dirent.h>
+#include <fstream>
+#include <metalsharp/Logger.h>
+#include <metalsharp/ShaderCache.h>
+#include <sys/stat.h>
 
 namespace metalsharp {
 
@@ -55,7 +56,8 @@ uint64_t ShaderCache::computeHash(const uint8_t* data, size_t size) {
 
 bool ShaderCache::lookup(uint64_t hash, CachedShader& out) {
     std::lock_guard<std::mutex> lock(m_mutex);
-    if (!m_initialized) return false;
+    if (!m_initialized)
+        return false;
 
     auto it = m_cache.find(hash);
     if (it != m_cache.end()) {
@@ -70,7 +72,8 @@ bool ShaderCache::lookup(uint64_t hash, CachedShader& out) {
 
 void ShaderCache::store(uint64_t hash, const CachedShader& shader) {
     std::lock_guard<std::mutex> lock(m_mutex);
-    if (!m_initialized) return;
+    if (!m_initialized)
+        return;
 
     m_cache[hash] = shader;
     m_cache[hash].hash = hash;
@@ -79,7 +82,8 @@ void ShaderCache::store(uint64_t hash, const CachedShader& shader) {
 
 bool ShaderCache::storeMetallib(uint64_t hash, const uint8_t* data, size_t size, const std::string& entryPoint) {
     std::lock_guard<std::mutex> lock(m_mutex);
-    if (!m_initialized) return false;
+    if (!m_initialized)
+        return false;
 
     auto& entry = m_cache[hash];
     entry.hash = hash;
@@ -97,7 +101,8 @@ bool ShaderCache::storeMetallib(uint64_t hash, const uint8_t* data, size_t size,
 
 bool ShaderCache::lookupMetallib(uint64_t hash, std::vector<uint8_t>& outData, std::string& outEntryPoint) {
     std::lock_guard<std::mutex> lock(m_mutex);
-    if (!m_initialized) return false;
+    if (!m_initialized)
+        return false;
 
     auto it = m_cache.find(hash);
     if (it != m_cache.end() && !it->second.metallib.empty()) {
@@ -125,7 +130,8 @@ uint64_t ShaderCache::totalCacheSize() const {
 }
 
 bool ShaderCache::saveToDisk() {
-    if (m_cacheDir.empty()) return false;
+    if (m_cacheDir.empty())
+        return false;
 
     for (auto& [hash, entry] : m_cache) {
         if (!entry.mslSource.empty()) {
@@ -139,19 +145,23 @@ bool ShaderCache::saveToDisk() {
 }
 
 bool ShaderCache::loadFromDisk() {
-    if (m_cacheDir.empty()) return false;
+    if (m_cacheDir.empty())
+        return false;
 
     DIR* dir = opendir(m_cacheDir.c_str());
-    if (!dir) return false;
+    if (!dir)
+        return false;
 
     struct dirent* ent;
     while ((ent = readdir(dir)) != nullptr) {
         std::string name = ent->d_name;
-        if (name.size() < 5) continue;
+        if (name.size() < 5)
+            continue;
 
         std::string ext = name.substr(name.size() - 4);
         auto dot = name.rfind('.');
-        if (dot == std::string::npos) continue;
+        if (dot == std::string::npos)
+            continue;
 
         std::string baseName = name.substr(0, dot);
         uint64_t hash = 0;
@@ -174,11 +184,12 @@ bool ShaderCache::loadFromDisk() {
 
 bool ShaderCache::loadEntry(const std::string& path, uint64_t hash) {
     std::ifstream file(path);
-    if (!file.is_open()) return false;
+    if (!file.is_open())
+        return false;
 
-    std::string source((std::istreambuf_iterator<char>(file)),
-                        std::istreambuf_iterator<char>());
-    if (source.empty()) return false;
+    std::string source((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+    if (source.empty())
+        return false;
 
     CachedShader entry;
     entry.hash = hash;
@@ -194,21 +205,25 @@ bool ShaderCache::loadEntry(const std::string& path, uint64_t hash) {
 
 bool ShaderCache::saveEntry(const std::string& path, uint64_t hash, const CachedShader& shader) {
     std::ofstream file(path);
-    if (!file.is_open()) return false;
+    if (!file.is_open())
+        return false;
     file << shader.mslSource;
     return true;
 }
 
 bool ShaderCache::loadMetallibEntry(const std::string& path, uint64_t hash) {
     std::ifstream file(path, std::ios::binary | std::ios::ate);
-    if (!file.is_open()) return false;
+    if (!file.is_open())
+        return false;
 
     auto fileSize = file.tellg();
-    if (fileSize <= 0) return false;
+    if (fileSize <= 0)
+        return false;
     file.seekg(0, std::ios::beg);
 
     std::vector<uint8_t> data(static_cast<size_t>(fileSize));
-    if (!file.read(reinterpret_cast<char*>(data.data()), fileSize)) return false;
+    if (!file.read(reinterpret_cast<char*>(data.data()), fileSize))
+        return false;
 
     if (!verifyHash(hash, data)) {
         MS_WARN("ShaderCache: metallib hash verification failed for %s", path.c_str());
@@ -223,12 +238,13 @@ bool ShaderCache::loadMetallibEntry(const std::string& path, uint64_t hash) {
 
 bool ShaderCache::saveMetallibEntry(const std::string& path, uint64_t hash) {
     auto it = m_cache.find(hash);
-    if (it == m_cache.end() || it->second.metallib.empty()) return false;
+    if (it == m_cache.end() || it->second.metallib.empty())
+        return false;
 
     std::ofstream file(path, std::ios::binary);
-    if (!file.is_open()) return false;
-    file.write(reinterpret_cast<const char*>(it->second.metallib.data()),
-               it->second.metallib.size());
+    if (!file.is_open())
+        return false;
+    file.write(reinterpret_cast<const char*>(it->second.metallib.data()), it->second.metallib.size());
     return true;
 }
 
@@ -257,4 +273,4 @@ void ShaderCache::clear() {
     m_misses = 0;
 }
 
-}
+} // namespace metalsharp

--- a/src/perf/ShaderCache.mm
+++ b/src/perf/ShaderCache.mm
@@ -1,22 +1,25 @@
 /// @file ShaderCache.mm
 /// @brief Metal shader compilation and library caching.
 ///
-/// Compiles MSL source strings into MTLLibrary and MTLFunction objects using the Metal device. Caches compiled Metal libraries in memory and synchronizes with the on-disk cache managed by ShaderCache.cpp for cross-session persistence.
-#include <metalsharp/ShaderCache.h>
-#import <Metal/Metal.h>
+/// Compiles MSL source strings into MTLLibrary and MTLFunction objects using the Metal device. Caches compiled Metal
+/// libraries in memory and synchronizes with the on-disk cache managed by ShaderCache.cpp for cross-session
+/// persistence.
 #import <Foundation/Foundation.h>
-#include <metalsharp/Logger.h>
 #include <fstream>
+#import <Metal/Metal.h>
+#include <metalsharp/Logger.h>
+#include <metalsharp/ShaderCache.h>
 
 namespace metalsharp {
 
 bool ShaderCache::loadEntry(const std::string& path, uint64_t hash) {
     std::ifstream file(path);
-    if (!file.is_open()) return false;
+    if (!file.is_open())
+        return false;
 
-    std::string source((std::istreambuf_iterator<char>(file)),
-                        std::istreambuf_iterator<char>());
-    if (source.empty()) return false;
+    std::string source((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+    if (source.empty())
+        return false;
 
     CachedShader entry;
     entry.hash = hash;
@@ -33,7 +36,8 @@ bool ShaderCache::loadEntry(const std::string& path, uint64_t hash) {
             NSArray<NSString*>* names = [library functionNames];
             for (NSString* name in names) {
                 id<MTLFunction> func = [library newFunctionWithName:name];
-                if (!func) continue;
+                if (!func)
+                    continue;
 
                 std::string nameStr = [name UTF8String];
                 if (nameStr.find("vertex") != std::string::npos || nameStr == "vs" || nameStr == "VS") {
@@ -47,8 +51,8 @@ bool ShaderCache::loadEntry(const std::string& path, uint64_t hash) {
                 }
             }
         } else if (error) {
-            MS_WARN("ShaderCache: failed to precompile %s: %s",
-                    path.c_str(), [[error localizedDescription] UTF8String]);
+            MS_WARN("ShaderCache: failed to precompile %s: %s", path.c_str(),
+                    [[error localizedDescription] UTF8String]);
         }
     }
 
@@ -56,4 +60,4 @@ bool ShaderCache::loadEntry(const std::string& path, uint64_t hash) {
     return true;
 }
 
-}
+} // namespace metalsharp

--- a/src/runtime/CompatDatabase.cpp
+++ b/src/runtime/CompatDatabase.cpp
@@ -5,13 +5,13 @@
 /// file using a manual parser instead of a JSON library. Provides add/update/remove
 /// operations, lookup by game ID, and generates summary reports for the launcher UI.
 
-#include <metalsharp/CompatDatabase.h>
-#include <metalsharp/Logger.h>
-#include <fstream>
-#include <sstream>
+#include <algorithm>
 #include <cstring>
 #include <ctime>
-#include <algorithm>
+#include <fstream>
+#include <metalsharp/CompatDatabase.h>
+#include <metalsharp/Logger.h>
+#include <sstream>
 
 namespace metalsharp {
 
@@ -23,11 +23,16 @@ CompatDatabase& CompatDatabase::instance() {
 }
 
 CompatStatus CompatDatabase::statusFromString(const std::string& s) {
-    if (s == "Platinum") return CompatStatus::Platinum;
-    if (s == "Gold") return CompatStatus::Gold;
-    if (s == "Silver") return CompatStatus::Silver;
-    if (s == "Bronze") return CompatStatus::Bronze;
-    if (s == "Broken") return CompatStatus::Broken;
+    if (s == "Platinum")
+        return CompatStatus::Platinum;
+    if (s == "Gold")
+        return CompatStatus::Gold;
+    if (s == "Silver")
+        return CompatStatus::Silver;
+    if (s == "Bronze")
+        return CompatStatus::Bronze;
+    if (s == "Broken")
+        return CompatStatus::Broken;
     return CompatStatus::Untested;
 }
 
@@ -77,7 +82,8 @@ const GameEntry* CompatDatabase::find(const std::string& gameId) const {
 std::vector<GameEntry> CompatDatabase::queryByStatus(CompatStatus status) const {
     std::vector<GameEntry> result;
     for (const auto& [id, entry] : m_entries) {
-        if (entry.status == status) result.push_back(entry);
+        if (entry.status == status)
+            result.push_back(entry);
     }
     return result;
 }
@@ -97,7 +103,8 @@ size_t CompatDatabase::count() const {
 size_t CompatDatabase::countByStatus(CompatStatus status) const {
     size_t c = 0;
     for (const auto& [id, entry] : m_entries) {
-        if (entry.status == status) c++;
+        if (entry.status == status)
+            c++;
     }
     return c;
 }
@@ -113,7 +120,8 @@ void CompatDatabase::addMissingImport(const std::string& gameId, const MissingIm
     }
 
     for (const auto& existing : entry->missingImports) {
-        if (existing.dll == imp.dll && existing.function == imp.function) return;
+        if (existing.dll == imp.dll && existing.function == imp.function)
+            return;
     }
     entry->missingImports.push_back(imp);
 }
@@ -135,7 +143,8 @@ void CompatDatabase::addCrashRecord(const std::string& gameId, const CrashRecord
 
 std::string CompatDatabase::generateReport(const std::string& gameId) const {
     const auto* entry = find(gameId);
-    if (!entry) return "Game not found: " + gameId + "\n";
+    if (!entry)
+        return "Game not found: " + gameId + "\n";
 
     std::ostringstream ss;
     ss << "=== Compatibility Report: " << entry->name << " ===\n";
@@ -166,7 +175,8 @@ std::string CompatDatabase::generateReport(const std::string& gameId) const {
         for (const auto& crash : entry->crashes) {
             ss << "  Signal " << crash.signal << " at 0x" << std::hex << crash.faultAddr << std::dec;
             ss << " (RIP 0x" << std::hex << crash.rip << std::dec << ")";
-            if (!crash.crashRVA.empty()) ss << " RVA " << crash.crashRVA;
+            if (!crash.crashRVA.empty())
+                ss << " RVA " << crash.crashRVA;
             ss << "\n";
         }
     }
@@ -185,29 +195,37 @@ std::string CompatDatabase::generateReport(const std::string& gameId) const {
 static std::string escapeJson(const std::string& s) {
     std::string out;
     for (char c : s) {
-        if (c == '"') out += "\\\"";
-        else if (c == '\\') out += "\\\\";
-        else if (c == '\n') out += "\\n";
-        else out += c;
+        if (c == '"')
+            out += "\\\"";
+        else if (c == '\\')
+            out += "\\\\";
+        else if (c == '\n')
+            out += "\\n";
+        else
+            out += c;
     }
     return out;
 }
 
 static std::string readQuotedString(const std::string& json, size_t& pos) {
     std::string result;
-    if (pos >= json.size() || json[pos] != '"') return result;
+    if (pos >= json.size() || json[pos] != '"')
+        return result;
     pos++;
     while (pos < json.size() && json[pos] != '"') {
         if (json[pos] == '\\' && pos + 1 < json.size()) {
             pos++;
-            if (json[pos] == 'n') result += '\n';
-            else result += json[pos];
+            if (json[pos] == 'n')
+                result += '\n';
+            else
+                result += json[pos];
         } else {
             result += json[pos];
         }
         pos++;
     }
-    if (pos < json.size()) pos++;
+    if (pos < json.size())
+        pos++;
     return result;
 }
 
@@ -218,8 +236,10 @@ static void skipWhitespace(const std::string& json, size_t& pos) {
 
 static std::string readValue(const std::string& json, size_t& pos) {
     skipWhitespace(json, pos);
-    if (pos >= json.size()) return "";
-    if (json[pos] == '"') return readQuotedString(json, pos);
+    if (pos >= json.size())
+        return "";
+    if (json[pos] == '"')
+        return readQuotedString(json, pos);
     size_t start = pos;
     while (pos < json.size() && json[pos] != ',' && json[pos] != '}' && json[pos] != ']')
         pos++;
@@ -228,26 +248,40 @@ static std::string readValue(const std::string& json, size_t& pos) {
 
 static uint64_t readUint(const std::string& json, size_t& pos) {
     std::string val = readValue(json, pos);
-    try { return std::stoull(val); } catch (...) { return 0; }
+    try {
+        return std::stoull(val);
+    } catch (...) {
+        return 0;
+    }
 }
 
 static uint32_t readUint32(const std::string& json, size_t& pos) {
     std::string val = readValue(json, pos);
-    try { return static_cast<uint32_t>(std::stoul(val)); } catch (...) { return 0; }
+    try {
+        return static_cast<uint32_t>(std::stoul(val));
+    } catch (...) {
+        return 0;
+    }
 }
 
 static int readInt(const std::string& json, size_t& pos) {
     std::string val = readValue(json, pos);
-    try { return std::stoi(val); } catch (...) { return 0; }
+    try {
+        return std::stoi(val);
+    } catch (...) {
+        return 0;
+    }
 }
 
 static std::string findField(const std::string& json, const std::string& key) {
     std::string search = "\"" + key + "\"";
     size_t pos = json.find(search);
-    if (pos == std::string::npos) return "";
+    if (pos == std::string::npos)
+        return "";
     pos += search.size();
     skipWhitespace(json, pos);
-    if (pos < json.size() && json[pos] == ':') pos++;
+    if (pos < json.size() && json[pos] == ':')
+        pos++;
     skipWhitespace(json, pos);
     return readValue(json, pos);
 }
@@ -256,12 +290,15 @@ static std::vector<std::string> findArray(const std::string& json, const std::st
     std::vector<std::string> items;
     std::string search = "\"" + key + "\"";
     size_t pos = json.find(search);
-    if (pos == std::string::npos) return items;
+    if (pos == std::string::npos)
+        return items;
     pos += search.size();
     skipWhitespace(json, pos);
-    if (pos < json.size() && json[pos] == ':') pos++;
+    if (pos < json.size() && json[pos] == ':')
+        pos++;
     skipWhitespace(json, pos);
-    if (pos >= json.size() || json[pos] != '[') return items;
+    if (pos >= json.size() || json[pos] != '[')
+        return items;
     pos++;
     while (pos < json.size() && json[pos] != ']') {
         skipWhitespace(json, pos);
@@ -275,15 +312,18 @@ static std::vector<std::string> findArray(const std::string& json, const std::st
 }
 
 bool CompatDatabase::saveToDisk() {
-    if (m_dbPath.empty()) return false;
+    if (m_dbPath.empty())
+        return false;
 
     std::ofstream file(m_dbPath);
-    if (!file.is_open()) return false;
+    if (!file.is_open())
+        return false;
 
     file << "{\n  \"version\": 1,\n  \"games\": [\n";
     bool first = true;
     for (const auto& [id, e] : m_entries) {
-        if (!first) file << ",\n";
+        if (!first)
+            file << ",\n";
         first = false;
 
         file << "    {\n";
@@ -304,24 +344,27 @@ bool CompatDatabase::saveToDisk() {
         file << "      \"missingImports\": [";
         for (size_t i = 0; i < e.missingImports.size(); i++) {
             const auto& imp = e.missingImports[i];
-            if (i > 0) file << ",";
+            if (i > 0)
+                file << ",";
             file << "\n        {\"dll\":\"" << escapeJson(imp.dll) << "\","
                  << "\"fn\":\"" << escapeJson(imp.function) << "\","
                  << "\"ord\":" << (imp.isOrdinal ? "true" : "false") << ","
                  << "\"n\":" << imp.ordinal << "}";
         }
-        if (!e.missingImports.empty()) file << "\n      ";
+        if (!e.missingImports.empty())
+            file << "\n      ";
         file << "],\n";
 
         file << "      \"crashes\": [";
         for (size_t i = 0; i < e.crashes.size(); i++) {
             const auto& c = e.crashes[i];
-            if (i > 0) file << ",";
-            file << "\n        {\"ts\":" << c.timestamp << ",\"sig\":" << c.signal
-                 << ",\"fa\":" << c.faultAddr << ",\"rip\":" << c.rip
-                 << ",\"rva\":\"" << escapeJson(c.crashRVA) << "\"}";
+            if (i > 0)
+                file << ",";
+            file << "\n        {\"ts\":" << c.timestamp << ",\"sig\":" << c.signal << ",\"fa\":" << c.faultAddr
+                 << ",\"rip\":" << c.rip << ",\"rva\":\"" << escapeJson(c.crashRVA) << "\"}";
         }
-        if (!e.crashes.empty()) file << "\n      ";
+        if (!e.crashes.empty())
+            file << "\n      ";
         file << "]\n";
 
         file << "    }";
@@ -333,28 +376,34 @@ bool CompatDatabase::saveToDisk() {
 }
 
 bool CompatDatabase::loadFromDisk() {
-    if (m_dbPath.empty()) return false;
+    if (m_dbPath.empty())
+        return false;
 
     std::ifstream file(m_dbPath);
-    if (!file.is_open()) return false;
+    if (!file.is_open())
+        return false;
 
-    std::string json((std::istreambuf_iterator<char>(file)),
-                      std::istreambuf_iterator<char>());
-    if (json.empty()) return false;
+    std::string json((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+    if (json.empty())
+        return false;
 
     size_t gamesPos = json.find("\"games\"");
-    if (gamesPos == std::string::npos) return true;
+    if (gamesPos == std::string::npos)
+        return true;
 
     size_t pos = json.find('[', gamesPos);
-    if (pos == std::string::npos) return true;
+    if (pos == std::string::npos)
+        return true;
     pos++;
 
     while (pos < json.size()) {
         size_t objStart = json.find('{', pos);
-        if (objStart == std::string::npos) break;
+        if (objStart == std::string::npos)
+            break;
 
         size_t objEnd = json.find('}', objStart);
-        if (objEnd == std::string::npos) break;
+        if (objEnd == std::string::npos)
+            break;
 
         std::string obj = json.substr(objStart, objEnd - objStart + 1);
 
@@ -371,7 +420,11 @@ bool CompatDatabase::loadFromDisk() {
         {
             size_t p = 0;
             std::string dv = findField(obj, "d3dVersion");
-            if (!dv.empty()) try { entry.d3dVersion = std::stoi(dv); } catch (...) {}
+            if (!dv.empty())
+                try {
+                    entry.d3dVersion = std::stoi(dv);
+                } catch (...) {
+                }
         }
 
         entry.antiCheat = findField(obj, "antiCheat");
@@ -382,11 +435,19 @@ bool CompatDatabase::loadFromDisk() {
 
         {
             std::string lt = findField(obj, "lastTested");
-            if (!lt.empty()) try { entry.lastTested = std::stoull(lt); } catch (...) {}
+            if (!lt.empty())
+                try {
+                    entry.lastTested = std::stoull(lt);
+                } catch (...) {
+                }
         }
         {
             std::string fps = findField(obj, "avgFPS");
-            if (!fps.empty()) try { entry.avgFPS = std::stoi(fps); } catch (...) {}
+            if (!fps.empty())
+                try {
+                    entry.avgFPS = std::stoi(fps);
+                } catch (...) {
+                }
         }
 
         size_t impPos = obj.find("\"missingImports\"");
@@ -398,9 +459,11 @@ bool CompatDatabase::loadFromDisk() {
                 size_t ip = 0;
                 while (ip < impArr.size()) {
                     size_t impObj = impArr.find('{', ip);
-                    if (impObj == std::string::npos) break;
+                    if (impObj == std::string::npos)
+                        break;
                     size_t impEnd = impArr.find('}', impObj);
-                    if (impEnd == std::string::npos) break;
+                    if (impEnd == std::string::npos)
+                        break;
 
                     std::string impData = impArr.substr(impObj, impEnd - impObj + 1);
                     MissingImport mi;
@@ -409,7 +472,11 @@ bool CompatDatabase::loadFromDisk() {
                     std::string ord = findField(impData, "ord");
                     mi.isOrdinal = (ord == "true");
                     std::string n = findField(impData, "n");
-                    if (!n.empty()) try { mi.ordinal = std::stoi(n); } catch (...) {}
+                    if (!n.empty())
+                        try {
+                            mi.ordinal = std::stoi(n);
+                        } catch (...) {
+                        }
                     entry.missingImports.push_back(mi);
 
                     ip = impEnd + 1;
@@ -428,4 +495,4 @@ bool CompatDatabase::loadFromDisk() {
     return true;
 }
 
-}
+} // namespace metalsharp

--- a/src/runtime/CrashDiagnostics.cpp
+++ b/src/runtime/CrashDiagnostics.cpp
@@ -5,11 +5,11 @@
 /// flags, and instruction pointer — and formats them into a human-readable dump
 /// file. Complements CrashReporter with lower-level diagnostic detail.
 
+#include <ctime>
+#include <fstream>
 #include <metalsharp/CrashDiagnostics.h>
 #include <metalsharp/Logger.h>
-#include <fstream>
 #include <sstream>
-#include <ctime>
 #include <sys/stat.h>
 
 namespace metalsharp {
@@ -52,7 +52,8 @@ std::string CrashDiagnostics::formatTimestamp(uint64_t epoch) {
 }
 
 void CrashDiagnostics::writeCrashDump(const CrashInfo& info) {
-    if (!m_initialized) return;
+    if (!m_initialized)
+        return;
 
     m_crashCount++;
 
@@ -73,11 +74,21 @@ void CrashDiagnostics::writeCrashDump(const CrashInfo& info) {
     file << "Signal:     " << info.signal << " (";
 
     switch (info.signal) {
-        case 11: file << "SIGSEGV"; break;
-        case 10: file << "SIGBUS"; break;
-        case 6:  file << "SIGABRT"; break;
-        case 8:  file << "SIGFPE"; break;
-        default: file << "unknown"; break;
+    case 11:
+        file << "SIGSEGV";
+        break;
+    case 10:
+        file << "SIGBUS";
+        break;
+    case 6:
+        file << "SIGABRT";
+        break;
+    case 8:
+        file << "SIGFPE";
+        break;
+    default:
+        file << "unknown";
+        break;
     }
     file << ")\n";
 
@@ -110,11 +121,13 @@ void CrashDiagnostics::writeCrashDump(const CrashInfo& info) {
 }
 
 void CrashDiagnostics::writeDiagnosticsBundle() {
-    if (!m_initialized) return;
+    if (!m_initialized)
+        return;
 
     std::string bundlePath = m_diagDir + "/diagnostics.txt";
     std::ofstream file(bundlePath);
-    if (!file.is_open()) return;
+    if (!file.is_open())
+        return;
 
     file << "=== MetalSharp Diagnostics Bundle ===\n";
     file << "Generated: " << formatTimestamp(static_cast<uint64_t>(time(nullptr))) << "\n\n";
@@ -131,4 +144,4 @@ void CrashDiagnostics::writeDiagnosticsBundle() {
     MS_INFO("CrashDiagnostics: diagnostics bundle written to %s", bundlePath.c_str());
 }
 
-}
+} // namespace metalsharp

--- a/src/runtime/CrashReporter.cpp
+++ b/src/runtime/CrashReporter.cpp
@@ -6,12 +6,12 @@
 /// be safe to call from signal handlers and other constrained contexts.
 
 #include "metalsharp/CrashReporter.h"
-#include <fstream>
-#include <sstream>
-#include <filesystem>
-#include <ctime>
 #include <cstdlib>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
 #include <random>
+#include <sstream>
 
 namespace metalsharp {
 
@@ -60,7 +60,8 @@ void CrashReporter::endSession(int exitCode) {
 
 std::string CrashReporter::getReportsDir() {
     const char* home = std::getenv("HOME");
-    if (!home) return "/tmp/metalsharp/crashes";
+    if (!home)
+        return "/tmp/metalsharp/crashes";
     return std::string(home) + "/.metalsharp/crashes";
 }
 
@@ -104,7 +105,8 @@ CrashReport CrashReporter::collectReport() {
 
     auto readFileIfExists = [&](const std::string& path) -> std::string {
         std::ifstream f(path);
-        if (!f.is_open()) return "";
+        if (!f.is_open())
+            return "";
         std::ostringstream buf;
         buf << f.rdbuf();
         return buf.str();
@@ -119,8 +121,7 @@ CrashReport CrashReporter::collectReport() {
                 auto mtime = fs::last_write_time(entry);
                 auto epoch = static_cast<int64_t>(
 #if __cplusplus >= 202002L
-                    std::chrono::duration_cast<std::chrono::seconds>(
-                        mtime.time_since_epoch()).count()
+                    std::chrono::duration_cast<std::chrono::seconds>(mtime.time_since_epoch()).count()
 #else
                     0
 #endif
@@ -145,7 +146,8 @@ CrashReport CrashReporter::collectReport() {
 std::vector<CrashReport> CrashReporter::getRecentReports(int count) {
     std::vector<CrashReport> reports;
     std::string dir = getReportsDir();
-    if (!fs::exists(dir)) return reports;
+    if (!fs::exists(dir))
+        return reports;
 
     try {
         std::vector<fs::path> files;
@@ -155,26 +157,32 @@ std::vector<CrashReport> CrashReporter::getRecentReports(int count) {
             }
         }
 
-        std::sort(files.begin(), files.end(), [](const fs::path& a, const fs::path& b) {
-            return fs::last_write_time(a) > fs::last_write_time(b);
-        });
+        std::sort(files.begin(), files.end(),
+                  [](const fs::path& a, const fs::path& b) { return fs::last_write_time(a) > fs::last_write_time(b); });
 
         int loaded = 0;
         for (const auto& f : files) {
-            if (loaded >= count) break;
+            if (loaded >= count)
+                break;
 
             std::ifstream file(f);
-            if (!file.is_open()) continue;
+            if (!file.is_open())
+                continue;
 
             CrashReport report;
             report.id = f.stem().string();
             std::string line;
             while (std::getline(file, line)) {
-                if (line.find("timestamp: ") == 0) report.timestamp = line.substr(11);
-                else if (line.find("game: ") == 0) report.gameName = line.substr(6);
-                else if (line.find("exe: ") == 0) report.exePath = line.substr(5);
-                else if (line.find("exit_code: ") == 0) report.exitCode = std::stoi(line.substr(11));
-                else if (line.find("fault_address: ") == 0) report.faultAddress = std::stoull(line.substr(15), nullptr, 16);
+                if (line.find("timestamp: ") == 0)
+                    report.timestamp = line.substr(11);
+                else if (line.find("game: ") == 0)
+                    report.gameName = line.substr(6);
+                else if (line.find("exe: ") == 0)
+                    report.exePath = line.substr(5);
+                else if (line.find("exit_code: ") == 0)
+                    report.exitCode = std::stoi(line.substr(11));
+                else if (line.find("fault_address: ") == 0)
+                    report.faultAddress = std::stoull(line.substr(15), nullptr, 16);
                 else if (line == "--- system ---") {
                     std::ostringstream sys;
                     while (std::getline(file, line) && line != "--- end ---") {
@@ -187,7 +195,8 @@ std::vector<CrashReport> CrashReporter::getRecentReports(int count) {
             reports.push_back(report);
             loaded++;
         }
-    } catch (...) {}
+    } catch (...) {
+    }
 
     return reports;
 }
@@ -198,7 +207,8 @@ bool CrashReporter::saveReport(const CrashReport& report) {
 
     std::string path = dir + "/" + report.id + ".crash";
     std::ofstream f(path);
-    if (!f.is_open()) return false;
+    if (!f.is_open())
+        return false;
 
     f << "id: " << report.id << "\n";
     f << "timestamp: " << report.timestamp << "\n";
@@ -230,4 +240,4 @@ bool CrashReporter::deleteReport(const std::string& id) {
     return fs::remove(path);
 }
 
-}
+} // namespace metalsharp

--- a/src/runtime/DRMDetector.cpp
+++ b/src/runtime/DRMDetector.cpp
@@ -6,11 +6,11 @@
 /// Returns a bitmask of detected DRM systems so the validation pipeline can assess
 /// compatibility impact.
 
+#include <cstring>
+#include <fstream>
 #include <metalsharp/DRMDetector.h>
 #include <metalsharp/Logger.h>
-#include <fstream>
 #include <vector>
-#include <cstring>
 
 namespace metalsharp {
 
@@ -54,9 +54,9 @@ DRMDetector& DRMDetector::instance() {
     return inst;
 }
 
-bool DRMDetector::matchPattern(const uint8_t* data, size_t dataLen,
-                                 const char* pattern, size_t patternLen) const {
-    if (patternLen > dataLen) return false;
+bool DRMDetector::matchPattern(const uint8_t* data, size_t dataLen, const char* pattern, size_t patternLen) const {
+    if (patternLen > dataLen)
+        return false;
 
     for (size_t i = 0; i <= dataLen - patternLen; i++) {
         if (memcmp(data + i, pattern, patternLen) == 0) {
@@ -74,22 +74,24 @@ std::vector<DRMDetection> DRMDetector::scanFile(const std::string& exePath) {
     }
 
     auto fileSize = file.tellg();
-    if (fileSize <= 0 || fileSize > 500 * 1024 * 1024) return {};
+    if (fileSize <= 0 || fileSize > 500 * 1024 * 1024)
+        return {};
 
     file.seekg(0, std::ios::beg);
     std::vector<uint8_t> data(static_cast<size_t>(fileSize));
-    if (!file.read(reinterpret_cast<char*>(data.data()), fileSize)) return {};
+    if (!file.read(reinterpret_cast<char*>(data.data()), fileSize))
+        return {};
 
     auto results = scanMemory(data.data(), data.size());
 
-    MS_INFO("DRMDetector: scanned %s (%zu bytes), %zu detections",
-            exePath.c_str(), data.size(), results.size());
+    MS_INFO("DRMDetector: scanned %s (%zu bytes), %zu detections", exePath.c_str(), data.size(), results.size());
     return results;
 }
 
 std::vector<DRMDetection> DRMDetector::scanMemory(const uint8_t* data, size_t size) {
     std::vector<DRMDetection> results;
-    if (!data || size == 0) return results;
+    if (!data || size == 0)
+        return results;
 
     size_t sigCount = sizeof(kSignatures) / sizeof(kSignatures[0]);
 
@@ -105,7 +107,8 @@ std::vector<DRMDetection> DRMDetector::scanMemory(const uint8_t* data, size_t si
                 break;
             }
         }
-        if (alreadyDetected) continue;
+        if (alreadyDetected)
+            continue;
 
         DRMDetection det;
         det.name = sig.name;
@@ -121,8 +124,10 @@ std::vector<DRMDetection> DRMDetector::scanMemory(const uint8_t* data, size_t si
 
 bool DRMDetector::hasKernelAntiCheat(const std::vector<DRMDetection>& results) const {
     for (const auto& r : results) {
-        if (!r.detected) continue;
-        if (r.type != "Anti-cheat") continue;
+        if (!r.detected)
+            continue;
+        if (r.type != "Anti-cheat")
+            continue;
 
         size_t sigCount = sizeof(kSignatures) / sizeof(kSignatures[0]);
         for (size_t i = 0; i < sigCount; i++) {
@@ -141,11 +146,13 @@ bool DRMDetector::isCompatible(const std::vector<DRMDetection>& results) const {
 std::string DRMDetector::summary(const std::vector<DRMDetection>& results) const {
     std::string s;
     for (const auto& r : results) {
-        if (!r.detected) continue;
-        if (!s.empty()) s += ", ";
+        if (!r.detected)
+            continue;
+        if (!s.empty())
+            s += ", ";
         s += r.name + " [" + r.type + "]";
     }
     return s.empty() ? "No DRM/anti-cheat detected" : s;
 }
 
-}
+} // namespace metalsharp

--- a/src/runtime/GameDetector.cpp
+++ b/src/runtime/GameDetector.cpp
@@ -7,11 +7,11 @@
 /// detected game entries regardless of source platform.
 
 #include "metalsharp/GameDetector.h"
-#include <fstream>
-#include <filesystem>
-#include <sstream>
 #include <algorithm>
 #include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
 
 #ifdef __APPLE__
 #include <sys/stat.h>
@@ -23,19 +23,28 @@ namespace fs = std::filesystem;
 
 std::string GameDetector::platformToString(GamePlatform p) {
     switch (p) {
-        case GamePlatform::Steam: return "steam";
-        case GamePlatform::EpicGamesStore: return "epic";
-        case GamePlatform::GOG: return "gog";
-        case GamePlatform::Local: return "local";
-        default: return "unknown";
+    case GamePlatform::Steam:
+        return "steam";
+    case GamePlatform::EpicGamesStore:
+        return "epic";
+    case GamePlatform::GOG:
+        return "gog";
+    case GamePlatform::Local:
+        return "local";
+    default:
+        return "unknown";
     }
 }
 
 GamePlatform GameDetector::platformFromString(const std::string& s) {
-    if (s == "steam") return GamePlatform::Steam;
-    if (s == "epic") return GamePlatform::EpicGamesStore;
-    if (s == "gog") return GamePlatform::GOG;
-    if (s == "local") return GamePlatform::Local;
+    if (s == "steam")
+        return GamePlatform::Steam;
+    if (s == "epic")
+        return GamePlatform::EpicGamesStore;
+    if (s == "gog")
+        return GamePlatform::GOG;
+    if (s == "local")
+        return GamePlatform::Local;
     return GamePlatform::Unknown;
 }
 
@@ -46,20 +55,19 @@ bool GameDetector::fileExists(const std::string& path) {
 int64_t GameDetector::calculateDirSize(const std::string& dir) {
     int64_t total = 0;
     try {
-        for (const auto& entry : fs::recursive_directory_iterator(dir,
-                     fs::directory_options::skip_permission_denied)) {
+        for (const auto& entry : fs::recursive_directory_iterator(dir, fs::directory_options::skip_permission_denied)) {
             if (entry.is_regular_file()) {
                 total += static_cast<int64_t>(entry.file_size());
             }
         }
-    } catch (...) {}
+    } catch (...) {
+    }
     return total;
 }
 
 std::string GameDetector::findGameExe(const std::string& dir) {
     try {
-        for (const auto& entry : fs::recursive_directory_iterator(dir,
-                     fs::directory_options::skip_permission_denied)) {
+        for (const auto& entry : fs::recursive_directory_iterator(dir, fs::directory_options::skip_permission_denied)) {
             if (entry.is_regular_file()) {
                 auto path = entry.path();
                 if (path.extension() == ".exe") {
@@ -67,7 +75,8 @@ std::string GameDetector::findGameExe(const std::string& dir) {
                 }
             }
         }
-    } catch (...) {}
+    } catch (...) {
+    }
     return "";
 }
 
@@ -90,10 +99,12 @@ std::string GameDetector::findSteamLibraryDirs(const std::string& steamInstallDi
 
 std::vector<DetectedGame> GameDetector::parseSteamLibraryFolders(const std::string& vdfPath) {
     std::vector<DetectedGame> games;
-    if (!fileExists(vdfPath)) return games;
+    if (!fileExists(vdfPath))
+        return games;
 
     std::ifstream f(vdfPath);
-    if (!f.is_open()) return games;
+    if (!f.is_open())
+        return games;
 
     std::string line;
     std::vector<std::string> libraryPaths;
@@ -122,16 +133,19 @@ std::vector<DetectedGame> GameDetector::parseSteamLibraryFolders(const std::stri
 std::vector<DetectedGame> GameDetector::scanSteamApps(const std::string& libraryDir) {
     std::vector<DetectedGame> games;
     std::string steamapps = libraryDir + "/steamapps";
-    if (!fs::exists(steamapps)) return games;
+    if (!fs::exists(steamapps))
+        return games;
 
     try {
         for (const auto& entry : fs::directory_iterator(steamapps)) {
-            if (!entry.is_regular_file()) continue;
+            if (!entry.is_regular_file())
+                continue;
             auto name = entry.path().filename().string();
             if (name.find("appmanifest_") == 0 && name.find(".acf") != std::string::npos) {
                 auto acfPath = entry.path().string();
                 std::ifstream af(acfPath);
-                if (!af.is_open()) continue;
+                if (!af.is_open())
+                    continue;
 
                 DetectedGame game;
                 game.platform = GamePlatform::Steam;
@@ -139,18 +153,24 @@ std::vector<DetectedGame> GameDetector::scanSteamApps(const std::string& library
                 std::string aline;
                 while (std::getline(af, aline)) {
                     auto trim = [](std::string s) {
-                        while (!s.empty() && (s.front() == ' ' || s.front() == '\t')) s.erase(s.begin());
-                        while (!s.empty() && (s.back() == ' ' || s.back() == '\t' || s.back() == '\r' || s.back() == '\n')) s.pop_back();
+                        while (!s.empty() && (s.front() == ' ' || s.front() == '\t'))
+                            s.erase(s.begin());
+                        while (!s.empty() &&
+                               (s.back() == ' ' || s.back() == '\t' || s.back() == '\r' || s.back() == '\n'))
+                            s.pop_back();
                         return s;
                     };
 
                     auto extractValue = [&trim](const std::string& l, const std::string& key) -> std::string {
                         auto p = l.find(key);
-                        if (p == std::string::npos) return "";
+                        if (p == std::string::npos)
+                            return "";
                         auto s = l.find('\"', p + key.length());
-                        if (s == std::string::npos) return "";
+                        if (s == std::string::npos)
+                            return "";
                         auto e = l.find('\"', s + 1);
-                        if (e == std::string::npos) return "";
+                        if (e == std::string::npos)
+                            return "";
                         return l.substr(s + 1, e - s - 1);
                     };
 
@@ -175,7 +195,8 @@ std::vector<DetectedGame> GameDetector::scanSteamApps(const std::string& library
                 }
             }
         }
-    } catch (...) {}
+    } catch (...) {
+    }
 
     return games;
 }
@@ -184,7 +205,8 @@ std::vector<DetectedGame> GameDetector::detectSteam() {
     std::vector<DetectedGame> games;
 
     const char* home = std::getenv("HOME");
-    if (!home) return games;
+    if (!home)
+        return games;
 
     std::string steamDir;
     std::string possiblePaths[] = {
@@ -200,7 +222,8 @@ std::vector<DetectedGame> GameDetector::detectSteam() {
         }
     }
 
-    if (steamDir.empty()) return games;
+    if (steamDir.empty())
+        return games;
 
     std::string vdfPath = findSteamLibraryDirs(steamDir);
     if (fileExists(vdfPath)) {
@@ -217,24 +240,30 @@ std::vector<DetectedGame> GameDetector::detectSteam() {
 
 std::string GameDetector::findEpicManifestDir() {
     const char* home = std::getenv("HOME");
-    if (!home) return "";
+    if (!home)
+        return "";
 
     std::string path = std::string(home) + "/Library/Application Support/Epic/Epic Games Launcher/Data/Manifests";
-    if (fileExists(path)) return path;
+    if (fileExists(path))
+        return path;
     return "";
 }
 
 std::vector<DetectedGame> GameDetector::parseEpicManifests(const std::string& manifestDir) {
     std::vector<DetectedGame> games;
-    if (manifestDir.empty()) return games;
+    if (manifestDir.empty())
+        return games;
 
     try {
         for (const auto& entry : fs::directory_iterator(manifestDir)) {
-            if (!entry.is_regular_file()) continue;
-            if (entry.path().extension() != ".item") continue;
+            if (!entry.is_regular_file())
+                continue;
+            if (entry.path().extension() != ".item")
+                continue;
 
             std::ifstream f(entry.path());
-            if (!f.is_open()) continue;
+            if (!f.is_open())
+                continue;
 
             DetectedGame game;
             game.platform = GamePlatform::EpicGamesStore;
@@ -243,11 +272,14 @@ std::vector<DetectedGame> GameDetector::parseEpicManifests(const std::string& ma
             while (std::getline(f, line)) {
                 auto extractString = [](const std::string& l, const std::string& key) -> std::string {
                     auto p = l.find(key);
-                    if (p == std::string::npos) return "";
+                    if (p == std::string::npos)
+                        return "";
                     auto s = l.find('\"', p + key.length());
-                    if (s == std::string::npos) return "";
+                    if (s == std::string::npos)
+                        return "";
                     auto e = l.find('\"', s + 1);
-                    if (e == std::string::npos) return "";
+                    if (e == std::string::npos)
+                        return "";
                     return l.substr(s + 1, e - s - 1);
                 };
 
@@ -270,7 +302,8 @@ std::vector<DetectedGame> GameDetector::parseEpicManifests(const std::string& ma
                 games.push_back(game);
             }
         }
-    } catch (...) {}
+    } catch (...) {
+    }
 
     return games;
 }
@@ -281,10 +314,12 @@ std::vector<DetectedGame> GameDetector::detectEpic() {
 
 std::string GameDetector::findGOGDbPath() {
     const char* home = std::getenv("HOME");
-    if (!home) return "";
+    if (!home)
+        return "";
 
     std::string path = std::string(home) + "/Library/Application Support/GOG.com/Galaxy/Communities";
-    if (fileExists(path)) return path;
+    if (fileExists(path))
+        return path;
     return "";
 }
 
@@ -298,12 +333,13 @@ std::vector<DetectedGame> GameDetector::detectGOG() {
 
 std::vector<DetectedGame> GameDetector::scanLocalDir(const std::string& dir) {
     std::vector<DetectedGame> games;
-    if (!fileExists(dir)) return games;
+    if (!fileExists(dir))
+        return games;
 
     try {
-        for (const auto& entry : fs::directory_iterator(dir,
-                     fs::directory_options::skip_permission_denied)) {
-            if (!entry.is_directory()) continue;
+        for (const auto& entry : fs::directory_iterator(dir, fs::directory_options::skip_permission_denied)) {
+            if (!entry.is_directory())
+                continue;
 
             DetectedGame game;
             game.id = "local_" + entry.path().filename().string();
@@ -317,17 +353,19 @@ std::vector<DetectedGame> GameDetector::scanLocalDir(const std::string& dir) {
                 games.push_back(game);
             }
         }
-    } catch (...) {}
+    } catch (...) {
+    }
 
     return games;
 }
 
 std::vector<DetectedGame> GameDetector::detectLocal() {
     const char* home = std::getenv("HOME");
-    if (!home) return {};
+    if (!home)
+        return {};
 
     std::string gameDir = std::string(home) + "/.metalsharp/games";
     return scanLocalDir(gameDir);
 }
 
-}
+} // namespace metalsharp

--- a/src/runtime/GameValidator.cpp
+++ b/src/runtime/GameValidator.cpp
@@ -6,11 +6,11 @@
 /// DLL shims, and producing an estimated compatibility status (perfect, partial,
 /// broken). Orchestrates DRMDetector and ImportReporter as pipeline stages.
 
+#include <cstring>
 #include <metalsharp/GameValidator.h>
 #include <metalsharp/ImportReporter.h>
 #include <metalsharp/Logger.h>
 #include <sstream>
-#include <cstring>
 
 namespace metalsharp {
 
@@ -37,7 +37,8 @@ std::string GameValidator::generateGameId(const std::string& exePath) const {
     std::string filename = (slash != std::string::npos) ? exePath.substr(slash + 1) : exePath;
 
     for (auto& c : filename) {
-        if (c == '.' || c == ' ' || c == '\\') c = '_';
+        if (c == '.' || c == ' ' || c == '\\')
+            c = '_';
     }
     return filename;
 }
@@ -56,19 +57,19 @@ CompatStatus GameValidator::estimateStatus(const ValidationResult& result) const
 
     size_t criticalMissing = 0;
     for (const auto& imp : result.missingImports) {
-        if (imp.dll.find("d3d") != std::string::npos ||
-            imp.dll.find("D3D") != std::string::npos ||
-            imp.dll.find("dxgi") != std::string::npos ||
-            imp.dll.find("DXGI") != std::string::npos ||
-            imp.dll.find("kernel32") != std::string::npos ||
-            imp.dll.find("user32") != std::string::npos) {
+        if (imp.dll.find("d3d") != std::string::npos || imp.dll.find("D3D") != std::string::npos ||
+            imp.dll.find("dxgi") != std::string::npos || imp.dll.find("DXGI") != std::string::npos ||
+            imp.dll.find("kernel32") != std::string::npos || imp.dll.find("user32") != std::string::npos) {
             criticalMissing++;
         }
     }
 
-    if (criticalMissing > 5) return CompatStatus::Broken;
-    if (criticalMissing > 0) return CompatStatus::Bronze;
-    if (result.missingImports.size() > 20) return CompatStatus::Silver;
+    if (criticalMissing > 5)
+        return CompatStatus::Broken;
+    if (criticalMissing > 0)
+        return CompatStatus::Bronze;
+    if (result.missingImports.size() > 20)
+        return CompatStatus::Silver;
     return CompatStatus::Gold;
 }
 
@@ -91,8 +92,8 @@ ValidationResult GameValidator::validate(const std::string& exePath, const std::
         bool anyDetected = false;
         for (const auto& d : result.drmResults) {
             if (d.detected) {
-                report << "  DETECTED: " << d.name << " [" << d.type
-                       << "] (confidence: " << (int)(d.confidence * 100) << "%)\n";
+                report << "  DETECTED: " << d.name << " [" << d.type << "] (confidence: " << (int)(d.confidence * 100)
+                       << "%)\n";
                 anyDetected = true;
             }
         }
@@ -146,8 +147,8 @@ ValidationResult GameValidator::quickCheck(const std::string& exePath) {
     auto& detector = DRMDetector::instance();
     result.drmResults = detector.scanFile(exePath);
     result.canLaunch = detector.isCompatible(result.drmResults);
-    result.suggestedStatus = detector.hasKernelAntiCheat(result.drmResults)
-        ? CompatStatus::Broken : CompatStatus::Untested;
+    result.suggestedStatus =
+        detector.hasKernelAntiCheat(result.drmResults) ? CompatStatus::Broken : CompatStatus::Untested;
 
     return result;
 }
@@ -179,4 +180,4 @@ std::string GameValidator::generateFullReport(const std::string& gameId) const {
     return CompatDatabase::instance().generateReport(gameId);
 }
 
-}
+} // namespace metalsharp

--- a/src/runtime/ImportReporter.cpp
+++ b/src/runtime/ImportReporter.cpp
@@ -5,10 +5,10 @@
 /// resolve versus which are missing, and generates a compatibility summary. Used by
 /// the validation pipeline to produce per-game import coverage reports.
 
+#include <algorithm>
 #include <metalsharp/ImportReporter.h>
 #include <metalsharp/Logger.h>
 #include <sstream>
-#include <algorithm>
 
 namespace metalsharp {
 
@@ -46,7 +46,8 @@ void ImportReporter::endModule() {
 std::vector<ImportReport> ImportReporter::missingImports() const {
     std::vector<ImportReport> result;
     for (const auto& r : m_reports) {
-        if (!r.resolved) result.push_back(r);
+        if (!r.resolved)
+            result.push_back(r);
     }
     return result;
 }
@@ -54,7 +55,8 @@ std::vector<ImportReport> ImportReporter::missingImports() const {
 std::vector<ImportReport> ImportReporter::resolvedImports() const {
     std::vector<ImportReport> result;
     for (const auto& r : m_reports) {
-        if (r.resolved) result.push_back(r);
+        if (r.resolved)
+            result.push_back(r);
     }
     return result;
 }
@@ -74,7 +76,8 @@ std::vector<std::string> ImportReporter::missingDlls() const {
 size_t ImportReporter::resolvedCount() const {
     size_t c = 0;
     for (const auto& r : m_reports) {
-        if (r.resolved) c++;
+        if (r.resolved)
+            c++;
     }
     return c;
 }
@@ -82,7 +85,8 @@ size_t ImportReporter::resolvedCount() const {
 size_t ImportReporter::missingCount() const {
     size_t c = 0;
     for (const auto& r : m_reports) {
-        if (!r.resolved) c++;
+        if (!r.resolved)
+            c++;
     }
     return c;
 }
@@ -112,7 +116,8 @@ std::string ImportReporter::generateSummary() const {
         for (const auto& dll : dlls) {
             size_t count = 0;
             for (const auto& r : missing) {
-                if (r.dllName == dll) count++;
+                if (r.dllName == dll)
+                    count++;
             }
             ss << "  " << dll << " (" << count << " missing)\n";
         }
@@ -126,4 +131,4 @@ void ImportReporter::clear() {
     m_currentModule.clear();
 }
 
-}
+} // namespace metalsharp

--- a/src/runtime/Logger.cpp
+++ b/src/runtime/Logger.cpp
@@ -5,9 +5,9 @@
 /// are timestamped and written to a configurable output sink. Thread-safety is
 /// handled internally so callers can log from any context without synchronization.
 
-#include <metalsharp/Logger.h>
 #include <cstring>
 #include <ctime>
+#include <metalsharp/Logger.h>
 
 namespace metalsharp {
 
@@ -18,7 +18,8 @@ void Logger::init(const std::string& logPath) {
     if (!logPath.empty()) {
         s_file = fopen(logPath.c_str(), "a");
     }
-    if (!s_file) s_file = stderr;
+    if (!s_file)
+        s_file = stderr;
 }
 
 void Logger::shutdown() {
@@ -28,17 +29,28 @@ void Logger::shutdown() {
     }
 }
 
-void Logger::setLevel(LogLevel level) { s_level = level; }
+void Logger::setLevel(LogLevel level) {
+    s_level = level;
+}
 
 void Logger::log(LogLevel level, const char* fmt, ...) {
-    if (level < s_level) return;
+    if (level < s_level)
+        return;
 
     const char* prefix = "INFO";
     switch (level) {
-        case LogLevel::Trace: prefix = "TRACE"; break;
-        case LogLevel::Info:  prefix = "INFO "; break;
-        case LogLevel::Warn:  prefix = "WARN "; break;
-        case LogLevel::Error: prefix = "ERROR"; break;
+    case LogLevel::Trace:
+        prefix = "TRACE";
+        break;
+    case LogLevel::Info:
+        prefix = "INFO ";
+        break;
+    case LogLevel::Warn:
+        prefix = "WARN ";
+        break;
+    case LogLevel::Error:
+        prefix = "ERROR";
+        break;
     }
 
     time_t now = time(nullptr);
@@ -59,4 +71,4 @@ void Logger::log(LogLevel level, const char* fmt, ...) {
     va_end(args);
 }
 
-}
+} // namespace metalsharp

--- a/src/runtime/PEHook.cpp
+++ b/src/runtime/PEHook.cpp
@@ -6,21 +6,16 @@
 /// environment variables so Wine loads MetalSharp's shims instead of the
 /// original Windows DLLs at runtime.
 
-#include <metalsharp/PEHook.h>
-#include <metalsharp/Logger.h>
 #include <cstdlib>
 #include <cstring>
+#include <metalsharp/Logger.h>
+#include <metalsharp/PEHook.h>
 
 namespace metalsharp {
 
-const char* PEHook::DYLIB_MAPPINGS[] = {
-    "d3d11.dll",    "d3d11.dylib",
-    "d3d12.dll",    "d3d12.dylib",
-    "dxgi.dll",     "dxgi.dylib",
-    "xaudio2_9.dll","xaudio2_9.dylib",
-    "xinput1_4.dll","xinput1_4.dylib",
-    nullptr
-};
+const char* PEHook::DYLIB_MAPPINGS[] = {"d3d11.dll",     "d3d11.dylib",     "d3d12.dll",     "d3d12.dylib",
+                                        "dxgi.dll",      "dxgi.dylib",      "xaudio2_9.dll", "xaudio2_9.dylib",
+                                        "xinput1_4.dll", "xinput1_4.dylib", nullptr};
 
 std::vector<DylibMapping> PEHook::getDylibMappings() {
     std::vector<DylibMapping> mappings;
@@ -45,9 +40,7 @@ bool PEHook::injectDylibs(const std::string& winePrefix) {
 bool PEHook::setupEnvironment(const std::string& winePrefix, bool debugMetal) {
     setenv("WINEPREFIX", winePrefix.c_str(), 1);
 
-    setenv("WINEDLLOVERRIDES",
-        "d3d11=native;d3d12=native;dxgi=native;xaudio2_9=native;xinput1_4=native",
-        1);
+    setenv("WINEDLLOVERRIDES", "d3d11=native;d3d12=native;dxgi=native;xaudio2_9=native;xinput1_4=native", 1);
 
     setenv("METALSHARP_WINE_PREFIX", winePrefix.c_str(), 1);
 
@@ -60,4 +53,4 @@ bool PEHook::setupEnvironment(const std::string& winePrefix, bool debugMetal) {
     return true;
 }
 
-}
+} // namespace metalsharp

--- a/src/runtime/SettingsManager.cpp
+++ b/src/runtime/SettingsManager.cpp
@@ -6,10 +6,10 @@
 /// clearing the cache to force a re-read from disk on next access.
 
 #include "metalsharp/SettingsManager.h"
+#include <cstdlib>
+#include <filesystem>
 #include <fstream>
 #include <sstream>
-#include <filesystem>
-#include <cstdlib>
 
 namespace metalsharp {
 
@@ -22,41 +22,58 @@ SettingsManager& SettingsManager::instance() {
 
 std::string SettingsManager::defaultSettingsPath() {
     const char* home = std::getenv("HOME");
-    if (!home) return "metalsharp.json";
+    if (!home)
+        return "metalsharp.json";
     return std::string(home) + "/.metalsharp/settings.json";
 }
 
 std::string SettingsManager::upscalingToString(UpscalingQuality q) {
     switch (q) {
-        case UpscalingQuality::Off: return "off";
-        case UpscalingQuality::Low: return "low";
-        case UpscalingQuality::Medium: return "medium";
-        case UpscalingQuality::High: return "high";
-        case UpscalingQuality::Ultra: return "ultra";
-        default: return "off";
+    case UpscalingQuality::Off:
+        return "off";
+    case UpscalingQuality::Low:
+        return "low";
+    case UpscalingQuality::Medium:
+        return "medium";
+    case UpscalingQuality::High:
+        return "high";
+    case UpscalingQuality::Ultra:
+        return "ultra";
+    default:
+        return "off";
     }
 }
 
 UpscalingQuality SettingsManager::upscalingFromString(const std::string& s) {
-    if (s == "low") return UpscalingQuality::Low;
-    if (s == "medium") return UpscalingQuality::Medium;
-    if (s == "high") return UpscalingQuality::High;
-    if (s == "ultra") return UpscalingQuality::Ultra;
+    if (s == "low")
+        return UpscalingQuality::Low;
+    if (s == "medium")
+        return UpscalingQuality::Medium;
+    if (s == "high")
+        return UpscalingQuality::High;
+    if (s == "ultra")
+        return UpscalingQuality::Ultra;
     return UpscalingQuality::Off;
 }
 
 std::string SettingsManager::windowModeToString(WindowMode w) {
     switch (w) {
-        case WindowMode::Windowed: return "windowed";
-        case WindowMode::Borderless: return "borderless";
-        case WindowMode::Fullscreen: return "fullscreen";
-        default: return "fullscreen";
+    case WindowMode::Windowed:
+        return "windowed";
+    case WindowMode::Borderless:
+        return "borderless";
+    case WindowMode::Fullscreen:
+        return "fullscreen";
+    default:
+        return "fullscreen";
     }
 }
 
 WindowMode SettingsManager::windowModeFromString(const std::string& s) {
-    if (s == "windowed") return WindowMode::Windowed;
-    if (s == "borderless") return WindowMode::Borderless;
+    if (s == "windowed")
+        return WindowMode::Windowed;
+    if (s == "borderless")
+        return WindowMode::Borderless;
     return WindowMode::Fullscreen;
 }
 
@@ -65,7 +82,8 @@ bool SettingsManager::load(const std::string& path) {
     m_path = p;
 
     std::ifstream f(p);
-    if (!f.is_open()) return false;
+    if (!f.is_open())
+        return false;
 
     std::ostringstream buf;
     buf << f.rdbuf();
@@ -74,44 +92,57 @@ bool SettingsManager::load(const std::string& path) {
     auto extractValue = [](const std::string& j, const std::string& key) -> std::string {
         std::string search = "\"" + key + "\"";
         auto pos = j.find(search);
-        if (pos == std::string::npos) return "";
+        if (pos == std::string::npos)
+            return "";
         auto colon = j.find(':', pos + search.length());
-        if (colon == std::string::npos) return "";
+        if (colon == std::string::npos)
+            return "";
         auto openQuote = j.find('"', colon + 1);
-        if (openQuote == std::string::npos) return "";
+        if (openQuote == std::string::npos)
+            return "";
         auto closeQuote = j.find('"', openQuote + 1);
-        if (closeQuote == std::string::npos) return "";
+        if (closeQuote == std::string::npos)
+            return "";
         return j.substr(openQuote + 1, closeQuote - openQuote - 1);
     };
 
     auto extractBool = [&extractValue](const std::string& j, const std::string& key, bool def) -> bool {
         std::string search = "\"" + key + "\"";
         auto pos = j.find(search);
-        if (pos == std::string::npos) return def;
+        if (pos == std::string::npos)
+            return def;
         auto colon = j.find(':', pos + search.length());
-        if (colon == std::string::npos) return def;
+        if (colon == std::string::npos)
+            return def;
         auto after = j.substr(colon + 1, 10);
-        if (after.find("true") != std::string::npos) return true;
-        if (after.find("false") != std::string::npos) return false;
+        if (after.find("true") != std::string::npos)
+            return true;
+        if (after.find("false") != std::string::npos)
+            return false;
         return def;
     };
 
     auto extractInt = [&extractValue](const std::string& j, const std::string& key, uint32_t def) -> uint32_t {
         std::string search = "\"" + key + "\"";
         auto pos = j.find(search);
-        if (pos == std::string::npos) return def;
+        if (pos == std::string::npos)
+            return def;
         auto colon = j.find(':', pos + search.length());
-        if (colon == std::string::npos) return def;
+        if (colon == std::string::npos)
+            return def;
         std::string rest = j.substr(colon + 1, 20);
         try {
             size_t idx = 0;
-            while (idx < rest.size() && (rest[idx] == ' ' || rest[idx] == '\t')) idx++;
+            while (idx < rest.size() && (rest[idx] == ' ' || rest[idx] == '\t'))
+                idx++;
             std::string num;
             while (idx < rest.size() && rest[idx] >= '0' && rest[idx] <= '9') {
                 num += rest[idx++];
             }
-            if (!num.empty()) return static_cast<uint32_t>(std::stoul(num));
-        } catch (...) {}
+            if (!num.empty())
+                return static_cast<uint32_t>(std::stoul(num));
+        } catch (...) {
+        }
         return def;
     };
 
@@ -142,7 +173,8 @@ bool SettingsManager::save(const std::string& path) {
     fs::create_directories(fs::path(p).parent_path());
 
     std::ofstream f(p);
-    if (!f.is_open()) return false;
+    if (!f.is_open())
+        return false;
 
     f << "{\n";
     f << "  \"render_width\": " << m_state.render.renderWidth << ",\n";
@@ -165,12 +197,17 @@ bool SettingsManager::save(const std::string& path) {
     return true;
 }
 
-SettingsState& SettingsManager::state() { return m_state; }
-const SettingsState& SettingsManager::state() const { return m_state; }
+SettingsState& SettingsManager::state() {
+    return m_state;
+}
+const SettingsState& SettingsManager::state() const {
+    return m_state;
+}
 
 void SettingsManager::clearShaderCache() {
     const char* home = std::getenv("HOME");
-    if (!home) return;
+    if (!home)
+        return;
     std::string cacheDir = std::string(home) + "/.metalsharp/cache/shader_cache";
     fs::remove_all(cacheDir);
     fs::create_directories(cacheDir);
@@ -178,7 +215,8 @@ void SettingsManager::clearShaderCache() {
 
 void SettingsManager::clearPipelineCache() {
     const char* home = std::getenv("HOME");
-    if (!home) return;
+    if (!home)
+        return;
     std::string cacheDir = std::string(home) + "/.metalsharp/cache/pipeline_cache";
     fs::remove_all(cacheDir);
     fs::create_directories(cacheDir);
@@ -186,20 +224,23 @@ void SettingsManager::clearPipelineCache() {
 
 uint64_t SettingsManager::shaderCacheSize() {
     const char* home = std::getenv("HOME");
-    if (!home) return 0;
+    if (!home)
+        return 0;
     std::string cacheDir = std::string(home) + "/.metalsharp/cache/shader_cache";
-    if (!fs::exists(cacheDir)) return 0;
+    if (!fs::exists(cacheDir))
+        return 0;
 
     uint64_t total = 0;
     try {
-        for (const auto& entry : fs::recursive_directory_iterator(cacheDir,
-                     fs::directory_options::skip_permission_denied)) {
+        for (const auto& entry :
+             fs::recursive_directory_iterator(cacheDir, fs::directory_options::skip_permission_denied)) {
             if (entry.is_regular_file()) {
                 total += entry.file_size();
             }
         }
-    } catch (...) {}
+    } catch (...) {
+    }
     return total;
 }
 
-}
+} // namespace metalsharp

--- a/src/runtime/UpdateChecker.cpp
+++ b/src/runtime/UpdateChecker.cpp
@@ -6,14 +6,16 @@
 /// names and download URLs without depending on an HTTP or JSON library.
 
 #include "metalsharp/UpdateChecker.h"
-#include <sstream>
 #include <algorithm>
+#include <sstream>
 
 namespace metalsharp {
 
 bool Version::operator>(const Version& o) const {
-    if (major != o.major) return major > o.major;
-    if (minor != o.minor) return minor > o.minor;
+    if (major != o.major)
+        return major > o.major;
+    if (minor != o.minor)
+        return minor > o.minor;
     return patch > o.patch;
 }
 
@@ -27,18 +29,21 @@ bool Version::operator>=(const Version& o) const {
 
 std::string Version::toString() const {
     std::string s = std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(patch);
-    if (!prerelease.empty()) s += "-" + prerelease;
+    if (!prerelease.empty())
+        s += "-" + prerelease;
     return s;
 }
 
 Version Version::parse(const std::string& s) {
     Version v;
     std::string input = s;
-    if (input.size() > 0 && input[0] == 'v') input = input.substr(1);
+    if (input.size() > 0 && input[0] == 'v')
+        input = input.substr(1);
 
     size_t dashPos = input.find('-');
     std::string versionPart = (dashPos != std::string::npos) ? input.substr(0, dashPos) : input;
-    if (dashPos != std::string::npos) v.prerelease = input.substr(dashPos + 1);
+    if (dashPos != std::string::npos)
+        v.prerelease = input.substr(dashPos + 1);
 
     std::istringstream ss(versionPart);
     std::string token;
@@ -46,10 +51,14 @@ Version Version::parse(const std::string& s) {
     while (std::getline(ss, token, '.')) {
         try {
             uint32_t val = static_cast<uint32_t>(std::stoul(token));
-            if (idx == 0) v.major = val;
-            else if (idx == 1) v.minor = val;
-            else if (idx == 2) v.patch = val;
-        } catch (...) {}
+            if (idx == 0)
+                v.major = val;
+            else if (idx == 1)
+                v.minor = val;
+            else if (idx == 2)
+                v.patch = val;
+        } catch (...) {
+        }
         idx++;
     }
 
@@ -75,13 +84,17 @@ UpdateInfo UpdateChecker::parseGitHubRelease(const std::string& json, const Vers
     auto extractJsonString = [](const std::string& j, const std::string& key) -> std::string {
         std::string search = "\"" + key + "\"";
         auto pos = j.find(search);
-        if (pos == std::string::npos) return "";
+        if (pos == std::string::npos)
+            return "";
         auto colon = j.find(':', pos + search.length());
-        if (colon == std::string::npos) return "";
+        if (colon == std::string::npos)
+            return "";
         auto openQuote = j.find('"', colon + 1);
-        if (openQuote == std::string::npos) return "";
+        if (openQuote == std::string::npos)
+            return "";
         auto closeQuote = j.find('"', openQuote + 1);
-        if (closeQuote == std::string::npos) return "";
+        if (closeQuote == std::string::npos)
+            return "";
         return j.substr(openQuote + 1, closeQuote - openQuote - 1);
     };
 
@@ -110,4 +123,4 @@ UpdateInfo UpdateChecker::checkForUpdates(const std::string& repo) {
     return parseGitHubRelease(json, current);
 }
 
-}
+} // namespace metalsharp

--- a/src/steam/bridge/unix_steamclient.c
+++ b/src/steam/bridge/unix_steamclient.c
@@ -1,60 +1,59 @@
 /// @file unix_steamclient.c
 /// @brief Steam client bridge forwarding to native libsteam_api.
 ///
-/// Implements the ISteamClient interface by loading libsteam_api.dylib and forwarding calls to the native Steam runtime. Handles Steam API initialization, user authentication, and AppID registration so MetalSharp games can use Steam features natively.
-#include <stdarg.h>
-#include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
-#include <stdio.h>
+/// Implements the ISteamClient interface by loading libsteam_api.dylib and forwarding calls to the native Steam
+/// runtime. Handles Steam API initialization, user authentication, and AppID registration so MetalSharp games can use
+/// Steam features natively.
 #include <dlfcn.h>
 #include <pthread.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
-#include <windef.h>
-#include <winbase.h>
-#include <winternl.h>
 #include "wine/unixlib.h"
+#include <winbase.h>
+#include <windef.h>
+#include <winternl.h>
 
 WINE_DEFAULT_DEBUG_CHANNEL(steamclient);
 
-static void *steamclient_handle;
+static void* steamclient_handle;
 
-static void *(*p_CreateInterface)(const char *name, int *return_code);
-static int8_t (*p_Steam_BGetCallback)(int32_t, void *, int32_t *);
-static int8_t (*p_Steam_GetAPICallResult)(int32_t, uint64_t, void *, int, int, int8_t *);
+static void* (*p_CreateInterface)(const char* name, int* return_code);
+static int8_t (*p_Steam_BGetCallback)(int32_t, void*, int32_t*);
+static int8_t (*p_Steam_GetAPICallResult)(int32_t, uint64_t, void*, int, int, int8_t*);
 static int8_t (*p_Steam_FreeLastCallback)(int32_t);
 static void (*p_Steam_ReleaseThreadLocalMemory)(int);
 
-NTSTATUS steamclient_init(void *args)
-{
+NTSTATUS steamclient_init(void* args) {
     char path[4096];
 
-    if (steamclient_handle) return 0;
+    if (steamclient_handle)
+        return 0;
 
-    const char *install_path = getenv("STEAM_COMPAT_CLIENT_INSTALL_PATH");
+    const char* install_path = getenv("STEAM_COMPAT_CLIENT_INSTALL_PATH");
     if (install_path)
         snprintf(path, sizeof(path), "%s/steamclient.dylib", install_path);
-    else
-    {
-        const char *home = getenv("HOME");
+    else {
+        const char* home = getenv("HOME");
         snprintf(path, sizeof(path),
-            "%s/Library/Application Support/Steam/Steam.AppBundle/Steam/Contents/MacOS/steamclient.dylib",
-            home ? home : "/Users/alexmondello");
+                 "%s/Library/Application Support/Steam/Steam.AppBundle/Steam/Contents/MacOS/steamclient.dylib",
+                 home ? home : "/Users/alexmondello");
     }
 
     TRACE("Loading steamclient from %s\n", debugstr_a(path));
 
-    if (!(steamclient_handle = dlopen(path, RTLD_NOW)))
-    {
+    if (!(steamclient_handle = dlopen(path, RTLD_NOW))) {
         ERR("unable to load native steamclient library: %s\n", dlerror());
         return -1;
     }
 
-#define LOAD_FUNC(x) \
-    if (!(p_##x = (typeof(p_##x))dlsym(steamclient_handle, #x))) \
-    { \
-        ERR("unable to load %s\n", #x); \
-        return -1; \
+#define LOAD_FUNC(x)                                                                                                   \
+    if (!(p_##x = (typeof(p_##x))dlsym(steamclient_handle, #x))) {                                                     \
+        ERR("unable to load %s\n", #x);                                                                                \
+        return -1;                                                                                                     \
     }
 
     LOAD_FUNC(CreateInterface);
@@ -67,49 +66,68 @@ NTSTATUS steamclient_init(void *args)
     return 0;
 }
 
-NTSTATUS steamclient_CreateInterface(void *args)
-{
-    struct { void *ret; const char *name; int *return_code; } *params = args;
+NTSTATUS steamclient_CreateInterface(void* args) {
+    struct {
+        void* ret;
+        const char* name;
+        int* return_code;
+    }* params = args;
     params->ret = p_CreateInterface(params->name, params->return_code);
     return 0;
 }
 
-NTSTATUS steamclient_Steam_BGetCallback(void *args)
-{
-    struct { int8_t ret; int32_t pipe; void *msg; int32_t *ignored; } *params = args;
+NTSTATUS steamclient_Steam_BGetCallback(void* args) {
+    struct {
+        int8_t ret;
+        int32_t pipe;
+        void* msg;
+        int32_t* ignored;
+    }* params = args;
     params->ret = p_Steam_BGetCallback(params->pipe, params->msg, params->ignored);
     return 0;
 }
 
-NTSTATUS steamclient_Steam_GetAPICallResult(void *args)
-{
-    struct { int8_t ret; int32_t pipe; uint64_t call; void *callback; int len; int id; int8_t *failed; } *params = args;
-    params->ret = p_Steam_GetAPICallResult(params->pipe, params->call, params->callback, params->len, params->id, params->failed);
+NTSTATUS steamclient_Steam_GetAPICallResult(void* args) {
+    struct {
+        int8_t ret;
+        int32_t pipe;
+        uint64_t call;
+        void* callback;
+        int len;
+        int id;
+        int8_t* failed;
+    }* params = args;
+    params->ret =
+        p_Steam_GetAPICallResult(params->pipe, params->call, params->callback, params->len, params->id, params->failed);
     return 0;
 }
 
-NTSTATUS steamclient_Steam_FreeLastCallback(void *args)
-{
-    struct { int8_t ret; int32_t pipe; } *params = args;
+NTSTATUS steamclient_Steam_FreeLastCallback(void* args) {
+    struct {
+        int8_t ret;
+        int32_t pipe;
+    }* params = args;
     params->ret = p_Steam_FreeLastCallback(params->pipe);
     return 0;
 }
 
-NTSTATUS steamclient_Steam_ReleaseThreadLocalMemory(void *args)
-{
-    struct { int thread_exit; } *params = args;
+NTSTATUS steamclient_Steam_ReleaseThreadLocalMemory(void* args) {
+    struct {
+        int thread_exit;
+    }* params = args;
     p_Steam_ReleaseThreadLocalMemory(params->thread_exit);
     return 0;
 }
 
-NTSTATUS steamclient_Steam_IsKnownInterface(void *args)
-{
-    struct { int8_t ret; const char *version; } *params = args;
+NTSTATUS steamclient_Steam_IsKnownInterface(void* args) {
+    struct {
+        int8_t ret;
+        const char* version;
+    }* params = args;
     params->ret = 1;
     return 0;
 }
 
-NTSTATUS steamclient_Steam_NotifyMissingInterface(void *args)
-{
+NTSTATUS steamclient_Steam_NotifyMissingInterface(void* args) {
     return 0;
 }

--- a/src/win32/extra/ExtraShims.cpp
+++ b/src/win32/extra/ExtraShims.cpp
@@ -34,28 +34,28 @@
 ///   only implemented where games actually depend on it.
 ///
 ///   Priority: prevent crashes > correct behavior > full API coverage.
+#include <arpa/inet.h>
+#include <cerrno>
+#include <csignal>
+#include <cstdlib>
+#include <cstring>
+#include <fcntl.h>
+#include <metalsharp/Logger.h>
+#include <metalsharp/NetworkContext.h>
 #include <metalsharp/PELoader.h>
 #include <metalsharp/Platform.h>
-#include <metalsharp/Win32Types.h>
-#include <metalsharp/Logger.h>
-#include <metalsharp/VirtualFileSystem.h>
 #include <metalsharp/Registry.h>
-#include <metalsharp/NetworkContext.h>
-#include <cstring>
-#include <cstdlib>
-#include <csignal>
-#include <unordered_map>
-#include <sys/socket.h>
-#include <sys/select.h>
+#include <metalsharp/VirtualFileSystem.h>
+#include <metalsharp/Win32Types.h>
+#include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
-#include <arpa/inet.h>
-#include <netdb.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <cerrno>
 #include <poll.h>
 #include <sys/ioctl.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <unordered_map>
 
 #if __has_include(<openssl/rand.h>)
 #include <openssl/rand.h>
@@ -69,11 +69,13 @@ static void* MSABI gdi32_CreateCompatibleDC(void*) {
 }
 
 static void* MSABI gdi32_CreateDIBSection(void*, const void*, UINT, void** ppv, void*, DWORD) {
-    if (ppv) *ppv = calloc(1, 1920 * 1080 * 4);
+    if (ppv)
+        *ppv = calloc(1, 1920 * 1080 * 4);
     return reinterpret_cast<void*>(0x9001);
 }
 
-static void* MSABI gdi32_CreateFontW(int, int, int, int, int, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, const wchar_t*) {
+static void* MSABI gdi32_CreateFontW(int, int, int, int, int, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD,
+                                     const wchar_t*) {
     return reinterpret_cast<void*>(0x9002);
 }
 
@@ -81,74 +83,147 @@ static void* MSABI gdi32_CreateICW(const wchar_t*, const wchar_t*, const wchar_t
     return reinterpret_cast<void*>(0x9003);
 }
 
-static BOOL MSABI gdi32_DeleteDC(void*) { return 1; }
+static BOOL MSABI gdi32_DeleteDC(void*) {
+    return 1;
+}
 
-static BOOL MSABI gdi32_DeleteObject(void*) { return 1; }
+static BOOL MSABI gdi32_DeleteObject(void*) {
+    return 1;
+}
 
-static void* MSABI gdi32_SelectObject(void*, void* old) { return old; }
+static void* MSABI gdi32_SelectObject(void*, void* old) {
+    return old;
+}
 
 static int MSABI gdi32_GetDeviceCaps(void*, int index) {
-    switch (index) { case 0: return 1920; case 1: return 1080; case 12: return 96; case 88: return 32; default: return 0; }
+    switch (index) {
+    case 0:
+        return 1920;
+    case 1:
+        return 1080;
+    case 12:
+        return 96;
+    case 88:
+        return 32;
+    default:
+        return 0;
+    }
 }
 
-static void* MSABI gdi32_GetStockObject(int) { return reinterpret_cast<void*>(0x9004); }
+static void* MSABI gdi32_GetStockObject(int) {
+    return reinterpret_cast<void*>(0x9004);
+}
 
 static BOOL MSABI gdi32_GetTextExtentPoint32W(void*, const wchar_t*, int, void* sz) {
-    auto* s = reinterpret_cast<DWORD*>(sz); s[0] = 8; s[1] = 16; return 1;
+    auto* s = reinterpret_cast<DWORD*>(sz);
+    s[0] = 8;
+    s[1] = 16;
+    return 1;
 }
 
-static DWORD MSABI gdi32_SetBkColor(void*, DWORD c) { return c; }
+static DWORD MSABI gdi32_SetBkColor(void*, DWORD c) {
+    return c;
+}
 
-static int MSABI gdi32_SetBkMode(void*, int m) { return m; }
+static int MSABI gdi32_SetBkMode(void*, int m) {
+    return m;
+}
 
-static DWORD MSABI gdi32_SetTextColor(void*, DWORD c) { return c; }
+static DWORD MSABI gdi32_SetTextColor(void*, DWORD c) {
+    return c;
+}
 
-static BOOL MSABI gdi32_TextOutW(void*, int, int, const wchar_t*, int) { return 1; }
+static BOOL MSABI gdi32_TextOutW(void*, int, int, const wchar_t*, int) {
+    return 1;
+}
 
-static BOOL MSABI gdi32_SwapBuffers(void*) { return 1; }
+static BOOL MSABI gdi32_SwapBuffers(void*) {
+    return 1;
+}
 
-static int MSABI gdi32_ChoosePixelFormat(void*, const void*) { return 1; }
+static int MSABI gdi32_ChoosePixelFormat(void*, const void*) {
+    return 1;
+}
 
-static BOOL MSABI gdi32_SetPixelFormat(void*, int, const void*) { return 1; }
+static BOOL MSABI gdi32_SetPixelFormat(void*, int, const void*) {
+    return 1;
+}
 
 static HANDLE MSABI gdi32_AddFontMemResourceEx(const void*, DWORD, void*, DWORD* cnt) {
-    if (cnt) *cnt = 1; return reinterpret_cast<void*>(0x9005);
+    if (cnt)
+        *cnt = 1;
+    return reinterpret_cast<void*>(0x9005);
 }
 
-static BOOL MSABI gdi32_RemoveFontMemResourceEx(void*) { return 1; }
+static BOOL MSABI gdi32_RemoveFontMemResourceEx(void*) {
+    return 1;
+}
 
-static BOOL MSABI gdi32_BitBlt(void*, int, int, int, int, void*, int, int, DWORD) { return 1; }
+static BOOL MSABI gdi32_BitBlt(void*, int, int, int, int, void*, int, int, DWORD) {
+    return 1;
+}
 
-static BOOL MSABI gdi32_StretchBlt(void*, int, int, int, int, void*, int, int, int, int, DWORD) { return 1; }
+static BOOL MSABI gdi32_StretchBlt(void*, int, int, int, int, void*, int, int, int, int, DWORD) {
+    return 1;
+}
 
 static int MSABI gdi32_DrawTextW(void*, const wchar_t* str, int len, void* rect, UINT) {
-    if (rect) { auto* r = reinterpret_cast<LONG*>(rect); r[0] = 0; r[1] = 0; r[2] = 200; r[3] = 100; }
-    if (!str) return 0;
+    if (rect) {
+        auto* r = reinterpret_cast<LONG*>(rect);
+        r[0] = 0;
+        r[1] = 0;
+        r[2] = 200;
+        r[3] = 100;
+    }
+    if (!str)
+        return 0;
     return len >= 0 ? len : (int)wcslen(str);
 }
 
-static void* MSABI gdi32_CreateFontIndirectW(const void*) { return reinterpret_cast<void*>(0x9006); }
+static void* MSABI gdi32_CreateFontIndirectW(const void*) {
+    return reinterpret_cast<void*>(0x9006);
+}
 
 static int MSABI gdi32_GetObjectW(void*, int sz, void* buf) {
-    if (buf && sz >= 4) { memset(buf, 0, sz); *reinterpret_cast<LONG*>(buf) = -13; }
+    if (buf && sz >= 4) {
+        memset(buf, 0, sz);
+        *reinterpret_cast<LONG*>(buf) = -13;
+    }
     return sz;
 }
 
-static void* MSABI gdi32_CreateCompatibleBitmap(void*, int, int) { return reinterpret_cast<void*>(0x9007); }
+static void* MSABI gdi32_CreateCompatibleBitmap(void*, int, int) {
+    return reinterpret_cast<void*>(0x9007);
+}
 
-static BOOL MSABI gdi32_PatBlt(void*, int, int, int, int, DWORD) { return 1; }
+static BOOL MSABI gdi32_PatBlt(void*, int, int, int, int, DWORD) {
+    return 1;
+}
 
-static BOOL MSABI gdi32_Rectangle(void*, int, int, int, int) { return 1; }
+static BOOL MSABI gdi32_Rectangle(void*, int, int, int, int) {
+    return 1;
+}
 
-static int MSABI gdi32_FillRect(void*, const void*, void*) { return 1; }
+static int MSABI gdi32_FillRect(void*, const void*, void*) {
+    return 1;
+}
 
-static void* MSABI gdi32_CreateSolidBrush(DWORD) { return reinterpret_cast<void*>(0x9008); }
+static void* MSABI gdi32_CreateSolidBrush(DWORD) {
+    return reinterpret_cast<void*>(0x9008);
+}
 
-static void* MSABI gdi32_CreateBitmap(int, int, UINT, UINT, const void*) { return reinterpret_cast<void*>(0x9009); }
+static void* MSABI gdi32_CreateBitmap(int, int, UINT, UINT, const void*) {
+    return reinterpret_cast<void*>(0x9009);
+}
 
-static int MSABI gdi32_SetDIBitsToDevice(void*, int, int, DWORD, DWORD, int, int, UINT, UINT, const void*, const void*, UINT) { return 1; }
+static int MSABI gdi32_SetDIBitsToDevice(void*, int, int, DWORD, DWORD, int, int, UINT, UINT, const void*, const void*,
+                                         UINT) {
+    return 1;
+}
 
-static BOOL MSABI gdi32_GdiFlush() { return 1; }
+static BOOL MSABI gdi32_GdiFlush() {
+    return 1;
+}
 
 ShimLibrary createGdi32Shim() {
     ShimLibrary lib;
@@ -196,69 +271,91 @@ static LONG MSABI advapi32_RegOpenKeyA(void* hKey, const char* subKey, void** ke
     return Registry::instance().openKey(hKey, subKey ? subKey : "", key);
 }
 
-static LONG MSABI advapi32_RegOpenKeyExA(void* hKey, const char* subKey, DWORD ulOptions, DWORD samDesired, void** key) {
+static LONG MSABI advapi32_RegOpenKeyExA(void* hKey, const char* subKey, DWORD ulOptions, DWORD samDesired,
+                                         void** key) {
     return Registry::instance().openKeyEx(hKey, subKey ? subKey : "", ulOptions, samDesired, key);
 }
 
-static LONG MSABI advapi32_RegOpenKeyExW(void* hKey, const wchar_t* subKey, DWORD ulOptions, DWORD samDesired, void** key) {
+static LONG MSABI advapi32_RegOpenKeyExW(void* hKey, const wchar_t* subKey, DWORD ulOptions, DWORD samDesired,
+                                         void** key) {
     char narrow[1024];
     if (subKey) {
         int j = 0;
-        for (int i = 0; subKey[i] && j < 1023; i++) narrow[j++] = (char)(subKey[i] & 0xFF);
+        for (int i = 0; subKey[i] && j < 1023; i++)
+            narrow[j++] = (char)(subKey[i] & 0xFF);
         narrow[j] = 0;
-    } else { narrow[0] = 0; }
+    } else {
+        narrow[0] = 0;
+    }
     return Registry::instance().openKeyEx(hKey, narrow, ulOptions, samDesired, key);
 }
 
 static LONG MSABI advapi32_RegCreateKeyExA(void* hKey, const char* subKey, DWORD reserved, char* lpClass,
-    DWORD dwOptions, DWORD samDesired, void* lpSecurityAttributes, void** key, void* lpdwDisposition) {
-    return Registry::instance().createKeyEx(hKey, subKey ? subKey : "", reserved, lpClass, dwOptions, samDesired, lpSecurityAttributes, key, lpdwDisposition);
+                                           DWORD dwOptions, DWORD samDesired, void* lpSecurityAttributes, void** key,
+                                           void* lpdwDisposition) {
+    return Registry::instance().createKeyEx(hKey, subKey ? subKey : "", reserved, lpClass, dwOptions, samDesired,
+                                            lpSecurityAttributes, key, lpdwDisposition);
 }
 
 static LONG MSABI advapi32_RegCreateKeyExW(void* hKey, const wchar_t* subKey, DWORD reserved, wchar_t* lpClass,
-    DWORD dwOptions, DWORD samDesired, void* lpSecurityAttributes, void** key, void* lpdwDisposition) {
+                                           DWORD dwOptions, DWORD samDesired, void* lpSecurityAttributes, void** key,
+                                           void* lpdwDisposition) {
     char narrow[1024];
     if (subKey) {
         int j = 0;
-        for (int i = 0; subKey[i] && j < 1023; i++) narrow[j++] = (char)(subKey[i] & 0xFF);
+        for (int i = 0; subKey[i] && j < 1023; i++)
+            narrow[j++] = (char)(subKey[i] & 0xFF);
         narrow[j] = 0;
-    } else { narrow[0] = 0; }
-    return Registry::instance().createKeyEx(hKey, narrow, reserved, nullptr, dwOptions, samDesired, lpSecurityAttributes, key, lpdwDisposition);
+    } else {
+        narrow[0] = 0;
+    }
+    return Registry::instance().createKeyEx(hKey, narrow, reserved, nullptr, dwOptions, samDesired,
+                                            lpSecurityAttributes, key, lpdwDisposition);
 }
 
 static LONG MSABI advapi32_RegCloseKey(void* hKey) {
     return Registry::instance().closeKey(hKey);
 }
 
-static LONG MSABI advapi32_RegQueryValueExA(void* hKey, const char* valueName, DWORD* lpReserved, DWORD* lpType, BYTE* lpData, DWORD* lpcbData) {
+static LONG MSABI advapi32_RegQueryValueExA(void* hKey, const char* valueName, DWORD* lpReserved, DWORD* lpType,
+                                            BYTE* lpData, DWORD* lpcbData) {
     (void)lpReserved;
     return Registry::instance().queryValue(hKey, valueName ? valueName : "", lpType, lpData, lpcbData);
 }
 
-static LONG MSABI advapi32_RegQueryValueExW(void* hKey, const wchar_t* valueName, DWORD* lpReserved, DWORD* lpType, BYTE* lpData, DWORD* lpcbData) {
+static LONG MSABI advapi32_RegQueryValueExW(void* hKey, const wchar_t* valueName, DWORD* lpReserved, DWORD* lpType,
+                                            BYTE* lpData, DWORD* lpcbData) {
     (void)lpReserved;
     char narrow[256];
     if (valueName) {
         int j = 0;
-        for (int i = 0; valueName[i] && j < 255; i++) narrow[j++] = (char)(valueName[i] & 0xFF);
+        for (int i = 0; valueName[i] && j < 255; i++)
+            narrow[j++] = (char)(valueName[i] & 0xFF);
         narrow[j] = 0;
-    } else { narrow[0] = 0; }
+    } else {
+        narrow[0] = 0;
+    }
     return Registry::instance().queryValue(hKey, narrow, lpType, lpData, lpcbData);
 }
 
-static LONG MSABI advapi32_RegSetValueExA(void* hKey, const char* valueName, DWORD reserved, DWORD dwType, const BYTE* lpData, DWORD cbData) {
+static LONG MSABI advapi32_RegSetValueExA(void* hKey, const char* valueName, DWORD reserved, DWORD dwType,
+                                          const BYTE* lpData, DWORD cbData) {
     (void)reserved;
     return Registry::instance().setValue(hKey, valueName ? valueName : "", dwType, lpData, cbData);
 }
 
-static LONG MSABI advapi32_RegSetValueExW(void* hKey, const wchar_t* valueName, DWORD reserved, DWORD dwType, const BYTE* lpData, DWORD cbData) {
+static LONG MSABI advapi32_RegSetValueExW(void* hKey, const wchar_t* valueName, DWORD reserved, DWORD dwType,
+                                          const BYTE* lpData, DWORD cbData) {
     (void)reserved;
     char narrow[256];
     if (valueName) {
         int j = 0;
-        for (int i = 0; valueName[i] && j < 255; i++) narrow[j++] = (char)(valueName[i] & 0xFF);
+        for (int i = 0; valueName[i] && j < 255; i++)
+            narrow[j++] = (char)(valueName[i] & 0xFF);
         narrow[j] = 0;
-    } else { narrow[0] = 0; }
+    } else {
+        narrow[0] = 0;
+    }
     return Registry::instance().setValue(hKey, narrow, dwType, lpData, cbData);
 }
 
@@ -274,35 +371,62 @@ static LONG MSABI advapi32_RegDeleteKeyW(void* hKey, const wchar_t* subKey) {
     char narrow[1024];
     if (subKey) {
         int j = 0;
-        for (int i = 0; subKey[i] && j < 1023; i++) narrow[j++] = (char)(subKey[i] & 0xFF);
+        for (int i = 0; subKey[i] && j < 1023; i++)
+            narrow[j++] = (char)(subKey[i] & 0xFF);
         narrow[j] = 0;
-    } else { narrow[0] = 0; }
+    } else {
+        narrow[0] = 0;
+    }
     return Registry::instance().deleteKey(hKey, narrow);
 }
 
-static LONG MSABI advapi32_RegEnumKeyExW(void* hKey, DWORD dwIndex, wchar_t* lpName, DWORD* lpcchName, DWORD* lpReserved,
-    wchar_t* lpClass, DWORD* lpcchClass, void* lpftLastWriteTime) {
-    (void)hKey; (void)dwIndex; (void)lpName; (void)lpcchName;
-    (void)lpReserved; (void)lpClass; (void)lpcchClass; (void)lpftLastWriteTime;
+static LONG MSABI advapi32_RegEnumKeyExW(void* hKey, DWORD dwIndex, wchar_t* lpName, DWORD* lpcchName,
+                                         DWORD* lpReserved, wchar_t* lpClass, DWORD* lpcchClass,
+                                         void* lpftLastWriteTime) {
+    (void)hKey;
+    (void)dwIndex;
+    (void)lpName;
+    (void)lpcchName;
+    (void)lpReserved;
+    (void)lpClass;
+    (void)lpcchClass;
+    (void)lpftLastWriteTime;
     return 2;
 }
 
 static LONG MSABI advapi32_RegEnumValueW(void* hKey, DWORD dwIndex, wchar_t* lpValueName, DWORD* lpcchValueName,
-    DWORD* lpReserved, DWORD* lpType, BYTE* lpData, DWORD* lpcbData) {
-    (void)hKey; (void)dwIndex; (void)lpValueName; (void)lpcchValueName;
-    (void)lpReserved; (void)lpType; (void)lpData; (void)lpcbData;
+                                         DWORD* lpReserved, DWORD* lpType, BYTE* lpData, DWORD* lpcbData) {
+    (void)hKey;
+    (void)dwIndex;
+    (void)lpValueName;
+    (void)lpcchValueName;
+    (void)lpReserved;
+    (void)lpType;
+    (void)lpData;
+    (void)lpcbData;
     return 2;
 }
 
-static BOOL MSABI advapi32_InitializeSecurityDescriptor(void* sd, DWORD) { memset(sd, 0, 32); return 1; }
+static BOOL MSABI advapi32_InitializeSecurityDescriptor(void* sd, DWORD) {
+    memset(sd, 0, 32);
+    return 1;
+}
 
-static BOOL MSABI advapi32_SetSecurityDescriptorDacl(void*, BOOL, void*, BOOL) { return 1; }
+static BOOL MSABI advapi32_SetSecurityDescriptorDacl(void*, BOOL, void*, BOOL) {
+    return 1;
+}
 
-static void* MSABI advapi32_RegisterEventSourceW(const wchar_t*, const wchar_t*) { return reinterpret_cast<void*>(0xA100); }
+static void* MSABI advapi32_RegisterEventSourceW(const wchar_t*, const wchar_t*) {
+    return reinterpret_cast<void*>(0xA100);
+}
 
-static BOOL MSABI advapi32_DeregisterEventSource(void*) { return 1; }
+static BOOL MSABI advapi32_DeregisterEventSource(void*) {
+    return 1;
+}
 
-static BOOL MSABI advapi32_ReportEventW(void*, WORD, WORD, DWORD, void*, WORD, DWORD, const wchar_t**, void*) { return 1; }
+static BOOL MSABI advapi32_ReportEventW(void*, WORD, WORD, DWORD, void*, WORD, DWORD, const wchar_t**, void*) {
+    return 1;
+}
 
 ShimLibrary createAdvapi32Shim() {
     ShimLibrary lib;
@@ -334,11 +458,16 @@ ShimLibrary createAdvapi32Shim() {
 }
 
 static int MSABI ws2_32_WSAStartup(WORD, void* data) {
-    if (data) { memset(data, 0, 400); reinterpret_cast<WORD*>(data)[0] = 0x0202; }
+    if (data) {
+        memset(data, 0, 400);
+        reinterpret_cast<WORD*>(data)[0] = 0x0202;
+    }
     return 0;
 }
 
-static int MSABI ws2_32_WSACleanup() { return 0; }
+static int MSABI ws2_32_WSACleanup() {
+    return 0;
+}
 
 static int MSABI ws2_32_WSAGetLastError() {
     return (int)NetworkContext::instance().getWsaError();
@@ -356,14 +485,20 @@ static void* MSABI ws2_32_WSASocketA(int af, int type, int proto, void*, DWORD, 
 
 static int MSABI ws2_32_closesocket(void* s) {
     int fd = NetworkContext::instance().releaseSocket((int)(intptr_t)s);
-    if (fd >= 0) { close(fd); return 0; }
+    if (fd >= 0) {
+        close(fd);
+        return 0;
+    }
     NetworkContext::instance().setWsaError(WSAENOTSOCK);
     return -1;
 }
 
 static int MSABI ws2_32_connect(void* s, const void* addr, int len) {
     int fd = NetworkContext::instance().getFd((int)(intptr_t)s);
-    if (fd < 0) { NetworkContext::instance().setWsaError(WSAENOTSOCK); return -1; }
+    if (fd < 0) {
+        NetworkContext::instance().setWsaError(WSAENOTSOCK);
+        return -1;
+    }
     int ret = ::connect(fd, (const sockaddr*)addr, (socklen_t)len);
     if (ret < 0) {
         if (errno == EINPROGRESS) {
@@ -377,39 +512,58 @@ static int MSABI ws2_32_connect(void* s, const void* addr, int len) {
 
 static int MSABI ws2_32_send(void* s, const char* buf, int len, int flags) {
     int fd = NetworkContext::instance().getFd((int)(intptr_t)s);
-    if (fd < 0) { NetworkContext::instance().setWsaError(WSAENOTSOCK); return -1; }
+    if (fd < 0) {
+        NetworkContext::instance().setWsaError(WSAENOTSOCK);
+        return -1;
+    }
     int ret = (int)::send(fd, buf, (size_t)len, flags);
-    if (ret < 0) NetworkContext::instance().setWsaError(NetworkContext::instance().mapErrnoToWsa(errno));
+    if (ret < 0)
+        NetworkContext::instance().setWsaError(NetworkContext::instance().mapErrnoToWsa(errno));
     return ret;
 }
 
 static int MSABI ws2_32_recv(void* s, char* buf, int len, int flags) {
     int fd = NetworkContext::instance().getFd((int)(intptr_t)s);
-    if (fd < 0) { NetworkContext::instance().setWsaError(WSAENOTSOCK); return -1; }
+    if (fd < 0) {
+        NetworkContext::instance().setWsaError(WSAENOTSOCK);
+        return -1;
+    }
     int ret = (int)::recv(fd, buf, (size_t)len, flags);
-    if (ret < 0) NetworkContext::instance().setWsaError(NetworkContext::instance().mapErrnoToWsa(errno));
+    if (ret < 0)
+        NetworkContext::instance().setWsaError(NetworkContext::instance().mapErrnoToWsa(errno));
     return ret;
 }
 
 static int MSABI ws2_32_bind(void* s, const void* addr, int len) {
     int fd = NetworkContext::instance().getFd((int)(intptr_t)s);
-    if (fd < 0) { NetworkContext::instance().setWsaError(WSAENOTSOCK); return -1; }
+    if (fd < 0) {
+        NetworkContext::instance().setWsaError(WSAENOTSOCK);
+        return -1;
+    }
     int ret = ::bind(fd, (const sockaddr*)addr, (socklen_t)len);
-    if (ret < 0) NetworkContext::instance().setWsaError(NetworkContext::instance().mapErrnoToWsa(errno));
+    if (ret < 0)
+        NetworkContext::instance().setWsaError(NetworkContext::instance().mapErrnoToWsa(errno));
     return ret;
 }
 
 static int MSABI ws2_32_listen(void* s, int backlog) {
     int fd = NetworkContext::instance().getFd((int)(intptr_t)s);
-    if (fd < 0) { NetworkContext::instance().setWsaError(WSAENOTSOCK); return -1; }
+    if (fd < 0) {
+        NetworkContext::instance().setWsaError(WSAENOTSOCK);
+        return -1;
+    }
     int ret = ::listen(fd, backlog);
-    if (ret < 0) NetworkContext::instance().setWsaError(NetworkContext::instance().mapErrnoToWsa(errno));
+    if (ret < 0)
+        NetworkContext::instance().setWsaError(NetworkContext::instance().mapErrnoToWsa(errno));
     return ret;
 }
 
 static void* MSABI ws2_32_accept(void* s, void* addr, int* len) {
     int fd = NetworkContext::instance().getFd((int)(intptr_t)s);
-    if (fd < 0) { NetworkContext::instance().setWsaError(WSAENOTSOCK); return reinterpret_cast<void*>(static_cast<intptr_t>(-1)); }
+    if (fd < 0) {
+        NetworkContext::instance().setWsaError(WSAENOTSOCK);
+        return reinterpret_cast<void*>(static_cast<intptr_t>(-1));
+    }
     int nfd = ::accept(fd, (sockaddr*)addr, (socklen_t*)len);
     if (nfd < 0) {
         NetworkContext::instance().setWsaError(NetworkContext::instance().mapErrnoToWsa(errno));
@@ -421,44 +575,57 @@ static void* MSABI ws2_32_accept(void* s, void* addr, int* len) {
 
 static int MSABI ws2_32_shutdown(void* s, int how) {
     int fd = NetworkContext::instance().getFd((int)(intptr_t)s);
-    if (fd < 0) { NetworkContext::instance().setWsaError(WSAENOTSOCK); return -1; }
+    if (fd < 0) {
+        NetworkContext::instance().setWsaError(WSAENOTSOCK);
+        return -1;
+    }
     int ret = ::shutdown(fd, how);
-    if (ret < 0) NetworkContext::instance().setWsaError(NetworkContext::instance().mapErrnoToWsa(errno));
+    if (ret < 0)
+        NetworkContext::instance().setWsaError(NetworkContext::instance().mapErrnoToWsa(errno));
     return ret;
 }
 
 static int MSABI ws2_32_ioctlsocket(void* s, long cmd, void* argp) {
     int fd = NetworkContext::instance().getFd((int)(intptr_t)s);
-    if (fd < 0) { NetworkContext::instance().setWsaError(WSAENOTSOCK); return -1; }
+    if (fd < 0) {
+        NetworkContext::instance().setWsaError(WSAENOTSOCK);
+        return -1;
+    }
     if (cmd == 0x8004667E) {
         int flags = fcntl(fd, F_GETFL, 0);
-        if (*(reinterpret_cast<uint32_t*>(argp))) fcntl(fd, F_SETFL, flags | O_NONBLOCK);
-        else fcntl(fd, F_SETFL, flags & ~O_NONBLOCK);
+        if (*(reinterpret_cast<uint32_t*>(argp)))
+            fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+        else
+            fcntl(fd, F_SETFL, flags & ~O_NONBLOCK);
     }
     return 0;
 }
 
 static int MSABI ws2_32_getsockname(void* s, void* addr, int* len) {
     int fd = NetworkContext::instance().getFd((int)(intptr_t)s);
-    if (fd < 0) return -1;
+    if (fd < 0)
+        return -1;
     return ::getsockname(fd, (sockaddr*)addr, (socklen_t*)len);
 }
 
 static int MSABI ws2_32_getpeername(void* s, void* addr, int* len) {
     int fd = NetworkContext::instance().getFd((int)(intptr_t)s);
-    if (fd < 0) return -1;
+    if (fd < 0)
+        return -1;
     return ::getpeername(fd, (sockaddr*)addr, (socklen_t*)len);
 }
 
 static int MSABI ws2_32_getsockopt(void* s, int level, int opt, char* val, int* len) {
     int fd = NetworkContext::instance().getFd((int)(intptr_t)s);
-    if (fd < 0) return -1;
+    if (fd < 0)
+        return -1;
     return ::getsockopt(fd, level, opt, val, (socklen_t*)len);
 }
 
 static int MSABI ws2_32_setsockopt(void* s, int level, int opt, const char* val, int len) {
     int fd = NetworkContext::instance().getFd((int)(intptr_t)s);
-    if (fd < 0) return -1;
+    if (fd < 0)
+        return -1;
     return ::setsockopt(fd, level, opt, val, (socklen_t)len);
 }
 
@@ -478,13 +645,15 @@ static int MSABI ws2_32_select(int nfds, void* readfds, void* writefds, void* ex
     int maxfd = 0;
 
     auto translateSet = [&](void* winSet, fd_set& posixSet) {
-        if (!winSet) return;
+        if (!winSet)
+            return;
         auto* wfd = reinterpret_cast<WinFDSet*>(winSet);
         for (uint32_t i = 0; i < wfd->fd_count; i++) {
             int fd = ctx.getFd((int)(intptr_t)wfd->fd_array[i]);
             if (fd >= 0) {
                 FD_SET(fd, &posixSet);
-                if (fd > maxfd) maxfd = fd;
+                if (fd > maxfd)
+                    maxfd = fd;
             }
         }
     };
@@ -509,7 +678,8 @@ static int MSABI ws2_32_select(int nfds, void* readfds, void* writefds, void* ex
     }
 
     auto translateBack = [&](void* winSet, fd_set& posixSet) {
-        if (!winSet) return;
+        if (!winSet)
+            return;
         auto* wfd = reinterpret_cast<WinFDSet*>(winSet);
         uint32_t outCount = 0;
         for (uint32_t i = 0; i < wfd->fd_count; i++) {
@@ -536,14 +706,28 @@ static int MSABI ws2_32_getaddrinfo(const char* node, const char* service, const
     return ret;
 }
 
-static void MSABI ws2_32_freeaddrinfo(void* p) { freeaddrinfo((addrinfo*)p); }
+static void MSABI ws2_32_freeaddrinfo(void* p) {
+    freeaddrinfo((addrinfo*)p);
+}
 
-static uint16_t MSABI ws2_32_htons(uint16_t v) { return __builtin_bswap16(v); }
-static uint16_t MSABI ws2_32_ntohs(uint16_t v) { return __builtin_bswap16(v); }
-static uint32_t MSABI ws2_32_htonl(uint32_t v) { return __builtin_bswap32(v); }
-static uint32_t MSABI ws2_32_ntohl(uint32_t v) { return __builtin_bswap32(v); }
-static uint32_t MSABI ws2_32_inet_addr(const char* cp) { return inet_addr(cp); }
-static char* MSABI ws2_32_inet_ntoa(struct in_addr in) { return inet_ntoa(in); }
+static uint16_t MSABI ws2_32_htons(uint16_t v) {
+    return __builtin_bswap16(v);
+}
+static uint16_t MSABI ws2_32_ntohs(uint16_t v) {
+    return __builtin_bswap16(v);
+}
+static uint32_t MSABI ws2_32_htonl(uint32_t v) {
+    return __builtin_bswap32(v);
+}
+static uint32_t MSABI ws2_32_ntohl(uint32_t v) {
+    return __builtin_bswap32(v);
+}
+static uint32_t MSABI ws2_32_inet_addr(const char* cp) {
+    return inet_addr(cp);
+}
+static char* MSABI ws2_32_inet_ntoa(struct in_addr in) {
+    return inet_ntoa(in);
+}
 
 static struct hostent g_hostent;
 static char* g_hostentAliases[2] = {nullptr, nullptr};
@@ -552,7 +736,8 @@ static uint32_t g_hostentAddr;
 static pthread_mutex_t g_hostentMutex = PTHREAD_MUTEX_INITIALIZER;
 
 static void* MSABI ws2_32_gethostbyname(const char* name) {
-    if (!name) return nullptr;
+    if (!name)
+        return nullptr;
     pthread_mutex_lock(&g_hostentMutex);
     struct addrinfo hints, *res;
     memset(&hints, 0, sizeof(hints));
@@ -578,38 +763,47 @@ static void* MSABI ws2_32_gethostbyname(const char* name) {
 }
 
 static int MSABI ws2_32_WSAIoctl(void* s, DWORD dwIoControlCode, void* lpvInBuffer, DWORD cbInBuffer,
-    void* lpvOutBuffer, DWORD cbOutBuffer, DWORD* lpcbBytesReturned, void*, void*) {
+                                 void* lpvOutBuffer, DWORD cbOutBuffer, DWORD* lpcbBytesReturned, void*, void*) {
     auto& ctx = NetworkContext::instance();
     if (dwIoControlCode == SIO_GET_EXTENSION_FUNCTION_POINTER) {
         if (lpvInBuffer && cbInBuffer >= sizeof(uint32_t)) {
             uint32_t guid0 = *reinterpret_cast<uint32_t*>(lpvInBuffer);
             if (lpvOutBuffer && cbOutBuffer >= sizeof(void*)) {
                 *reinterpret_cast<void**>(lpvOutBuffer) = reinterpret_cast<void*>(static_cast<intptr_t>(guid0));
-                if (lpcbBytesReturned) *lpcbBytesReturned = sizeof(void*);
+                if (lpcbBytesReturned)
+                    *lpcbBytesReturned = sizeof(void*);
                 return 0;
             }
         }
     }
 
     int fd = ctx.getFd((int)(intptr_t)s);
-    if (fd < 0) return -1;
+    if (fd < 0)
+        return -1;
 
     if (dwIoControlCode == 0x4004667F || dwIoControlCode == 0x8004667D) {
         int arg = 0;
-        if (dwIoControlCode == 0x8004667D) arg = 1;
+        if (dwIoControlCode == 0x8004667D)
+            arg = 1;
         int ret = ::ioctl(fd, FIONBIO, &arg);
-        if (ret < 0) { ctx.setWsaError(ctx.mapErrnoToWsa(errno)); return -1; }
+        if (ret < 0) {
+            ctx.setWsaError(ctx.mapErrnoToWsa(errno));
+            return -1;
+        }
         return 0;
     }
 
     return 0;
 }
 
-static int MSABI ws2_32_WSARecv(void* s, void* lpBuffers, DWORD dwBufferCount,
-    DWORD* lpNumberOfBytesRecvd, DWORD* lpFlags, void* lpOverlapped, void* lpCompletionRoutine) {
+static int MSABI ws2_32_WSARecv(void* s, void* lpBuffers, DWORD dwBufferCount, DWORD* lpNumberOfBytesRecvd,
+                                DWORD* lpFlags, void* lpOverlapped, void* lpCompletionRoutine) {
     auto& ctx = NetworkContext::instance();
     int fd = ctx.getFd((int)(intptr_t)s);
-    if (fd < 0) { ctx.setWsaError(WSAENOTSOCK); return -1; }
+    if (fd < 0) {
+        ctx.setWsaError(WSAENOTSOCK);
+        return -1;
+    }
 
     auto* bufs = reinterpret_cast<WSABUF*>(lpBuffers);
     if (lpOverlapped) {
@@ -622,22 +816,28 @@ static int MSABI ws2_32_WSARecv(void* s, void* lpBuffers, DWORD dwBufferCount,
         ssize_t n = ::recv(fd, bufs[i].buf, bufs[i].len, 0);
         if (n < 0) {
             ctx.setWsaError(ctx.mapErrnoToWsa(errno));
-            if (totalRead > 0) break;
+            if (totalRead > 0)
+                break;
             return -1;
         }
         totalRead += (DWORD)n;
-        if ((DWORD)n < bufs[i].len) break;
+        if ((DWORD)n < bufs[i].len)
+            break;
     }
-    if (lpNumberOfBytesRecvd) *lpNumberOfBytesRecvd = totalRead;
+    if (lpNumberOfBytesRecvd)
+        *lpNumberOfBytesRecvd = totalRead;
     return 0;
 }
 
-static int MSABI ws2_32_WSARecvFrom(void* s, void* lpBuffers, DWORD dwBufferCount,
-    DWORD* lpNumberOfBytesRecvd, DWORD* lpFlags, void* lpFrom, int* lpFromlen,
-    void* lpOverlapped, void* lpCompletionRoutine) {
+static int MSABI ws2_32_WSARecvFrom(void* s, void* lpBuffers, DWORD dwBufferCount, DWORD* lpNumberOfBytesRecvd,
+                                    DWORD* lpFlags, void* lpFrom, int* lpFromlen, void* lpOverlapped,
+                                    void* lpCompletionRoutine) {
     auto& ctx = NetworkContext::instance();
     int fd = ctx.getFd((int)(intptr_t)s);
-    if (fd < 0) { ctx.setWsaError(WSAENOTSOCK); return -1; }
+    if (fd < 0) {
+        ctx.setWsaError(WSAENOTSOCK);
+        return -1;
+    }
 
     auto* bufs = reinterpret_cast<WSABUF*>(lpBuffers);
     if (lpOverlapped) {
@@ -647,25 +847,30 @@ static int MSABI ws2_32_WSARecvFrom(void* s, void* lpBuffers, DWORD dwBufferCoun
 
     DWORD totalRead = 0;
     for (DWORD i = 0; i < dwBufferCount; i++) {
-        ssize_t n = ::recvfrom(fd, bufs[i].buf, bufs[i].len, 0,
-            (sockaddr*)lpFrom, (socklen_t*)(lpFromlen));
+        ssize_t n = ::recvfrom(fd, bufs[i].buf, bufs[i].len, 0, (sockaddr*)lpFrom, (socklen_t*)(lpFromlen));
         if (n < 0) {
             ctx.setWsaError(ctx.mapErrnoToWsa(errno));
-            if (totalRead > 0) break;
+            if (totalRead > 0)
+                break;
             return -1;
         }
         totalRead += (DWORD)n;
-        if ((DWORD)n < bufs[i].len) break;
+        if ((DWORD)n < bufs[i].len)
+            break;
     }
-    if (lpNumberOfBytesRecvd) *lpNumberOfBytesRecvd = totalRead;
+    if (lpNumberOfBytesRecvd)
+        *lpNumberOfBytesRecvd = totalRead;
     return 0;
 }
 
-static int MSABI ws2_32_WSASend(void* s, void* lpBuffers, DWORD dwBufferCount,
-    DWORD* lpNumberOfBytesSent, DWORD dwFlags, void* lpOverlapped, void* lpCompletionRoutine) {
+static int MSABI ws2_32_WSASend(void* s, void* lpBuffers, DWORD dwBufferCount, DWORD* lpNumberOfBytesSent,
+                                DWORD dwFlags, void* lpOverlapped, void* lpCompletionRoutine) {
     auto& ctx = NetworkContext::instance();
     int fd = ctx.getFd((int)(intptr_t)s);
-    if (fd < 0) { ctx.setWsaError(WSAENOTSOCK); return -1; }
+    if (fd < 0) {
+        ctx.setWsaError(WSAENOTSOCK);
+        return -1;
+    }
 
     auto* bufs = reinterpret_cast<WSABUF*>(lpBuffers);
     if (lpOverlapped) {
@@ -678,21 +883,26 @@ static int MSABI ws2_32_WSASend(void* s, void* lpBuffers, DWORD dwBufferCount,
         ssize_t n = ::send(fd, bufs[i].buf, bufs[i].len, dwFlags);
         if (n < 0) {
             ctx.setWsaError(ctx.mapErrnoToWsa(errno));
-            if (totalSent > 0) break;
+            if (totalSent > 0)
+                break;
             return -1;
         }
         totalSent += (DWORD)n;
     }
-    if (lpNumberOfBytesSent) *lpNumberOfBytesSent = totalSent;
+    if (lpNumberOfBytesSent)
+        *lpNumberOfBytesSent = totalSent;
     return 0;
 }
 
-static int MSABI ws2_32_WSASendTo(void* s, void* lpBuffers, DWORD dwBufferCount,
-    DWORD* lpNumberOfBytesSent, DWORD dwFlags, const void* lpTo, int iTolen,
-    void* lpOverlapped, void* lpCompletionRoutine) {
+static int MSABI ws2_32_WSASendTo(void* s, void* lpBuffers, DWORD dwBufferCount, DWORD* lpNumberOfBytesSent,
+                                  DWORD dwFlags, const void* lpTo, int iTolen, void* lpOverlapped,
+                                  void* lpCompletionRoutine) {
     auto& ctx = NetworkContext::instance();
     int fd = ctx.getFd((int)(intptr_t)s);
-    if (fd < 0) { ctx.setWsaError(WSAENOTSOCK); return -1; }
+    if (fd < 0) {
+        ctx.setWsaError(WSAENOTSOCK);
+        return -1;
+    }
 
     auto* bufs = reinterpret_cast<WSABUF*>(lpBuffers);
     if (lpOverlapped) {
@@ -702,16 +912,17 @@ static int MSABI ws2_32_WSASendTo(void* s, void* lpBuffers, DWORD dwBufferCount,
 
     DWORD totalSent = 0;
     for (DWORD i = 0; i < dwBufferCount; i++) {
-        ssize_t n = ::sendto(fd, bufs[i].buf, bufs[i].len, dwFlags,
-            (const sockaddr*)lpTo, (socklen_t)iTolen);
+        ssize_t n = ::sendto(fd, bufs[i].buf, bufs[i].len, dwFlags, (const sockaddr*)lpTo, (socklen_t)iTolen);
         if (n < 0) {
             ctx.setWsaError(ctx.mapErrnoToWsa(errno));
-            if (totalSent > 0) break;
+            if (totalSent > 0)
+                break;
             return -1;
         }
         totalSent += (DWORD)n;
     }
-    if (lpNumberOfBytesSent) *lpNumberOfBytesSent = totalSent;
+    if (lpNumberOfBytesSent)
+        *lpNumberOfBytesSent = totalSent;
     return 0;
 }
 
@@ -719,7 +930,10 @@ static int MSABI ws2_32_WSAEventSelect(void* s, void* hEventObject, uint32_t lNe
     auto& ctx = NetworkContext::instance();
     int handle = (int)(intptr_t)s;
     int fd = ctx.getFd(handle);
-    if (fd < 0) { ctx.setWsaError(WSAENOTSOCK); return -1; }
+    if (fd < 0) {
+        ctx.setWsaError(WSAENOTSOCK);
+        return -1;
+    }
 
     ctx.setSocketEventMask(handle, lNetworkEvents, hEventObject);
 
@@ -734,7 +948,10 @@ static int MSABI ws2_32_WSAAsyncSelect(void* s, void* hWnd, uint32_t wMsg, uint3
     auto& ctx = NetworkContext::instance();
     int handle = (int)(intptr_t)s;
     int fd = ctx.getFd(handle);
-    if (fd < 0) { ctx.setWsaError(WSAENOTSOCK); return -1; }
+    if (fd < 0) {
+        ctx.setWsaError(WSAENOTSOCK);
+        return -1;
+    }
 
     ctx.setSocketEventMask(handle, lEvent, hWnd);
 
@@ -745,16 +962,21 @@ static int MSABI ws2_32_WSAAsyncSelect(void* s, void* hWnd, uint32_t wMsg, uint3
     return 0;
 }
 
-static int MSABI ws2_32_WSAGetOverlappedResult(void* s, void* lpOverlapped,
-    DWORD* lpcbTransfer, BOOL fWait, DWORD* lpdwFlags) {
-    (void)s; (void)lpOverlapped; (void)fWait;
-    if (lpcbTransfer) *lpcbTransfer = 0;
-    if (lpdwFlags) *lpdwFlags = 0;
+static int MSABI ws2_32_WSAGetOverlappedResult(void* s, void* lpOverlapped, DWORD* lpcbTransfer, BOOL fWait,
+                                               DWORD* lpdwFlags) {
+    (void)s;
+    (void)lpOverlapped;
+    (void)fWait;
+    if (lpcbTransfer)
+        *lpcbTransfer = 0;
+    if (lpdwFlags)
+        *lpdwFlags = 0;
     return 1;
 }
 
 static int MSABI ws2_32_WSACreateEvent(void** lpEvent) {
-    if (lpEvent) *lpEvent = reinterpret_cast<void*>(0xEE00);
+    if (lpEvent)
+        *lpEvent = reinterpret_cast<void*>(0xEE00);
     return 0;
 }
 
@@ -763,10 +985,12 @@ static int MSABI ws2_32_WSACloseEvent(void* hEvent) {
     return 1;
 }
 
-static int MSABI ws2_32_WSAWaitForMultipleEvents(DWORD cEvents, void** lphEvents,
-    BOOL fWaitAll, DWORD dwTimeout, BOOL fAlertable) {
-    (void)fWaitAll; (void)fAlertable;
-    if (cEvents == 0) return -1;
+static int MSABI ws2_32_WSAWaitForMultipleEvents(DWORD cEvents, void** lphEvents, BOOL fWaitAll, DWORD dwTimeout,
+                                                 BOOL fAlertable) {
+    (void)fWaitAll;
+    (void)fAlertable;
+    if (cEvents == 0)
+        return -1;
     if (dwTimeout == 0xFFFFFFFF) {
         pollfd pfd;
         pfd.fd = 0;
@@ -782,7 +1006,8 @@ static int MSABI ws2_32_WSAWaitForMultipleEvents(DWORD cEvents, void** lphEvents
 }
 
 static int MSABI ws2_32_WSAEnumNetworkEvents(void* s, void* hEvent, void* lpNetworkEvents) {
-    (void)s; (void)hEvent;
+    (void)s;
+    (void)hEvent;
     if (lpNetworkEvents) {
         auto* ne = reinterpret_cast<uint32_t*>(lpNetworkEvents);
         ne[0] = FD_READ | FD_WRITE | FD_ACCEPT | FD_CONNECT;
@@ -797,7 +1022,8 @@ static int MSABI ws2_32_ord3(void* s) {
 
 static int MSABI ws2_32_ord4(void* s, int level, int opt) {
     int fd = NetworkContext::instance().getFd((int)(intptr_t)s);
-    if (fd < 0) return -1;
+    if (fd < 0)
+        return -1;
     int val = 0;
     return ::getsockopt(fd, level, opt, reinterpret_cast<char*>(&val), nullptr) == 0 ? val : 0;
 }
@@ -863,17 +1089,25 @@ static int MSABI ws2_32_ord151(void* s, const char* host, const char* service, c
 
 static int MSABI ws2_32_recvfrom(void* s, char* buf, int len, int flags, void* from, int* fromlen) {
     int fd = NetworkContext::instance().getFd((int)(intptr_t)s);
-    if (fd < 0) { NetworkContext::instance().setWsaError(WSAENOTSOCK); return -1; }
+    if (fd < 0) {
+        NetworkContext::instance().setWsaError(WSAENOTSOCK);
+        return -1;
+    }
     int ret = (int)::recvfrom(fd, buf, (size_t)len, flags, (sockaddr*)from, (socklen_t*)fromlen);
-    if (ret < 0) NetworkContext::instance().setWsaError(NetworkContext::instance().mapErrnoToWsa(errno));
+    if (ret < 0)
+        NetworkContext::instance().setWsaError(NetworkContext::instance().mapErrnoToWsa(errno));
     return ret;
 }
 
 static int MSABI ws2_32_sendto(void* s, const char* buf, int len, int flags, const void* to, int tolen) {
     int fd = NetworkContext::instance().getFd((int)(intptr_t)s);
-    if (fd < 0) { NetworkContext::instance().setWsaError(WSAENOTSOCK); return -1; }
+    if (fd < 0) {
+        NetworkContext::instance().setWsaError(WSAENOTSOCK);
+        return -1;
+    }
     int ret = (int)::sendto(fd, buf, (size_t)len, flags, (const sockaddr*)to, (socklen_t)tolen);
-    if (ret < 0) NetworkContext::instance().setWsaError(NetworkContext::instance().mapErrnoToWsa(errno));
+    if (ret < 0)
+        NetworkContext::instance().setWsaError(NetworkContext::instance().mapErrnoToWsa(errno));
     return ret;
 }
 
@@ -949,22 +1183,29 @@ ShimLibrary createWs2_32Shim() {
 }
 
 static wchar_t** MSABI shell32_CommandLineToArgvW(const wchar_t*, int* argc) {
-    if (argc) *argc = 1;
+    if (argc)
+        *argc = 1;
     auto** argv = (wchar_t**)malloc(sizeof(wchar_t*) * 2);
     argv[0] = (wchar_t*)L"steam.exe";
     argv[1] = nullptr;
     return argv;
 }
 
-static DWORD MSABI shell32_SHGetFileInfoW(const wchar_t*, DWORD, void*, UINT, UINT) { return 0; }
+static DWORD MSABI shell32_SHGetFileInfoW(const wchar_t*, DWORD, void*, UINT, UINT) {
+    return 0;
+}
 
 static LONG MSABI shell32_SHGetKnownFolderPath(const void*, DWORD, void*, wchar_t** ppszPath) {
-    if (ppszPath) { *ppszPath = (wchar_t*)malloc(64); wcscpy(*ppszPath, L"C:\\Users\\user"); }
+    if (ppszPath) {
+        *ppszPath = (wchar_t*)malloc(64);
+        wcscpy(*ppszPath, L"C:\\Users\\user");
+    }
     return 0;
 }
 
 static LONG MSABI shell32_SHGetFolderPathW(void*, int, void*, DWORD, wchar_t* path) {
-    if (path) wcscpy(path, L"C:\\Users\\user");
+    if (path)
+        wcscpy(path, L"C:\\Users\\user");
     return 0;
 }
 
@@ -983,31 +1224,48 @@ ShimLibrary createShell32Shim() {
     return lib;
 }
 
-static void MSABI ole32_CoTaskMemFree(void* p) { free(p); }
+static void MSABI ole32_CoTaskMemFree(void* p) {
+    free(p);
+}
 
-static HRESULT MSABI ole32_CoInitialize(void*) { return 0; }
-static HRESULT MSABI ole32_CoInitializeEx(void*, DWORD) { return 0; }
+static HRESULT MSABI ole32_CoInitialize(void*) {
+    return 0;
+}
+static HRESULT MSABI ole32_CoInitializeEx(void*, DWORD) {
+    return 0;
+}
 static void MSABI ole32_CoUninitialize() {}
-static HRESULT MSABI ole32_CoCreateInstance(const GUID* rclsid, void* punkOuter, DWORD dwClsCtx, const GUID* riid, void** ppv) {
-    if (ppv) *ppv = nullptr;
+static HRESULT MSABI ole32_CoCreateInstance(const GUID* rclsid, void* punkOuter, DWORD dwClsCtx, const GUID* riid,
+                                            void** ppv) {
+    if (ppv)
+        *ppv = nullptr;
     return (HRESULT)0x80040154L;
 }
-static void* MSABI ole32_CoTaskMemAlloc(SIZE_T cb) { return malloc(cb); }
-static void* MSABI ole32_CoTaskMemRealloc(void* pv, SIZE_T cb) { return realloc(pv, cb); }
+static void* MSABI ole32_CoTaskMemAlloc(SIZE_T cb) {
+    return malloc(cb);
+}
+static void* MSABI ole32_CoTaskMemRealloc(void* pv, SIZE_T cb) {
+    return realloc(pv, cb);
+}
 static int MSABI ole32_StringFromGUID2(const GUID* guid, wchar_t* lpsz, int cchMax) {
-    if (!guid || !lpsz || cchMax < 39) return 0;
-    swprintf(lpsz, cchMax, L"{%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X}",
-        guid->Data1, guid->Data2, guid->Data3,
-        guid->Data4[0], guid->Data4[1], guid->Data4[2], guid->Data4[3],
-        guid->Data4[4], guid->Data4[5], guid->Data4[6], guid->Data4[7]);
+    if (!guid || !lpsz || cchMax < 39)
+        return 0;
+    swprintf(lpsz, cchMax, L"{%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X}", guid->Data1, guid->Data2, guid->Data3,
+             guid->Data4[0], guid->Data4[1], guid->Data4[2], guid->Data4[3], guid->Data4[4], guid->Data4[5],
+             guid->Data4[6], guid->Data4[7]);
     return 39;
 }
 static HRESULT MSABI ole32_IIDFromString(const wchar_t*, GUID* guid) {
-    if (guid) memset(guid, 0, sizeof(GUID));
+    if (guid)
+        memset(guid, 0, sizeof(GUID));
     return 0;
 }
-static HRESULT MSABI ole32_CoGetClassObject(const GUID*, DWORD, void*, const GUID*, void**) { return (HRESULT)0x80040154L; }
-static HRESULT MSABI ole32_OleInitialize(void*) { return 0; }
+static HRESULT MSABI ole32_CoGetClassObject(const GUID*, DWORD, void*, const GUID*, void**) {
+    return (HRESULT)0x80040154L;
+}
+static HRESULT MSABI ole32_OleInitialize(void*) {
+    return 0;
+}
 static void MSABI ole32_OleUninitialize() {}
 
 ShimLibrary createOle32Shim() {
@@ -1030,31 +1288,60 @@ ShimLibrary createOle32Shim() {
 }
 
 static void* MSABI oleaut32_SysAllocString(const wchar_t* str) {
-    if (!str) return nullptr;
+    if (!str)
+        return nullptr;
     size_t len = wcslen(str);
     wchar_t* buf = (wchar_t*)malloc((len + 1) * sizeof(wchar_t));
     wcscpy(buf, str);
     return buf;
 }
 
-static void MSABI oleaut32_SysFreeString(void* bstr) { free(bstr); }
+static void MSABI oleaut32_SysFreeString(void* bstr) {
+    free(bstr);
+}
 static void* MSABI oleaut32_SysAllocStringLen(const wchar_t*, UINT len) {
     return malloc((len + 1) * sizeof(wchar_t));
 }
 static UINT MSABI oleaut32_SysStringLen(void* bstr) {
-    if (!bstr) return 0;
+    if (!bstr)
+        return 0;
     return (UINT)wcslen((const wchar_t*)bstr);
 }
-static void MSABI oleaut32_VariantInit(void* pv) { if (pv) memset(pv, 0, 16); }
-static HRESULT MSABI oleaut32_VariantClear(void* pv) { if (pv) memset(pv, 0, 16); return 0; }
-static HRESULT MSABI oleaut32_VariantChangeType(void*, void*, UINT, UINT) { return 0; }
-static HRESULT MSABI oleaut32_VariantChangeTypeEx(void*, void*, DWORD, UINT, UINT) { return 0; }
-static void* MSABI oleaut32_SafeArrayCreate(UINT, UINT, void*) { return calloc(1, 32); }
-static HRESULT MSABI oleaut32_SafeArrayDestroy(void*) { return 0; }
-static HRESULT MSABI oleaut32_SafeArrayAccessData(void*, void** ppv) { if (ppv) *ppv = nullptr; return 0; }
-static HRESULT MSABI oleaut32_SafeArrayUnaccessData(void*) { return 0; }
-static HRESULT MSABI oleaut32_SafeArrayGetLBound(void*, UINT, LONG*) { return 0; }
-static HRESULT MSABI oleaut32_SafeArrayGetUBound(void*, UINT, LONG*) { return 0; }
+static void MSABI oleaut32_VariantInit(void* pv) {
+    if (pv)
+        memset(pv, 0, 16);
+}
+static HRESULT MSABI oleaut32_VariantClear(void* pv) {
+    if (pv)
+        memset(pv, 0, 16);
+    return 0;
+}
+static HRESULT MSABI oleaut32_VariantChangeType(void*, void*, UINT, UINT) {
+    return 0;
+}
+static HRESULT MSABI oleaut32_VariantChangeTypeEx(void*, void*, DWORD, UINT, UINT) {
+    return 0;
+}
+static void* MSABI oleaut32_SafeArrayCreate(UINT, UINT, void*) {
+    return calloc(1, 32);
+}
+static HRESULT MSABI oleaut32_SafeArrayDestroy(void*) {
+    return 0;
+}
+static HRESULT MSABI oleaut32_SafeArrayAccessData(void*, void** ppv) {
+    if (ppv)
+        *ppv = nullptr;
+    return 0;
+}
+static HRESULT MSABI oleaut32_SafeArrayUnaccessData(void*) {
+    return 0;
+}
+static HRESULT MSABI oleaut32_SafeArrayGetLBound(void*, UINT, LONG*) {
+    return 0;
+}
+static HRESULT MSABI oleaut32_SafeArrayGetUBound(void*, UINT, LONG*) {
+    return 0;
+}
 
 ShimLibrary createOleAut32Shim() {
     ShimLibrary lib;
@@ -1078,22 +1365,33 @@ ShimLibrary createOleAut32Shim() {
     return lib;
 }
 
-static void* MSABI crypt32_CertOpenStore(const char*, DWORD, void*, DWORD, const void*) { return reinterpret_cast<void*>(0xC000); }
+static void* MSABI crypt32_CertOpenStore(const char*, DWORD, void*, DWORD, const void*) {
+    return reinterpret_cast<void*>(0xC000);
+}
 
-static BOOL MSABI crypt32_CertCloseStore(void*, DWORD) { return 1; }
+static BOOL MSABI crypt32_CertCloseStore(void*, DWORD) {
+    return 1;
+}
 
-static void* MSABI crypt32_CertCreateCertificateContext(DWORD, const BYTE*, DWORD) { return reinterpret_cast<void*>(0xC001); }
+static void* MSABI crypt32_CertCreateCertificateContext(DWORD, const BYTE*, DWORD) {
+    return reinterpret_cast<void*>(0xC001);
+}
 
-static BOOL MSABI crypt32_CertFreeCertificateContext(void*) { return 1; }
+static BOOL MSABI crypt32_CertFreeCertificateContext(void*) {
+    return 1;
+}
 
 static BOOL MSABI crypt32_CertGetCertificateChain(void*, void*, void*, void*, const void*, DWORD, void*, void** chain) {
-    if (chain) *chain = reinterpret_cast<void*>(0xC002);
+    if (chain)
+        *chain = reinterpret_cast<void*>(0xC002);
     return 1;
 }
 
 static void MSABI crypt32_CertFreeCertificateChain(void*) {}
 
-static BOOL MSABI crypt32_CertAddCertificateContextToStore(void*, void*, DWORD, void**) { return 1; }
+static BOOL MSABI crypt32_CertAddCertificateContextToStore(void*, void*, DWORD, void**) {
+    return 1;
+}
 
 ShimLibrary createCrypt32Shim() {
     ShimLibrary lib;
@@ -1112,13 +1410,19 @@ ShimLibrary createCrypt32Shim() {
 }
 
 static DWORD MSABI psapi_GetModuleFileNameExW(void*, void*, wchar_t* buf, DWORD sz) {
-    if (buf && sz > 0) { buf[0] = 0; } return 0;
+    if (buf && sz > 0) {
+        buf[0] = 0;
+    }
+    return 0;
 }
 
-static BOOL MSABI psapi_GetModuleInformation(void*, void*, void*, DWORD) { return 1; }
+static BOOL MSABI psapi_GetModuleInformation(void*, void*, void*, DWORD) {
+    return 1;
+}
 
 static BOOL MSABI psapi_GetProcessMemoryInfo(void*, void* pmc, DWORD sz) {
-    memset(pmc, 0, sz); return 1;
+    memset(pmc, 0, sz);
+    return 1;
 }
 
 ShimLibrary createPsapiShim() {
@@ -1150,12 +1454,15 @@ struct FakeVersionResource {
 };
 
 static DWORD MSABI version_GetFileVersionInfoSizeW(const wchar_t* lptstrFilename, DWORD* lpdwHandle) {
-    if (lpdwHandle) *lpdwHandle = 0;
+    if (lpdwHandle)
+        *lpdwHandle = 0;
     return sizeof(FakeVersionResource) + 512;
 }
 
-static BOOL MSABI version_GetFileVersionInfoW(const wchar_t* lptstrFilename, DWORD dwHandle, DWORD dwLen, void* lpData) {
-    if (!lpData || dwLen < sizeof(FakeVersionResource)) return 0;
+static BOOL MSABI version_GetFileVersionInfoW(const wchar_t* lptstrFilename, DWORD dwHandle, DWORD dwLen,
+                                              void* lpData) {
+    if (!lpData || dwLen < sizeof(FakeVersionResource))
+        return 0;
     auto* info = reinterpret_cast<FakeVersionResource*>(lpData);
     memset(info, 0, sizeof(FakeVersionResource));
     info->dwSignature = 0xFEEF04BD;
@@ -1172,20 +1479,25 @@ static BOOL MSABI version_GetFileVersionInfoW(const wchar_t* lptstrFilename, DWO
     return 1;
 }
 
-static BOOL MSABI version_VerQueryValueW(const void* pBlock, const wchar_t* lpSubBlock, void** lplpBuffer, UINT* puLen) {
-    if (!pBlock || !lplpBuffer) return 0;
+static BOOL MSABI version_VerQueryValueW(const void* pBlock, const wchar_t* lpSubBlock, void** lplpBuffer,
+                                         UINT* puLen) {
+    if (!pBlock || !lplpBuffer)
+        return 0;
     if (wcsncmp(lpSubBlock, L"\\", 2) == 0) {
         *lplpBuffer = const_cast<void*>(pBlock);
-        if (puLen) *puLen = sizeof(FakeVersionResource);
+        if (puLen)
+            *puLen = sizeof(FakeVersionResource);
         return 1;
     }
     if (wcsncmp(lpSubBlock, L"\\VarFileInfo\\Translation", 24) == 0) {
         static DWORD translation = 0x040904B0;
         *lplpBuffer = &translation;
-        if (puLen) *puLen = 4;
+        if (puLen)
+            *puLen = 4;
         return 1;
     }
-    if (puLen) *puLen = 0;
+    if (puLen)
+        *puLen = 0;
     *lplpBuffer = nullptr;
     return 0;
 }
@@ -1203,7 +1515,8 @@ ShimLibrary createVersionShim() {
 }
 
 static LONG MSABI bcrypt_BCryptGenRandom(void*, BYTE* buf, ULONG len, ULONG) {
-    for (ULONG i = 0; i < len; i++) buf[i] = (BYTE)(rand() & 0xFF);
+    for (ULONG i = 0; i < len; i++)
+        buf[i] = (BYTE)(rand() & 0xFF);
     return 0;
 }
 
@@ -1215,7 +1528,9 @@ ShimLibrary createBcryptShim() {
     return lib;
 }
 
-static BOOL MSABI comctl32_InitCommonControlsEx(const void*) { return 1; }
+static BOOL MSABI comctl32_InitCommonControlsEx(const void*) {
+    return 1;
+}
 
 ShimLibrary createComCtl32Shim() {
     ShimLibrary lib;
@@ -1226,7 +1541,10 @@ ShimLibrary createComCtl32Shim() {
 }
 
 static int MSABI wsock32_ord1142(WORD, void* data) {
-    if (data) { memset(data, 0, 400); reinterpret_cast<WORD*>(data)[0] = 0x0202; }
+    if (data) {
+        memset(data, 0, 400);
+        reinterpret_cast<WORD*>(data)[0] = 0x0202;
+    }
     return 0;
 }
 
@@ -1238,5 +1556,5 @@ ShimLibrary createWsock32Shim() {
     return lib;
 }
 
-}
-}
+} // namespace win32
+} // namespace metalsharp

--- a/src/win32/kernel32/DRMShims.cpp
+++ b/src/win32/kernel32/DRMShims.cpp
@@ -1,22 +1,23 @@
 /// @file DRMShims.cpp
 /// @brief Anti-DRM detection shims for volume serial, MAC address, and timing.
 ///
-/// Spoofs volume serial numbers, MAC addresses, and system timing to bypass DRM checks that validate hardware fingerprints. Also provides anti-debug detection shims to hide the Wine environment from copy protection.
-#include <metalsharp/Win32Types.h>
-#include <metalsharp/PELoader.h>
-#include <metalsharp/Logger.h>
-#include <cstring>
-#include <cstdlib>
+/// Spoofs volume serial numbers, MAC addresses, and system timing to bypass DRM checks that validate hardware
+/// fingerprints. Also provides anti-debug detection shims to hide the Wine environment from copy protection.
 #include <chrono>
-#include <ctime>
 #include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <metalsharp/Logger.h>
+#include <metalsharp/PELoader.h>
+#include <metalsharp/Win32Types.h>
 
 #ifdef __APPLE__
-#include <sys/sysctl.h>
+#include <ifaddrs.h>
 #include <mach/mach_time.h>
 #include <net/if.h>
 #include <net/if_dl.h>
-#include <ifaddrs.h>
+#include <sys/sysctl.h>
 #endif
 
 namespace metalsharp {
@@ -25,8 +26,8 @@ namespace win32 {
 static const uint8_t STABLE_MAC[6] = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E};
 static const uint32_t STABLE_DISK_SERIAL = 0xABCDEF12;
 
-static BOOL MSABI shim_GetSystemFirmwareTable(DWORD FirmwareTableProviderSignature,
-    DWORD FirmwareTableID, void* pFirmwareTableBuffer, DWORD BufferSize) {
+static BOOL MSABI shim_GetSystemFirmwareTable(DWORD FirmwareTableProviderSignature, DWORD FirmwareTableID,
+                                              void* pFirmwareTableBuffer, DWORD BufferSize) {
 
     if (BufferSize == 0 && pFirmwareTableBuffer == nullptr) {
         return 0;
@@ -47,23 +48,10 @@ static BOOL MSABI shim_GetSystemFirmwareTable(DWORD FirmwareTableProviderSignatu
         };
 
         static const uint8_t fakeSMBIOS[] = {
-            0x00,
-            0x03, 0x04,
-            0x00,
-            0x00, 0x00, 0x00, 0x00,
-            0x01, 0x1F,
-            0x00, 0x00, 0x00, 0x00, 0x00,
-            0x00,
-            0x02, 0x08,
-            0x00, 0x00, 0x00, 0x00, 0x00,
-            0x00,
-            0x03, 0x17,
-            0x01, 0x02, 0x00,
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x00,
-            'A', 'p', 'p', 'l', 'e', ' ', 'I', 'n', 'c', '.', '\0',
-            'M', 'a', 'c', 'B', 'o', 'o', 'k', ' ', 'P', 'r', 'o', '\0',
-            '\0',
+            0x00, 0x03, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x1F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x02, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x17, 0x01, 0x02, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 'A',  'p',  'p',  'l',  'e',  ' ',  'I',  'n',  'c',  '.',  '\0',
+            'M',  'a',  'c',  'B',  'o',  'o',  'k',  ' ',  'P',  'r',  'o',  '\0', '\0',
         };
 
         uint32_t totalSize = sizeof(RawSMBIOSData) - 1 + sizeof(fakeSMBIOS);
@@ -90,7 +78,8 @@ static BOOL MSABI shim_GetSystemFirmwareTable(DWORD FirmwareTableProviderSignatu
 }
 
 static uint32_t MSABI shim_GetAdaptersInfo(void* pAdapterInfo, uint32_t* pOutBufLen) {
-    if (!pOutBufLen) return 111;
+    if (!pOutBufLen)
+        return 111;
 
     struct IP_ADAPTER_INFO_LAYOUT {
         void* Next;
@@ -133,9 +122,11 @@ static uint32_t MSABI shim_GetAdaptersInfo(void* pAdapterInfo, uint32_t* pOutBuf
 }
 
 static uint32_t MSABI shim_GetAdaptersAddresses(uint32_t Family, uint32_t Flags, void* Reserved,
-    void* pAdapterAddresses, uint32_t* pOutBufLen) {
-    if (!pOutBufLen) return 111;
-    if (Reserved) return 87;
+                                                void* pAdapterAddresses, uint32_t* pOutBufLen) {
+    if (!pOutBufLen)
+        return 111;
+    if (Reserved)
+        return 87;
 
     uint32_t needed = 256;
     if (!pAdapterAddresses || *pOutBufLen < needed) {
@@ -171,7 +162,8 @@ static uint32_t MSABI shim_GetAdaptersAddresses(uint32_t Family, uint32_t Flags,
 }
 
 static void MSABI shim_GetLocalTime(void* lpSystemTime) {
-    if (!lpSystemTime) return;
+    if (!lpSystemTime)
+        return;
 
     auto now = std::chrono::system_clock::now();
     time_t t = std::chrono::system_clock::to_time_t(now);
@@ -196,48 +188,57 @@ static DWORD MSABI shim_timeGetTime() {
     return static_cast<DWORD>(ms.count());
 }
 
-static DWORD MSABI shim_timeBeginPeriod(UINT) { return 0; }
-static DWORD MSABI shim_timeEndPeriod(UINT) { return 0; }
+static DWORD MSABI shim_timeBeginPeriod(UINT) {
+    return 0;
+}
+static DWORD MSABI shim_timeEndPeriod(UINT) {
+    return 0;
+}
 
-static BOOL MSABI shim_DeviceIoControl_DRM(HANDLE hDevice, DWORD dwIoControlCode,
-    void* lpInBuffer, DWORD nInBufferSize, void* lpOutBuffer, DWORD nOutBufferSize,
-    DWORD* lpBytesReturned, void* lpOverlapped) {
+static BOOL MSABI shim_DeviceIoControl_DRM(HANDLE hDevice, DWORD dwIoControlCode, void* lpInBuffer, DWORD nInBufferSize,
+                                           void* lpOutBuffer, DWORD nOutBufferSize, DWORD* lpBytesReturned,
+                                           void* lpOverlapped) {
 
-    if (lpBytesReturned) *lpBytesReturned = 0;
+    if (lpBytesReturned)
+        *lpBytesReturned = 0;
 
     switch (dwIoControlCode) {
-        case 0x00074008:
-        case 0x0007C028:
-        case 0x0004D014: {
-            if (lpOutBuffer && nOutBufferSize >= 4) {
-                uint32_t serial = STABLE_DISK_SERIAL;
-                memcpy(lpOutBuffer, &serial, 4);
-                if (lpBytesReturned) *lpBytesReturned = 4;
-            }
-            return 1;
+    case 0x00074008:
+    case 0x0007C028:
+    case 0x0004D014: {
+        if (lpOutBuffer && nOutBufferSize >= 4) {
+            uint32_t serial = STABLE_DISK_SERIAL;
+            memcpy(lpOutBuffer, &serial, 4);
+            if (lpBytesReturned)
+                *lpBytesReturned = 4;
         }
-        case 0x0007404C:
-        case 0x00074060: {
-            if (lpOutBuffer && nOutBufferSize >= 512) {
-                memset(lpOutBuffer, 0, 512);
-                auto* out = static_cast<uint8_t*>(lpOutBuffer);
-                memcpy(out, "MetalSharp", 10);
-                out[20] = 0x01;
-                out[21] = 0x00;
-                out[22] = 0x01;
-                out[23] = 0x00;
-                if (lpBytesReturned) *lpBytesReturned = 512;
-            }
-            return 1;
+        return 1;
+    }
+    case 0x0007404C:
+    case 0x00074060: {
+        if (lpOutBuffer && nOutBufferSize >= 512) {
+            memset(lpOutBuffer, 0, 512);
+            auto* out = static_cast<uint8_t*>(lpOutBuffer);
+            memcpy(out, "MetalSharp", 10);
+            out[20] = 0x01;
+            out[21] = 0x00;
+            out[22] = 0x01;
+            out[23] = 0x00;
+            if (lpBytesReturned)
+                *lpBytesReturned = 512;
         }
-        default:
-            return 0;
+        return 1;
+    }
+    default:
+        return 0;
     }
 }
 
-static void MSABI shim_RaiseException_Fixed(DWORD dwExceptionCode, DWORD dwExceptionFlags,
-    DWORD nNumberOfArguments, void* lpArguments) {
-    (void)dwExceptionFlags; (void)nNumberOfArguments; (void)lpArguments;
+static void MSABI shim_RaiseException_Fixed(DWORD dwExceptionCode, DWORD dwExceptionFlags, DWORD nNumberOfArguments,
+                                            void* lpArguments) {
+    (void)dwExceptionFlags;
+    (void)nNumberOfArguments;
+    (void)lpArguments;
     MS_INFO("PELoader: RaiseException(0x%08X) — dispatching to VEH chain", dwExceptionCode);
 
     struct FakeExceptionRecord {
@@ -264,7 +265,7 @@ static void MSABI shim_RaiseException_Fixed(DWORD dwExceptionCode, DWORD dwExcep
                 struct FakePointers {
                     FakeExceptionRecord* ExceptionRecord;
                     void* ContextRecord;
-                } pointers = { &record, nullptr };
+                } pointers = {&record, nullptr};
 
                 typedef int32_t (*VEHHandler)(void*);
                 auto veh = reinterpret_cast<VEHHandler>(handler);
@@ -281,7 +282,7 @@ static void MSABI shim_RaiseException_Fixed(DWORD dwExceptionCode, DWORD dwExcep
         struct FakePointers {
             void* ExceptionRecord;
             void* ContextRecord;
-        } pointers = { &record, nullptr };
+        } pointers = {&record, nullptr};
 
         typedef void* (*FilterFunc)(void*);
         auto filter = reinterpret_cast<FilterFunc>(s_unhandledExceptionFilter);
@@ -294,9 +295,7 @@ static void MSABI shim_RaiseException_Fixed(DWORD dwExceptionCode, DWORD dwExcep
 }
 
 void addDRMShims(ShimLibrary& kernel32, ShimLibrary& winmm) {
-    auto fn = [](void* ptr) -> ExportedFunction {
-        return [ptr]() -> void* { return ptr; };
-    };
+    auto fn = [](void* ptr) -> ExportedFunction { return [ptr]() -> void* { return ptr; }; };
 
     kernel32.functions["GetSystemFirmwareTable"] = fn((void*)shim_GetSystemFirmwareTable);
     kernel32.functions["GetAdaptersInfo"] = fn((void*)shim_GetAdaptersInfo);
@@ -326,5 +325,5 @@ void addDRMShims(ShimLibrary& kernel32, ShimLibrary& winmm) {
     winmm.functions["waveOutUnprepareHeader"] = fn((void*)nullptr);
 }
 
-}
-}
+} // namespace win32
+} // namespace metalsharp

--- a/src/win32/kernel32/Kernel32Extra.cpp
+++ b/src/win32/kernel32/Kernel32Extra.cpp
@@ -45,31 +45,31 @@
 ///
 /// Status: ~70% of commonly-used kernel32 exports implemented. Games that call
 /// obscure kernel32 functions will log "MISSING" in the import resolver.
-#include <metalsharp/PELoader.h>
-#include <metalsharp/Win32Types.h>
-#include <metalsharp/Logger.h>
-#include <metalsharp/VirtualFileSystem.h>
-#include <metalsharp/Registry.h>
-#include <metalsharp/NetworkContext.h>
-#include <metalsharp/SyncContext.h>
-#include <metalsharp/PEHeader.h>
-#include <mutex>
-#include <cstring>
-#include <cstdlib>
-#include <cstdio>
-#include <sys/mman.h>
-#include <unistd.h>
-#include <pthread.h>
-#include <chrono>
-#include <ctime>
 #include <cerrno>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <dirent.h>
 #include <dlfcn.h>
+#include <fcntl.h>
+#include <metalsharp/Logger.h>
+#include <metalsharp/NetworkContext.h>
+#include <metalsharp/PEHeader.h>
+#include <metalsharp/PELoader.h>
+#include <metalsharp/Registry.h>
+#include <metalsharp/SyncContext.h>
+#include <metalsharp/VirtualFileSystem.h>
+#include <metalsharp/Win32Types.h>
+#include <mutex>
+#include <pthread.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <dirent.h>
-#include <fcntl.h>
-#include <sys/socket.h>
 #include <sys/un.h>
+#include <unistd.h>
 
 namespace metalsharp {
 namespace win32 {
@@ -79,19 +79,28 @@ static thread_local DWORD t_lastError = 0;
 static std::atomic<int> g_callCount{0};
 static thread_local int t_callDepth = 0;
 
-static void* MSABI stub_zero() { return nullptr; }
-static BOOL MSABI stub_true() { return 1; }
-static DWORD MSABI stub_zero_dword() { return 0; }
+static void* MSABI stub_zero() {
+    return nullptr;
+}
+static BOOL MSABI stub_true() {
+    return 1;
+}
+static DWORD MSABI stub_zero_dword() {
+    return 0;
+}
 static void MSABI stub_void() {}
 
 static void* MSABI shim_VirtualProtect(void* lpAddress, SIZE_T dwSize, DWORD flNewProtect, DWORD* lpflOldProtect) {
-    (void)dwSize; (void)flNewProtect;
-    if (lpflOldProtect) *lpflOldProtect = PAGE_EXECUTE_READWRITE;
+    (void)dwSize;
+    (void)flNewProtect;
+    if (lpflOldProtect)
+        *lpflOldProtect = PAGE_EXECUTE_READWRITE;
     return reinterpret_cast<void*>(1);
 }
 
 static BOOL MSABI shim_VirtualQuery(void* lpAddress, void* lpBuffer, SIZE_T dwLength, SIZE_T* lpResultLength) {
-    (void)lpAddress; (void)dwLength;
+    (void)lpAddress;
+    (void)dwLength;
     auto* mbi = reinterpret_cast<MEMORY_BASIC_INFORMATION*>(lpBuffer);
     memset(mbi, 0, sizeof(MEMORY_BASIC_INFORMATION));
     mbi->BaseAddress = lpAddress;
@@ -100,7 +109,8 @@ static BOOL MSABI shim_VirtualQuery(void* lpAddress, void* lpBuffer, SIZE_T dwLe
     mbi->State = 0x1000;
     mbi->Protect = PAGE_EXECUTE_READWRITE;
     mbi->Type = 0x20000;
-    if (lpResultLength) *lpResultLength = sizeof(MEMORY_BASIC_INFORMATION);
+    if (lpResultLength)
+        *lpResultLength = sizeof(MEMORY_BASIC_INFORMATION);
     return 1;
 }
 
@@ -113,9 +123,11 @@ void* s_unhandledExceptionFilter = nullptr;
 std::vector<std::pair<void*, bool>> s_vehHandlers;
 std::mutex s_vehMutex;
 
-static void MSABI shim_RaiseException(DWORD dwExceptionCode, DWORD dwExceptionFlags,
-    DWORD nNumberOfArguments, void* lpArguments) {
-    (void)dwExceptionFlags; (void)nNumberOfArguments; (void)lpArguments;
+static void MSABI shim_RaiseException(DWORD dwExceptionCode, DWORD dwExceptionFlags, DWORD nNumberOfArguments,
+                                      void* lpArguments) {
+    (void)dwExceptionFlags;
+    (void)nNumberOfArguments;
+    (void)lpArguments;
     MS_INFO("PELoader: RaiseException(0x%08X) — dispatching to VEH chain", dwExceptionCode);
 
     struct FakeExceptionRecord {
@@ -133,8 +145,11 @@ static void MSABI shim_RaiseException(DWORD dwExceptionCode, DWORD dwExceptionFl
         std::lock_guard<std::mutex> lock(s_vehMutex);
         for (auto& [handler, isFirst] : s_vehHandlers) {
             if (handler) {
-                struct FakePointers { void* ExceptionRecord; void* ContextRecord; };
-                FakePointers pointers = { &record, nullptr };
+                struct FakePointers {
+                    void* ExceptionRecord;
+                    void* ContextRecord;
+                };
+                FakePointers pointers = {&record, nullptr};
                 typedef int32_t (*VEHHandler)(void*);
                 auto veh = reinterpret_cast<VEHHandler>(handler);
                 int32_t result = veh(&pointers);
@@ -147,8 +162,11 @@ static void MSABI shim_RaiseException(DWORD dwExceptionCode, DWORD dwExceptionFl
     }
 
     if (s_unhandledExceptionFilter) {
-        struct FakePointers { void* ExceptionRecord; void* ContextRecord; };
-        FakePointers pointers = { &record, nullptr };
+        struct FakePointers {
+            void* ExceptionRecord;
+            void* ContextRecord;
+        };
+        FakePointers pointers = {&record, nullptr};
         typedef void* (*FilterFunc)(void*);
         auto filter = reinterpret_cast<FilterFunc>(s_unhandledExceptionFilter);
         filter(&pointers);
@@ -234,19 +252,26 @@ static wchar_t s_cmdLineW[4096] = {0};
 
 void setCommandLine(const char* cmd) {
     strncpy(s_cmdLineA, cmd, sizeof(s_cmdLineA) - 1);
-    for (size_t i = 0; i < sizeof(s_cmdLineW)/sizeof(wchar_t) - 1 && cmd[i]; i++) {
+    for (size_t i = 0; i < sizeof(s_cmdLineW) / sizeof(wchar_t) - 1 && cmd[i]; i++) {
         s_cmdLineW[i] = (wchar_t)(unsigned char)cmd[i];
     }
 }
 
-static char* MSABI shim_GetCommandLineA() { MS_INFO("TRACE: GetCommandLineA()"); return s_cmdLineA; }
-static wchar_t* MSABI shim_GetCommandLineW() { MS_INFO("TRACE: GetCommandLineW()"); return s_cmdLineW; }
+static char* MSABI shim_GetCommandLineA() {
+    MS_INFO("TRACE: GetCommandLineA()");
+    return s_cmdLineA;
+}
+static wchar_t* MSABI shim_GetCommandLineW() {
+    MS_INFO("TRACE: GetCommandLineW()");
+    return s_cmdLineW;
+}
 
 static std::unordered_map<std::string, std::string> s_envStore;
 static bool s_envInitialized = false;
 
 static void ensureEnvInit() {
-    if (s_envInitialized) return;
+    if (s_envInitialized)
+        return;
     s_envInitialized = true;
     const char* home = getenv("HOME");
     std::string homeDir = home ? home : "/tmp";
@@ -285,48 +310,60 @@ static void ensureEnvInit() {
 
 static DWORD MSABI shim_GetEnvironmentVariableW(const wchar_t* lpName, wchar_t* lpBuffer, DWORD nSize) {
     ensureEnvInit();
-    if (!lpName) return 0;
+    if (!lpName)
+        return 0;
     char name[256];
     int j = 0;
-    for (int i = 0; lpName[i] && j < 255; i++) name[j++] = (char)(lpName[i] & 0x7F);
+    for (int i = 0; lpName[i] && j < 255; i++)
+        name[j++] = (char)(lpName[i] & 0x7F);
     name[j] = 0;
 
     std::string upper;
-    for (auto c : std::string(name)) upper += toupper(c);
+    for (auto c : std::string(name))
+        upper += toupper(c);
 
     auto it = s_envStore.find(upper);
     if (it == s_envStore.end()) {
         const char* env = getenv(name);
-        if (env) it = s_envStore.insert({upper, env}).first;
-        else return 0;
+        if (env)
+            it = s_envStore.insert({upper, env}).first;
+        else
+            return 0;
     }
 
     const std::string& val = it->second;
     DWORD needed = static_cast<DWORD>(val.size());
-    if (nSize == 0) return needed + 1;
+    if (nSize == 0)
+        return needed + 1;
     if (lpBuffer && nSize > needed) {
-        for (size_t i = 0; i <= needed; i++) lpBuffer[i] = (wchar_t)(unsigned char)val[i];
+        for (size_t i = 0; i <= needed; i++)
+            lpBuffer[i] = (wchar_t)(unsigned char)val[i];
     }
     return needed;
 }
 
 static DWORD MSABI shim_GetEnvironmentVariableA(const char* lpName, char* lpBuffer, DWORD nSize) {
     ensureEnvInit();
-    if (!lpName) return 0;
+    if (!lpName)
+        return 0;
 
     std::string upper;
-    for (auto c : std::string(lpName)) upper += tolower(c);
+    for (auto c : std::string(lpName))
+        upper += tolower(c);
 
     auto it = s_envStore.find(upper);
     if (it == s_envStore.end()) {
         const char* env = getenv(lpName);
-        if (env) it = s_envStore.insert({upper, env}).first;
-        else return 0;
+        if (env)
+            it = s_envStore.insert({upper, env}).first;
+        else
+            return 0;
     }
 
     const std::string& val = it->second;
     DWORD needed = static_cast<DWORD>(val.size());
-    if (nSize == 0) return needed + 1;
+    if (nSize == 0)
+        return needed + 1;
     if (lpBuffer && nSize > needed) {
         memcpy(lpBuffer, val.c_str(), needed + 1);
     }
@@ -335,19 +372,23 @@ static DWORD MSABI shim_GetEnvironmentVariableA(const char* lpName, char* lpBuff
 
 static BOOL MSABI shim_SetEnvironmentVariableW(const wchar_t* lpName, const wchar_t* lpValue) {
     ensureEnvInit();
-    if (!lpName) return 0;
+    if (!lpName)
+        return 0;
     char name[256];
     int j = 0;
-    for (int i = 0; lpName[i] && j < 255; i++) name[j++] = (char)(lpName[i] & 0x7F);
+    for (int i = 0; lpName[i] && j < 255; i++)
+        name[j++] = (char)(lpName[i] & 0x7F);
     name[j] = 0;
 
     std::string upper;
-    for (auto c : std::string(name)) upper += toupper(c);
+    for (auto c : std::string(name))
+        upper += toupper(c);
 
     if (lpValue) {
         char val[1024];
         int k = 0;
-        for (int i = 0; lpValue[i] && k < 1023; i++) val[k++] = (char)(lpValue[i] & 0x7F);
+        for (int i = 0; lpValue[i] && k < 1023; i++)
+            val[k++] = (char)(lpValue[i] & 0x7F);
         val[k] = 0;
         s_envStore[upper] = val;
         setenv(upper.c_str(), val, 1);
@@ -360,10 +401,12 @@ static BOOL MSABI shim_SetEnvironmentVariableW(const wchar_t* lpName, const wcha
 
 static DWORD MSABI shim_ExpandEnvironmentStringsW(const wchar_t* lpSrc, wchar_t* lpDst, DWORD nSize) {
     ensureEnvInit();
-    if (!lpSrc) return 0;
+    if (!lpSrc)
+        return 0;
 
     std::string src;
-    for (int i = 0; lpSrc[i]; i++) src += (char)(lpSrc[i] & 0x7F);
+    for (int i = 0; lpSrc[i]; i++)
+        src += (char)(lpSrc[i] & 0x7F);
 
     std::string result;
     size_t pos = 0;
@@ -373,14 +416,17 @@ static DWORD MSABI shim_ExpandEnvironmentStringsW(const wchar_t* lpSrc, wchar_t*
             if (end != std::string::npos) {
                 std::string varName = src.substr(pos + 1, end - pos - 1);
                 std::string upper;
-                for (auto c : varName) upper += toupper(c);
+                for (auto c : varName)
+                    upper += toupper(c);
                 auto it = s_envStore.find(upper);
                 if (it != s_envStore.end()) {
                     result += it->second;
                 } else {
                     const char* env = getenv(varName.c_str());
-                    if (env) result += env;
-                    else result += src.substr(pos, end - pos + 1);
+                    if (env)
+                        result += env;
+                    else
+                        result += src.substr(pos, end - pos + 1);
                 }
                 pos = end + 1;
             } else {
@@ -392,10 +438,13 @@ static DWORD MSABI shim_ExpandEnvironmentStringsW(const wchar_t* lpSrc, wchar_t*
     }
 
     DWORD needed = static_cast<DWORD>(result.size()) + 1;
-    if (nSize == 0 || !lpDst) return needed;
+    if (nSize == 0 || !lpDst)
+        return needed;
     DWORD copyLen = needed < nSize ? needed : nSize;
-    for (DWORD i = 0; i < copyLen; i++) lpDst[i] = (wchar_t)(unsigned char)result[i];
-    if (copyLen > 0) lpDst[copyLen - 1] = 0;
+    for (DWORD i = 0; i < copyLen; i++)
+        lpDst[i] = (wchar_t)(unsigned char)result[i];
+    if (copyLen > 0)
+        lpDst[copyLen - 1] = 0;
     return needed;
 }
 
@@ -408,15 +457,20 @@ static void MSABI shim_GetStartupInfoW(STARTUPINFOW* lpStartupInfo) {
 static void* MSABI shim_GetStdHandle(DWORD nStdHandle) {
     MS_INFO("TRACE: GetStdHandle(0x%X)", nStdHandle);
     switch (nStdHandle) {
-        case 0xFFFFFFF6: return reinterpret_cast<void*>(stdin);
-        case 0xFFFFFFF5: return reinterpret_cast<void*>(stdout);
-        case 0xFFFFFFF4: return reinterpret_cast<void*>(stderr);
-        default: return INVALID_HANDLE_VALUE;
+    case 0xFFFFFFF6:
+        return reinterpret_cast<void*>(stdin);
+    case 0xFFFFFFF5:
+        return reinterpret_cast<void*>(stdout);
+    case 0xFFFFFFF4:
+        return reinterpret_cast<void*>(stderr);
+    default:
+        return INVALID_HANDLE_VALUE;
     }
 }
 
 static BOOL MSABI shim_SetStdHandle(DWORD nStdHandle, HANDLE hHandle) {
-    (void)nStdHandle; (void)hHandle;
+    (void)nStdHandle;
+    (void)hHandle;
     return 1;
 }
 
@@ -426,94 +480,128 @@ static BOOL MSABI shim_FreeLibrary(HMODULE hLibModule) {
 }
 
 static HMODULE MSABI shim_LoadLibraryExA(const char* lpLibFileName, HANDLE hFile, DWORD dwFlags) {
-    (void)hFile; (void)dwFlags;
-    if (!lpLibFileName) return nullptr;
+    (void)hFile;
+    (void)dwFlags;
+    if (!lpLibFileName)
+        return nullptr;
     MS_INFO("PELoader: LoadLibraryExA(\"%s\")", lpLibFileName);
     return PELoader::instance()->loadLibrary(std::string(lpLibFileName));
 }
 
 static HMODULE MSABI shim_LoadLibraryExW(const wchar_t* lpLibFileName, HANDLE hFile, DWORD dwFlags) {
-    (void)hFile; (void)dwFlags;
-    if (!lpLibFileName) return nullptr;
+    (void)hFile;
+    (void)dwFlags;
+    if (!lpLibFileName)
+        return nullptr;
     const auto* u16 = reinterpret_cast<const uint16_t*>(lpLibFileName);
     char narrow[1024];
     int j = 0;
     for (int i = 0; u16[i] && j < 1023; i++) {
         char c = (char)(u16[i] & 0x7F);
-        if (c >= 0x20) narrow[j++] = c;
+        if (c >= 0x20)
+            narrow[j++] = c;
     }
     narrow[j] = 0;
     MS_INFO("PELoader: LoadLibraryExW(\"%s\")", narrow);
-    if (j == 0) return nullptr;
+    if (j == 0)
+        return nullptr;
     return PELoader::instance()->loadLibrary(std::string(narrow));
 }
 
 static HMODULE MSABI shim_GetModuleHandleExA(DWORD dwFlags, const char* lpModuleName, HMODULE* phModule) {
-    (void)dwFlags; (void)lpModuleName;
-    if (phModule) *phModule = reinterpret_cast<HMODULE>(0x2);
+    (void)dwFlags;
+    (void)lpModuleName;
+    if (phModule)
+        *phModule = reinterpret_cast<HMODULE>(0x2);
     return reinterpret_cast<HMODULE>(0x2);
 }
 
 static HMODULE MSABI shim_GetModuleHandleExW(DWORD dwFlags, const wchar_t* lpModuleName, HMODULE* phModule) {
-    (void)dwFlags; (void)lpModuleName;
-    if (phModule) *phModule = reinterpret_cast<HMODULE>(0x2);
+    (void)dwFlags;
+    (void)lpModuleName;
+    if (phModule)
+        *phModule = reinterpret_cast<HMODULE>(0x2);
     return reinterpret_cast<HMODULE>(0x2);
 }
 
-static void* MSABI shim_CreateEventA(void* lpEventAttributes, BOOL bManualReset, BOOL bInitialState, const char* lpName) {
+static void* MSABI shim_CreateEventA(void* lpEventAttributes, BOOL bManualReset, BOOL bInitialState,
+                                     const char* lpName) {
     (void)lpEventAttributes;
     std::string name = lpName ? lpName : "";
     return SyncContext::instance().createEvent(bManualReset != 0, bInitialState != 0, name);
 }
 
-static BOOL MSABI shim_ResetEvent(HANDLE hEvent) { return SyncContext::instance().resetEvent(hEvent) ? 1 : 0; }
-static BOOL MSABI shim_SetEvent(HANDLE hEvent) { return SyncContext::instance().setEvent(hEvent) ? 1 : 0; }
+static BOOL MSABI shim_ResetEvent(HANDLE hEvent) {
+    return SyncContext::instance().resetEvent(hEvent) ? 1 : 0;
+}
+static BOOL MSABI shim_SetEvent(HANDLE hEvent) {
+    return SyncContext::instance().setEvent(hEvent) ? 1 : 0;
+}
 
 static HANDLE MSABI shim_OpenEventA(DWORD dwDesiredAccess, BOOL bInheritHandle, const char* lpName) {
-    (void)dwDesiredAccess; (void)bInheritHandle;
-    if (!lpName) return nullptr;
+    (void)dwDesiredAccess;
+    (void)bInheritHandle;
+    if (!lpName)
+        return nullptr;
     return SyncContext::instance().createEvent(true, false, lpName);
 }
 
-static void* MSABI shim_CreateIoCompletionPort(HANDLE FileHandle, HANDLE ExistingCompletionPort,
-    void* CompletionKey, DWORD NumberOfConcurrentThreads) {
-    (void)FileHandle; (void)ExistingCompletionPort; (void)CompletionKey; (void)NumberOfConcurrentThreads;
+static void* MSABI shim_CreateIoCompletionPort(HANDLE FileHandle, HANDLE ExistingCompletionPort, void* CompletionKey,
+                                               DWORD NumberOfConcurrentThreads) {
+    (void)FileHandle;
+    (void)ExistingCompletionPort;
+    (void)CompletionKey;
+    (void)NumberOfConcurrentThreads;
     return reinterpret_cast<void*>(0x101);
 }
 
 static BOOL MSABI shim_PostQueuedCompletionStatus(HANDLE CompletionPort, DWORD dwNumberOfBytesTransferred,
-    void* dwCompletionKey, void* lpOverlapped) {
-    (void)CompletionPort; (void)dwNumberOfBytesTransferred; (void)dwCompletionKey; (void)lpOverlapped;
+                                                  void* dwCompletionKey, void* lpOverlapped) {
+    (void)CompletionPort;
+    (void)dwNumberOfBytesTransferred;
+    (void)dwCompletionKey;
+    (void)lpOverlapped;
     return 1;
 }
 
-static BOOL MSABI shim_DuplicateHandle(HANDLE hSourceProcessHandle, HANDLE hSourceHandle,
-    HANDLE hTargetProcessHandle, HANDLE* lpTargetHandle, DWORD dwDesiredAccess,
-    BOOL bInheritHandle, DWORD dwOptions) {
-    (void)hSourceProcessHandle; (void)hSourceHandle; (void)hTargetProcessHandle;
-    (void)dwDesiredAccess; (void)bInheritHandle; (void)dwOptions;
-    if (lpTargetHandle) *lpTargetHandle = hSourceHandle;
+static BOOL MSABI shim_DuplicateHandle(HANDLE hSourceProcessHandle, HANDLE hSourceHandle, HANDLE hTargetProcessHandle,
+                                       HANDLE* lpTargetHandle, DWORD dwDesiredAccess, BOOL bInheritHandle,
+                                       DWORD dwOptions) {
+    (void)hSourceProcessHandle;
+    (void)hSourceHandle;
+    (void)hTargetProcessHandle;
+    (void)dwDesiredAccess;
+    (void)bInheritHandle;
+    (void)dwOptions;
+    if (lpTargetHandle)
+        *lpTargetHandle = hSourceHandle;
     return 1;
 }
 
 static HANDLE MSABI shim_OpenProcess(DWORD dwDesiredAccess, BOOL bInheritHandle, DWORD dwProcessId) {
-    (void)dwDesiredAccess; (void)bInheritHandle; (void)dwProcessId;
+    (void)dwDesiredAccess;
+    (void)bInheritHandle;
+    (void)dwProcessId;
     return reinterpret_cast<HANDLE>(0x200);
 }
 
 static HANDLE MSABI shim_OpenThread(DWORD dwDesiredAccess, BOOL bInheritHandle, DWORD dwThreadId) {
-    (void)dwDesiredAccess; (void)bInheritHandle; (void)dwThreadId;
+    (void)dwDesiredAccess;
+    (void)bInheritHandle;
+    (void)dwThreadId;
     return reinterpret_cast<HANDLE>(0x201);
 }
 
 static BOOL MSABI shim_TerminateProcess(HANDLE hProcess, UINT uExitCode) {
-    (void)hProcess; (void)uExitCode;
+    (void)hProcess;
+    (void)uExitCode;
     return 1;
 }
 
 static BOOL MSABI shim_GetExitCodeProcess(HANDLE hProcess, DWORD* lpExitCode) {
     (void)hProcess;
-    if (lpExitCode) *lpExitCode = 259;
+    if (lpExitCode)
+        *lpExitCode = 259;
     return 1;
 }
 
@@ -530,31 +618,56 @@ static BOOL MSABI shim_GetExitCodeThread(HANDLE hThread, DWORD* lpExitCode) {
 }
 
 static BOOL MSABI shim_TerminateThread(HANDLE hThread, DWORD dwExitCode) {
-    (void)hThread; (void)dwExitCode;
+    (void)hThread;
+    (void)dwExitCode;
     return 1;
 }
 
-static DWORD MSABI shim_SuspendThread(HANDLE hThread) { (void)hThread; return 0; }
-static DWORD MSABI shim_ResumeThread(HANDLE hThread) { (void)hThread; return 0; }
-static BOOL MSABI shim_SetThreadPriority(HANDLE hThread, int nPriority) { (void)hThread; (void)nPriority; return 1; }
-static DWORD MSABI shim_SetThreadAffinityMask(HANDLE hThread, DWORD_PTR dwThreadAffinityMask) {
-    (void)hThread; (void)dwThreadAffinityMask; return 1;
+static DWORD MSABI shim_SuspendThread(HANDLE hThread) {
+    (void)hThread;
+    return 0;
 }
-static BOOL MSABI shim_GetProcessAffinityMask(HANDLE hProcess, DWORD_PTR* lpProcessAffinityMask, DWORD_PTR* lpSystemAffinityMask) {
+static DWORD MSABI shim_ResumeThread(HANDLE hThread) {
+    (void)hThread;
+    return 0;
+}
+static BOOL MSABI shim_SetThreadPriority(HANDLE hThread, int nPriority) {
+    (void)hThread;
+    (void)nPriority;
+    return 1;
+}
+static DWORD MSABI shim_SetThreadAffinityMask(HANDLE hThread, DWORD_PTR dwThreadAffinityMask) {
+    (void)hThread;
+    (void)dwThreadAffinityMask;
+    return 1;
+}
+static BOOL MSABI shim_GetProcessAffinityMask(HANDLE hProcess, DWORD_PTR* lpProcessAffinityMask,
+                                              DWORD_PTR* lpSystemAffinityMask) {
     (void)hProcess;
-    if (lpProcessAffinityMask) *lpProcessAffinityMask = 1;
-    if (lpSystemAffinityMask) *lpSystemAffinityMask = 1;
+    if (lpProcessAffinityMask)
+        *lpProcessAffinityMask = 1;
+    if (lpSystemAffinityMask)
+        *lpSystemAffinityMask = 1;
     return 1;
 }
 static BOOL MSABI shim_SetProcessAffinityMask(HANDLE hProcess, DWORD_PTR dwProcessAffinityMask) {
-    (void)hProcess; (void)dwProcessAffinityMask; return 1;
+    (void)hProcess;
+    (void)dwProcessAffinityMask;
+    return 1;
 }
 
-static BOOL MSABI shim_SwitchToThread() { sched_yield(); return 1; }
+static BOOL MSABI shim_SwitchToThread() {
+    sched_yield();
+    return 1;
+}
 
-static void MSABI shim_InitializeSListHead(void* ListHead) { memset(ListHead, 0, 16); }
+static void MSABI shim_InitializeSListHead(void* ListHead) {
+    memset(ListHead, 0, 16);
+}
 static void* MSABI shim_InterlockedPushEntrySList(void* ListHead, void* ListEntry) {
-    (void)ListHead; (void)ListEntry; return nullptr;
+    (void)ListHead;
+    (void)ListEntry;
+    return nullptr;
 }
 
 static void MSABI shim_AcquireSRWLockExclusive(void* SRWLock) {
@@ -568,10 +681,12 @@ static void MSABI shim_ReleaseSRWLockExclusive(void* SRWLock) {
 }
 
 static BOOL MSABI shim_TryAcquireSRWLockExclusive(void* SRWLock) {
-    (void)SRWLock; return 1;
+    (void)SRWLock;
+    return 1;
 }
 
-static BOOL MSABI shim_SleepConditionVariableSRW(void* ConditionVariable, void* SRWLock, DWORD dwMilliseconds, ULONG Flags) {
+static BOOL MSABI shim_SleepConditionVariableSRW(void* ConditionVariable, void* SRWLock, DWORD dwMilliseconds,
+                                                 ULONG Flags) {
     (void)Flags;
     auto* cond = static_cast<pthread_cond_t*>(ConditionVariable);
     auto* mtx = static_cast<pthread_mutex_t*>(SRWLock);
@@ -618,38 +733,51 @@ static void MSABI shim_InitializeCriticalSectionEx(void* lpCriticalSection, DWOR
 }
 
 static BOOL MSABI shim_TryEnterCriticalSection(void* lpCriticalSection) {
-    (void)lpCriticalSection; return 1;
+    (void)lpCriticalSection;
+    return 1;
 }
 
 static BOOL MSABI shim_InitOnceBeginInitialize(void* InitOnce, DWORD dwFlags, BOOL* fPending, void** lpContext) {
-    (void)InitOnce; (void)dwFlags; (void)lpContext;
-    if (fPending) *fPending = 0;
+    (void)InitOnce;
+    (void)dwFlags;
+    (void)lpContext;
+    if (fPending)
+        *fPending = 0;
     return 1;
 }
 
 static BOOL MSABI shim_InitOnceComplete(void* InitOnce, DWORD dwFlags, void* lpContext) {
-    (void)InitOnce; (void)dwFlags; (void)lpContext; return 1;
+    (void)InitOnce;
+    (void)dwFlags;
+    (void)lpContext;
+    return 1;
 }
 
 static thread_local void* s_tlsSlots[1088];
 static DWORD s_nextTlsSlot = 64;
 
 static DWORD MSABI shim_TlsAlloc() {
-    if (s_nextTlsSlot >= 1088) return 0xFFFFFFFF;
+    if (s_nextTlsSlot >= 1088)
+        return 0xFFFFFFFF;
     DWORD slot = s_nextTlsSlot++;
     MS_INFO("TRACE: TlsAlloc() -> %u", slot);
     return slot;
 }
 
-static BOOL MSABI shim_TlsFree(DWORD dwTlsIndex) { (void)dwTlsIndex; return 1; }
+static BOOL MSABI shim_TlsFree(DWORD dwTlsIndex) {
+    (void)dwTlsIndex;
+    return 1;
+}
 
 static void* MSABI shim_TlsGetValue(DWORD dwTlsIndex) {
-    if (dwTlsIndex >= 1088) return nullptr;
+    if (dwTlsIndex >= 1088)
+        return nullptr;
     return s_tlsSlots[dwTlsIndex];
 }
 
 static BOOL MSABI shim_TlsSetValue(DWORD dwTlsIndex, void* lpTlsValue) {
-    if (dwTlsIndex >= 1088) return 0;
+    if (dwTlsIndex >= 1088)
+        return 0;
     s_tlsSlots[dwTlsIndex] = lpTlsValue;
     return 1;
 }
@@ -659,30 +787,47 @@ static void* s_flsSlots[256];
 
 static DWORD MSABI shim_FlsAlloc(void* lpCallback) {
     (void)lpCallback;
-    if (s_flsNext >= 256) return 0xFFFFFFFF;
+    if (s_flsNext >= 256)
+        return 0xFFFFFFFF;
     s_flsSlots[s_flsNext] = nullptr;
     return s_flsNext++;
 }
 
-static BOOL MSABI shim_FlsFree(DWORD dwFlsIndex) { (void)dwFlsIndex; return 1; }
+static BOOL MSABI shim_FlsFree(DWORD dwFlsIndex) {
+    (void)dwFlsIndex;
+    return 1;
+}
 static void* MSABI shim_FlsGetValue(DWORD dwFlsIndex) {
-    if (dwFlsIndex >= 256) return nullptr;
+    if (dwFlsIndex >= 256)
+        return nullptr;
     return s_flsSlots[dwFlsIndex];
 }
 static BOOL MSABI shim_FlsSetValue(DWORD dwFlsIndex, void* lpFlsValue) {
-    if (dwFlsIndex >= 256) return 0;
+    if (dwFlsIndex >= 256)
+        return 0;
     s_flsSlots[dwFlsIndex] = lpFlsValue;
     return 1;
 }
 
-static void* MSABI shim_ConvertThreadToFiber(void* lpParameter) { (void)lpParameter; return reinterpret_cast<void*>(0x300); }
-static BOOL MSABI shim_ConvertFiberToThread() { return 1; }
+static void* MSABI shim_ConvertThreadToFiber(void* lpParameter) {
+    (void)lpParameter;
+    return reinterpret_cast<void*>(0x300);
+}
+static BOOL MSABI shim_ConvertFiberToThread() {
+    return 1;
+}
 static void* MSABI shim_CreateFiber(SIZE_T dwStackSize, void* lpStartAddress, void* lpParameter) {
-    (void)dwStackSize; (void)lpStartAddress; (void)lpParameter;
+    (void)dwStackSize;
+    (void)lpStartAddress;
+    (void)lpParameter;
     return reinterpret_cast<void*>(0x301);
 }
-static void MSABI shim_DeleteFiber(void* lpFiber) { (void)lpFiber; }
-static void MSABI shim_SwitchToFiber(void* lpFiber) { (void)lpFiber; }
+static void MSABI shim_DeleteFiber(void* lpFiber) {
+    (void)lpFiber;
+}
+static void MSABI shim_SwitchToFiber(void* lpFiber) {
+    (void)lpFiber;
+}
 
 static void MSABI shim_GetSystemTime(void* lpSystemTime) {
     auto* st = reinterpret_cast<WORD*>(lpSystemTime);
@@ -709,39 +854,57 @@ static void MSABI shim_GetSystemTimeAsFileTime(void* lpFileTime) {
 }
 
 static void MSABI shim_FileTimeToSystemTime(const void* lpFileTime, void* lpSystemTime) {
-    (void)lpFileTime; (void)lpSystemTime;
+    (void)lpFileTime;
+    (void)lpSystemTime;
 }
 
 static void MSABI shim_SystemTimeToFileTime(const void* lpSystemTime, void* lpFileTime) {
-    (void)lpSystemTime; (void)lpFileTime;
+    (void)lpSystemTime;
+    (void)lpFileTime;
 }
 
-static void MSABI shim_SystemTimeToTzSpecificLocalTime(void* lpTimeZone, const void* lpUniversalTime, void* lpLocalTime) {
+static void MSABI shim_SystemTimeToTzSpecificLocalTime(void* lpTimeZone, const void* lpUniversalTime,
+                                                       void* lpLocalTime) {
     (void)lpTimeZone;
-    if (lpLocalTime && lpUniversalTime) memcpy(lpLocalTime, lpUniversalTime, 16);
+    if (lpLocalTime && lpUniversalTime)
+        memcpy(lpLocalTime, lpUniversalTime, 16);
 }
 
 static DWORD MSABI shim_GetTimeZoneInformation(void* lpTimeZoneInformation) {
-    (void)lpTimeZoneInformation; return 0;
-}
-
-static int MSABI shim_GetDateFormatW(void* Locale, DWORD dwFlags, const void* lpDate,
-    const wchar_t* lpFormat, wchar_t* lpDateStr, int cchDate) {
-    (void)Locale; (void)dwFlags; (void)lpDate; (void)lpFormat;
-    if (lpDateStr && cchDate > 0) { lpDateStr[0] = 0; return 0; }
+    (void)lpTimeZoneInformation;
     return 0;
 }
 
-static int MSABI shim_GetTimeFormatW(void* Locale, DWORD dwFlags, const void* lpTime,
-    const wchar_t* lpFormat, wchar_t* lpTimeStr, int cchTime) {
-    (void)Locale; (void)dwFlags; (void)lpTime; (void)lpFormat;
-    if (lpTimeStr && cchTime > 0) { lpTimeStr[0] = 0; return 0; }
+static int MSABI shim_GetDateFormatW(void* Locale, DWORD dwFlags, const void* lpDate, const wchar_t* lpFormat,
+                                     wchar_t* lpDateStr, int cchDate) {
+    (void)Locale;
+    (void)dwFlags;
+    (void)lpDate;
+    (void)lpFormat;
+    if (lpDateStr && cchDate > 0) {
+        lpDateStr[0] = 0;
+        return 0;
+    }
+    return 0;
+}
+
+static int MSABI shim_GetTimeFormatW(void* Locale, DWORD dwFlags, const void* lpTime, const wchar_t* lpFormat,
+                                     wchar_t* lpTimeStr, int cchTime) {
+    (void)Locale;
+    (void)dwFlags;
+    (void)lpTime;
+    (void)lpFormat;
+    if (lpTimeStr && cchTime > 0) {
+        lpTimeStr[0] = 0;
+        return 0;
+    }
     return 0;
 }
 
 static BOOL MSABI shim_GetVersionExA(void* lpVersionInformation) {
     auto* vi = reinterpret_cast<BYTE*>(lpVersionInformation);
-    if (vi[0] < 156) return 0;
+    if (vi[0] < 156)
+        return 0;
     memset(vi, 0, 156);
     vi[0] = 156;
     auto* dw = reinterpret_cast<DWORD*>(vi);
@@ -754,17 +917,25 @@ static BOOL MSABI shim_GetVersionExA(void* lpVersionInformation) {
 }
 
 static BOOL MSABI shim_VerifyVersionInfoW(void* lpVersionInformation, DWORD dwTypeMask, uint64_t dwlConditionMask) {
-    (void)lpVersionInformation; (void)dwTypeMask; (void)dwlConditionMask;
+    (void)lpVersionInformation;
+    (void)dwTypeMask;
+    (void)dwlConditionMask;
     return 1;
 }
 
 static uint64_t MSABI shim_VerSetConditionMask(uint64_t dwlConditionMask, DWORD dwTypeBitMask, BYTE dwCondition) {
-    (void)dwTypeBitMask; (void)dwCondition;
+    (void)dwTypeBitMask;
+    (void)dwCondition;
     return dwlConditionMask;
 }
 
-static void* MSABI shim_GlobalLock(HANDLE hMem) { return hMem; }
-static BOOL MSABI shim_GlobalUnlock(HANDLE hMem) { (void)hMem; return 1; }
+static void* MSABI shim_GlobalLock(HANDLE hMem) {
+    return hMem;
+}
+static BOOL MSABI shim_GlobalUnlock(HANDLE hMem) {
+    (void)hMem;
+    return 1;
+}
 
 static void MSABI shim_GlobalMemoryStatusEx(void* lpBuffer) {
     auto* ms = reinterpret_cast<DWORD*>(lpBuffer);
@@ -775,48 +946,81 @@ static void MSABI shim_GlobalMemoryStatusEx(void* lpBuffer) {
     ms[3] = static_cast<DWORD>(8ULL * 1024 * 1024 * 1024);
 }
 
-static BOOL MSABI shim_HeapLock(HANDLE hHeap) { (void)hHeap; return 1; }
-static BOOL MSABI shim_HeapUnlock(HANDLE hHeap) { (void)hHeap; return 1; }
-static BOOL MSABI shim_HeapWalk(HANDLE hHeap, void* lpEntry) { (void)hHeap; (void)lpEntry; return 0; }
-static BOOL MSABI shim_HeapQueryInformation(HANDLE hHeap, DWORD HeapInformationClass,
-    void* HeapInformation, SIZE_T HeapInformationLength, SIZE_T* ReturnLength) {
-    (void)hHeap; (void)HeapInformationClass; (void)HeapInformation; (void)HeapInformationLength; (void)ReturnLength;
+static BOOL MSABI shim_HeapLock(HANDLE hHeap) {
+    (void)hHeap;
     return 1;
 }
-static BOOL MSABI shim_HeapSetInformation(HANDLE hHeap, DWORD HeapInformationClass,
-    void* HeapInformation, SIZE_T HeapInformationLength) {
-    (void)hHeap; (void)HeapInformationClass; (void)HeapInformation; (void)HeapInformationLength;
+static BOOL MSABI shim_HeapUnlock(HANDLE hHeap) {
+    (void)hHeap;
+    return 1;
+}
+static BOOL MSABI shim_HeapWalk(HANDLE hHeap, void* lpEntry) {
+    (void)hHeap;
+    (void)lpEntry;
+    return 0;
+}
+static BOOL MSABI shim_HeapQueryInformation(HANDLE hHeap, DWORD HeapInformationClass, void* HeapInformation,
+                                            SIZE_T HeapInformationLength, SIZE_T* ReturnLength) {
+    (void)hHeap;
+    (void)HeapInformationClass;
+    (void)HeapInformation;
+    (void)HeapInformationLength;
+    (void)ReturnLength;
+    return 1;
+}
+static BOOL MSABI shim_HeapSetInformation(HANDLE hHeap, DWORD HeapInformationClass, void* HeapInformation,
+                                          SIZE_T HeapInformationLength) {
+    (void)hHeap;
+    (void)HeapInformationClass;
+    (void)HeapInformation;
+    (void)HeapInformationLength;
     return 1;
 }
 static SIZE_T MSABI shim_HeapSize(HANDLE hHeap, DWORD dwFlags, const void* lpMem) {
     MS_INFO("TRACE: HeapSize(%p, 0x%X, %p)", hHeap, dwFlags, lpMem);
-    (void)hHeap; (void)dwFlags; (void)lpMem;
+    (void)hHeap;
+    (void)dwFlags;
+    (void)lpMem;
     return 1024;
 }
 static void* MSABI shim_HeapReAlloc(HANDLE hHeap, DWORD dwFlags, void* lpMem, SIZE_T dwBytes) {
     MS_INFO("TRACE: HeapReAlloc(%p, 0x%X, %p, %zu)", hHeap, dwFlags, lpMem, dwBytes);
-    (void)hHeap; (void)dwFlags;
+    (void)hHeap;
+    (void)dwFlags;
     return realloc(lpMem, dwBytes);
 }
 
 static DWORD MSABI shim_GetProcessHeaps(DWORD NumberOfHeaps, HANDLE* ProcessHeaps) {
     (void)NumberOfHeaps;
-    if (ProcessHeaps) ProcessHeaps[0] = reinterpret_cast<HANDLE>(0x1);
+    if (ProcessHeaps)
+        ProcessHeaps[0] = reinterpret_cast<HANDLE>(0x1);
     return 1;
 }
 
-static BOOL MSABI shim_IsBadWritePtr(void* lp, size_t ucb) { (void)lp; (void)ucb; return 0; }
-static BOOL MSABI shim_DeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, void* lpInBuffer,
-    DWORD nInBufferSize, void* lpOutBuffer, DWORD nOutBufferSize, DWORD* lpBytesReturned, void* lpOverlapped) {
-    (void)hDevice; (void)dwIoControlCode; (void)lpInBuffer; (void)nInBufferSize;
-    (void)lpOutBuffer; (void)nOutBufferSize; (void)lpOverlapped;
-    if (lpBytesReturned) *lpBytesReturned = 0;
+static BOOL MSABI shim_IsBadWritePtr(void* lp, size_t ucb) {
+    (void)lp;
+    (void)ucb;
+    return 0;
+}
+static BOOL MSABI shim_DeviceIoControl(HANDLE hDevice, DWORD dwIoControlCode, void* lpInBuffer, DWORD nInBufferSize,
+                                       void* lpOutBuffer, DWORD nOutBufferSize, DWORD* lpBytesReturned,
+                                       void* lpOverlapped) {
+    (void)hDevice;
+    (void)dwIoControlCode;
+    (void)lpInBuffer;
+    (void)nInBufferSize;
+    (void)lpOutBuffer;
+    (void)nOutBufferSize;
+    (void)lpOverlapped;
+    if (lpBytesReturned)
+        *lpBytesReturned = 0;
     return 0;
 }
 
 static BOOL MSABI shim_ProcessIdToSessionId(DWORD dwProcessId, DWORD* pSessionId) {
     (void)dwProcessId;
-    if (pSessionId) *pSessionId = 0;
+    if (pSessionId)
+        *pSessionId = 0;
     return 1;
 }
 
@@ -824,28 +1028,42 @@ static void MSABI shim_OutputDebugStringW(const wchar_t* lpOutputString) {
     (void)lpOutputString;
 }
 
-static BOOL MSABI shim_PeekNamedPipe(HANDLE hNamedPipe, void* lpBuffer, DWORD nBufferSize,
-    DWORD* lpBytesRead, DWORD* lpTotalBytesAvail, DWORD* lpBytesLeftThisMessage) {
-    (void)hNamedPipe; (void)lpBuffer; (void)nBufferSize;
-    if (lpBytesRead) *lpBytesRead = 0;
-    if (lpTotalBytesAvail) *lpTotalBytesAvail = 0;
-    if (lpBytesLeftThisMessage) *lpBytesLeftThisMessage = 0;
+static BOOL MSABI shim_PeekNamedPipe(HANDLE hNamedPipe, void* lpBuffer, DWORD nBufferSize, DWORD* lpBytesRead,
+                                     DWORD* lpTotalBytesAvail, DWORD* lpBytesLeftThisMessage) {
+    (void)hNamedPipe;
+    (void)lpBuffer;
+    (void)nBufferSize;
+    if (lpBytesRead)
+        *lpBytesRead = 0;
+    if (lpTotalBytesAvail)
+        *lpTotalBytesAvail = 0;
+    if (lpBytesLeftThisMessage)
+        *lpBytesLeftThisMessage = 0;
     return 0;
 }
 
 static BOOL MSABI shim_SetConsoleCtrlHandler(void* HandlerRoutine, BOOL Add) {
-    (void)HandlerRoutine; (void)Add; return 1;
+    (void)HandlerRoutine;
+    (void)Add;
+    return 1;
 }
 static BOOL MSABI shim_SetConsoleMode(HANDLE hConsoleHandle, DWORD dwMode) {
-    (void)hConsoleHandle; (void)dwMode; return 1;
+    (void)hConsoleHandle;
+    (void)dwMode;
+    return 1;
 }
 static BOOL MSABI shim_GetConsoleMode(HANDLE hConsoleHandle, DWORD* lpMode) {
     (void)hConsoleHandle;
-    if (lpMode) *lpMode = 0x1FF;
+    if (lpMode)
+        *lpMode = 0x1FF;
     return 1;
 }
-static UINT MSABI shim_GetConsoleOutputCP() { return 437; }
-static UINT MSABI shim_GetOEMCP() { return 437; }
+static UINT MSABI shim_GetConsoleOutputCP() {
+    return 437;
+}
+static UINT MSABI shim_GetOEMCP() {
+    return 437;
+}
 
 static BOOL MSABI shim_GetCPInfo(UINT CodePage, void* lpCPInfo) {
     (void)CodePage;
@@ -855,31 +1073,42 @@ static BOOL MSABI shim_GetCPInfo(UINT CodePage, void* lpCPInfo) {
     return 1;
 }
 
-static void* MSABI shim_GetCurrentThread() { return reinterpret_cast<void*>(static_cast<intptr_t>(-2)); }
+static void* MSABI shim_GetCurrentThread() {
+    return reinterpret_cast<void*>(static_cast<intptr_t>(-2));
+}
 
 static int MSABI shim_CompareStringW(void* Locale, DWORD dwCmpFlags, const wchar_t* lpString1, int cchCount1,
-    const wchar_t* lpString2, int cchCount2) {
-    (void)Locale; (void)dwCmpFlags;
+                                     const wchar_t* lpString2, int cchCount2) {
+    (void)Locale;
+    (void)dwCmpFlags;
     int len1 = cchCount1 > 0 ? cchCount1 : (int)wcslen(lpString1);
     int len2 = cchCount2 > 0 ? cchCount2 : (int)wcslen(lpString2);
     int minLen = len1 < len2 ? len1 : len2;
     for (int i = 0; i < minLen; i++) {
-        if (lpString1[i] < lpString2[i]) return 1;
-        if (lpString1[i] > lpString2[i]) return 3;
+        if (lpString1[i] < lpString2[i])
+            return 1;
+        if (lpString1[i] > lpString2[i])
+            return 3;
     }
-    if (len1 < len2) return 1;
-    if (len1 > len2) return 3;
+    if (len1 < len2)
+        return 1;
+    if (len1 > len2)
+        return 3;
     return 2;
 }
 
 static int MSABI shim_LCMapStringW(void* Locale, DWORD dwMapFlags, const wchar_t* lpSrcStr, int cchSrc,
-    wchar_t* lpDestStr, int cchDest) {
-    (void)Locale; (void)dwMapFlags;
-    if (!lpSrcStr) return 0;
+                                   wchar_t* lpDestStr, int cchDest) {
+    (void)Locale;
+    (void)dwMapFlags;
+    if (!lpSrcStr)
+        return 0;
     int len = cchSrc > 0 ? cchSrc : (int)wcslen(lpSrcStr);
-    if (cchDest == 0) return len;
+    if (cchDest == 0)
+        return len;
     int copyLen = len < cchDest ? len : cchDest;
-    for (int i = 0; i < copyLen; i++) lpDestStr[i] = lpSrcStr[i];
+    for (int i = 0; i < copyLen; i++)
+        lpDestStr[i] = lpSrcStr[i];
     return copyLen;
 }
 
@@ -889,9 +1118,12 @@ static BOOL MSABI shim_GetStringTypeW(DWORD dwInfoType, const wchar_t* lpSrcStr,
     for (int i = 0; i < len; i++) {
         lpCharType[i] = 0;
         wchar_t c = lpSrcStr[i];
-        if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) lpCharType[i] |= 0x0001 | 0x0002;
-        if (c >= '0' && c <= '9') lpCharType[i] |= 0x0004;
-        if (c == ' ' || c == '\t' || c == '\n' || c == '\r') lpCharType[i] |= 0x0008;
+        if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z'))
+            lpCharType[i] |= 0x0001 | 0x0002;
+        if (c >= '0' && c <= '9')
+            lpCharType[i] |= 0x0004;
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\r')
+            lpCharType[i] |= 0x0008;
     }
     return 1;
 }
@@ -912,9 +1144,11 @@ static wchar_t* MSABI shim_GetEnvironmentStringsW() {
     auto* block = static_cast<wchar_t*>(malloc(totalChars * sizeof(wchar_t)));
     size_t pos = 0;
     for (auto& [key, val] : s_envStore) {
-        for (size_t i = 0; i < key.size(); i++) block[pos++] = (wchar_t)(unsigned char)key[i];
+        for (size_t i = 0; i < key.size(); i++)
+            block[pos++] = (wchar_t)(unsigned char)key[i];
         block[pos++] = L'=';
-        for (size_t i = 0; i < val.size(); i++) block[pos++] = (wchar_t)(unsigned char)val[i];
+        for (size_t i = 0; i < val.size(); i++)
+            block[pos++] = (wchar_t)(unsigned char)val[i];
         block[pos++] = 0;
     }
     block[pos++] = 0;
@@ -922,21 +1156,28 @@ static wchar_t* MSABI shim_GetEnvironmentStringsW() {
 }
 
 static BOOL MSABI shim_CopyFileExW(const wchar_t* lpExistingFileName, const wchar_t* lpNewFileName,
-    void* lpProgressRoutine, void* lpData, BOOL* pbCancel, DWORD dwCopyFlags) {
-    (void)lpProgressRoutine; (void)lpData; (void)pbCancel; (void)dwCopyFlags;
-    if (!lpExistingFileName || !lpNewFileName) return 0;
+                                   void* lpProgressRoutine, void* lpData, BOOL* pbCancel, DWORD dwCopyFlags) {
+    (void)lpProgressRoutine;
+    (void)lpData;
+    (void)pbCancel;
+    (void)dwCopyFlags;
+    if (!lpExistingFileName || !lpNewFileName)
+        return 0;
 
     char srcW[1024], dstW[1024];
-    for (int i = 0; lpExistingFileName[i] && i < 1023; i++) srcW[i] = (char)(lpExistingFileName[i] & 0xFF);
+    for (int i = 0; lpExistingFileName[i] && i < 1023; i++)
+        srcW[i] = (char)(lpExistingFileName[i] & 0xFF);
     srcW[1023] = 0;
-    for (int i = 0; lpNewFileName[i] && i < 1023; i++) dstW[i] = (char)(lpNewFileName[i] & 0xFF);
+    for (int i = 0; lpNewFileName[i] && i < 1023; i++)
+        dstW[i] = (char)(lpNewFileName[i] & 0xFF);
     dstW[1023] = 0;
 
     std::string src = VirtualFileSystem::instance().winToHost(srcW);
     std::string dst = VirtualFileSystem::instance().winToHost(dstW);
 
     FILE* fin = fopen(src.c_str(), "rb");
-    if (!fin) return 0;
+    if (!fin)
+        return 0;
     {
         size_t pos = dst.rfind('/');
         if (pos != std::string::npos) {
@@ -945,7 +1186,10 @@ static BOOL MSABI shim_CopyFileExW(const wchar_t* lpExistingFileName, const wcha
         }
     }
     FILE* fout = fopen(dst.c_str(), "wb");
-    if (!fout) { fclose(fin); return 0; }
+    if (!fout) {
+        fclose(fin);
+        return 0;
+    }
 
     char buf[65536];
     size_t n;
@@ -960,58 +1204,79 @@ static BOOL MSABI shim_CopyFileExW(const wchar_t* lpExistingFileName, const wcha
 static BOOL MSABI shim_CreateDirectoryW(const wchar_t* lpPathName, void* lpSecurityAttributes) {
     (void)lpSecurityAttributes;
     char path[1024];
-    for (int i = 0; lpPathName[i] && i < 1023; i++) path[i] = (char)(lpPathName[i] & 0xFF);
+    for (int i = 0; lpPathName[i] && i < 1023; i++)
+        path[i] = (char)(lpPathName[i] & 0xFF);
     path[1023] = 0;
     return mkdir(path, 0755) == 0 ? 1 : 0;
 }
 
-static BOOL MSABI shim_RemoveDirectoryA(const char* lpPathName) { return rmdir(lpPathName) == 0 ? 1 : 0; }
+static BOOL MSABI shim_RemoveDirectoryA(const char* lpPathName) {
+    return rmdir(lpPathName) == 0 ? 1 : 0;
+}
 static BOOL MSABI shim_RemoveDirectoryW(const wchar_t* lpPathName) {
     char path[1024];
-    for (int i = 0; lpPathName[i] && i < 1023; i++) path[i] = (char)(lpPathName[i] & 0xFF);
+    for (int i = 0; lpPathName[i] && i < 1023; i++)
+        path[i] = (char)(lpPathName[i] & 0xFF);
     path[1023] = 0;
     return rmdir(path) == 0 ? 1 : 0;
 }
 static BOOL MSABI shim_DeleteFileW(const wchar_t* lpFileName) {
     char path[1024];
-    for (int i = 0; lpFileName[i] && i < 1023; i++) path[i] = (char)(lpFileName[i] & 0xFF);
+    for (int i = 0; lpFileName[i] && i < 1023; i++)
+        path[i] = (char)(lpFileName[i] & 0xFF);
     path[1023] = 0;
     return unlink(path) == 0 ? 1 : 0;
 }
 static BOOL MSABI shim_MoveFileExW(const wchar_t* lpExistingFileName, const wchar_t* lpNewFileName, DWORD dwFlags) {
     (void)dwFlags;
     char src[1024], dst[1024];
-    for (int i = 0; lpExistingFileName[i] && i < 1023; i++) src[i] = (char)(lpExistingFileName[i] & 0xFF);
+    for (int i = 0; lpExistingFileName[i] && i < 1023; i++)
+        src[i] = (char)(lpExistingFileName[i] & 0xFF);
     src[1023] = 0;
-    for (int i = 0; lpNewFileName[i] && i < 1023; i++) dst[i] = (char)(lpNewFileName[i] & 0xFF);
+    for (int i = 0; lpNewFileName[i] && i < 1023; i++)
+        dst[i] = (char)(lpNewFileName[i] & 0xFF);
     dst[1023] = 0;
     return rename(src, dst) == 0 ? 1 : 0;
 }
 static BOOL MSABI shim_ReplaceFileW(const wchar_t* lpReplacedFileName, const wchar_t* lpReplacementFileName,
-    const wchar_t* lpBackupFileName, DWORD dwReplaceFlags, void* lpExclude, void* lpReserved) {
-    (void)lpReplacedFileName; (void)lpReplacementFileName; (void)lpBackupFileName;
-    (void)dwReplaceFlags; (void)lpExclude; (void)lpReserved;
+                                    const wchar_t* lpBackupFileName, DWORD dwReplaceFlags, void* lpExclude,
+                                    void* lpReserved) {
+    (void)lpReplacedFileName;
+    (void)lpReplacementFileName;
+    (void)lpBackupFileName;
+    (void)dwReplaceFlags;
+    (void)lpExclude;
+    (void)lpReserved;
     return 0;
 }
-static BOOL MSABI shim_CreateSymbolicLinkW(const wchar_t* lpSymlinkFileName, const wchar_t* lpTargetFileName, DWORD dwFlags) {
-    (void)lpSymlinkFileName; (void)lpTargetFileName; (void)dwFlags;
+static BOOL MSABI shim_CreateSymbolicLinkW(const wchar_t* lpSymlinkFileName, const wchar_t* lpTargetFileName,
+                                           DWORD dwFlags) {
+    (void)lpSymlinkFileName;
+    (void)lpTargetFileName;
+    (void)dwFlags;
     return 0;
 }
 static BOOL MSABI shim_SetFileAttributesW(const wchar_t* lpFileName, DWORD dwFileAttributes) {
-    (void)lpFileName; (void)dwFileAttributes; return 1;
+    (void)lpFileName;
+    (void)dwFileAttributes;
+    return 1;
 }
 static BOOL MSABI shim_SetCurrentDirectoryW(const wchar_t* lpPathName) {
     char path[1024];
-    for (int i = 0; lpPathName[i] && i < 1023; i++) path[i] = (char)(lpPathName[i] & 0xFF);
+    for (int i = 0; lpPathName[i] && i < 1023; i++)
+        path[i] = (char)(lpPathName[i] & 0xFF);
     path[1023] = 0;
     return chdir(path) == 0 ? 1 : 0;
 }
 
-static DWORD MSABI shim_GetFullPathNameW(const wchar_t* lpFileName, DWORD nBufferLength, wchar_t* lpBuffer, wchar_t** lpFilePart) {
-    if (!lpFileName) return 0;
+static DWORD MSABI shim_GetFullPathNameW(const wchar_t* lpFileName, DWORD nBufferLength, wchar_t* lpBuffer,
+                                         wchar_t** lpFilePart) {
+    if (!lpFileName)
+        return 0;
     char narrow[1024];
     int j = 0;
-    for (int i = 0; lpFileName[i] && j < 1023; i++) narrow[j++] = (char)(lpFileName[i] & 0xFF);
+    for (int i = 0; lpFileName[i] && j < 1023; i++)
+        narrow[j++] = (char)(lpFileName[i] & 0xFF);
     narrow[j] = 0;
 
     std::string full = VirtualFileSystem::instance().getFullPathName(narrow);
@@ -1027,32 +1292,41 @@ static DWORD MSABI shim_GetFullPathNameW(const wchar_t* lpFileName, DWORD nBuffe
         }
     }
 
-    if (nBufferLength == 0 || !lpBuffer) return needed + 1;
+    if (nBufferLength == 0 || !lpBuffer)
+        return needed + 1;
     DWORD copyLen = needed < nBufferLength ? needed : nBufferLength - 1;
-    for (DWORD i = 0; i < copyLen; i++) lpBuffer[i] = (wchar_t)(unsigned char)full[i];
+    for (DWORD i = 0; i < copyLen; i++)
+        lpBuffer[i] = (wchar_t)(unsigned char)full[i];
     lpBuffer[copyLen] = 0;
     return needed;
 }
 
 static BOOL MSABI shim_CreateProcessW(const wchar_t* lpApplicationName, const wchar_t* lpCommandLine,
-    void* lpProcessAttributes, void* lpThreadAttributes, BOOL bInheritHandles,
-    DWORD dwCreationFlags, void* lpEnvironment, const wchar_t* lpCurrentDirectory,
-    void* lpStartupInfo, void* lpProcessInformation) {
-    (void)lpProcessAttributes; (void)lpThreadAttributes; (void)bInheritHandles;
-    (void)dwCreationFlags; (void)lpEnvironment; (void)lpStartupInfo;
+                                      void* lpProcessAttributes, void* lpThreadAttributes, BOOL bInheritHandles,
+                                      DWORD dwCreationFlags, void* lpEnvironment, const wchar_t* lpCurrentDirectory,
+                                      void* lpStartupInfo, void* lpProcessInformation) {
+    (void)lpProcessAttributes;
+    (void)lpThreadAttributes;
+    (void)bInheritHandles;
+    (void)dwCreationFlags;
+    (void)lpEnvironment;
+    (void)lpStartupInfo;
 
     char appName[1024] = {};
     char cmdLine[2048] = {};
     char workDir[1024] = {};
 
     if (lpApplicationName) {
-        for (int i = 0; i < 1023 && lpApplicationName[i]; i++) appName[i] = (char)lpApplicationName[i];
+        for (int i = 0; i < 1023 && lpApplicationName[i]; i++)
+            appName[i] = (char)lpApplicationName[i];
     }
     if (lpCommandLine) {
-        for (int i = 0; i < 2047 && lpCommandLine[i]; i++) cmdLine[i] = (char)lpCommandLine[i];
+        for (int i = 0; i < 2047 && lpCommandLine[i]; i++)
+            cmdLine[i] = (char)lpCommandLine[i];
     }
     if (lpCurrentDirectory) {
-        for (int i = 0; i < 1023 && lpCurrentDirectory[i]; i++) workDir[i] = (char)lpCurrentDirectory[i];
+        for (int i = 0; i < 1023 && lpCurrentDirectory[i]; i++)
+            workDir[i] = (char)lpCurrentDirectory[i];
     }
 
     MS_INFO("PELoader: CreateProcessW(\"%s\", \"%s\", cwd=\"%s\")", appName, cmdLine, workDir);
@@ -1086,9 +1360,10 @@ static BOOL MSABI shim_CreateProcessW(const wchar_t* lpApplicationName, const wc
 
         setenv("METALSHARP_CHILD_PROCESS", "1", 1);
         setenv("METALSHARP_CMDLINE", exeArgs, 1);
-        if (workDir[0]) setenv("METALSHARP_CWD", workDir, 1);
+        if (workDir[0])
+            setenv("METALSHARP_CWD", workDir, 1);
 
-        char* argv[] = { exePath, const_cast<char*>(targetExe), nullptr };
+        char* argv[] = {exePath, const_cast<char*>(targetExe), nullptr};
         execv(exePath, argv);
         _exit(127);
     }
@@ -1105,18 +1380,24 @@ static BOOL MSABI shim_CreateProcessW(const wchar_t* lpApplicationName, const wc
     return pid > 0 ? 1 : 0;
 }
 
-static BOOL MSABI shim_FindFirstFileExW(const wchar_t* lpFileName, DWORD fInfoLevelId,
-    void* lpFindFileData, DWORD fSearchOp, void* lpSearchFilter, DWORD dwAdditionalFlags) {
-    (void)lpFileName; (void)fInfoLevelId; (void)lpFindFileData;
-    (void)fSearchOp; (void)lpSearchFilter; (void)dwAdditionalFlags;
+static BOOL MSABI shim_FindFirstFileExW(const wchar_t* lpFileName, DWORD fInfoLevelId, void* lpFindFileData,
+                                        DWORD fSearchOp, void* lpSearchFilter, DWORD dwAdditionalFlags) {
+    (void)lpFileName;
+    (void)fInfoLevelId;
+    (void)lpFindFileData;
+    (void)fSearchOp;
+    (void)lpSearchFilter;
+    (void)dwAdditionalFlags;
     return 0;
 }
 
 static void* MSABI shim_FindFirstFileW(const wchar_t* lpFileName, void* lpFindFileData) {
-    if (!lpFileName) return INVALID_HANDLE_VALUE;
+    if (!lpFileName)
+        return INVALID_HANDLE_VALUE;
     char narrow[1024];
     int j = 0;
-    for (int i = 0; lpFileName[i] && j < 1023; i++) narrow[j++] = (char)(lpFileName[i] & 0xFF);
+    for (int i = 0; lpFileName[i] && j < 1023; i++)
+        narrow[j++] = (char)(lpFileName[i] & 0xFF);
     narrow[j] = 0;
     return VirtualFileSystem::instance().findFirstFileW(narrow, lpFindFileData);
 }
@@ -1126,19 +1407,23 @@ static BOOL MSABI shim_FindNextFileW(void* hFindFile, void* lpFindFileData) {
 }
 
 static BOOL MSABI shim_GetFileAttributesExW(const wchar_t* lpFileName, DWORD fInfoLevelId, void* lpFileInformation) {
-    if (!lpFileName) return 0;
+    if (!lpFileName)
+        return 0;
     char narrow[1024];
     int j = 0;
-    for (int i = 0; lpFileName[i] && j < 1023; i++) narrow[j++] = (char)(lpFileName[i] & 0xFF);
+    for (int i = 0; lpFileName[i] && j < 1023; i++)
+        narrow[j++] = (char)(lpFileName[i] & 0xFF);
     narrow[j] = 0;
     return VirtualFileSystem::instance().getFileAttributesEx(narrow, lpFileInformation);
 }
 
 static DWORD MSABI shim_GetFileAttributesW(const wchar_t* lpFileName) {
-    if (!lpFileName) return 0xFFFFFFFF;
+    if (!lpFileName)
+        return 0xFFFFFFFF;
     char narrow[1024];
     int j = 0;
-    for (int i = 0; lpFileName[i] && j < 1023; i++) narrow[j++] = (char)(lpFileName[i] & 0xFF);
+    for (int i = 0; lpFileName[i] && j < 1023; i++)
+        narrow[j++] = (char)(lpFileName[i] & 0xFF);
     narrow[j] = 0;
     return VirtualFileSystem::instance().getFileAttributes(narrow);
 }
@@ -1149,20 +1434,30 @@ static BOOL MSABI shim_GetFileInformationByHandle(HANDLE hFile, void* lpFileInfo
 
 static BOOL MSABI shim_GetFileTime(HANDLE hFile, void* lpCreationTime, void* lpLastAccessTime, void* lpLastWriteTime) {
     auto* entry = VirtualFileSystem::instance().getHandle(hFile);
-    if (!entry || entry->type != HandleType::File) return 0;
+    if (!entry || entry->type != HandleType::File)
+        return 0;
     auto* fs = static_cast<FileState*>(entry->data);
     struct stat st;
-    if (fstat(fs->fd, &st) != 0) return 0;
+    if (fstat(fs->fd, &st) != 0)
+        return 0;
     uint64_t ctime = static_cast<uint64_t>(st.st_ctime) * 10000000ULL + 116444736000000000ULL;
     uint64_t atime = static_cast<uint64_t>(st.st_atime) * 10000000ULL + 116444736000000000ULL;
     uint64_t mtime = static_cast<uint64_t>(st.st_mtime) * 10000000ULL + 116444736000000000ULL;
-    if (lpCreationTime) memcpy(lpCreationTime, &ctime, 8);
-    if (lpLastAccessTime) memcpy(lpLastAccessTime, &atime, 8);
-    if (lpLastWriteTime) memcpy(lpLastWriteTime, &mtime, 8);
+    if (lpCreationTime)
+        memcpy(lpCreationTime, &ctime, 8);
+    if (lpLastAccessTime)
+        memcpy(lpLastAccessTime, &atime, 8);
+    if (lpLastWriteTime)
+        memcpy(lpLastWriteTime, &mtime, 8);
     return 1;
 }
-static BOOL MSABI shim_SetFileTime(HANDLE hFile, const void* lpCreationTime, const void* lpLastAccessTime, const void* lpLastWriteTime) {
-    (void)hFile; (void)lpCreationTime; (void)lpLastAccessTime; (void)lpLastWriteTime; return 1;
+static BOOL MSABI shim_SetFileTime(HANDLE hFile, const void* lpCreationTime, const void* lpLastAccessTime,
+                                   const void* lpLastWriteTime) {
+    (void)hFile;
+    (void)lpCreationTime;
+    (void)lpLastAccessTime;
+    (void)lpLastWriteTime;
+    return 1;
 }
 
 static DWORD MSABI shim_GetFileType(HANDLE hFile) {
@@ -1170,26 +1465,35 @@ static DWORD MSABI shim_GetFileType(HANDLE hFile) {
 }
 
 static BOOL MSABI shim_GetDiskFreeSpaceA(const char* lpRootPathName, DWORD* lpSectorsPerCluster,
-    DWORD* lpBytesPerSector, DWORD* lpNumberOfFreeClusters, DWORD* lpTotalNumberOfClusters) {
+                                         DWORD* lpBytesPerSector, DWORD* lpNumberOfFreeClusters,
+                                         DWORD* lpTotalNumberOfClusters) {
     (void)lpRootPathName;
-    if (lpSectorsPerCluster) *lpSectorsPerCluster = 8;
-    if (lpBytesPerSector) *lpBytesPerSector = 512;
-    if (lpNumberOfFreeClusters) *lpNumberOfFreeClusters = 1000000;
-    if (lpTotalNumberOfClusters) *lpTotalNumberOfClusters = 2000000;
+    if (lpSectorsPerCluster)
+        *lpSectorsPerCluster = 8;
+    if (lpBytesPerSector)
+        *lpBytesPerSector = 512;
+    if (lpNumberOfFreeClusters)
+        *lpNumberOfFreeClusters = 1000000;
+    if (lpTotalNumberOfClusters)
+        *lpTotalNumberOfClusters = 2000000;
     return 1;
 }
 
 static BOOL MSABI shim_GetDiskFreeSpaceExW(const wchar_t* lpDirectoryName, uint64_t* lpFreeBytesAvailable,
-    uint64_t* lpTotalNumberOfBytes, uint64_t* lpTotalNumberOfFreeBytes) {
+                                           uint64_t* lpTotalNumberOfBytes, uint64_t* lpTotalNumberOfFreeBytes) {
     (void)lpDirectoryName;
-    if (lpFreeBytesAvailable) *lpFreeBytesAvailable = 8ULL * 1024 * 1024 * 1024 * 1024;
-    if (lpTotalNumberOfBytes) *lpTotalNumberOfBytes = 16ULL * 1024 * 1024 * 1024 * 1024;
-    if (lpTotalNumberOfFreeBytes) *lpTotalNumberOfFreeBytes = 8ULL * 1024 * 1024 * 1024 * 1024;
+    if (lpFreeBytesAvailable)
+        *lpFreeBytesAvailable = 8ULL * 1024 * 1024 * 1024 * 1024;
+    if (lpTotalNumberOfBytes)
+        *lpTotalNumberOfBytes = 16ULL * 1024 * 1024 * 1024 * 1024;
+    if (lpTotalNumberOfFreeBytes)
+        *lpTotalNumberOfFreeBytes = 8ULL * 1024 * 1024 * 1024 * 1024;
     return 1;
 }
 
 static UINT MSABI shim_GetDriveTypeW(const wchar_t* lpRootPathName) {
-    (void)lpRootPathName; return 3;
+    (void)lpRootPathName;
+    return 3;
 }
 
 static BOOL MSABI shim_FlushFileBuffers(HANDLE hFile) {
@@ -1197,17 +1501,26 @@ static BOOL MSABI shim_FlushFileBuffers(HANDLE hFile) {
 }
 static BOOL MSABI shim_SetEndOfFile(HANDLE hFile) {
     auto* entry = VirtualFileSystem::instance().getHandle(hFile);
-    if (!entry || entry->type != HandleType::File) return 0;
+    if (!entry || entry->type != HandleType::File)
+        return 0;
     auto* fs = static_cast<FileState*>(entry->data);
     off_t pos = lseek(fs->fd, 0, SEEK_CUR);
-    if (pos == (off_t)-1) return 0;
-    if (ftruncate(fs->fd, pos) != 0) return 0;
+    if (pos == (off_t)-1)
+        return 0;
+    if (ftruncate(fs->fd, pos) != 0)
+        return 0;
     return 1;
 }
 static BOOL MSABI shim_SetHandleInformation(HANDLE hObject, DWORD dwMask, DWORD dwFlags) {
-    (void)hObject; (void)dwMask; (void)dwFlags; return 1;
+    (void)hObject;
+    (void)dwMask;
+    (void)dwFlags;
+    return 1;
 }
-static DWORD MSABI shim_SetErrorMode(DWORD uMode) { (void)uMode; return 0; }
+static DWORD MSABI shim_SetErrorMode(DWORD uMode) {
+    (void)uMode;
+    return 0;
+}
 
 static void* findResourceEntry(uint8_t* base, IMAGE_RESOURCE_DIRECTORY* dir, uint32_t id) {
     auto* entries = reinterpret_cast<IMAGE_RESOURCE_DIRECTORY_ENTRY*>(dir + 1);
@@ -1227,30 +1540,38 @@ static void* findResourceEntry(uint8_t* base, IMAGE_RESOURCE_DIRECTORY* dir, uin
 
 static void* MSABI shim_FindResourceA(HMODULE hModule, const char* lpName, const char* lpType) {
     auto* mod = PELoader::instance()->getMainModule();
-    if (!mod || !mod->base) return nullptr;
+    if (!mod || !mod->base)
+        return nullptr;
 
     uint8_t* base = mod->base;
     auto* dos = reinterpret_cast<const IMAGE_DOS_HEADER*>(base);
-    auto* opt = reinterpret_cast<const IMAGE_OPTIONAL_HEADER64*>(
-        base + dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER));
+    auto* opt = reinterpret_cast<const IMAGE_OPTIONAL_HEADER64*>(base + dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER));
 
-    if (opt->DataDirectory[DIRECTORY_RESOURCE].Size == 0) return nullptr;
+    if (opt->DataDirectory[DIRECTORY_RESOURCE].Size == 0)
+        return nullptr;
 
     uint32_t rsrcRVA = opt->DataDirectory[DIRECTORY_RESOURCE].VirtualAddress;
     auto* rsrcDir = reinterpret_cast<IMAGE_RESOURCE_DIRECTORY*>(base + rsrcRVA);
 
-    uint32_t typeId = (reinterpret_cast<uintptr_t>(lpType) >= 0x10000) ? 0 : static_cast<uint32_t>(reinterpret_cast<uintptr_t>(lpType));
+    uint32_t typeId = (reinterpret_cast<uintptr_t>(lpType) >= 0x10000)
+                          ? 0
+                          : static_cast<uint32_t>(reinterpret_cast<uintptr_t>(lpType));
 
     auto* typeDir = reinterpret_cast<IMAGE_RESOURCE_DIRECTORY*>(findResourceEntry(base, rsrcDir, typeId));
-    if (!typeDir) return nullptr;
+    if (!typeDir)
+        return nullptr;
 
-    uint32_t nameId = (reinterpret_cast<uintptr_t>(lpName) >= 0x10000) ? 0 : static_cast<uint32_t>(reinterpret_cast<uintptr_t>(lpName));
+    uint32_t nameId = (reinterpret_cast<uintptr_t>(lpName) >= 0x10000)
+                          ? 0
+                          : static_cast<uint32_t>(reinterpret_cast<uintptr_t>(lpName));
 
     auto* nameDir = reinterpret_cast<IMAGE_RESOURCE_DIRECTORY*>(findResourceEntry(base, typeDir, nameId));
-    if (!nameDir) return nullptr;
+    if (!nameDir)
+        return nullptr;
 
     auto* langEntry = reinterpret_cast<IMAGE_RESOURCE_DATA_ENTRY*>(findResourceEntry(base, nameDir, 0));
-    if (!langEntry) return nullptr;
+    if (!langEntry)
+        return nullptr;
 
     return langEntry;
 }
@@ -1259,50 +1580,67 @@ static void* MSABI shim_LoadResource(HMODULE hModule, void* hResInfo) {
     return hResInfo;
 }
 static void* MSABI shim_LockResource(void* hResData) {
-    if (!hResData) return nullptr;
+    if (!hResData)
+        return nullptr;
     auto* dataEntry = static_cast<IMAGE_RESOURCE_DATA_ENTRY*>(hResData);
     auto* mod = PELoader::instance()->getMainModule();
-    if (!mod || !mod->base) return nullptr;
+    if (!mod || !mod->base)
+        return nullptr;
     return mod->base + dataEntry->OffsetToData;
 }
 static DWORD MSABI shim_SizeofResource(HMODULE hModule, void* hResInfo) {
     (void)hModule;
-    if (!hResInfo) return 0;
+    if (!hResInfo)
+        return 0;
     auto* dataEntry = static_cast<IMAGE_RESOURCE_DATA_ENTRY*>(hResInfo);
     return dataEntry->Size;
 }
 
 static int MSABI shim_MulDiv(int nNumber, int nNumerator, int nDenominator) {
-    if (nDenominator == 0) return -1;
+    if (nDenominator == 0)
+        return -1;
     return (int)((int64_t)nNumber * nNumerator / nDenominator);
 }
 
 static BOOL MSABI shim_ReadConsoleA(HANDLE hConsoleInput, void* lpBuffer, DWORD nNumberOfCharsToRead,
-    DWORD* lpNumberOfCharsRead, void* pInputControl) {
-    (void)hConsoleInput; (void)lpBuffer; (void)nNumberOfCharsToRead; (void)pInputControl;
-    if (lpNumberOfCharsRead) *lpNumberOfCharsRead = 0;
+                                    DWORD* lpNumberOfCharsRead, void* pInputControl) {
+    (void)hConsoleInput;
+    (void)lpBuffer;
+    (void)nNumberOfCharsToRead;
+    (void)pInputControl;
+    if (lpNumberOfCharsRead)
+        *lpNumberOfCharsRead = 0;
     return 0;
 }
 
 static BOOL MSABI shim_ReadConsoleW(HANDLE hConsoleInput, void* lpBuffer, DWORD nNumberOfCharsToRead,
-    DWORD* lpNumberOfCharsRead, void* pInputControl) {
-    (void)hConsoleInput; (void)lpBuffer; (void)nNumberOfCharsToRead; (void)pInputControl;
-    if (lpNumberOfCharsRead) *lpNumberOfCharsRead = 0;
+                                    DWORD* lpNumberOfCharsRead, void* pInputControl) {
+    (void)hConsoleInput;
+    (void)lpBuffer;
+    (void)nNumberOfCharsToRead;
+    (void)pInputControl;
+    if (lpNumberOfCharsRead)
+        *lpNumberOfCharsRead = 0;
     return 0;
 }
 
 static BOOL MSABI shim_WriteConsoleW(HANDLE hConsoleOutput, const void* lpBuffer, DWORD nNumberOfCharsToWrite,
-    DWORD* lpNumberOfCharsWritten, void* lpReserved) {
-    (void)hConsoleOutput; (void)lpReserved;
-    if (lpNumberOfCharsWritten) *lpNumberOfCharsWritten = nNumberOfCharsToWrite;
+                                     DWORD* lpNumberOfCharsWritten, void* lpReserved) {
+    (void)hConsoleOutput;
+    (void)lpReserved;
+    if (lpNumberOfCharsWritten)
+        *lpNumberOfCharsWritten = nNumberOfCharsToWrite;
     return 1;
 }
 
-static BOOL MSABI shim_GetProductInfo(DWORD dwOSMajorVersion, DWORD dwOSMinorVersion,
-    DWORD dwSpMajorVersion, DWORD dwSpMinorVersion, DWORD* pdwReturnedProductType) {
-    (void)dwOSMajorVersion; (void)dwOSMinorVersion;
-    (void)dwSpMajorVersion; (void)dwSpMinorVersion;
-    if (pdwReturnedProductType) *pdwReturnedProductType = 1;
+static BOOL MSABI shim_GetProductInfo(DWORD dwOSMajorVersion, DWORD dwOSMinorVersion, DWORD dwSpMajorVersion,
+                                      DWORD dwSpMinorVersion, DWORD* pdwReturnedProductType) {
+    (void)dwOSMajorVersion;
+    (void)dwOSMinorVersion;
+    (void)dwSpMajorVersion;
+    (void)dwSpMinorVersion;
+    if (pdwReturnedProductType)
+        *pdwReturnedProductType = 1;
     return 1;
 }
 
@@ -1351,17 +1689,20 @@ static void MSABI shim_RtlCaptureContext(void* ContextRecord) {
         ctx->Rip = reinterpret_cast<uintptr_t>(__builtin_return_address(0));
         uint64_t rbp_val = 0;
 #if defined(__x86_64__)
-        __asm__ volatile ("movq %%rbp, %0" : "=r"(rbp_val));
+        __asm__ volatile("movq %%rbp, %0" : "=r"(rbp_val));
 #endif
         ctx->Rsp = rbp_val + 16;
     }
-    MS_INFO("TRACE: RtlCaptureContext(%p) -> Rip=0x%llX, Rsp=0x%llX",
-        ContextRecord, (unsigned long long)(ctx ? ctx->Rip : 0), (unsigned long long)(ctx ? ctx->Rsp : 0));
+    MS_INFO("TRACE: RtlCaptureContext(%p) -> Rip=0x%llX, Rsp=0x%llX", ContextRecord,
+            (unsigned long long)(ctx ? ctx->Rip : 0), (unsigned long long)(ctx ? ctx->Rsp : 0));
 }
-static void* MSABI shim_RtlCaptureStackBackTrace(DWORD FramesToSkip, DWORD FramesToCapture,
-    void** BackTrace, DWORD* BackTraceHash) {
-    (void)FramesToSkip; (void)FramesToCapture; (void)BackTrace;
-    if (BackTraceHash) *BackTraceHash = 0;
+static void* MSABI shim_RtlCaptureStackBackTrace(DWORD FramesToSkip, DWORD FramesToCapture, void** BackTrace,
+                                                 DWORD* BackTraceHash) {
+    (void)FramesToSkip;
+    (void)FramesToCapture;
+    (void)BackTrace;
+    if (BackTraceHash)
+        *BackTraceHash = 0;
     return nullptr;
 }
 static uint32_t s_fakeRuntimeFunc[3] = {0, 0, 0};
@@ -1369,16 +1710,20 @@ static uint8_t s_fakeUnwindInfo[8] = {1, 0, 0, 0, 0, 0, 0, 0};
 
 static void* MSABI shim_RtlLookupFunctionEntry(uint64_t ControlPoint, uint64_t* ImageBase, void* HistoryTable) {
     MS_INFO("TRACE: RtlLookupFunctionEntry(0x%llX)", (unsigned long long)ControlPoint);
-    (void)ControlPoint; (void)HistoryTable;
-    if (ImageBase) *ImageBase = 0;
+    (void)ControlPoint;
+    (void)HistoryTable;
+    if (ImageBase)
+        *ImageBase = 0;
     void* result = PELoader::instance()->lookupFunctionEntry(ControlPoint, ImageBase);
     if (!result) {
         MS_INFO("TRACE: RtlLookupFunctionEntry -> returning fake entry");
         s_fakeRuntimeFunc[0] = 0;
         s_fakeRuntimeFunc[1] = 0x1000;
         auto* base = reinterpret_cast<uint8_t*>(*ImageBase);
-        if (!base) base = reinterpret_cast<uint8_t*>(PELoader::instance()->getMainModule()->base);
-        s_fakeRuntimeFunc[2] = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(s_fakeUnwindInfo) - reinterpret_cast<uintptr_t>(base));
+        if (!base)
+            base = reinterpret_cast<uint8_t*>(PELoader::instance()->getMainModule()->base);
+        s_fakeRuntimeFunc[2] =
+            static_cast<uint32_t>(reinterpret_cast<uintptr_t>(s_fakeUnwindInfo) - reinterpret_cast<uintptr_t>(base));
         result = s_fakeRuntimeFunc;
     }
     return result;
@@ -1386,25 +1731,33 @@ static void* MSABI shim_RtlLookupFunctionEntry(uint64_t ControlPoint, uint64_t* 
 static void* MSABI shim_RtlPcToFileHeader(uint64_t PcValue, uint64_t* ImageBase) {
     MS_INFO("TRACE: RtlPcToFileHeader(0x%llX)", PcValue);
     (void)PcValue;
-    if (ImageBase) *ImageBase = 0;
+    if (ImageBase)
+        *ImageBase = 0;
     return nullptr;
 }
 static void MSABI shim_RtlUnwind(void* TargetFrame, void* TargetIp, void* ExceptionRecord, void* ReturnValue) {
     MS_INFO("TRACE: RtlUnwind(%p, %p, %p, %p)", TargetFrame, TargetIp, ExceptionRecord, ReturnValue);
 }
-static void MSABI shim_RtlUnwindEx(void* TargetFrame, void* TargetIp, void* ExceptionRecord, void* ReturnValue, void* ContextRecord) {
-    MS_INFO("TRACE: RtlUnwindEx(%p, %p, %p, %p, %p)", TargetFrame, TargetIp, ExceptionRecord, ReturnValue, ContextRecord);
+static void MSABI shim_RtlUnwindEx(void* TargetFrame, void* TargetIp, void* ExceptionRecord, void* ReturnValue,
+                                   void* ContextRecord) {
+    MS_INFO("TRACE: RtlUnwindEx(%p, %p, %p, %p, %p)", TargetFrame, TargetIp, ExceptionRecord, ReturnValue,
+            ContextRecord);
 }
-static void MSABI shim_RtlVirtualUnwind(DWORD HandlerType, uint64_t ImageBase, uint64_t ControlPc,
-    void* FunctionEntry, void* ContextRecord, void** HandlerData, uint64_t* EstablisherFrame, void* ContextPointers) {
-    (void)HandlerType; (void)ControlPc; (void)ContextPointers;
+static void MSABI shim_RtlVirtualUnwind(DWORD HandlerType, uint64_t ImageBase, uint64_t ControlPc, void* FunctionEntry,
+                                        void* ContextRecord, void** HandlerData, uint64_t* EstablisherFrame,
+                                        void* ContextPointers) {
+    (void)HandlerType;
+    (void)ControlPc;
+    (void)ContextPointers;
     (void)FunctionEntry;
 
     auto* ctx = reinterpret_cast<WIN64_CONTEXT*>(ContextRecord);
 
     uint64_t frame = ctx ? ctx->Rsp : 0;
-    if (EstablisherFrame) *EstablisherFrame = frame;
-    if (HandlerData) *HandlerData = nullptr;
+    if (EstablisherFrame)
+        *EstablisherFrame = frame;
+    if (HandlerData)
+        *HandlerData = nullptr;
 
     if (ctx) {
         ctx->Rip = 0;
@@ -1414,34 +1767,50 @@ static void MSABI shim_RtlVirtualUnwind(DWORD HandlerType, uint64_t ImageBase, u
     MS_INFO("TRACE: RtlVirtualUnwind -> Establisher=0x%llX", (unsigned long long)frame);
 }
 
-static void* MSABI shim_EncodePointer(void* Ptr) { return Ptr; }
-static void* MSABI shim_DecodePointer(void* Ptr) { return Ptr; }
+static void* MSABI shim_EncodePointer(void* Ptr) {
+    return Ptr;
+}
+static void* MSABI shim_DecodePointer(void* Ptr) {
+    return Ptr;
+}
 
 static BOOL MSABI stub_GetFileSizeEx(void* hFile, int64_t* size) {
     return VirtualFileSystem::instance().getFileSizeEx(hFile, size);
 }
-static DWORD MSABI stub_SetFilePointer(void* hFile, LONG lDistanceToMove, LONG* lpDistanceToMoveHigh, DWORD dwMoveMethod) {
+static DWORD MSABI stub_SetFilePointer(void* hFile, LONG lDistanceToMove, LONG* lpDistanceToMoveHigh,
+                                       DWORD dwMoveMethod) {
     return VirtualFileSystem::instance().setFilePointer(hFile, lDistanceToMove, lpDistanceToMoveHigh, dwMoveMethod);
 }
-static BOOL MSABI stub_SetFilePointerEx(void* hFile, int64_t liDistanceToMove, int64_t* lpNewFilePointer, DWORD dwMoveMethod) {
+static BOOL MSABI stub_SetFilePointerEx(void* hFile, int64_t liDistanceToMove, int64_t* lpNewFilePointer,
+                                        DWORD dwMoveMethod) {
     return VirtualFileSystem::instance().setFilePointerEx(hFile, liDistanceToMove, lpNewFilePointer, dwMoveMethod);
 }
 
-static void* MSABI shim_CreateNamedPipeW(const wchar_t* lpName, DWORD dwOpenMode, DWORD dwPipeMode,
-    DWORD nMaxInstances, DWORD nOutBufferSize, DWORD nInBufferSize, DWORD nDefaultTimeOut, void* lpSecurityAttributes) {
-    (void)dwOpenMode; (void)dwPipeMode; (void)nMaxInstances;
-    (void)nOutBufferSize; (void)nInBufferSize; (void)nDefaultTimeOut; (void)lpSecurityAttributes;
-    if (!lpName) return INVALID_HANDLE_VALUE;
+static void* MSABI shim_CreateNamedPipeW(const wchar_t* lpName, DWORD dwOpenMode, DWORD dwPipeMode, DWORD nMaxInstances,
+                                         DWORD nOutBufferSize, DWORD nInBufferSize, DWORD nDefaultTimeOut,
+                                         void* lpSecurityAttributes) {
+    (void)dwOpenMode;
+    (void)dwPipeMode;
+    (void)nMaxInstances;
+    (void)nOutBufferSize;
+    (void)nInBufferSize;
+    (void)nDefaultTimeOut;
+    (void)lpSecurityAttributes;
+    if (!lpName)
+        return INVALID_HANDLE_VALUE;
 
     char nameA[256] = {0};
-    for (int i = 0; lpName[i] && i < 255; i++) nameA[i] = (char)(lpName[i] & 0x7F);
+    for (int i = 0; lpName[i] && i < 255; i++)
+        nameA[i] = (char)(lpName[i] & 0x7F);
 
     std::string pipeName(nameA);
     size_t pipePos = pipeName.find("pipe");
-    if (pipePos != std::string::npos) pipeName = pipeName.substr(pipePos + 5);
+    if (pipePos != std::string::npos)
+        pipeName = pipeName.substr(pipePos + 5);
 
     int* handles = NetworkContext::instance().allocPipePair(pipeName, true);
-    if (!handles) return INVALID_HANDLE_VALUE;
+    if (!handles)
+        return INVALID_HANDLE_VALUE;
 
     MS_INFO("TRACE: CreateNamedPipeW(\"%s\") -> handle %d", nameA, handles[0]);
     return reinterpret_cast<void*>(static_cast<intptr_t>(handles[0]));
@@ -1451,15 +1820,18 @@ static BOOL MSABI shim_ConnectNamedPipe(void* hNamedPipe, void* lpOverlapped) {
     (void)lpOverlapped;
     int handle = (int)(intptr_t)hNamedPipe;
     int listenFd = NetworkContext::instance().getPipeReadFd(handle);
-    if (listenFd < 0) return 0;
+    if (listenFd < 0)
+        return 0;
 
     int clientFd = accept(listenFd, nullptr, nullptr);
-    if (clientFd < 0) return 0;
+    if (clientFd < 0)
+        return 0;
 
     MS_INFO("TRACE: ConnectNamedPipe(%d) -> client fd %d", handle, clientFd);
 
     int pipeHandles[2];
-    if (pipe(pipeHandles) < 0) return 0;
+    if (pipe(pipeHandles) < 0)
+        return 0;
 
     fcntl(pipeHandles[0], F_SETFL, O_NONBLOCK);
     fcntl(pipeHandles[1], F_SETFL, O_NONBLOCK);
@@ -1469,22 +1841,30 @@ static BOOL MSABI shim_ConnectNamedPipe(void* hNamedPipe, void* lpOverlapped) {
 
 static BOOL MSABI shim_WaitNamedPipeW(const wchar_t* lpNamedPipeName, DWORD nTimeOut) {
     (void)nTimeOut;
-    if (!lpNamedPipeName) return 0;
+    if (!lpNamedPipeName)
+        return 0;
     return 1;
 }
 
 static BOOL MSABI shim_CallNamedPipeW(const wchar_t* lpNamedPipeName, void* lpInBuffer, DWORD nInBufferSize,
-    void* lpOutBuffer, DWORD nOutBufferSize, DWORD* lpBytesRead, DWORD nTimeOut) {
-    (void)lpNamedPipeName; (void)lpInBuffer; (void)nInBufferSize;
-    (void)lpOutBuffer; (void)nOutBufferSize; (void)nTimeOut;
-    if (lpBytesRead) *lpBytesRead = 0;
+                                      void* lpOutBuffer, DWORD nOutBufferSize, DWORD* lpBytesRead, DWORD nTimeOut) {
+    (void)lpNamedPipeName;
+    (void)lpInBuffer;
+    (void)nInBufferSize;
+    (void)lpOutBuffer;
+    (void)nOutBufferSize;
+    (void)nTimeOut;
+    if (lpBytesRead)
+        *lpBytesRead = 0;
     return 0;
 }
 
 static BOOL MSABI shim_CreatePipe(void* hReadPipe, void* hWritePipe, void* lpPipeAttributes, DWORD nSize) {
-    (void)lpPipeAttributes; (void)nSize;
+    (void)lpPipeAttributes;
+    (void)nSize;
     int fds[2];
-    if (pipe(fds) < 0) return 0;
+    if (pipe(fds) < 0)
+        return 0;
 
     auto& vfs = VirtualFileSystem::instance();
     *(reinterpret_cast<HANDLE*>(hReadPipe)) = vfs.registerPipeFd(fds[0]);
@@ -1495,11 +1875,16 @@ static BOOL MSABI shim_CreatePipe(void* hReadPipe, void* hWritePipe, void* lpPip
     return 1;
 }
 
-static BOOL MSABI shim_TransactNamedPipe(void* hNamedPipe, void* lpInBuffer, DWORD nInBufferSize,
-    void* lpOutBuffer, DWORD nOutBufferSize, DWORD* lpBytesRead, void* lpOverlapped) {
-    (void)hNamedPipe; (void)lpInBuffer; (void)nInBufferSize;
-    (void)lpOutBuffer; (void)nOutBufferSize; (void)lpOverlapped;
-    if (lpBytesRead) *lpBytesRead = 0;
+static BOOL MSABI shim_TransactNamedPipe(void* hNamedPipe, void* lpInBuffer, DWORD nInBufferSize, void* lpOutBuffer,
+                                         DWORD nOutBufferSize, DWORD* lpBytesRead, void* lpOverlapped) {
+    (void)hNamedPipe;
+    (void)lpInBuffer;
+    (void)nInBufferSize;
+    (void)lpOutBuffer;
+    (void)nOutBufferSize;
+    (void)lpOverlapped;
+    if (lpBytesRead)
+        *lpBytesRead = 0;
     return 0;
 }
 
@@ -1513,7 +1898,8 @@ static BOOL MSABI shim_ReleaseMutex(HANDLE hMutex) {
     return SyncContext::instance().releaseMutex(hMutex) ? 1 : 0;
 }
 
-static void* MSABI shim_CreateSemaphoreA(void* lpSemaphoreAttributes, LONG lInitialCount, LONG lMaximumCount, const char* lpName) {
+static void* MSABI shim_CreateSemaphoreA(void* lpSemaphoreAttributes, LONG lInitialCount, LONG lMaximumCount,
+                                         const char* lpName) {
     (void)lpSemaphoreAttributes;
     std::string name = lpName ? lpName : "";
     return SyncContext::instance().createSemaphore(lInitialCount, lMaximumCount, name);
@@ -1523,12 +1909,14 @@ static BOOL MSABI shim_ReleaseSemaphore(HANDLE hSemaphore, LONG lReleaseCount, L
     return SyncContext::instance().releaseSemaphore(hSemaphore, lReleaseCount, lpPreviousCount) ? 1 : 0;
 }
 
-static void* MSABI shim_CreateEventW(void* lpEventAttributes, BOOL bManualReset, BOOL bInitialState, const wchar_t* lpName) {
+static void* MSABI shim_CreateEventW(void* lpEventAttributes, BOOL bManualReset, BOOL bInitialState,
+                                     const wchar_t* lpName) {
     (void)lpEventAttributes;
     std::string name;
     if (lpName) {
         char buf[256] = {0};
-        for (int i = 0; lpName[i] && i < 255; i++) buf[i] = (char)(lpName[i] & 0x7F);
+        for (int i = 0; lpName[i] && i < 255; i++)
+            buf[i] = (char)(lpName[i] & 0x7F);
         name = buf;
     }
     return SyncContext::instance().createEvent(bManualReset != 0, bInitialState != 0, name);
@@ -1539,16 +1927,15 @@ static void* MSABI shim_CreateMutexW(void* lpMutexAttributes, BOOL bInitialOwner
     std::string name;
     if (lpName) {
         char buf[256] = {0};
-        for (int i = 0; lpName[i] && i < 255; i++) buf[i] = (char)(lpName[i] & 0x7F);
+        for (int i = 0; lpName[i] && i < 255; i++)
+            buf[i] = (char)(lpName[i] & 0x7F);
         name = buf;
     }
     return SyncContext::instance().createMutex(bInitialOwner != 0, name);
 }
 
 void addMissingKernel32(ShimLibrary& lib) {
-    auto fn = [](void* ptr) -> ExportedFunction {
-        return [ptr]() -> void* { return ptr; };
-    };
+    auto fn = [](void* ptr) -> ExportedFunction { return [ptr]() -> void* { return ptr; }; };
 
     lib.functions["VirtualProtect"] = fn((void*)shim_VirtualProtect);
     lib.functions["VirtualQuery"] = fn((void*)shim_VirtualQuery);
@@ -1727,5 +2114,5 @@ void addMissingKernel32(ShimLibrary& lib) {
     lib.functions["TransactNamedPipe"] = fn((void*)shim_TransactNamedPipe);
 }
 
-}
-}
+} // namespace win32
+} // namespace metalsharp

--- a/src/win32/kernel32/Kernel32Shim.cpp
+++ b/src/win32/kernel32/Kernel32Shim.cpp
@@ -36,19 +36,19 @@
 ///
 /// This shim is registered first and handles ~40 of the most critical kernel32 exports.
 /// Additional kernel32 functions are in Kernel32Extra.cpp.
-#include <metalsharp/Kernel32Shim.h>
-#include <metalsharp/Win32Types.h>
-#include <metalsharp/PELoader.h>
-#include <metalsharp/Logger.h>
-#include <metalsharp/VirtualFileSystem.h>
-#include <metalsharp/SyncContext.h>
-#include <cstring>
-#include <cstdlib>
 #include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <errno.h>
+#include <metalsharp/Kernel32Shim.h>
+#include <metalsharp/Logger.h>
+#include <metalsharp/PELoader.h>
+#include <metalsharp/SyncContext.h>
+#include <metalsharp/VirtualFileSystem.h>
+#include <metalsharp/Win32Types.h>
+#include <pthread.h>
 #include <sys/mman.h>
 #include <unistd.h>
-#include <pthread.h>
-#include <errno.h>
 
 namespace metalsharp {
 namespace win32 {
@@ -90,7 +90,8 @@ static void* MSABI shim_VirtualAlloc(void* lpAddress, SIZE_T dwSize, DWORD flAll
 
 static BOOL MSABI shim_VirtualFree(void* lpAddress, SIZE_T dwSize, DWORD dwFreeType) {
     auto it = Kernel32Shim::s_allocations.find(reinterpret_cast<uintptr_t>(lpAddress));
-    if (it == Kernel32Shim::s_allocations.end()) return 0;
+    if (it == Kernel32Shim::s_allocations.end())
+        return 0;
 
     size_t size = it->second;
     Kernel32Shim::s_allocations.erase(it);
@@ -106,7 +107,9 @@ static void* MSABI shim_GetProcessHeap() {
 }
 
 static void* MSABI shim_HeapCreate(DWORD flOptions, SIZE_T dwInitialSize, SIZE_T dwMaximumSize) {
-    (void)flOptions; (void)dwInitialSize; (void)dwMaximumSize;
+    (void)flOptions;
+    (void)dwInitialSize;
+    (void)dwMaximumSize;
     MS_INFO("TRACE: HeapCreate(0x%X, %zu, %zu) -> fake heap", flOptions, dwInitialSize, dwMaximumSize);
     return reinterpret_cast<void*>(0x1);
 }
@@ -125,7 +128,8 @@ static BOOL MSABI shim_HeapFree(void* hHeap, DWORD dwFlags, void* lpMem) {
 }
 
 static void* MSABI shim_LocalAlloc(UINT uFlags, SIZE_T uBytes) {
-    if (uFlags & 0x40) return calloc(1, uBytes);
+    if (uFlags & 0x40)
+        return calloc(1, uBytes);
     return malloc(uBytes);
 }
 
@@ -134,7 +138,8 @@ static void MSABI shim_LocalFree(void* hMem) {
 }
 
 static void* MSABI shim_GlobalAlloc(UINT uFlags, SIZE_T uBytes) {
-    if (uFlags & 0x40) return calloc(1, uBytes);
+    if (uFlags & 0x40)
+        return calloc(1, uBytes);
     return malloc(uBytes);
 }
 
@@ -143,25 +148,29 @@ static void MSABI shim_GlobalFree(void* hMem) {
 }
 
 static HANDLE MSABI shim_CreateFileA(const char* lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode,
-    void* lpSecurityAttributes, DWORD dwCreationDisposition, DWORD dwFlagsAndAttributes, HANDLE hTemplateFile) {
-    (void)lpSecurityAttributes; (void)hTemplateFile;
-    return VirtualFileSystem::instance().createFile(lpFileName, dwDesiredAccess, dwShareMode, dwCreationDisposition, dwFlagsAndAttributes);
+                                     void* lpSecurityAttributes, DWORD dwCreationDisposition,
+                                     DWORD dwFlagsAndAttributes, HANDLE hTemplateFile) {
+    (void)lpSecurityAttributes;
+    (void)hTemplateFile;
+    return VirtualFileSystem::instance().createFile(lpFileName, dwDesiredAccess, dwShareMode, dwCreationDisposition,
+                                                    dwFlagsAndAttributes);
 }
 
-static BOOL MSABI shim_ReadFile(HANDLE hFile, void* lpBuffer, DWORD nNumberOfBytesToRead,
-    DWORD* lpNumberOfBytesRead, void* lpOverlapped) {
+static BOOL MSABI shim_ReadFile(HANDLE hFile, void* lpBuffer, DWORD nNumberOfBytesToRead, DWORD* lpNumberOfBytesRead,
+                                void* lpOverlapped) {
     (void)lpOverlapped;
     return VirtualFileSystem::instance().readFile(hFile, lpBuffer, nNumberOfBytesToRead, lpNumberOfBytesRead);
 }
 
 static BOOL MSABI shim_WriteFile(HANDLE hFile, const void* lpBuffer, DWORD nNumberOfBytesToWrite,
-    DWORD* lpNumberOfBytesWritten, void* lpOverlapped) {
+                                 DWORD* lpNumberOfBytesWritten, void* lpOverlapped) {
     (void)lpOverlapped;
     return VirtualFileSystem::instance().writeFile(hFile, lpBuffer, nNumberOfBytesToWrite, lpNumberOfBytesWritten);
 }
 
 static BOOL MSABI shim_CloseHandle(HANDLE hObject) {
-    if (!hObject || hObject == INVALID_HANDLE_VALUE) return 1;
+    if (!hObject || hObject == INVALID_HANDLE_VALUE)
+        return 1;
     return VirtualFileSystem::instance().closeHandle(hObject) ? 1 : 1;
 }
 
@@ -171,7 +180,8 @@ static DWORD MSABI shim_GetFileSize(HANDLE hFile, DWORD* lpFileSizeHigh) {
 
 static DWORD MSABI shim_GetCurrentDirectoryA(DWORD nBufferLength, char* lpBuffer) {
     MS_INFO("TRACE: GetCurrentDirectoryA(%u, %p)", nBufferLength, lpBuffer);
-    if (nBufferLength == 0) return 0;
+    if (nBufferLength == 0)
+        return 0;
     if (getcwd(lpBuffer, nBufferLength)) {
         return static_cast<DWORD>(strlen(lpBuffer));
     }
@@ -195,7 +205,8 @@ static DWORD MSABI shim_GetModuleFileNameA(HMODULE hModule, char* lpFilename, DW
     (void)hModule;
     if (nSize > 0) {
         size_t len = strlen(exe);
-        if (len >= nSize) len = nSize - 1;
+        if (len >= nSize)
+            len = nSize - 1;
         memcpy(lpFilename, exe, len);
         lpFilename[len] = 0;
         return static_cast<DWORD>(len);
@@ -205,17 +216,21 @@ static DWORD MSABI shim_GetModuleFileNameA(HMODULE hModule, char* lpFilename, DW
 
 static HMODULE MSABI shim_GetModuleHandleA(const char* lpModuleName) {
     MS_INFO("TRACE: GetModuleHandleA(\"%s\")", lpModuleName ? lpModuleName : "(null)");
-    if (!lpModuleName) return reinterpret_cast<HMODULE>(PELoader::instance()->getMainModule()->base);
+    if (!lpModuleName)
+        return reinterpret_cast<HMODULE>(PELoader::instance()->getMainModule()->base);
     auto* mod = PELoader::instance()->getModule(lpModuleName);
-    if (mod) return reinterpret_cast<HMODULE>(mod->base);
+    if (mod)
+        return reinterpret_cast<HMODULE>(mod->base);
     return PELoader::instance()->loadLibrary(lpModuleName);
 }
 
 static FARPROC MSABI shim_GetProcAddress(HMODULE hModule, const char* lpProcName) {
-    if (!hModule || !lpProcName) return nullptr;
+    if (!hModule || !lpProcName)
+        return nullptr;
     if (reinterpret_cast<uintptr_t>(lpProcName) > 0xFFFF) {
         void* addr = PELoader::instance()->getProcAddress(hModule, std::string(lpProcName));
-        if (addr) return reinterpret_cast<FARPROC>(addr);
+        if (addr)
+            return reinterpret_cast<FARPROC>(addr);
     }
     return nullptr;
 }
@@ -268,20 +283,23 @@ static void MSABI shim_DeleteCriticalSection(CRITICAL_SECTION* lpCriticalSection
     }
 }
 
-static HANDLE MSABI shim_CreateThread(void* lpThreadAttributes, SIZE_T dwStackSize,
-    void* lpStartAddress, void* lpParameter, DWORD dwCreationFlags, DWORD* lpThreadId) {
-    MS_INFO("TRACE: CreateThread(%p, %zu, %p, %p, 0x%X, %p)", lpThreadAttributes, dwStackSize, lpStartAddress, lpParameter, dwCreationFlags, lpThreadId);
-    (void)lpThreadAttributes; (void)dwStackSize; (void)dwCreationFlags;
+static HANDLE MSABI shim_CreateThread(void* lpThreadAttributes, SIZE_T dwStackSize, void* lpStartAddress,
+                                      void* lpParameter, DWORD dwCreationFlags, DWORD* lpThreadId) {
+    MS_INFO("TRACE: CreateThread(%p, %zu, %p, %p, 0x%X, %p)", lpThreadAttributes, dwStackSize, lpStartAddress,
+            lpParameter, dwCreationFlags, lpThreadId);
+    (void)lpThreadAttributes;
+    (void)dwStackSize;
+    (void)dwCreationFlags;
 
     pthread_t thread;
-    int result = pthread_create(&thread, nullptr,
-        reinterpret_cast<void*(*)(void*)>(lpStartAddress), lpParameter);
+    int result = pthread_create(&thread, nullptr, reinterpret_cast<void* (*)(void*)>(lpStartAddress), lpParameter);
     if (result != 0) {
         t_lastError = result;
         return nullptr;
     }
 
-    if (lpThreadId) *lpThreadId = static_cast<DWORD>(reinterpret_cast<uintptr_t>(thread));
+    if (lpThreadId)
+        *lpThreadId = static_cast<DWORD>(reinterpret_cast<uintptr_t>(thread));
 
     HANDLE h = SyncContext::instance().createThread(thread);
     MS_INFO("TRACE: CreateThread -> handle %p (pthread %p)", h, (void*)thread);
@@ -331,17 +349,21 @@ static void MSABI shim_OutputDebugStringA(const char* lpOutputString) {
 
 static BOOL MSABI shim_IsProcessorFeaturePresent(DWORD ProcessorFeature) {
     MS_INFO("TRACE: IsProcessorFeaturePresent(%u)", ProcessorFeature);
-    if (ProcessorFeature == 23) return 0;
+    if (ProcessorFeature == 23)
+        return 0;
     return 1;
 }
 
-static int MSABI shim_MultiByteToWideChar(UINT CodePage, DWORD dwFlags,
-    const char* lpMultiByteStr, int cbMultiByte, wchar_t* lpWideCharStr, int cchWideChar) {
-    (void)CodePage; (void)dwFlags;
-    if (!lpMultiByteStr) return 0;
+static int MSABI shim_MultiByteToWideChar(UINT CodePage, DWORD dwFlags, const char* lpMultiByteStr, int cbMultiByte,
+                                          wchar_t* lpWideCharStr, int cchWideChar) {
+    (void)CodePage;
+    (void)dwFlags;
+    if (!lpMultiByteStr)
+        return 0;
 
     int len = cbMultiByte > 0 ? cbMultiByte : static_cast<int>(strlen(lpMultiByteStr));
-    if (cchWideChar == 0) return len;
+    if (cchWideChar == 0)
+        return len;
 
     int copyLen = len < cchWideChar ? len : cchWideChar;
     for (int i = 0; i < copyLen; i++) {
@@ -350,14 +372,19 @@ static int MSABI shim_MultiByteToWideChar(UINT CodePage, DWORD dwFlags,
     return copyLen;
 }
 
-static int MSABI shim_WideCharToMultiByte(UINT CodePage, DWORD dwFlags,
-    const wchar_t* lpWideCharStr, int cchWideChar, char* lpMultiByteStr,
-    int cbMultiByte, const char* lpDefaultChar, BOOL* lpUsedDefaultChar) {
-    (void)CodePage; (void)dwFlags; (void)lpDefaultChar; (void)lpUsedDefaultChar;
-    if (!lpWideCharStr) return 0;
+static int MSABI shim_WideCharToMultiByte(UINT CodePage, DWORD dwFlags, const wchar_t* lpWideCharStr, int cchWideChar,
+                                          char* lpMultiByteStr, int cbMultiByte, const char* lpDefaultChar,
+                                          BOOL* lpUsedDefaultChar) {
+    (void)CodePage;
+    (void)dwFlags;
+    (void)lpDefaultChar;
+    (void)lpUsedDefaultChar;
+    if (!lpWideCharStr)
+        return 0;
 
     int len = cchWideChar > 0 ? cchWideChar : static_cast<int>(wcslen(lpWideCharStr));
-    if (cbMultiByte == 0) return len;
+    if (cbMultiByte == 0)
+        return len;
 
     int copyLen = len < cbMultiByte ? len : cbMultiByte;
     for (int i = 0; i < copyLen; i++) {
@@ -430,7 +457,8 @@ static DWORD MSABI stub_GetFileAttributesA(const char* p) {
 static DWORD MSABI stub_GetTempPathA(DWORD n, char* b) {
     const char* t = "/tmp/";
     size_t l = strlen(t);
-    if (n > l) memcpy(b, t, l + 1);
+    if (n > l)
+        memcpy(b, t, l + 1);
     return (DWORD)l;
 }
 
@@ -439,14 +467,13 @@ static BOOL MSABI stub_IsDebuggerPresent() {
 }
 
 ShimLibrary Kernel32Shim::create() {
-    if (!s_initialized) s_initialized = true;
+    if (!s_initialized)
+        s_initialized = true;
 
     ShimLibrary lib;
     lib.name = "kernel32.dll";
 
-    auto fn = [](void* ptr) -> ExportedFunction {
-        return [ptr]() -> void* { return ptr; };
-    };
+    auto fn = [](void* ptr) -> ExportedFunction { return [ptr]() -> void* { return ptr; }; };
 
     lib.functions["GetLastError"] = fn((void*)shim_GetLastError);
     lib.functions["SetLastError"] = fn((void*)shim_SetLastError);
@@ -558,5 +585,5 @@ ShimLibrary Kernel32Shim::create() {
     return lib;
 }
 
-}
-}
+} // namespace win32
+} // namespace metalsharp

--- a/src/win32/kernel32/NetworkContext.cpp
+++ b/src/win32/kernel32/NetworkContext.cpp
@@ -1,22 +1,23 @@
 /// @file NetworkContext.cpp
 /// @brief Winsock shim for socket handle management and pipe pairs.
 ///
-/// Wraps POSIX socket operations behind Win32 SOCKET handles and implements Winsock initialization, socket creation, and named pipe pairs. Provides the networking layer that some games need for multiplayer or DRM.
-#include <metalsharp/NetworkContext.h>
-#include <metalsharp/Logger.h>
-#include <cstring>
+/// Wraps POSIX socket operations behind Win32 SOCKET handles and implements Winsock initialization, socket creation,
+/// and named pipe pairs. Provides the networking layer that some games need for multiplayer or DRM.
+#include <arpa/inet.h>
+#include <cerrno>
 #include <cstdlib>
-#include <sys/socket.h>
-#include <sys/un.h>
+#include <cstring>
+#include <fcntl.h>
+#include <metalsharp/Logger.h>
+#include <metalsharp/NetworkContext.h>
+#include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
-#include <arpa/inet.h>
-#include <netdb.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <cerrno>
 #include <sys/select.h>
+#include <sys/socket.h>
 #include <sys/stat.h>
+#include <sys/un.h>
+#include <unistd.h>
 
 namespace metalsharp {
 namespace win32 {
@@ -42,7 +43,8 @@ int NetworkContext::allocSocket(int fd) {
 int NetworkContext::releaseSocket(int handle) {
     std::lock_guard<std::mutex> lock(m_mutex);
     auto it = m_sockets.find(handle);
-    if (it == m_sockets.end()) return -1;
+    if (it == m_sockets.end())
+        return -1;
     int fd = it->second.fd;
     m_sockets.erase(it);
     return fd;
@@ -64,35 +66,64 @@ uint32_t NetworkContext::getWsaError() const {
 
 uint32_t NetworkContext::mapErrnoToWsa(int err) const {
     switch (err) {
-        case EWOULDBLOCK: return WSAEWOULDBLOCK;
-        case EINPROGRESS: return WSAEINPROGRESS;
-        case EALREADY: return WSAEALREADY;
-        case ENOTSOCK: return WSAENOTSOCK;
-        case EDESTADDRREQ: return WSAEDESTADDRREQ;
-        case EMSGSIZE: return WSAEMSGSIZE;
-        case EPROTOTYPE: return WSAEPROTOTYPE;
-        case ENOPROTOOPT: return WSAENOPROTOOPT;
-        case EPROTONOSUPPORT: return WSAEPROTONOSUPPORT;
-        case ESOCKTNOSUPPORT: return WSAESOCKTNOSUPPORT;
-        case EOPNOTSUPP: return WSAEOPNOTSUPP;
-        case EPFNOSUPPORT: return WSAEPFNOSUPPORT;
-        case EAFNOSUPPORT: return WSAEAFNOSUPPORT;
-        case EADDRINUSE: return WSAEADDRINUSE;
-        case EADDRNOTAVAIL: return WSAEADDRNOTAVAIL;
-        case ENETDOWN: return WSAENETDOWN;
-        case ENETUNREACH: return WSAENETUNREACH;
-        case ENETRESET: return WSAENETRESET;
-        case ECONNABORTED: return WSAECONNABORTED;
-        case ECONNRESET: return WSAECONNRESET;
-        case ENOBUFS: return WSAENOBUFS;
-        case EISCONN: return WSAEISCONN;
-        case ENOTCONN: return WSAENOTCONN;
-        case ESHUTDOWN: return WSAESHUTDOWN;
-        case ETIMEDOUT: return WSAETIMEDOUT;
-        case ECONNREFUSED: return WSAECONNREFUSED;
-        case EHOSTDOWN: return WSAEHOSTDOWN;
-        case EHOSTUNREACH: return WSAEHOSTUNREACH;
-        default: return WSASYSCALLFAILURE;
+    case EWOULDBLOCK:
+        return WSAEWOULDBLOCK;
+    case EINPROGRESS:
+        return WSAEINPROGRESS;
+    case EALREADY:
+        return WSAEALREADY;
+    case ENOTSOCK:
+        return WSAENOTSOCK;
+    case EDESTADDRREQ:
+        return WSAEDESTADDRREQ;
+    case EMSGSIZE:
+        return WSAEMSGSIZE;
+    case EPROTOTYPE:
+        return WSAEPROTOTYPE;
+    case ENOPROTOOPT:
+        return WSAENOPROTOOPT;
+    case EPROTONOSUPPORT:
+        return WSAEPROTONOSUPPORT;
+    case ESOCKTNOSUPPORT:
+        return WSAESOCKTNOSUPPORT;
+    case EOPNOTSUPP:
+        return WSAEOPNOTSUPP;
+    case EPFNOSUPPORT:
+        return WSAEPFNOSUPPORT;
+    case EAFNOSUPPORT:
+        return WSAEAFNOSUPPORT;
+    case EADDRINUSE:
+        return WSAEADDRINUSE;
+    case EADDRNOTAVAIL:
+        return WSAEADDRNOTAVAIL;
+    case ENETDOWN:
+        return WSAENETDOWN;
+    case ENETUNREACH:
+        return WSAENETUNREACH;
+    case ENETRESET:
+        return WSAENETRESET;
+    case ECONNABORTED:
+        return WSAECONNABORTED;
+    case ECONNRESET:
+        return WSAECONNRESET;
+    case ENOBUFS:
+        return WSAENOBUFS;
+    case EISCONN:
+        return WSAEISCONN;
+    case ENOTCONN:
+        return WSAENOTCONN;
+    case ESHUTDOWN:
+        return WSAESHUTDOWN;
+    case ETIMEDOUT:
+        return WSAETIMEDOUT;
+    case ECONNREFUSED:
+        return WSAECONNREFUSED;
+    case EHOSTDOWN:
+        return WSAEHOSTDOWN;
+    case EHOSTUNREACH:
+        return WSAEHOSTUNREACH;
+    default:
+        return WSASYSCALLFAILURE;
     }
 }
 
@@ -121,13 +152,15 @@ int* NetworkContext::allocPipePair(const std::string& name, bool server) {
 
     std::string pipePath = baseDir + "/" + name;
     for (auto& c : pipePath) {
-        if (c == '\\') c = '_';
+        if (c == '\\')
+            c = '_';
     }
 
     if (server) {
         unlink(pipePath.c_str());
         int listenFd = socket(AF_UNIX, SOCK_STREAM, 0);
-        if (listenFd < 0) return nullptr;
+        if (listenFd < 0)
+            return nullptr;
 
         struct sockaddr_un addr;
         memset(&addr, 0, sizeof(addr));
@@ -154,7 +187,8 @@ int* NetworkContext::allocPipePair(const std::string& name, bool server) {
         return returnHandles;
     } else {
         int fd = socket(AF_UNIX, SOCK_STREAM, 0);
-        if (fd < 0) return nullptr;
+        if (fd < 0)
+            return nullptr;
 
         struct sockaddr_un addr;
         memset(&addr, 0, sizeof(addr));
@@ -184,26 +218,32 @@ int* NetworkContext::allocPipePair(const std::string& name, bool server) {
 int NetworkContext::getPipeReadFd(int handle) const {
     std::lock_guard<std::mutex> lock(m_mutex);
     auto it = m_pipes.find(handle);
-    if (it == m_pipes.end()) return -1;
+    if (it == m_pipes.end())
+        return -1;
     return it->second.fds[0];
 }
 
 int NetworkContext::getPipeWriteFd(int handle) const {
     std::lock_guard<std::mutex> lock(m_mutex);
     auto it = m_pipes.find(handle);
-    if (it == m_pipes.end()) return -1;
-    if (it->second.serverSide && !it->second.connected) return -1;
+    if (it == m_pipes.end())
+        return -1;
+    if (it->second.serverSide && !it->second.connected)
+        return -1;
     return it->second.fds[1];
 }
 
 void NetworkContext::closePipe(int handle) {
     std::lock_guard<std::mutex> lock(m_mutex);
     auto it = m_pipes.find(handle);
-    if (it == m_pipes.end()) return;
-    if (it->second.fds[0] >= 0) close(it->second.fds[0]);
-    if (it->second.fds[1] >= 0 && it->second.fds[1] != it->second.fds[0]) close(it->second.fds[1]);
+    if (it == m_pipes.end())
+        return;
+    if (it->second.fds[0] >= 0)
+        close(it->second.fds[0]);
+    if (it->second.fds[1] >= 0 && it->second.fds[1] != it->second.fds[0])
+        close(it->second.fds[1]);
     m_pipes.erase(it);
 }
 
-}
-}
+} // namespace win32
+} // namespace metalsharp

--- a/src/win32/kernel32/NtdllShim.cpp
+++ b/src/win32/kernel32/NtdllShim.cpp
@@ -1,12 +1,14 @@
 /// @file NtdllShim.cpp
 /// @brief NTDLL shims for system time, memory, and handle operations.
 ///
-/// Implements NtQuerySystemTime, Rtl* memory functions (RtlZeroMemory, RtlCopyMemory, etc.), and NtClose to cover the ntdll.dll imports that games commonly reference. These are low-level NT native API calls used internally by kernel32.
+/// Implements NtQuerySystemTime, Rtl* memory functions (RtlZeroMemory, RtlCopyMemory, etc.), and NtClose to cover the
+/// ntdll.dll imports that games commonly reference. These are low-level NT native API calls used internally by
+/// kernel32.
+#include <cstdlib>
+#include <cstring>
+#include <metalsharp/Logger.h>
 #include <metalsharp/NtdllShim.h>
 #include <metalsharp/Win32Types.h>
-#include <metalsharp/Logger.h>
-#include <cstring>
-#include <cstdlib>
 #include <sched.h>
 
 namespace metalsharp {
@@ -18,7 +20,8 @@ static int64_t MSABI shim_RtlGetVersion(void* lpVersionInformation) {
 }
 
 static void* MSABI shim_RtlAllocateHeap(void* HeapHandle, uint32_t Flags, size_t Size) {
-    if (Flags & 0x8) return calloc(1, Size);
+    if (Flags & 0x8)
+        return calloc(1, Size);
     return malloc(Size);
 }
 
@@ -28,7 +31,9 @@ static int MSABI shim_RtlFreeHeap(void* HeapHandle, uint32_t Flags, void* BaseAd
 }
 
 static size_t MSABI shim_RtlSizeHeap(void* HeapHandle, uint32_t Flags, void* BaseAddress) {
-    (void)HeapHandle; (void)Flags; (void)BaseAddress;
+    (void)HeapHandle;
+    (void)Flags;
+    (void)BaseAddress;
     return 0;
 }
 
@@ -52,27 +57,45 @@ static void MSABI shim_RtlInitializeCriticalSection(void* lpCriticalSection) {
 
 static void MSABI shim_RtlEnterCriticalSection(void* lpCriticalSection) {
     auto** mtx = reinterpret_cast<pthread_mutex_t**>(lpCriticalSection);
-    if (*mtx) pthread_mutex_lock(*mtx);
+    if (*mtx)
+        pthread_mutex_lock(*mtx);
 }
 
 static void MSABI shim_RtlLeaveCriticalSection(void* lpCriticalSection) {
     auto** mtx = reinterpret_cast<pthread_mutex_t**>(lpCriticalSection);
-    if (*mtx) pthread_mutex_unlock(*mtx);
+    if (*mtx)
+        pthread_mutex_unlock(*mtx);
 }
 
-static void MSABI wrap_memset(void* d, int c, size_t n) { memset(d, c, n); }
-static void MSABI wrap_memcpy(void* d, const void* s, size_t n) { memcpy(d, s, n); }
-static void MSABI wrap_memmove(void* d, const void* s, size_t n) { memmove(d, s, n); }
-static int MSABI wrap_memcmp(const void* a, const void* b, size_t n) { return memcmp(a, b, n); }
+static void MSABI wrap_memset(void* d, int c, size_t n) {
+    memset(d, c, n);
+}
+static void MSABI wrap_memcpy(void* d, const void* s, size_t n) {
+    memcpy(d, s, n);
+}
+static void MSABI wrap_memmove(void* d, const void* s, size_t n) {
+    memmove(d, s, n);
+}
+static int MSABI wrap_memcmp(const void* a, const void* b, size_t n) {
+    return memcmp(a, b, n);
+}
 
-static int MSABI stub_NtYieldExecution() { sched_yield(); return 0; }
+static int MSABI stub_NtYieldExecution() {
+    sched_yield();
+    return 0;
+}
 
-static void MSABI stub_NtTerminateProcess(void*, int code) { exit(code); }
+static void MSABI stub_NtTerminateProcess(void*, int code) {
+    exit(code);
+}
 
-static void MSABI wrap_RtlZeroMemory(void* d, size_t n) { memset(d, 0, n); }
+static void MSABI wrap_RtlZeroMemory(void* d, size_t n) {
+    memset(d, 0, n);
+}
 
 static void MSABI shim_RtlRaiseException(void* exceptionRecord) {
-    if (!exceptionRecord) return;
+    if (!exceptionRecord)
+        return;
     uint32_t code = *reinterpret_cast<uint32_t*>(exceptionRecord);
 
     extern std::vector<std::pair<void*, bool>> s_vehHandlers;
@@ -83,19 +106,26 @@ static void MSABI shim_RtlRaiseException(void* exceptionRecord) {
         std::lock_guard<std::mutex> lock(s_vehMutex);
         for (auto& [handler, isFirst] : s_vehHandlers) {
             if (handler) {
-                struct FakePointers { void* ExceptionRecord; void* ContextRecord; };
-                FakePointers pointers = { exceptionRecord, nullptr };
+                struct FakePointers {
+                    void* ExceptionRecord;
+                    void* ContextRecord;
+                };
+                FakePointers pointers = {exceptionRecord, nullptr};
                 typedef int32_t (*VEHHandler)(void*);
                 auto veh = reinterpret_cast<VEHHandler>(handler);
                 int32_t result = veh(&pointers);
-                if (result == -1) return;
+                if (result == -1)
+                    return;
             }
         }
     }
 
     if (s_unhandledExceptionFilter) {
-        struct FakePointers { void* ExceptionRecord; void* ContextRecord; };
-        FakePointers pointers = { exceptionRecord, nullptr };
+        struct FakePointers {
+            void* ExceptionRecord;
+            void* ContextRecord;
+        };
+        FakePointers pointers = {exceptionRecord, nullptr};
         typedef void* (*FilterFunc)(void*);
         auto filter = reinterpret_cast<FilterFunc>(s_unhandledExceptionFilter);
         filter(&pointers);
@@ -110,9 +140,7 @@ ShimLibrary createNtdllShim() {
     ShimLibrary lib;
     lib.name = "ntdll.dll";
 
-    auto fn = [](void* ptr) -> ExportedFunction {
-        return [ptr]() -> void* { return ptr; };
-    };
+    auto fn = [](void* ptr) -> ExportedFunction { return [ptr]() -> void* { return ptr; }; };
 
     lib.functions["RtlGetVersion"] = fn((void*)shim_RtlGetVersion);
     lib.functions["RtlAllocateHeap"] = fn((void*)shim_RtlAllocateHeap);
@@ -173,5 +201,5 @@ ShimLibrary createNtdllShim() {
     return lib;
 }
 
-}
-}
+} // namespace win32
+} // namespace metalsharp

--- a/src/win32/kernel32/Registry.cpp
+++ b/src/win32/kernel32/Registry.cpp
@@ -1,15 +1,17 @@
 /// @file Registry.cpp
 /// @brief Windows registry simulation with in-memory store and persistence.
 ///
-/// Implements a full Windows registry (HKLM, HKCU, etc.) backed by an in-memory tree. Seeds common Steam-related keys at startup and persists the hive to JSON on disk. Registry values are queried by games for install paths, settings, and DRM validation.
-#include <metalsharp/Registry.h>
-#include <metalsharp/Logger.h>
-#include <cstring>
-#include <cstdlib>
-#include <cstdio>
-#include <fstream>
-#include <sstream>
+/// Implements a full Windows registry (HKLM, HKCU, etc.) backed by an in-memory tree. Seeds common Steam-related keys
+/// at startup and persists the hive to JSON on disk. Registry values are queried by games for install paths, settings,
+/// and DRM validation.
 #include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <metalsharp/Logger.h>
+#include <metalsharp/Registry.h>
+#include <sstream>
 
 namespace metalsharp {
 namespace win32 {
@@ -22,32 +24,43 @@ Registry& Registry::instance() {
 }
 
 std::string Registry::keyToString(HKEY hKey) {
-    if (hKey == reinterpret_cast<HKEY>(static_cast<intptr_t>(0x80000000))) return "HKEY_CLASSES_ROOT";
-    if (hKey == reinterpret_cast<HKEY>(static_cast<intptr_t>(0x80000001))) return "HKEY_CURRENT_USER";
-    if (hKey == reinterpret_cast<HKEY>(static_cast<intptr_t>(0x80000002))) return "HKEY_LOCAL_MACHINE";
-    if (hKey == reinterpret_cast<HKEY>(static_cast<intptr_t>(0x80000003))) return "HKEY_USERS";
-    if (hKey == reinterpret_cast<HKEY>(static_cast<intptr_t>(0x80000005))) return "HKEY_CURRENT_CONFIG";
+    if (hKey == reinterpret_cast<HKEY>(static_cast<intptr_t>(0x80000000)))
+        return "HKEY_CLASSES_ROOT";
+    if (hKey == reinterpret_cast<HKEY>(static_cast<intptr_t>(0x80000001)))
+        return "HKEY_CURRENT_USER";
+    if (hKey == reinterpret_cast<HKEY>(static_cast<intptr_t>(0x80000002)))
+        return "HKEY_LOCAL_MACHINE";
+    if (hKey == reinterpret_cast<HKEY>(static_cast<intptr_t>(0x80000003)))
+        return "HKEY_USERS";
+    if (hKey == reinterpret_cast<HKEY>(static_cast<intptr_t>(0x80000005)))
+        return "HKEY_CURRENT_CONFIG";
 
     auto it = m_openKeys.find(hKey);
-    if (it != m_openKeys.end()) return it->second;
+    if (it != m_openKeys.end())
+        return it->second;
     return "";
 }
 
 std::string Registry::normalizePath(HKEY hKey, const std::string& subKey) {
     std::string root = keyToString(hKey);
-    if (root.empty()) return "";
+    if (root.empty())
+        return "";
 
     std::string path = subKey;
     for (auto& c : path) {
-        if (c == '\\') c = '/';
+        if (c == '\\')
+            c = '/';
     }
 
-    while (!path.empty() && path[0] == '/') path.erase(0, 1);
-    while (!path.empty() && path.back() == '/') path.pop_back();
+    while (!path.empty() && path[0] == '/')
+        path.erase(0, 1);
+    while (!path.empty() && path.back() == '/')
+        path.pop_back();
 
     std::string result = root + "/" + path;
     std::string lower;
-    for (auto c : result) lower += tolower(c);
+    for (auto c : result)
+        lower += tolower(c);
     return lower;
 }
 
@@ -201,13 +214,15 @@ LONG Registry::openKeyEx(HKEY hKey, const std::string& subKey, DWORD, DWORD, HKE
     std::lock_guard<std::mutex> lock(m_mutex);
 
     std::string path = normalizePath(hKey, subKey);
-    if (path.empty()) return ERROR_PATH_NOT_FOUND;
+    if (path.empty())
+        return ERROR_PATH_NOT_FOUND;
 
     MS_INFO("Registry: OpenKey(\"%s\")", path.c_str());
 
     HKEY newKey = reinterpret_cast<HKEY>(m_nextKey);
     m_nextKey += 4;
-    if (m_nextKey < 0xA000) m_nextKey = 0xA000;
+    if (m_nextKey < 0xA000)
+        m_nextKey = 0xA000;
 
     m_openKeys[newKey] = path;
 
@@ -215,15 +230,18 @@ LONG Registry::openKeyEx(HKEY hKey, const std::string& subKey, DWORD, DWORD, HKE
         m_store[path] = {};
     }
 
-    if (result) *result = newKey;
+    if (result)
+        *result = newKey;
     return ERROR_SUCCESS;
 }
 
-LONG Registry::createKeyEx(HKEY hKey, const std::string& subKey, DWORD, char*, DWORD, DWORD, void*, HKEY* phkResult, void*) {
+LONG Registry::createKeyEx(HKEY hKey, const std::string& subKey, DWORD, char*, DWORD, DWORD, void*, HKEY* phkResult,
+                           void*) {
     std::lock_guard<std::mutex> lock(m_mutex);
 
     std::string path = normalizePath(hKey, subKey);
-    if (path.empty()) return ERROR_PATH_NOT_FOUND;
+    if (path.empty())
+        return ERROR_PATH_NOT_FOUND;
 
     MS_INFO("Registry: CreateKey(\"%s\")", path.c_str());
 
@@ -233,10 +251,12 @@ LONG Registry::createKeyEx(HKEY hKey, const std::string& subKey, DWORD, char*, D
 
     HKEY newKey = reinterpret_cast<HKEY>(m_nextKey);
     m_nextKey += 4;
-    if (m_nextKey < 0xA000) m_nextKey = 0xA000;
+    if (m_nextKey < 0xA000)
+        m_nextKey = 0xA000;
 
     m_openKeys[newKey] = path;
-    if (phkResult) *phkResult = newKey;
+    if (phkResult)
+        *phkResult = newKey;
     return ERROR_SUCCESS;
 }
 
@@ -250,10 +270,12 @@ LONG Registry::queryValue(HKEY hKey, const std::string& valueName, DWORD* lpType
     std::lock_guard<std::mutex> lock(m_mutex);
 
     std::string path = keyToString(hKey);
-    if (path.empty()) return ERROR_PATH_NOT_FOUND;
+    if (path.empty())
+        return ERROR_PATH_NOT_FOUND;
 
     std::string lowerPath;
-    for (auto c : path) lowerPath += tolower(c);
+    for (auto c : path)
+        lowerPath += tolower(c);
 
     auto it = m_store.find(lowerPath);
     if (it == m_store.end()) {
@@ -262,13 +284,15 @@ LONG Registry::queryValue(HKEY hKey, const std::string& valueName, DWORD* lpType
     }
 
     std::string lookupName = valueName;
-    for (auto& c : lookupName) c = tolower(c);
+    for (auto& c : lookupName)
+        c = tolower(c);
 
     auto vit = it->second.find(lookupName);
     if (vit == it->second.end()) {
         if (lookupName.empty()) {
             RegistryValue empty = {1, {0, 0}};
-            if (lpType) *lpType = empty.type;
+            if (lpType)
+                *lpType = empty.type;
             if (lpcbData) {
                 if (lpData && *lpcbData >= empty.data.size()) {
                     memcpy(lpData, empty.data.data(), empty.data.size());
@@ -282,10 +306,11 @@ LONG Registry::queryValue(HKEY hKey, const std::string& valueName, DWORD* lpType
     }
 
     const RegistryValue& val = vit->second;
-    MS_INFO("Registry: QueryValue(\"%s\\%s\") -> type=%u, size=%zu",
-        lowerPath.c_str(), lookupName.c_str(), val.type, val.data.size());
+    MS_INFO("Registry: QueryValue(\"%s\\%s\") -> type=%u, size=%zu", lowerPath.c_str(), lookupName.c_str(), val.type,
+            val.data.size());
 
-    if (lpType) *lpType = val.type;
+    if (lpType)
+        *lpType = val.type;
     if (lpcbData) {
         DWORD needed = static_cast<DWORD>(val.data.size());
         if (lpData && *lpcbData >= needed) {
@@ -303,13 +328,16 @@ LONG Registry::setValue(HKEY hKey, const std::string& valueName, DWORD dwType, c
     std::lock_guard<std::mutex> lock(m_mutex);
 
     std::string path = keyToString(hKey);
-    if (path.empty()) return ERROR_PATH_NOT_FOUND;
+    if (path.empty())
+        return ERROR_PATH_NOT_FOUND;
 
     std::string lowerPath;
-    for (auto c : path) lowerPath += tolower(c);
+    for (auto c : path)
+        lowerPath += tolower(c);
 
     std::string lookupName = valueName;
-    for (auto& c : lookupName) c = tolower(c);
+    for (auto& c : lookupName)
+        c = tolower(c);
 
     RegistryValue val;
     val.type = dwType;
@@ -320,8 +348,7 @@ LONG Registry::setValue(HKEY hKey, const std::string& valueName, DWORD dwType, c
 
     m_store[lowerPath][lookupName] = std::move(val);
 
-    MS_INFO("Registry: SetValue(\"%s\\%s\", type=%u, size=%u)",
-        lowerPath.c_str(), lookupName.c_str(), dwType, cbData);
+    MS_INFO("Registry: SetValue(\"%s\\%s\", type=%u, size=%u)", lowerPath.c_str(), lookupName.c_str(), dwType, cbData);
     return ERROR_SUCCESS;
 }
 
@@ -329,16 +356,20 @@ LONG Registry::deleteValue(HKEY hKey, const std::string& valueName) {
     std::lock_guard<std::mutex> lock(m_mutex);
 
     std::string path = keyToString(hKey);
-    if (path.empty()) return ERROR_PATH_NOT_FOUND;
+    if (path.empty())
+        return ERROR_PATH_NOT_FOUND;
 
     std::string lowerPath;
-    for (auto c : path) lowerPath += tolower(c);
+    for (auto c : path)
+        lowerPath += tolower(c);
 
     std::string lookupName = valueName;
-    for (auto& c : lookupName) c = tolower(c);
+    for (auto& c : lookupName)
+        c = tolower(c);
 
     auto it = m_store.find(lowerPath);
-    if (it == m_store.end()) return ERROR_FILE_NOT_FOUND;
+    if (it == m_store.end())
+        return ERROR_FILE_NOT_FOUND;
     it->second.erase(lookupName);
     return ERROR_SUCCESS;
 }
@@ -347,10 +378,12 @@ LONG Registry::deleteKey(HKEY hKey, const std::string& subKey) {
     std::lock_guard<std::mutex> lock(m_mutex);
 
     std::string path = normalizePath(hKey, subKey);
-    if (path.empty()) return ERROR_PATH_NOT_FOUND;
+    if (path.empty())
+        return ERROR_PATH_NOT_FOUND;
 
     std::string lowerPath;
-    for (auto c : path) lowerPath += tolower(c);
+    for (auto c : path)
+        lowerPath += tolower(c);
 
     m_store.erase(lowerPath);
     return ERROR_SUCCESS;
@@ -358,21 +391,25 @@ LONG Registry::deleteKey(HKEY hKey, const std::string& subKey) {
 
 void Registry::saveToFile(const std::string& path) {
     std::ofstream out(path);
-    if (!out.is_open()) return;
+    if (!out.is_open())
+        return;
 
     out << "{\n";
     bool firstKey = true;
     for (auto& [keyPath, values] : m_store) {
-        if (!firstKey) out << ",\n";
+        if (!firstKey)
+            out << ",\n";
         firstKey = false;
         out << "  \"" << keyPath << "\": {\n";
         bool firstVal = true;
         for (auto& [name, val] : values) {
-            if (!firstVal) out << ",\n";
+            if (!firstVal)
+                out << ",\n";
             firstVal = false;
             out << "    \"" << name << "\": {\"type\": " << val.type << ", \"data\": [";
             for (size_t i = 0; i < val.data.size(); i++) {
-                if (i > 0) out << ", ";
+                if (i > 0)
+                    out << ", ";
                 out << static_cast<int>(val.data[i]);
             }
             out << "]}";
@@ -386,38 +423,52 @@ void Registry::saveToFile(const std::string& path) {
 
 void Registry::loadFromFile(const std::string& path) {
     std::ifstream in(path);
-    if (!in.is_open()) return;
+    if (!in.is_open())
+        return;
 
     std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
     in.close();
 
     size_t pos = 0;
     auto skipWS = [&]() {
-        while (pos < content.size() && (content[pos] == ' ' || content[pos] == '\n' || content[pos] == '\r' || content[pos] == '\t')) pos++;
+        while (pos < content.size() &&
+               (content[pos] == ' ' || content[pos] == '\n' || content[pos] == '\r' || content[pos] == '\t'))
+            pos++;
     };
     auto expect = [&](char c) -> bool {
         skipWS();
-        if (pos < content.size() && content[pos] == c) { pos++; return true; }
+        if (pos < content.size() && content[pos] == c) {
+            pos++;
+            return true;
+        }
         return false;
     };
     auto readString = [&]() -> std::string {
         skipWS();
-        if (pos >= content.size() || content[pos] != '"') return "";
+        if (pos >= content.size() || content[pos] != '"')
+            return "";
         pos++;
         std::string result;
         while (pos < content.size() && content[pos] != '"') {
-            if (content[pos] == '\\' && pos + 1 < content.size()) { pos++; result += content[pos]; }
-            else result += content[pos];
+            if (content[pos] == '\\' && pos + 1 < content.size()) {
+                pos++;
+                result += content[pos];
+            } else
+                result += content[pos];
             pos++;
         }
-        if (pos < content.size()) pos++;
+        if (pos < content.size())
+            pos++;
         return result;
     };
     auto readNumber = [&]() -> int {
         skipWS();
         int n = 0;
         bool neg = false;
-        if (pos < content.size() && content[pos] == '-') { neg = true; pos++; }
+        if (pos < content.size() && content[pos] == '-') {
+            neg = true;
+            pos++;
+        }
         while (pos < content.size() && content[pos] >= '0' && content[pos] <= '9') {
             n = n * 10 + (content[pos] - '0');
             pos++;
@@ -425,49 +476,77 @@ void Registry::loadFromFile(const std::string& path) {
         return neg ? -n : n;
     };
 
-    if (!expect('{')) return;
+    if (!expect('{'))
+        return;
 
     while (pos < content.size()) {
         skipWS();
-        if (content[pos] == '}') break;
+        if (content[pos] == '}')
+            break;
 
         std::string keyPath = readString();
-        if (keyPath.empty()) break;
+        if (keyPath.empty())
+            break;
 
-        if (!expect(':')) break;
-        if (!expect('{')) break;
+        if (!expect(':'))
+            break;
+        if (!expect('{'))
+            break;
 
         std::unordered_map<std::string, RegistryValue> values;
 
         while (pos < content.size()) {
             skipWS();
-            if (content[pos] == '}') { pos++; break; }
-            if (content[pos] == ',') { pos++; continue; }
+            if (content[pos] == '}') {
+                pos++;
+                break;
+            }
+            if (content[pos] == ',') {
+                pos++;
+                continue;
+            }
 
             std::string valName = readString();
-            if (valName.empty()) break;
+            if (valName.empty())
+                break;
 
-            if (!expect(':')) break;
-            if (!expect('{')) break;
+            if (!expect(':'))
+                break;
+            if (!expect('{'))
+                break;
 
             RegistryValue rv;
 
             while (pos < content.size()) {
                 skipWS();
-                if (content[pos] == '}') { pos++; break; }
-                if (content[pos] == ',') { pos++; continue; }
+                if (content[pos] == '}') {
+                    pos++;
+                    break;
+                }
+                if (content[pos] == ',') {
+                    pos++;
+                    continue;
+                }
 
                 std::string fieldName = readString();
-                if (!expect(':')) break;
+                if (!expect(':'))
+                    break;
 
                 if (fieldName == "type") {
                     rv.type = static_cast<DWORD>(readNumber());
                 } else if (fieldName == "data") {
-                    if (!expect('[')) break;
+                    if (!expect('['))
+                        break;
                     while (pos < content.size()) {
                         skipWS();
-                        if (content[pos] == ']') { pos++; break; }
-                        if (content[pos] == ',') { pos++; continue; }
+                        if (content[pos] == ']') {
+                            pos++;
+                            break;
+                        }
+                        if (content[pos] == ',') {
+                            pos++;
+                            continue;
+                        }
                         rv.data.push_back(static_cast<BYTE>(readNumber()));
                     }
                 }
@@ -478,11 +557,12 @@ void Registry::loadFromFile(const std::string& path) {
 
         m_store[keyPath] = std::move(values);
         skipWS();
-        if (pos < content.size() && content[pos] == ',') pos++;
+        if (pos < content.size() && content[pos] == ',')
+            pos++;
     }
 
     MS_INFO("Registry: Loaded from %s", path.c_str());
 }
 
-}
-}
+} // namespace win32
+} // namespace metalsharp

--- a/src/win32/kernel32/SecureTransport.mm
+++ b/src/win32/kernel32/SecureTransport.mm
@@ -1,16 +1,18 @@
 /// @file SecureTransport.mm
 /// @brief SSL/TLS via Apple Security framework.
 ///
-/// Implements Win32 SecureChannel/Schannel TLS operations using Apple's Security framework. Handles certificate validation, SSL context creation, and encrypted read/write. Required by games that use HTTPS for multiplayer, telemetry, or DRM.
-#include <metalsharp/SecureTransport.h>
-#include <metalsharp/Logger.h>
+/// Implements Win32 SecureChannel/Schannel TLS operations using Apple's Security framework. Handles certificate
+/// validation, SSL context creation, and encrypted read/write. Required by games that use HTTPS for multiplayer,
+/// telemetry, or DRM.
 #include <cstring>
+#include <metalsharp/Logger.h>
+#include <metalsharp/SecureTransport.h>
 #include <unistd.h>
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#include <Security/Security.h>
 #include <Security/SecureTransport.h>
+#include <Security/Security.h>
 #pragma clang diagnostic pop
 
 namespace metalsharp {
@@ -28,7 +30,10 @@ void SecureTransport::initialize() {
 static OSStatus sslReadCallback(SSLConnectionRef conn, void* data, size_t* len) {
     int fd = (int)(intptr_t)conn;
     ssize_t n = read(fd, data, *len);
-    if (n < 0) { *len = 0; return errSSLClosedAbort; }
+    if (n < 0) {
+        *len = 0;
+        return errSSLClosedAbort;
+    }
     *len = (size_t)n;
     return noErr;
 }
@@ -36,7 +41,10 @@ static OSStatus sslReadCallback(SSLConnectionRef conn, void* data, size_t* len) 
 static OSStatus sslWriteCallback(SSLConnectionRef conn, const void* data, size_t* len) {
     int fd = (int)(intptr_t)conn;
     ssize_t n = write(fd, data, *len);
-    if (n < 0) { *len = 0; return errSSLClosedAbort; }
+    if (n < 0) {
+        *len = 0;
+        return errSSLClosedAbort;
+    }
     *len = (size_t)n;
     return noErr;
 }
@@ -69,7 +77,8 @@ void* SecureTransport::createSSLSession(int socketFd) {
 void SecureTransport::destroySSLSession(void* handle) {
     std::lock_guard<std::mutex> lock(m_mutex);
     auto it = m_sessions.find((intptr_t)handle);
-    if (it == m_sessions.end()) return;
+    if (it == m_sessions.end())
+        return;
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -86,7 +95,8 @@ void SecureTransport::destroySSLSession(void* handle) {
 int SecureTransport::sslConnect(void* handle, const char* hostname) {
     std::lock_guard<std::mutex> lock(m_mutex);
     auto it = m_sessions.find((intptr_t)handle);
-    if (it == m_sessions.end() || !it->second.sslContext) return -1;
+    if (it == m_sessions.end() || !it->second.sslContext)
+        return -1;
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -103,7 +113,8 @@ int SecureTransport::sslConnect(void* handle, const char* hostname) {
     }
 #pragma clang diagnostic pop
 
-    if (status == errSSLWouldBlock) return -1;
+    if (status == errSSLWouldBlock)
+        return -1;
 
     MS_INFO("SecureTransport: SSLHandshake failed with %ld", (long)status);
     return -1;
@@ -112,7 +123,8 @@ int SecureTransport::sslConnect(void* handle, const char* hostname) {
 int SecureTransport::sslRead(void* handle, char* buf, int len) {
     std::lock_guard<std::mutex> lock(m_mutex);
     auto it = m_sessions.find((intptr_t)handle);
-    if (it == m_sessions.end() || !it->second.sslContext) return -1;
+    if (it == m_sessions.end() || !it->second.sslContext)
+        return -1;
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -125,14 +137,16 @@ int SecureTransport::sslRead(void* handle, char* buf, int len) {
         return (int)processed;
     }
 
-    if (status == errSSLClosedGraceful) return 0;
+    if (status == errSSLClosedGraceful)
+        return 0;
     return -1;
 }
 
 int SecureTransport::sslWrite(void* handle, const char* buf, int len) {
     std::lock_guard<std::mutex> lock(m_mutex);
     auto it = m_sessions.find((intptr_t)handle);
-    if (it == m_sessions.end() || !it->second.sslContext) return -1;
+    if (it == m_sessions.end() || !it->second.sslContext)
+        return -1;
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -147,5 +161,5 @@ int SecureTransport::sslWrite(void* handle, const char* buf, int len) {
     return -1;
 }
 
-}
-}
+} // namespace win32
+} // namespace metalsharp

--- a/src/win32/kernel32/SyncContext.cpp
+++ b/src/win32/kernel32/SyncContext.cpp
@@ -1,14 +1,15 @@
 /// @file SyncContext.cpp
 /// @brief Win32 synchronization primitives via pthreads.
 ///
-/// Implements Win32 Events, Mutexes, Semaphores, and critical sections using pthreads and POSIX synchronization primitives. Each Win32 sync object is tracked by handle for CreateEvent/OpenMutex style access.
-#include <metalsharp/SyncContext.h>
-#include <metalsharp/Logger.h>
-#include <cstring>
-#include <cstdlib>
-#include <unistd.h>
+/// Implements Win32 Events, Mutexes, Semaphores, and critical sections using pthreads and POSIX synchronization
+/// primitives. Each Win32 sync object is tracked by handle for CreateEvent/OpenMutex style access.
 #include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <metalsharp/Logger.h>
+#include <metalsharp/SyncContext.h>
 #include <sys/time.h>
+#include <unistd.h>
 
 namespace metalsharp {
 namespace win32 {
@@ -46,7 +47,8 @@ void* SyncContext::createEvent(bool manualReset, bool initialState, const std::s
     sh.name = name;
     m_handles[handle] = sh;
 
-    if (!name.empty()) m_namedHandles[name] = handle;
+    if (!name.empty())
+        m_namedHandles[name] = handle;
 
     return reinterpret_cast<void*>(static_cast<intptr_t>(handle));
 }
@@ -54,7 +56,8 @@ void* SyncContext::createEvent(bool manualReset, bool initialState, const std::s
 bool SyncContext::setEvent(void* handle) {
     std::lock_guard<std::mutex> lock(m_mutex);
     auto it = m_handles.find((intptr_t)handle);
-    if (it == m_handles.end() || it->second.type != SyncHandleType::Event) return false;
+    if (it == m_handles.end() || it->second.type != SyncHandleType::Event)
+        return false;
 
     auto* evt = static_cast<SyncEventState*>(it->second.data);
     pthread_mutex_lock(&evt->mutex);
@@ -71,7 +74,8 @@ bool SyncContext::setEvent(void* handle) {
 bool SyncContext::resetEvent(void* handle) {
     std::lock_guard<std::mutex> lock(m_mutex);
     auto it = m_handles.find((intptr_t)handle);
-    if (it == m_handles.end() || it->second.type != SyncHandleType::Event) return false;
+    if (it == m_handles.end() || it->second.type != SyncHandleType::Event)
+        return false;
 
     auto* evt = static_cast<SyncEventState*>(it->second.data);
     pthread_mutex_lock(&evt->mutex);
@@ -113,7 +117,8 @@ void* SyncContext::createMutex(bool initialOwner, const std::string& name) {
     sh.name = name;
     m_handles[handle] = sh;
 
-    if (!name.empty()) m_namedHandles[name] = handle;
+    if (!name.empty())
+        m_namedHandles[name] = handle;
 
     return reinterpret_cast<void*>(static_cast<intptr_t>(handle));
 }
@@ -121,10 +126,12 @@ void* SyncContext::createMutex(bool initialOwner, const std::string& name) {
 bool SyncContext::releaseMutex(void* handle) {
     std::lock_guard<std::mutex> lock(m_mutex);
     auto it = m_handles.find((intptr_t)handle);
-    if (it == m_handles.end() || it->second.type != SyncHandleType::Mutex) return false;
+    if (it == m_handles.end() || it->second.type != SyncHandleType::Mutex)
+        return false;
 
     auto* mtx = static_cast<SyncMutexState*>(it->second.data);
-    if (mtx->owningThread != (DWORD)(uintptr_t)pthread_self()) return false;
+    if (mtx->owningThread != (DWORD)(uintptr_t)pthread_self())
+        return false;
 
     mtx->recursionCount--;
     if (mtx->recursionCount == 0) {
@@ -158,7 +165,8 @@ void* SyncContext::createSemaphore(int32_t initialCount, int32_t maxCount, const
     sh.name = name;
     m_handles[handle] = sh;
 
-    if (!name.empty()) m_namedHandles[name] = handle;
+    if (!name.empty())
+        m_namedHandles[name] = handle;
 
     return reinterpret_cast<void*>(static_cast<intptr_t>(handle));
 }
@@ -166,13 +174,16 @@ void* SyncContext::createSemaphore(int32_t initialCount, int32_t maxCount, const
 bool SyncContext::releaseSemaphore(void* handle, int32_t releaseCount, int32_t* prevCount) {
     std::lock_guard<std::mutex> lock(m_mutex);
     auto it = m_handles.find((intptr_t)handle);
-    if (it == m_handles.end() || it->second.type != SyncHandleType::Semaphore) return false;
+    if (it == m_handles.end() || it->second.type != SyncHandleType::Semaphore)
+        return false;
 
     auto* sem = static_cast<SyncSemaphoreState*>(it->second.data);
     pthread_mutex_lock(&sem->mutex);
-    if (prevCount) *prevCount = sem->count;
+    if (prevCount)
+        *prevCount = sem->count;
     sem->count += releaseCount;
-    if (sem->count > sem->maxCount) sem->count = sem->maxCount;
+    if (sem->count > sem->maxCount)
+        sem->count = sem->maxCount;
     for (int32_t i = 0; i < releaseCount; i++) {
         pthread_cond_signal(&sem->cond);
     }
@@ -204,7 +215,8 @@ void* SyncContext::createThread(pthread_t thread) {
 SyncThreadState* SyncContext::getThreadState(void* handle) {
     std::lock_guard<std::mutex> lock(m_mutex);
     auto it = m_handles.find((intptr_t)handle);
-    if (it == m_handles.end() || it->second.type != SyncHandleType::Thread) return nullptr;
+    if (it == m_handles.end() || it->second.type != SyncHandleType::Thread)
+        return nullptr;
     return static_cast<SyncThreadState*>(it->second.data);
 }
 
@@ -290,9 +302,10 @@ uint32_t SyncContext::waitForMutex(SyncMutexState* mtx, uint32_t ms) {
             mtx->recursionCount++;
             return 0;
         }
-        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::steady_clock::now() - start).count();
-        if ((uint32_t)elapsed >= ms) break;
+        auto elapsed =
+            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
+        if ((uint32_t)elapsed >= ms)
+            break;
         usleep(1000);
     }
     return 258;
@@ -339,7 +352,8 @@ uint32_t SyncContext::waitForSemaphore(SyncSemaphoreState* sem, uint32_t ms) {
 }
 
 uint32_t SyncContext::waitForThread(SyncThreadState* thr, uint32_t ms) {
-    if (thr->joined.load()) return 0;
+    if (thr->joined.load())
+        return 0;
 
     if (ms == 0xFFFFFFFF) {
         pthread_mutex_lock(&thr->joinMutex);
@@ -384,24 +398,26 @@ uint32_t SyncContext::waitForThread(SyncThreadState* thr, uint32_t ms) {
 uint32_t SyncContext::waitForSingleObject(void* handle, uint32_t milliseconds) {
     std::lock_guard<std::mutex> lock(m_mutex);
     auto it = m_handles.find((intptr_t)handle);
-    if (it == m_handles.end()) return 0xFFFFFFFF;
+    if (it == m_handles.end())
+        return 0xFFFFFFFF;
 
     switch (it->second.type) {
-        case SyncHandleType::Event:
-            return waitForEvent(static_cast<SyncEventState*>(it->second.data), milliseconds);
-        case SyncHandleType::Mutex:
-            return waitForMutex(static_cast<SyncMutexState*>(it->second.data), milliseconds);
-        case SyncHandleType::Semaphore:
-            return waitForSemaphore(static_cast<SyncSemaphoreState*>(it->second.data), milliseconds);
-        case SyncHandleType::Thread:
-            return waitForThread(static_cast<SyncThreadState*>(it->second.data), milliseconds);
-        default:
-            return 0xFFFFFFFF;
+    case SyncHandleType::Event:
+        return waitForEvent(static_cast<SyncEventState*>(it->second.data), milliseconds);
+    case SyncHandleType::Mutex:
+        return waitForMutex(static_cast<SyncMutexState*>(it->second.data), milliseconds);
+    case SyncHandleType::Semaphore:
+        return waitForSemaphore(static_cast<SyncSemaphoreState*>(it->second.data), milliseconds);
+    case SyncHandleType::Thread:
+        return waitForThread(static_cast<SyncThreadState*>(it->second.data), milliseconds);
+    default:
+        return 0xFFFFFFFF;
     }
 }
 
 uint32_t SyncContext::waitForMultipleObjects(uint32_t count, void** handles, bool waitAll, uint32_t milliseconds) {
-    if (count == 0) return 0xFFFFFFFF;
+    if (count == 0)
+        return 0xFFFFFFFF;
 
     if (waitAll) {
         for (uint32_t i = 0; i < count; i++) {
@@ -409,9 +425,11 @@ uint32_t SyncContext::waitForMultipleObjects(uint32_t count, void** handles, boo
             if (milliseconds != 0xFFFFFFFF) {
                 auto start = std::chrono::steady_clock::now();
                 uint32_t result = waitForSingleObject(handles[i], milliseconds);
-                if (result != 0) return 0xFFFFFFFF;
-                auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-                    std::chrono::steady_clock::now() - start).count();
+                if (result != 0)
+                    return 0xFFFFFFFF;
+                auto elapsed =
+                    std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start)
+                        .count();
                 if (milliseconds > (uint32_t)elapsed) {
                     milliseconds -= (uint32_t)elapsed;
                 } else {
@@ -419,7 +437,8 @@ uint32_t SyncContext::waitForMultipleObjects(uint32_t count, void** handles, boo
                 }
             } else {
                 uint32_t result = waitForSingleObject(handles[i], 0xFFFFFFFF);
-                if (result != 0) return 0xFFFFFFFF;
+                if (result != 0)
+                    return 0xFFFFFFFF;
             }
         }
         return 0;
@@ -433,52 +452,58 @@ uint32_t SyncContext::waitForMultipleObjects(uint32_t count, void** handles, boo
             std::lock_guard<std::mutex> lock(m_mutex);
             for (uint32_t i = 0; i < count; i++) {
                 auto it = m_handles.find((intptr_t)handles[i]);
-                if (it == m_handles.end()) continue;
+                if (it == m_handles.end())
+                    continue;
 
                 bool signaled = false;
                 switch (it->second.type) {
-                    case SyncHandleType::Event: {
-                        auto* evt = static_cast<SyncEventState*>(it->second.data);
-                        pthread_mutex_lock(&evt->mutex);
-                        signaled = evt->signaled;
-                        if (signaled && !evt->manualReset) evt->signaled = false;
-                        pthread_mutex_unlock(&evt->mutex);
-                        break;
-                    }
-                    case SyncHandleType::Semaphore: {
-                        auto* sem = static_cast<SyncSemaphoreState*>(it->second.data);
-                        pthread_mutex_lock(&sem->mutex);
-                        signaled = sem->count > 0;
-                        if (signaled) sem->count--;
-                        pthread_mutex_unlock(&sem->mutex);
-                        break;
-                    }
-                    case SyncHandleType::Thread: {
-                        auto* thr = static_cast<SyncThreadState*>(it->second.data);
-                        signaled = thr->finished.load();
-                        break;
-                    }
-                    case SyncHandleType::Mutex: {
-                        auto* mtx = static_cast<SyncMutexState*>(it->second.data);
-                        if (pthread_mutex_trylock(&mtx->mutex) == 0) {
-                            mtx->owningThread = (DWORD)(uintptr_t)pthread_self();
-                            mtx->recursionCount++;
-                            signaled = true;
-                        }
-                        break;
-                    }
-                    default:
-                        break;
+                case SyncHandleType::Event: {
+                    auto* evt = static_cast<SyncEventState*>(it->second.data);
+                    pthread_mutex_lock(&evt->mutex);
+                    signaled = evt->signaled;
+                    if (signaled && !evt->manualReset)
+                        evt->signaled = false;
+                    pthread_mutex_unlock(&evt->mutex);
+                    break;
                 }
-                if (signaled) return i;
+                case SyncHandleType::Semaphore: {
+                    auto* sem = static_cast<SyncSemaphoreState*>(it->second.data);
+                    pthread_mutex_lock(&sem->mutex);
+                    signaled = sem->count > 0;
+                    if (signaled)
+                        sem->count--;
+                    pthread_mutex_unlock(&sem->mutex);
+                    break;
+                }
+                case SyncHandleType::Thread: {
+                    auto* thr = static_cast<SyncThreadState*>(it->second.data);
+                    signaled = thr->finished.load();
+                    break;
+                }
+                case SyncHandleType::Mutex: {
+                    auto* mtx = static_cast<SyncMutexState*>(it->second.data);
+                    if (pthread_mutex_trylock(&mtx->mutex) == 0) {
+                        mtx->owningThread = (DWORD)(uintptr_t)pthread_self();
+                        mtx->recursionCount++;
+                        signaled = true;
+                    }
+                    break;
+                }
+                default:
+                    break;
+                }
+                if (signaled)
+                    return i;
             }
         }
 
-        if (totalMs == 0) return 258;
+        if (totalMs == 0)
+            return 258;
         if (totalMs != 0xFFFFFFFF) {
-            auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-                std::chrono::steady_clock::now() - start).count();
-            if ((uint32_t)elapsed >= totalMs) return 258;
+            auto elapsed =
+                std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
+            if ((uint32_t)elapsed >= totalMs)
+                return 258;
             usleep(1000);
         } else {
             usleep(1000);
@@ -489,38 +514,39 @@ uint32_t SyncContext::waitForMultipleObjects(uint32_t count, void** handles, boo
 void SyncContext::destroyHandle(void* handle) {
     std::lock_guard<std::mutex> lock(m_mutex);
     auto it = m_handles.find((intptr_t)handle);
-    if (it == m_handles.end()) return;
+    if (it == m_handles.end())
+        return;
 
     switch (it->second.type) {
-        case SyncHandleType::Event: {
-            auto* evt = static_cast<SyncEventState*>(it->second.data);
-            pthread_mutex_destroy(&evt->mutex);
-            pthread_cond_destroy(&evt->cond);
-            delete evt;
-            break;
-        }
-        case SyncHandleType::Mutex: {
-            auto* mtx = static_cast<SyncMutexState*>(it->second.data);
-            pthread_mutex_destroy(&mtx->mutex);
-            delete mtx;
-            break;
-        }
-        case SyncHandleType::Semaphore: {
-            auto* sem = static_cast<SyncSemaphoreState*>(it->second.data);
-            pthread_mutex_destroy(&sem->mutex);
-            pthread_cond_destroy(&sem->cond);
-            delete sem;
-            break;
-        }
-        case SyncHandleType::Thread: {
-            auto* thr = static_cast<SyncThreadState*>(it->second.data);
-            pthread_mutex_destroy(&thr->joinMutex);
-            pthread_cond_destroy(&thr->joinCond);
-            delete thr;
-            break;
-        }
-        default:
-            break;
+    case SyncHandleType::Event: {
+        auto* evt = static_cast<SyncEventState*>(it->second.data);
+        pthread_mutex_destroy(&evt->mutex);
+        pthread_cond_destroy(&evt->cond);
+        delete evt;
+        break;
+    }
+    case SyncHandleType::Mutex: {
+        auto* mtx = static_cast<SyncMutexState*>(it->second.data);
+        pthread_mutex_destroy(&mtx->mutex);
+        delete mtx;
+        break;
+    }
+    case SyncHandleType::Semaphore: {
+        auto* sem = static_cast<SyncSemaphoreState*>(it->second.data);
+        pthread_mutex_destroy(&sem->mutex);
+        pthread_cond_destroy(&sem->cond);
+        delete sem;
+        break;
+    }
+    case SyncHandleType::Thread: {
+        auto* thr = static_cast<SyncThreadState*>(it->second.data);
+        pthread_mutex_destroy(&thr->joinMutex);
+        pthread_cond_destroy(&thr->joinCond);
+        delete thr;
+        break;
+    }
+    default:
+        break;
     }
 
     if (!it->second.name.empty()) {
@@ -529,5 +555,5 @@ void SyncContext::destroyHandle(void* handle) {
     m_handles.erase(it);
 }
 
-}
-}
+} // namespace win32
+} // namespace metalsharp

--- a/src/win32/kernel32/VirtualFileSystem.cpp
+++ b/src/win32/kernel32/VirtualFileSystem.cpp
@@ -1,26 +1,29 @@
 /// @file VirtualFileSystem.cpp
 /// @brief Win32-to-Unix file system translation layer.
 ///
-/// Translates Win32 path conventions (backslashes, drive letters) to POSIX paths and implements CreateFile, ReadFile, WriteFile, FindFirstFile/FindNextFile. Manages virtual file handles and maps Win32 file attributes to Unix stat results.
-#include <metalsharp/VirtualFileSystem.h>
-#include <metalsharp/Logger.h>
-#include <cstring>
-#include <cstdlib>
+/// Translates Win32 path conventions (backslashes, drive letters) to POSIX paths and implements CreateFile, ReadFile,
+/// WriteFile, FindFirstFile/FindNextFile. Manages virtual file handles and maps Win32 file attributes to Unix stat
+/// results.
+#include <algorithm>
 #include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <fnmatch.h>
+#include <metalsharp/Logger.h>
+#include <metalsharp/VirtualFileSystem.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <dirent.h>
-#include <fcntl.h>
 #include <unistd.h>
-#include <errno.h>
-#include <fnmatch.h>
-#include <algorithm>
 
 namespace metalsharp {
 namespace win32 {
 
 static std::string toLower(std::string s) {
-    for (auto& c : s) c = tolower(c);
+    for (auto& c : s)
+        c = tolower(c);
     return s;
 }
 
@@ -64,7 +67,8 @@ void VirtualFileSystem::setPrefix(const std::string& prefix) {
 }
 
 std::string VirtualFileSystem::winToHost(const std::string& winPath) {
-    if (winPath.empty()) return "";
+    if (winPath.empty())
+        return "";
 
     std::string path = winPath;
 
@@ -73,7 +77,8 @@ std::string VirtualFileSystem::winToHost(const std::string& winPath) {
     }
 
     for (auto& c : path) {
-        if (c == '\\') c = '/';
+        if (c == '\\')
+            c = '/';
     }
 
     if (path.size() >= 2 && path[1] == ':') {
@@ -113,68 +118,87 @@ std::string VirtualFileSystem::hostToWin(const std::string& hostPath) {
 HANDLE VirtualFileSystem::allocHandle(HandleType type, void* data) {
     uintptr_t h = m_nextHandle;
     m_nextHandle += 4;
-    if (m_nextHandle < 0x00010000) m_nextHandle = 0x00010000;
+    if (m_nextHandle < 0x00010000)
+        m_nextHandle = 0x00010000;
     m_handles[h] = {type, data};
     return reinterpret_cast<HANDLE>(h);
 }
 
 HandleEntry* VirtualFileSystem::getHandle(HANDLE h) {
     auto it = m_handles.find(reinterpret_cast<uintptr_t>(h));
-    if (it == m_handles.end()) return nullptr;
+    if (it == m_handles.end())
+        return nullptr;
     return &it->second;
 }
 
 bool VirtualFileSystem::closeHandle(HANDLE h) {
     auto it = m_handles.find(reinterpret_cast<uintptr_t>(h));
-    if (it == m_handles.end()) return false;
+    if (it == m_handles.end())
+        return false;
 
     HandleEntry& entry = it->second;
     switch (entry.type) {
-        case HandleType::File: {
-            auto* fs = static_cast<FileState*>(entry.data);
-            if (fs->fd >= 0) close(fs->fd);
-            delete fs;
-            break;
-        }
-        case HandleType::Find: {
-            auto* fnd = static_cast<FindState*>(entry.data);
-            if (fnd->dir) closedir(fnd->dir);
-            delete fnd;
-            break;
-        }
-        default:
-            break;
+    case HandleType::File: {
+        auto* fs = static_cast<FileState*>(entry.data);
+        if (fs->fd >= 0)
+            close(fs->fd);
+        delete fs;
+        break;
+    }
+    case HandleType::Find: {
+        auto* fnd = static_cast<FindState*>(entry.data);
+        if (fnd->dir)
+            closedir(fnd->dir);
+        delete fnd;
+        break;
+    }
+    default:
+        break;
     }
 
     m_handles.erase(it);
     return true;
 }
 
-HANDLE VirtualFileSystem::createFile(const char* lpFileName, DWORD dwDesiredAccess,
-    DWORD dwShareMode, DWORD dwCreationDisposition, DWORD dwFlagsAndAttributes) {
-    if (!lpFileName) return INVALID_HANDLE_VALUE;
+HANDLE VirtualFileSystem::createFile(const char* lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode,
+                                     DWORD dwCreationDisposition, DWORD dwFlagsAndAttributes) {
+    if (!lpFileName)
+        return INVALID_HANDLE_VALUE;
 
     std::string hostPath = winToHost(lpFileName);
 
-    MS_INFO("VFS: CreateFile(\"%s\" -> \"%s\", access=0x%X, disp=%u)",
-        lpFileName, hostPath.c_str(), dwDesiredAccess, dwCreationDisposition);
+    MS_INFO("VFS: CreateFile(\"%s\" -> \"%s\", access=0x%X, disp=%u)", lpFileName, hostPath.c_str(), dwDesiredAccess,
+            dwCreationDisposition);
 
     int flags = 0;
     bool readOnly = !(dwDesiredAccess & 0x40000000);
     bool writeAccess = (dwDesiredAccess & 0x40000000) != 0;
     bool readAccess = (dwDesiredAccess & 0x80000000) != 0;
 
-    if (readAccess && writeAccess) flags = O_RDWR;
-    else if (writeAccess) flags = O_WRONLY;
-    else if (readAccess) flags = O_RDONLY;
-    else flags = O_RDONLY;
+    if (readAccess && writeAccess)
+        flags = O_RDWR;
+    else if (writeAccess)
+        flags = O_WRONLY;
+    else if (readAccess)
+        flags = O_RDONLY;
+    else
+        flags = O_RDONLY;
 
     switch (dwCreationDisposition) {
-        case 1: flags |= O_CREAT | O_EXCL; break;
-        case 2: flags |= O_CREAT | O_TRUNC; break;
-        case 3: break;
-        case 4: flags |= O_CREAT; break;
-        case 5: flags |= O_TRUNC; break;
+    case 1:
+        flags |= O_CREAT | O_EXCL;
+        break;
+    case 2:
+        flags |= O_CREAT | O_TRUNC;
+        break;
+    case 3:
+        break;
+    case 4:
+        flags |= O_CREAT;
+        break;
+    case 5:
+        flags |= O_TRUNC;
+        break;
     }
 
     if (writeAccess || (flags & O_CREAT)) {
@@ -193,77 +217,99 @@ HANDLE VirtualFileSystem::createFile(const char* lpFileName, DWORD dwDesiredAcce
 
 BOOL VirtualFileSystem::readFile(HANDLE hFile, void* lpBuffer, DWORD nNumberOfBytesToRead, DWORD* lpNumberOfBytesRead) {
     auto* entry = getHandle(hFile);
-    if (!entry || entry->type != HandleType::File) return 0;
+    if (!entry || entry->type != HandleType::File)
+        return 0;
 
     auto* fs = static_cast<FileState*>(entry->data);
     ssize_t bytesRead = read(fs->fd, lpBuffer, nNumberOfBytesToRead);
     if (bytesRead < 0) {
-        if (lpNumberOfBytesRead) *lpNumberOfBytesRead = 0;
+        if (lpNumberOfBytesRead)
+            *lpNumberOfBytesRead = 0;
         return 0;
     }
 
     fs->position += bytesRead;
-    if (lpNumberOfBytesRead) *lpNumberOfBytesRead = static_cast<DWORD>(bytesRead);
+    if (lpNumberOfBytesRead)
+        *lpNumberOfBytesRead = static_cast<DWORD>(bytesRead);
     return 1;
 }
 
-BOOL VirtualFileSystem::writeFile(HANDLE hFile, const void* lpBuffer, DWORD nNumberOfBytesToWrite, DWORD* lpNumberOfBytesWritten) {
+BOOL VirtualFileSystem::writeFile(HANDLE hFile, const void* lpBuffer, DWORD nNumberOfBytesToWrite,
+                                  DWORD* lpNumberOfBytesWritten) {
     auto* entry = getHandle(hFile);
-    if (!entry || entry->type != HandleType::File) return 0;
+    if (!entry || entry->type != HandleType::File)
+        return 0;
 
     auto* fs = static_cast<FileState*>(entry->data);
     ssize_t bytesWritten = write(fs->fd, lpBuffer, nNumberOfBytesToWrite);
     if (bytesWritten < 0) {
-        if (lpNumberOfBytesWritten) *lpNumberOfBytesWritten = 0;
+        if (lpNumberOfBytesWritten)
+            *lpNumberOfBytesWritten = 0;
         return 0;
     }
 
     fs->position += bytesWritten;
-    if (lpNumberOfBytesWritten) *lpNumberOfBytesWritten = static_cast<DWORD>(bytesWritten);
+    if (lpNumberOfBytesWritten)
+        *lpNumberOfBytesWritten = static_cast<DWORD>(bytesWritten);
     return 1;
 }
 
 DWORD VirtualFileSystem::getFileSize(HANDLE hFile, DWORD* lpFileSizeHigh) {
     auto* entry = getHandle(hFile);
     if (!entry || entry->type != HandleType::File) {
-        if (lpFileSizeHigh) *lpFileSizeHigh = 0;
+        if (lpFileSizeHigh)
+            *lpFileSizeHigh = 0;
         return 0xFFFFFFFF;
     }
 
     auto* fs = static_cast<FileState*>(entry->data);
     struct stat st;
     if (fstat(fs->fd, &st) != 0) {
-        if (lpFileSizeHigh) *lpFileSizeHigh = 0;
+        if (lpFileSizeHigh)
+            *lpFileSizeHigh = 0;
         return 0xFFFFFFFF;
     }
 
-    if (lpFileSizeHigh) *lpFileSizeHigh = static_cast<DWORD>(st.st_size >> 32);
+    if (lpFileSizeHigh)
+        *lpFileSizeHigh = static_cast<DWORD>(st.st_size >> 32);
     return static_cast<DWORD>(st.st_size & 0xFFFFFFFF);
 }
 
 BOOL VirtualFileSystem::getFileSizeEx(HANDLE hFile, int64_t* lpFileSize) {
     auto* entry = getHandle(hFile);
-    if (!entry || entry->type != HandleType::File) return 0;
+    if (!entry || entry->type != HandleType::File)
+        return 0;
 
     auto* fs = static_cast<FileState*>(entry->data);
     struct stat st;
-    if (fstat(fs->fd, &st) != 0) return 0;
+    if (fstat(fs->fd, &st) != 0)
+        return 0;
 
-    if (lpFileSize) *lpFileSize = st.st_size;
+    if (lpFileSize)
+        *lpFileSize = st.st_size;
     return 1;
 }
 
-DWORD VirtualFileSystem::setFilePointer(HANDLE hFile, LONG lDistanceToMove, LONG* lpDistanceToMoveHigh, DWORD dwMoveMethod) {
+DWORD VirtualFileSystem::setFilePointer(HANDLE hFile, LONG lDistanceToMove, LONG* lpDistanceToMoveHigh,
+                                        DWORD dwMoveMethod) {
     auto* entry = getHandle(hFile);
-    if (!entry || entry->type != HandleType::File) return 0xFFFFFFFF;
+    if (!entry || entry->type != HandleType::File)
+        return 0xFFFFFFFF;
 
     auto* fs = static_cast<FileState*>(entry->data);
     int whence;
     switch (dwMoveMethod) {
-        case 0: whence = SEEK_SET; break;
-        case 1: whence = SEEK_CUR; break;
-        case 2: whence = SEEK_END; break;
-        default: return 0xFFFFFFFF;
+    case 0:
+        whence = SEEK_SET;
+        break;
+    case 1:
+        whence = SEEK_CUR;
+        break;
+    case 2:
+        whence = SEEK_END;
+        break;
+    default:
+        return 0xFFFFFFFF;
     }
 
     off_t offset = lDistanceToMove;
@@ -273,36 +319,49 @@ DWORD VirtualFileSystem::setFilePointer(HANDLE hFile, LONG lDistanceToMove, LONG
     }
 
     off_t result = lseek(fs->fd, offset, whence);
-    if (result == (off_t)-1) return 0xFFFFFFFF;
+    if (result == (off_t)-1)
+        return 0xFFFFFFFF;
 
     fs->position = result;
     return static_cast<DWORD>(result & 0xFFFFFFFF);
 }
 
-BOOL VirtualFileSystem::setFilePointerEx(HANDLE hFile, int64_t liDistanceToMove, int64_t* lpNewFilePointer, DWORD dwMoveMethod) {
+BOOL VirtualFileSystem::setFilePointerEx(HANDLE hFile, int64_t liDistanceToMove, int64_t* lpNewFilePointer,
+                                         DWORD dwMoveMethod) {
     auto* entry = getHandle(hFile);
-    if (!entry || entry->type != HandleType::File) return 0;
+    if (!entry || entry->type != HandleType::File)
+        return 0;
 
     auto* fs = static_cast<FileState*>(entry->data);
     int whence;
     switch (dwMoveMethod) {
-        case 0: whence = SEEK_SET; break;
-        case 1: whence = SEEK_CUR; break;
-        case 2: whence = SEEK_END; break;
-        default: return 0;
+    case 0:
+        whence = SEEK_SET;
+        break;
+    case 1:
+        whence = SEEK_CUR;
+        break;
+    case 2:
+        whence = SEEK_END;
+        break;
+    default:
+        return 0;
     }
 
     off_t result = lseek(fs->fd, liDistanceToMove, whence);
-    if (result == (off_t)-1) return 0;
+    if (result == (off_t)-1)
+        return 0;
 
     fs->position = result;
-    if (lpNewFilePointer) *lpNewFilePointer = result;
+    if (lpNewFilePointer)
+        *lpNewFilePointer = result;
     return 1;
 }
 
 BOOL VirtualFileSystem::flushFileBuffers(HANDLE hFile) {
     auto* entry = getHandle(hFile);
-    if (!entry || entry->type != HandleType::File) return 0;
+    if (!entry || entry->type != HandleType::File)
+        return 0;
 
     auto* fs = static_cast<FileState*>(entry->data);
     return fsync(fs->fd) == 0 ? 1 : 0;
@@ -310,23 +369,30 @@ BOOL VirtualFileSystem::flushFileBuffers(HANDLE hFile) {
 
 DWORD VirtualFileSystem::getFileType(HANDLE hFile) {
     auto* entry = getHandle(hFile);
-    if (!entry || entry->type != HandleType::File) return 0;
+    if (!entry || entry->type != HandleType::File)
+        return 0;
 
     auto* fs = static_cast<FileState*>(entry->data);
     struct stat st;
-    if (fstat(fs->fd, &st) != 0) return 0;
+    if (fstat(fs->fd, &st) != 0)
+        return 0;
 
-    if (S_ISREG(st.st_mode)) return 0x0001;
-    if (S_ISCHR(st.st_mode)) return 0x0002;
-    if (S_ISDIR(st.st_mode)) return 0x0001;
+    if (S_ISREG(st.st_mode))
+        return 0x0001;
+    if (S_ISCHR(st.st_mode))
+        return 0x0002;
+    if (S_ISDIR(st.st_mode))
+        return 0x0001;
     return 0x0001;
 }
 
 static void fillWin32FindData(void* lpFindFileData, const char* name, bool isDir, int64_t fileSize) {
     uint8_t* data = static_cast<uint8_t*>(lpFindFileData);
     DWORD attrs = 0x80;
-    if (isDir) attrs |= 0x10;
-    if (name[0] == '.') attrs |= 0x02;
+    if (isDir)
+        attrs |= 0x10;
+    if (name[0] == '.')
+        attrs |= 0x02;
     memcpy(data, &attrs, 4);
 
     uint64_t ft = 0;
@@ -357,7 +423,8 @@ HANDLE VirtualFileSystem::findFirstFileW(const char* pattern, void* lpFindFileDa
         glob = hostPattern;
     }
 
-    if (glob.empty()) glob = "*";
+    if (glob.empty())
+        glob = "*";
 
     DIR* d = opendir(dir.c_str());
     if (!d) {
@@ -378,10 +445,12 @@ HANDLE VirtualFileSystem::findFirstFileW(const char* pattern, void* lpFindFileDa
 
 BOOL VirtualFileSystem::findNextFileW(HANDLE hFindFile, void* lpFindFileData) {
     auto* entry = getHandle(hFindFile);
-    if (!entry || entry->type != HandleType::Find) return 0;
+    if (!entry || entry->type != HandleType::Find)
+        return 0;
 
     auto* fnd = static_cast<FindState*>(entry->data);
-    if (!fnd->dir) return 0;
+    if (!fnd->dir)
+        return 0;
 
     struct dirent* de;
     while ((de = readdir(fnd->dir)) != nullptr) {
@@ -409,23 +478,29 @@ BOOL VirtualFileSystem::findClose(HANDLE hFindFile) {
 DWORD VirtualFileSystem::getFileAttributes(const std::string& path) {
     std::string host = winToHost(path);
     struct stat st;
-    if (stat(host.c_str(), &st) != 0) return 0xFFFFFFFF;
+    if (stat(host.c_str(), &st) != 0)
+        return 0xFFFFFFFF;
 
     DWORD attrs = 0x80;
-    if (S_ISDIR(st.st_mode)) attrs |= 0x10;
-    if (path[0] == '.' || path.find("/.") != std::string::npos) attrs |= 0x02;
-    if (!(st.st_mode & S_IWUSR)) attrs |= 0x01;
+    if (S_ISDIR(st.st_mode))
+        attrs |= 0x10;
+    if (path[0] == '.' || path.find("/.") != std::string::npos)
+        attrs |= 0x02;
+    if (!(st.st_mode & S_IWUSR))
+        attrs |= 0x01;
     return attrs;
 }
 
 BOOL VirtualFileSystem::getFileAttributesEx(const std::string& path, void* lpFileInformation) {
     std::string host = winToHost(path);
     struct stat st;
-    if (stat(host.c_str(), &st) != 0) return 0;
+    if (stat(host.c_str(), &st) != 0)
+        return 0;
 
     uint8_t* data = static_cast<uint8_t*>(lpFileInformation);
     DWORD attrs = 0x80;
-    if (S_ISDIR(st.st_mode)) attrs |= 0x10;
+    if (S_ISDIR(st.st_mode))
+        attrs |= 0x10;
     memcpy(data, &attrs, 4);
 
     uint64_t ft = static_cast<uint64_t>(st.st_mtime) * 10000000ULL + 116444736000000000ULL;
@@ -440,16 +515,19 @@ BOOL VirtualFileSystem::getFileAttributesEx(const std::string& path, void* lpFil
 
 BOOL VirtualFileSystem::getFileInformationByHandle(HANDLE hFile, void* lpFileInformation) {
     auto* entry = getHandle(hFile);
-    if (!entry || entry->type != HandleType::File) return 0;
+    if (!entry || entry->type != HandleType::File)
+        return 0;
 
     auto* fs = static_cast<FileState*>(entry->data);
     struct stat st;
-    if (fstat(fs->fd, &st) != 0) return 0;
+    if (fstat(fs->fd, &st) != 0)
+        return 0;
 
     uint8_t* data = static_cast<uint8_t*>(lpFileInformation);
     memset(data, 0, 52);
     DWORD attrs = 0x80;
-    if (S_ISDIR(st.st_mode)) attrs |= 0x10;
+    if (S_ISDIR(st.st_mode))
+        attrs |= 0x10;
     memcpy(data, &attrs, 4);
     uint64_t ft = static_cast<uint64_t>(st.st_mtime) * 10000000ULL + 116444736000000000ULL;
     memcpy(data + 4, &ft, 8);
@@ -466,11 +544,13 @@ BOOL VirtualFileSystem::getFileInformationByHandle(HANDLE hFile, void* lpFileInf
 }
 
 std::string VirtualFileSystem::getFullPathName(const std::string& path) {
-    if (path.empty()) return "";
+    if (path.empty())
+        return "";
 
     std::string result = path;
     for (auto& c : result) {
-        if (c == '\\') c = '/';
+        if (c == '\\')
+            c = '/';
     }
 
     if (result.size() >= 2 && result[1] == ':') {
@@ -492,5 +572,5 @@ HANDLE VirtualFileSystem::registerPipeFd(int fd) {
     return allocHandle(HandleType::Pipe, state);
 }
 
-}
-}
+} // namespace win32
+} // namespace metalsharp

--- a/src/win32/user32/User32Shim.cpp
+++ b/src/win32/user32/User32Shim.cpp
@@ -1,23 +1,28 @@
 /// @file User32Shim.cpp
 /// @brief user32.dll shim factory for window and message API exports.
 ///
-/// Registers user32.dll exports (CreateWindowEx, DefWindowProc, etc.) with the PE loader. Routes window management calls to the WindowManager and provides stubs for dialog, menu, and clipboard functions that games rarely use.
-#include <metalsharp/PELoader.h>
-#include <metalsharp/Win32Types.h>
-#include <metalsharp/Logger.h>
-#include <metalsharp/WindowManager.h>
-#include <cstring>
-#include <cstdlib>
+/// Registers user32.dll exports (CreateWindowEx, DefWindowProc, etc.) with the PE loader. Routes window management
+/// calls to the WindowManager and provides stubs for dialog, menu, and clipboard functions that games rarely use.
 #include <cstdarg>
 #include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <metalsharp/Logger.h>
+#include <metalsharp/PELoader.h>
+#include <metalsharp/Win32Types.h>
+#include <metalsharp/WindowManager.h>
 #include <unistd.h>
 
 namespace metalsharp {
 namespace win32 {
 
 static int MSABI shim_wsprintfA(char* buf, const char* fmt, ...) {
-    if (!buf) return 0;
-    if (!fmt) { buf[0] = 0; return 0; }
+    if (!buf)
+        return 0;
+    if (!fmt) {
+        buf[0] = 0;
+        return 0;
+    }
     buf[0] = 0;
 
     uintptr_t* stack = (uintptr_t*)&fmt + 1;
@@ -28,51 +33,66 @@ static int MSABI shim_wsprintfA(char* buf, const char* fmt, ...) {
     while (*p && (out - buf) < 2047) {
         if (*p == '%') {
             p++;
-            while (*p == '0' || *p == '-' || *p == '+' || *p == ' ' || *p == '#' || (*p >= '1' && *p <= '9') || *p == '.' || *p == 'l' || *p == 'I') p++;
+            while (*p == '0' || *p == '-' || *p == '+' || *p == ' ' || *p == '#' || (*p >= '1' && *p <= '9') ||
+                   *p == '.' || *p == 'l' || *p == 'I')
+                p++;
             char spec = *p++;
             switch (spec) {
-                case 's': {
-                    const char* s = (argIdx < 4) ? (const char*)stack[argIdx++] : "";
-                    if (s) { while (*s && (out - buf) < 2047) *out++ = *s++; }
-                    break;
+            case 's': {
+                const char* s = (argIdx < 4) ? (const char*)stack[argIdx++] : "";
+                if (s) {
+                    while (*s && (out - buf) < 2047)
+                        *out++ = *s++;
                 }
-                case 'S': {
-                    const wchar_t* ws = (argIdx < 4) ? (const wchar_t*)stack[argIdx++] : L"";
-                    if (ws) { while (*ws && (out - buf) < 2046) { *out++ = (char)*ws++; } }
-                    break;
+                break;
+            }
+            case 'S': {
+                const wchar_t* ws = (argIdx < 4) ? (const wchar_t*)stack[argIdx++] : L"";
+                if (ws) {
+                    while (*ws && (out - buf) < 2046) {
+                        *out++ = (char)*ws++;
+                    }
                 }
-                case 'd': case 'i': {
-                    int val = (argIdx < 4) ? (int)stack[argIdx++] : 0;
-                    out += snprintf(out, 2047 - (out - buf), "%d", val);
-                    break;
-                }
-                case 'u': {
-                    unsigned val = (argIdx < 4) ? (unsigned)stack[argIdx++] : 0;
-                    out += snprintf(out, 2047 - (out - buf), "%u", val);
-                    break;
-                }
-                case 'x': {
-                    unsigned val = (argIdx < 4) ? (unsigned)stack[argIdx++] : 0;
-                    out += snprintf(out, 2047 - (out - buf), "%x", val);
-                    break;
-                }
-                case 'X': {
-                    unsigned val = (argIdx < 4) ? (unsigned)stack[argIdx++] : 0;
-                    out += snprintf(out, 2047 - (out - buf), "%X", val);
-                    break;
-                }
-                case 'p': {
-                    void* val = (argIdx < 4) ? (void*)stack[argIdx++] : nullptr;
-                    out += snprintf(out, 2047 - (out - buf), "%p", val);
-                    break;
-                }
-                case 'c': {
-                    char c = (argIdx < 4) ? (char)stack[argIdx++] : ' ';
-                    *out++ = c;
-                    break;
-                }
-                case '%': *out++ = '%'; break;
-                default: *out++ = '%'; *out++ = spec; break;
+                break;
+            }
+            case 'd':
+            case 'i': {
+                int val = (argIdx < 4) ? (int)stack[argIdx++] : 0;
+                out += snprintf(out, 2047 - (out - buf), "%d", val);
+                break;
+            }
+            case 'u': {
+                unsigned val = (argIdx < 4) ? (unsigned)stack[argIdx++] : 0;
+                out += snprintf(out, 2047 - (out - buf), "%u", val);
+                break;
+            }
+            case 'x': {
+                unsigned val = (argIdx < 4) ? (unsigned)stack[argIdx++] : 0;
+                out += snprintf(out, 2047 - (out - buf), "%x", val);
+                break;
+            }
+            case 'X': {
+                unsigned val = (argIdx < 4) ? (unsigned)stack[argIdx++] : 0;
+                out += snprintf(out, 2047 - (out - buf), "%X", val);
+                break;
+            }
+            case 'p': {
+                void* val = (argIdx < 4) ? (void*)stack[argIdx++] : nullptr;
+                out += snprintf(out, 2047 - (out - buf), "%p", val);
+                break;
+            }
+            case 'c': {
+                char c = (argIdx < 4) ? (char)stack[argIdx++] : ' ';
+                *out++ = c;
+                break;
+            }
+            case '%':
+                *out++ = '%';
+                break;
+            default:
+                *out++ = '%';
+                *out++ = spec;
+                break;
             }
         } else {
             *out++ = *p++;
@@ -83,10 +103,10 @@ static int MSABI shim_wsprintfA(char* buf, const char* fmt, ...) {
 }
 
 static void* MSABI shim_CreateWindowExW(DWORD dwExStyle, const wchar_t* lpClassName, const wchar_t* lpWindowName,
-    DWORD dwStyle, int x, int y, int nWidth, int nHeight,
-    void* hWndParent, void* hMenu, void* hInstance, void* lpParam) {
-    return WindowManager::instance().createWindow(dwExStyle, lpClassName, lpWindowName, dwStyle,
-        x, y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
+                                        DWORD dwStyle, int x, int y, int nWidth, int nHeight, void* hWndParent,
+                                        void* hMenu, void* hInstance, void* lpParam) {
+    return WindowManager::instance().createWindow(dwExStyle, lpClassName, lpWindowName, dwStyle, x, y, nWidth, nHeight,
+                                                  hWndParent, hMenu, hInstance, lpParam);
 }
 
 static WORD MSABI shim_RegisterClassExW(void* lpwcx) {
@@ -147,13 +167,21 @@ static void* MSABI stub_BeginPaint(void* hWnd, void* ps) {
     return reinterpret_cast<void*>(0x6000);
 }
 
-static BOOL MSABI stub_EndPaint(void*, void*) { return 1; }
+static BOOL MSABI stub_EndPaint(void*, void*) {
+    return 1;
+}
 
-static void* MSABI stub_GetDC(void*) { return reinterpret_cast<void*>(0x6000); }
+static void* MSABI stub_GetDC(void*) {
+    return reinterpret_cast<void*>(0x6000);
+}
 
-static int MSABI stub_ReleaseDC(void*, void*) { return 1; }
+static int MSABI stub_ReleaseDC(void*, void*) {
+    return 1;
+}
 
-static BOOL MSABI stub_RedrawWindow(void*, const void*, void*, UINT) { return 1; }
+static BOOL MSABI stub_RedrawWindow(void*, const void*, void*, UINT) {
+    return 1;
+}
 
 static BOOL MSABI shim_GetWindowRect(void* hWnd, void* rect) {
     return WindowManager::instance().getWindowRect(hWnd, rect);
@@ -175,23 +203,36 @@ static BOOL MSABI shim_GetClientRect(void* hWnd, void* rect) {
     return WindowManager::instance().getClientRect(hWnd, rect);
 }
 
-static intptr_t MSABI stub_SetWindowLongPtrW(void*, int, intptr_t) { return 0; }
-static intptr_t MSABI stub_GetWindowLongPtrW(void*, int) { return 0; }
-static ULONG MSABI stub_SetClassLongPtrW(void*, int, LONG) { return 0; }
+static intptr_t MSABI stub_SetWindowLongPtrW(void*, int, intptr_t) {
+    return 0;
+}
+static intptr_t MSABI stub_GetWindowLongPtrW(void*, int) {
+    return 0;
+}
+static ULONG MSABI stub_SetClassLongPtrW(void*, int, LONG) {
+    return 0;
+}
 
 static void* MSABI stub_GetDesktopWindow() {
     return reinterpret_cast<void*>(0x5000);
 }
 
-static BOOL MSABI stub_IsWindowVisible(void*) { return 1; }
-
-static DWORD MSABI stub_GetWindowThreadProcessId(void*, DWORD* pid) {
-    if (pid) *pid = (DWORD)getpid();
+static BOOL MSABI stub_IsWindowVisible(void*) {
     return 1;
 }
 
-static BOOL MSABI stub_EnumWindows(void*, intptr_t) { return 1; }
-static BOOL MSABI stub_EnumChildWindows(void*, void*, intptr_t) { return 1; }
+static DWORD MSABI stub_GetWindowThreadProcessId(void*, DWORD* pid) {
+    if (pid)
+        *pid = (DWORD)getpid();
+    return 1;
+}
+
+static BOOL MSABI stub_EnumWindows(void*, intptr_t) {
+    return 1;
+}
+static BOOL MSABI stub_EnumChildWindows(void*, void*, intptr_t) {
+    return 1;
+}
 
 static void* MSABI stub_LoadCursorW(void*, const wchar_t*) {
     return reinterpret_cast<void*>(0x7000);
@@ -201,14 +242,21 @@ static void* MSABI stub_LoadIconW(void*, const wchar_t*) {
     return reinterpret_cast<void*>(0x7001);
 }
 
-static int MSABI stub_MessageBoxA(void*, const char*, const char*, UINT) { return 1; }
-static int MSABI stub_MessageBoxW(void*, const wchar_t*, const wchar_t*, UINT) { return 1; }
+static int MSABI stub_MessageBoxA(void*, const char*, const char*, UINT) {
+    return 1;
+}
+static int MSABI stub_MessageBoxW(void*, const wchar_t*, const wchar_t*, UINT) {
+    return 1;
+}
 
 static BOOL MSABI stub_GetMonitorInfoW(void*, void* mi) {
     memset(mi, 0, 72);
     reinterpret_cast<DWORD*>(mi)[0] = 72;
     auto* r = reinterpret_cast<LONG*>((uint8_t*)mi + 4);
-    r[0] = 0; r[1] = 0; r[2] = 1920; r[3] = 1080;
+    r[0] = 0;
+    r[1] = 0;
+    r[2] = 1920;
+    r[3] = 1080;
     return 1;
 }
 
@@ -224,25 +272,63 @@ static DWORD MSABI stub_MsgWaitForMultipleObjects(DWORD, void*, BOOL, DWORD, DWO
     return WAIT_OBJECT_0;
 }
 
-static BOOL MSABI stub_OpenClipboard(void*) { return 1; }
-static BOOL MSABI stub_CloseClipboard() { return 1; }
-static BOOL MSABI stub_EmptyClipboard() { return 1; }
-static void* MSABI stub_SetClipboardData(UINT, void*) { return nullptr; }
-static BOOL MSABI stub_GetClassInfoExW(void*, const wchar_t*, void*) { return 0; }
-static intptr_t MSABI stub_DialogBoxParamA(void*, const char*, void*, void*, intptr_t) { return 0; }
-static BOOL MSABI stub_EndDialog(void*, intptr_t) { return 1; }
-static void* MSABI stub_GetDlgItem(void*, int) { return reinterpret_cast<void*>(0x5000); }
-static UINT MSABI stub_GetDlgItemInt(void*, int, BOOL*, BOOL) { return 0; }
-static BOOL MSABI stub_SetDlgItemInt(void*, int, UINT, BOOL) { return 1; }
-static BOOL MSABI stub_SetDlgItemTextA(void*, int, const char*) { return 1; }
-static int MSABI stub_GetWindowTextLengthA(void*) { return 0; }
-static int MSABI stub_MapWindowPoints(void*, void*, void*, UINT) { return 0; }
-static BOOL MSABI stub_AllowSetForegroundWindow(DWORD) { return 1; }
-static BOOL MSABI stub_KillTimer(void*, intptr_t) { return 1; }
-static intptr_t MSABI stub_SetTimer(void*, intptr_t, UINT, void*) { return 1; }
-static BOOL MSABI stub_UnregisterClassW(const wchar_t*, void*) { return 1; }
-static void* MSABI stub_GetProcessWindowStation() { return reinterpret_cast<void*>(0x8000); }
-static BOOL MSABI stub_GetUserObjectInformationW(void*, int, void*, DWORD, DWORD*) { return 0; }
+static BOOL MSABI stub_OpenClipboard(void*) {
+    return 1;
+}
+static BOOL MSABI stub_CloseClipboard() {
+    return 1;
+}
+static BOOL MSABI stub_EmptyClipboard() {
+    return 1;
+}
+static void* MSABI stub_SetClipboardData(UINT, void*) {
+    return nullptr;
+}
+static BOOL MSABI stub_GetClassInfoExW(void*, const wchar_t*, void*) {
+    return 0;
+}
+static intptr_t MSABI stub_DialogBoxParamA(void*, const char*, void*, void*, intptr_t) {
+    return 0;
+}
+static BOOL MSABI stub_EndDialog(void*, intptr_t) {
+    return 1;
+}
+static void* MSABI stub_GetDlgItem(void*, int) {
+    return reinterpret_cast<void*>(0x5000);
+}
+static UINT MSABI stub_GetDlgItemInt(void*, int, BOOL*, BOOL) {
+    return 0;
+}
+static BOOL MSABI stub_SetDlgItemInt(void*, int, UINT, BOOL) {
+    return 1;
+}
+static BOOL MSABI stub_SetDlgItemTextA(void*, int, const char*) {
+    return 1;
+}
+static int MSABI stub_GetWindowTextLengthA(void*) {
+    return 0;
+}
+static int MSABI stub_MapWindowPoints(void*, void*, void*, UINT) {
+    return 0;
+}
+static BOOL MSABI stub_AllowSetForegroundWindow(DWORD) {
+    return 1;
+}
+static BOOL MSABI stub_KillTimer(void*, intptr_t) {
+    return 1;
+}
+static intptr_t MSABI stub_SetTimer(void*, intptr_t, UINT, void*) {
+    return 1;
+}
+static BOOL MSABI stub_UnregisterClassW(const wchar_t*, void*) {
+    return 1;
+}
+static void* MSABI stub_GetProcessWindowStation() {
+    return reinterpret_cast<void*>(0x8000);
+}
+static BOOL MSABI stub_GetUserObjectInformationW(void*, int, void*, DWORD, DWORD*) {
+    return 0;
+}
 
 static BOOL MSABI shim_PostMessageW(void* hWnd, UINT msg, uintptr_t wParam, intptr_t lParam) {
     return WindowManager::instance().postMessage(hWnd, msg, wParam, lParam);
@@ -252,9 +338,7 @@ ShimLibrary createUser32Shim() {
     ShimLibrary lib;
     lib.name = "USER32.dll";
 
-    auto fn = [](void* ptr) -> ExportedFunction {
-        return [ptr]() -> void* { return ptr; };
-    };
+    auto fn = [](void* ptr) -> ExportedFunction { return [ptr]() -> void* { return ptr; }; };
 
     lib.functions["CreateWindowExW"] = fn((void*)shim_CreateWindowExW);
     lib.functions["RegisterClassExW"] = fn((void*)shim_RegisterClassExW);
@@ -325,5 +409,5 @@ ShimLibrary createUser32Shim() {
     return lib;
 }
 
-}
-}
+} // namespace win32
+} // namespace metalsharp

--- a/src/win32/user32/WindowManager.mm
+++ b/src/win32/user32/WindowManager.mm
@@ -1,13 +1,14 @@
 /// @file WindowManager.mm
 /// @brief HWND-to-NSWindow bridge with Win32 message pump dispatch.
 ///
-/// Maps Win32 HWND handles to NSWindow/CAMetalLayer objects for Metal rendering. Implements the Win32 message pump (GetMessage, DispatchMessage, WNDPROC callbacks) and handles window creation, sizing, and input event routing.
+/// Maps Win32 HWND handles to NSWindow/CAMetalLayer objects for Metal rendering. Implements the Win32 message pump
+/// (GetMessage, DispatchMessage, WNDPROC callbacks) and handles window creation, sizing, and input event routing.
 #import <AppKit/AppKit.h>
-#include <metalsharp/WindowManager.h>
-#include <metalsharp/Logger.h>
-#include <cstring>
-#include <cstdlib>
 #include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <metalsharp/Logger.h>
+#include <metalsharp/WindowManager.h>
 
 @class MetalSharpWindowDelegate;
 
@@ -20,8 +21,7 @@
 
 - (void)windowWillClose:(NSNotification*)notification {
     (void)notification;
-    _manager->postMessage(reinterpret_cast<metalsharp::win32::HANDLE>(_hwnd),
-        metalsharp::win32::WM_CLOSE, 0, 0);
+    _manager->postMessage(reinterpret_cast<metalsharp::win32::HANDLE>(_hwnd), metalsharp::win32::WM_CLOSE, 0, 0);
 }
 
 - (void)windowDidResize:(NSNotification*)notification {
@@ -30,20 +30,18 @@
     NSRect content = [window contentRectForFrameRect:[window frame]];
     uintptr_t w = static_cast<uintptr_t>(content.size.width);
     uintptr_t h = static_cast<uintptr_t>(content.size.height);
-    _manager->postMessage(reinterpret_cast<metalsharp::win32::HANDLE>(_hwnd),
-        metalsharp::win32::WM_SIZE, 0, (intptr_t)((h << 16) | (w & 0xFFFF)));
+    _manager->postMessage(reinterpret_cast<metalsharp::win32::HANDLE>(_hwnd), metalsharp::win32::WM_SIZE, 0,
+                          (intptr_t)((h << 16) | (w & 0xFFFF)));
 }
 
 - (void)windowDidBecomeKey:(NSNotification*)notification {
     (void)notification;
-    _manager->postMessage(reinterpret_cast<metalsharp::win32::HANDLE>(_hwnd),
-        metalsharp::win32::WM_ACTIVATE, 1, 0);
+    _manager->postMessage(reinterpret_cast<metalsharp::win32::HANDLE>(_hwnd), metalsharp::win32::WM_ACTIVATE, 1, 0);
 }
 
 - (void)windowDidResignKey:(NSNotification*)notification {
     (void)notification;
-    _manager->postMessage(reinterpret_cast<metalsharp::win32::HANDLE>(_hwnd),
-        metalsharp::win32::WM_ACTIVATE, 0, 0);
+    _manager->postMessage(reinterpret_cast<metalsharp::win32::HANDLE>(_hwnd), metalsharp::win32::WM_ACTIVATE, 0, 0);
 }
 
 @end
@@ -51,37 +49,66 @@
 static uint16_t macKeyToVK(NSString* chars, unichar keyCode) {
     if ([chars length] > 0) {
         unichar ch = [chars characterAtIndex:0];
-        if (ch >= 'A' && ch <= 'Z') return ch;
-        if (ch >= 'a' && ch <= 'z') return toupper(ch);
-        if (ch >= '0' && ch <= '9') return ch;
+        if (ch >= 'A' && ch <= 'Z')
+            return ch;
+        if (ch >= 'a' && ch <= 'z')
+            return toupper(ch);
+        if (ch >= '0' && ch <= '9')
+            return ch;
     }
     switch (keyCode) {
-        case 0x7B: return 0x25;
-        case 0x7C: return 0x27;
-        case 0x7E: return 0x26;
-        case 0x7D: return 0x28;
-        case 0x24: return 0x0D;
-        case 0x35: return 0x08;
-        case 0x31: return 0x20;
-        case 0x30: return 0x09;
-        case 0x7A: return 0x70;
-        case 0x78: return 0x71;
-        case 0x63: return 0x72;
-        case 0x76: return 0x73;
-        case 0x60: return 0x74;
-        case 0x61: return 0x75;
-        case 0x62: return 0x76;
-        case 0x64: return 0x77;
-        case 0x65: return 0x78;
-        case 0x6D: return 0x79;
-        case 0x67: return 0x7A;
-        case 0x6F: return 0x7B;
-        case 0x69: return 0x7C;
-        case 0x6B: return 0x7D;
-        case 0x73: return 0x24;
-        case 0x74: return 0x23;
-        case 0x79: return 0x2D;
-        default: return 0;
+    case 0x7B:
+        return 0x25;
+    case 0x7C:
+        return 0x27;
+    case 0x7E:
+        return 0x26;
+    case 0x7D:
+        return 0x28;
+    case 0x24:
+        return 0x0D;
+    case 0x35:
+        return 0x08;
+    case 0x31:
+        return 0x20;
+    case 0x30:
+        return 0x09;
+    case 0x7A:
+        return 0x70;
+    case 0x78:
+        return 0x71;
+    case 0x63:
+        return 0x72;
+    case 0x76:
+        return 0x73;
+    case 0x60:
+        return 0x74;
+    case 0x61:
+        return 0x75;
+    case 0x62:
+        return 0x76;
+    case 0x64:
+        return 0x77;
+    case 0x65:
+        return 0x78;
+    case 0x6D:
+        return 0x79;
+    case 0x67:
+        return 0x7A;
+    case 0x6F:
+        return 0x7B;
+    case 0x69:
+        return 0x7C;
+    case 0x6B:
+        return 0x7D;
+    case 0x73:
+        return 0x24;
+    case 0x74:
+        return 0x23;
+    case 0x79:
+        return 0x2D;
+    default:
+        return 0;
     }
 }
 
@@ -102,13 +129,18 @@ void WindowManager::init() {
 }
 
 HANDLE WindowManager::createWindow(DWORD dwExStyle, const wchar_t* lpClassName, const wchar_t* lpWindowName,
-    DWORD dwStyle, int x, int y, int nWidth, int nHeight,
-    HANDLE hWndParent, HANDLE hMenu, HANDLE hInstance, void* lpParam) {
-    (void)dwExStyle; (void)hWndParent; (void)hMenu; (void)hInstance; (void)lpParam;
+                                   DWORD dwStyle, int x, int y, int nWidth, int nHeight, HANDLE hWndParent,
+                                   HANDLE hMenu, HANDLE hInstance, void* lpParam) {
+    (void)dwExStyle;
+    (void)hWndParent;
+    (void)hMenu;
+    (void)hInstance;
+    (void)lpParam;
 
     std::string className;
     if (lpClassName) {
-        for (int i = 0; lpClassName[i]; i++) className += (char)(lpClassName[i] & 0xFF);
+        for (int i = 0; lpClassName[i]; i++)
+            className += (char)(lpClassName[i] & 0xFF);
     }
 
     WNDPROC wndProc = nullptr;
@@ -117,10 +149,14 @@ HANDLE WindowManager::createWindow(DWORD dwExStyle, const wchar_t* lpClassName, 
         wndProc = it->second.lpfnWndProc;
     }
 
-    if (nWidth <= 0 || nWidth > 4096) nWidth = 800;
-    if (nHeight <= 0 || nHeight > 4096) nHeight = 600;
-    if (x < 0) x = 100;
-    if (y < 0) y = 100;
+    if (nWidth <= 0 || nWidth > 4096)
+        nWidth = 800;
+    if (nHeight <= 0 || nHeight > 4096)
+        nHeight = 600;
+    if (x < 0)
+        x = 100;
+    if (y < 0)
+        y = 100;
 
     NSRect frame = NSMakeRect(x, 0, nWidth, nHeight);
     NSScreen* screen = [NSScreen mainScreen];
@@ -129,21 +165,22 @@ HANDLE WindowManager::createWindow(DWORD dwExStyle, const wchar_t* lpClassName, 
         frame.origin.y = screenFrame.size.height - y - nHeight;
     }
 
-    NSUInteger styleMask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable;
+    NSUInteger styleMask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable |
+                           NSWindowStyleMaskResizable;
     if (!(dwStyle & 0x00C00000)) {
         styleMask &= ~NSWindowStyleMaskTitled;
     }
 
     NSWindow* window = [[NSWindow alloc] initWithContentRect:frame
-        styleMask:styleMask
-        backing:NSBackingStoreBuffered
-        defer:NO];
+                                                   styleMask:styleMask
+                                                     backing:NSBackingStoreBuffered
+                                                       defer:NO];
 
     if (lpWindowName) {
         std::vector<unichar> uchars;
-        for (int i = 0; lpWindowName[i]; i++) uchars.push_back(lpWindowName[i]);
-        NSString* title = uchars.empty() ? @"" :
-            [NSString stringWithCharacters:uchars.data() length:uchars.size()];
+        for (int i = 0; lpWindowName[i]; i++)
+            uchars.push_back(lpWindowName[i]);
+        NSString* title = uchars.empty() ? @"" : [NSString stringWithCharacters:uchars.data() length:uchars.size()];
         [window setTitle:title];
     }
 
@@ -161,12 +198,13 @@ HANDLE WindowManager::createWindow(DWORD dwExStyle, const wchar_t* lpClassName, 
         std::lock_guard<std::mutex> lock(m_mutex);
         m_hwndToNSWindow[h] = (__bridge_retained void*)window;
         m_nsWindowToHwnd[(__bridge void*)window] = h;
-        if (wndProc) m_wndProcs[h] = wndProc;
+        if (wndProc)
+            m_wndProcs[h] = wndProc;
         m_messageQueues[h] = std::queue<MSG>();
     }
 
-    MS_INFO("WindowManager: CreateWindow(\"%s\") -> HWND=0x%llX, NSWindow=%p, WNDPROC=%p",
-        className.c_str(), (unsigned long long)h, window, wndProc);
+    MS_INFO("WindowManager: CreateWindow(\"%s\") -> HWND=0x%llX, NSWindow=%p, WNDPROC=%p", className.c_str(),
+            (unsigned long long)h, window, wndProc);
 
     if (wndProc) {
         wndProc(reinterpret_cast<HANDLE>(h), 0x0001, 0, 0);
@@ -184,7 +222,8 @@ WORD WindowManager::registerClass(const void* lpwcx) {
     const wchar_t* className = *reinterpret_cast<const wchar_t* const*>(data + 40);
     std::string name;
     if (className) {
-        for (int i = 0; className[i]; i++) name += (char)(className[i] & 0xFF);
+        for (int i = 0; className[i]; i++)
+            name += (char)(className[i] & 0xFF);
     }
 
     std::lock_guard<std::mutex> lock(m_mutex);
@@ -201,7 +240,8 @@ BOOL WindowManager::destroyWindow(HANDLE hWnd) {
     std::lock_guard<std::mutex> lock(m_mutex);
 
     auto it = m_hwndToNSWindow.find(h);
-    if (it == m_hwndToNSWindow.end()) return 0;
+    if (it == m_hwndToNSWindow.end())
+        return 0;
 
     NSWindow* window = (__bridge NSWindow*)it->second;
 
@@ -225,7 +265,8 @@ BOOL WindowManager::showWindow(HANDLE hWnd, int nCmdShow) {
     std::lock_guard<std::mutex> lock(m_mutex);
 
     auto it = m_hwndToNSWindow.find(h);
-    if (it == m_hwndToNSWindow.end()) return 0;
+    if (it == m_hwndToNSWindow.end())
+        return 0;
 
     NSWindow* window = (__bridge NSWindow*)it->second;
     if (nCmdShow == 5 || nCmdShow == 1 || nCmdShow == 3) {
@@ -250,7 +291,8 @@ BOOL WindowManager::getWindowRect(HANDLE hWnd, void* lpRect) {
     std::lock_guard<std::mutex> lock(m_mutex);
 
     auto it = m_hwndToNSWindow.find(h);
-    if (it == m_hwndToNSWindow.end()) return 0;
+    if (it == m_hwndToNSWindow.end())
+        return 0;
 
     NSWindow* window = (__bridge NSWindow*)it->second;
     NSRect frame = [window frame];
@@ -270,7 +312,8 @@ BOOL WindowManager::getClientRect(HANDLE hWnd, void* lpRect) {
     std::lock_guard<std::mutex> lock(m_mutex);
 
     auto it = m_hwndToNSWindow.find(h);
-    if (it == m_hwndToNSWindow.end()) return 0;
+    if (it == m_hwndToNSWindow.end())
+        return 0;
 
     NSWindow* window = (__bridge NSWindow*)it->second;
     NSRect content = [window contentRectForFrameRect:[window frame]];
@@ -289,7 +332,8 @@ BOOL WindowManager::moveWindow(HANDLE hWnd, int x, int y, int w, int h, BOOL rep
     std::lock_guard<std::mutex> lock(m_mutex);
 
     auto it = m_hwndToNSWindow.find(hwnd);
-    if (it == m_hwndToNSWindow.end()) return 0;
+    if (it == m_hwndToNSWindow.end())
+        return 0;
 
     NSWindow* window = (__bridge NSWindow*)it->second;
     NSScreen* screen = [NSScreen mainScreen];
@@ -300,7 +344,8 @@ BOOL WindowManager::moveWindow(HANDLE hWnd, int x, int y, int w, int h, BOOL rep
 }
 
 BOOL WindowManager::setWindowPos(HANDLE hWnd, HANDLE hWndAfter, int x, int y, int w, int h, UINT flags) {
-    (void)hWndAfter; (void)flags;
+    (void)hWndAfter;
+    (void)flags;
     return moveWindow(hWnd, x, y, w, h, 1);
 }
 
@@ -309,14 +354,15 @@ BOOL WindowManager::setWindowTextW(HANDLE hWnd, const wchar_t* lpString) {
     std::lock_guard<std::mutex> lock(m_mutex);
 
     auto it = m_hwndToNSWindow.find(h);
-    if (it == m_hwndToNSWindow.end()) return 0;
+    if (it == m_hwndToNSWindow.end())
+        return 0;
 
     NSWindow* window = (__bridge NSWindow*)it->second;
     if (lpString) {
         std::vector<unichar> uchars;
-        for (int i = 0; lpString[i]; i++) uchars.push_back(lpString[i]);
-        NSString* title = uchars.empty() ? @"" :
-            [NSString stringWithCharacters:uchars.data() length:uchars.size()];
+        for (int i = 0; lpString[i]; i++)
+            uchars.push_back(lpString[i]);
+        NSString* title = uchars.empty() ? @"" : [NSString stringWithCharacters:uchars.data() length:uchars.size()];
         [window setTitle:title];
     }
     return 1;
@@ -326,97 +372,99 @@ void WindowManager::pumpEvents() {
     @autoreleasepool {
         for (;;) {
             NSEvent* event = [NSApp nextEventMatchingMask:NSEventMaskAny
-                untilDate:[NSDate distantPast]
-                inMode:NSDefaultRunLoopMode
-                dequeue:YES];
+                                                untilDate:[NSDate distantPast]
+                                                   inMode:NSDefaultRunLoopMode
+                                                  dequeue:YES];
 
-            if (!event) break;
+            if (!event)
+                break;
 
             NSWindow* eventWindow = [event window];
             uintptr_t targetHwnd = 0;
 
             if (eventWindow) {
                 auto hit = m_nsWindowToHwnd.find((__bridge void*)eventWindow);
-                if (hit != m_nsWindowToHwnd.end()) targetHwnd = hit->second;
+                if (hit != m_nsWindowToHwnd.end())
+                    targetHwnd = hit->second;
             }
 
             switch ([event type]) {
-                case NSEventTypeLeftMouseDown: {
-                    if (targetHwnd) {
-                        NSPoint loc = [event locationInWindow];
-                        postMessage(reinterpret_cast<HANDLE>(targetHwnd), WM_LBUTTONDOWN, 0,
-                            (intptr_t)((static_cast<int>(loc.y) << 16) | (static_cast<int>(loc.x) & 0xFFFF)));
-                    }
-                    break;
-                }
-                case NSEventTypeLeftMouseUp: {
-                    if (targetHwnd) {
-                        NSPoint loc = [event locationInWindow];
-                        postMessage(reinterpret_cast<HANDLE>(targetHwnd), WM_LBUTTONUP, 0,
-                            (intptr_t)((static_cast<int>(loc.y) << 16) | (static_cast<int>(loc.x) & 0xFFFF)));
-                    }
-                    break;
-                }
-                case NSEventTypeMouseMoved:
-                case NSEventTypeLeftMouseDragged: {
-                    if (targetHwnd) {
-                        NSPoint loc = [event locationInWindow];
-                        postMessage(reinterpret_cast<HANDLE>(targetHwnd), WM_MOUSEMOVE, 0,
-                            (intptr_t)((static_cast<int>(loc.y) << 16) | (static_cast<int>(loc.x) & 0xFFFF)));
-                    }
-                    break;
-                }
-                case NSEventTypeRightMouseDown: {
-                    if (targetHwnd) {
-                        NSPoint loc = [event locationInWindow];
-                        postMessage(reinterpret_cast<HANDLE>(targetHwnd), WM_RBUTTONDOWN, 0,
-                            (intptr_t)((static_cast<int>(loc.y) << 16) | (static_cast<int>(loc.x) & 0xFFFF)));
-                    }
-                    break;
-                }
-                case NSEventTypeRightMouseUp: {
-                    if (targetHwnd) {
-                        NSPoint loc = [event locationInWindow];
-                        postMessage(reinterpret_cast<HANDLE>(targetHwnd), WM_RBUTTONUP, 0,
-                            (intptr_t)((static_cast<int>(loc.y) << 16) | (static_cast<int>(loc.x) & 0xFFFF)));
-                    }
-                    break;
-                }
-                case NSEventTypeKeyDown: {
-                    if (targetHwnd) {
-                        uint16_t vk = macKeyToVK([event characters], [event keyCode]);
-                        postMessage(reinterpret_cast<HANDLE>(targetHwnd), WM_KEYDOWN, vk, 1);
-                        NSString* chars = [event characters];
-                        if ([chars length] > 0) {
-                            unichar ch = [chars characterAtIndex:0];
-                            if (ch >= 32 && ch < 127) {
-                                postMessage(reinterpret_cast<HANDLE>(targetHwnd), WM_CHAR, ch, 1);
-                            }
-                        }
-                    }
-                    break;
-                }
-                case NSEventTypeKeyUp: {
-                    if (targetHwnd) {
-                        uint16_t vk = macKeyToVK([event characters], [event keyCode]);
-                        postMessage(reinterpret_cast<HANDLE>(targetHwnd), WM_KEYUP, vk, 1);
-                    }
-                    break;
-                }
-                case NSEventTypeScrollWheel: {
-                    if (targetHwnd) {
-                        CGFloat delta = [event deltaY];
-                        if (delta != 0) {
-                            uintptr_t wParam = (static_cast<uintptr_t>(static_cast<int>(delta * 120)) << 16);
-                            NSPoint loc = [event locationInWindow];
-                            postMessage(reinterpret_cast<HANDLE>(targetHwnd), WM_MOUSEWHEEL, wParam,
+            case NSEventTypeLeftMouseDown: {
+                if (targetHwnd) {
+                    NSPoint loc = [event locationInWindow];
+                    postMessage(reinterpret_cast<HANDLE>(targetHwnd), WM_LBUTTONDOWN, 0,
                                 (intptr_t)((static_cast<int>(loc.y) << 16) | (static_cast<int>(loc.x) & 0xFFFF)));
+                }
+                break;
+            }
+            case NSEventTypeLeftMouseUp: {
+                if (targetHwnd) {
+                    NSPoint loc = [event locationInWindow];
+                    postMessage(reinterpret_cast<HANDLE>(targetHwnd), WM_LBUTTONUP, 0,
+                                (intptr_t)((static_cast<int>(loc.y) << 16) | (static_cast<int>(loc.x) & 0xFFFF)));
+                }
+                break;
+            }
+            case NSEventTypeMouseMoved:
+            case NSEventTypeLeftMouseDragged: {
+                if (targetHwnd) {
+                    NSPoint loc = [event locationInWindow];
+                    postMessage(reinterpret_cast<HANDLE>(targetHwnd), WM_MOUSEMOVE, 0,
+                                (intptr_t)((static_cast<int>(loc.y) << 16) | (static_cast<int>(loc.x) & 0xFFFF)));
+                }
+                break;
+            }
+            case NSEventTypeRightMouseDown: {
+                if (targetHwnd) {
+                    NSPoint loc = [event locationInWindow];
+                    postMessage(reinterpret_cast<HANDLE>(targetHwnd), WM_RBUTTONDOWN, 0,
+                                (intptr_t)((static_cast<int>(loc.y) << 16) | (static_cast<int>(loc.x) & 0xFFFF)));
+                }
+                break;
+            }
+            case NSEventTypeRightMouseUp: {
+                if (targetHwnd) {
+                    NSPoint loc = [event locationInWindow];
+                    postMessage(reinterpret_cast<HANDLE>(targetHwnd), WM_RBUTTONUP, 0,
+                                (intptr_t)((static_cast<int>(loc.y) << 16) | (static_cast<int>(loc.x) & 0xFFFF)));
+                }
+                break;
+            }
+            case NSEventTypeKeyDown: {
+                if (targetHwnd) {
+                    uint16_t vk = macKeyToVK([event characters], [event keyCode]);
+                    postMessage(reinterpret_cast<HANDLE>(targetHwnd), WM_KEYDOWN, vk, 1);
+                    NSString* chars = [event characters];
+                    if ([chars length] > 0) {
+                        unichar ch = [chars characterAtIndex:0];
+                        if (ch >= 32 && ch < 127) {
+                            postMessage(reinterpret_cast<HANDLE>(targetHwnd), WM_CHAR, ch, 1);
                         }
                     }
-                    break;
                 }
-                default:
-                    break;
+                break;
+            }
+            case NSEventTypeKeyUp: {
+                if (targetHwnd) {
+                    uint16_t vk = macKeyToVK([event characters], [event keyCode]);
+                    postMessage(reinterpret_cast<HANDLE>(targetHwnd), WM_KEYUP, vk, 1);
+                }
+                break;
+            }
+            case NSEventTypeScrollWheel: {
+                if (targetHwnd) {
+                    CGFloat delta = [event deltaY];
+                    if (delta != 0) {
+                        uintptr_t wParam = (static_cast<uintptr_t>(static_cast<int>(delta * 120)) << 16);
+                        NSPoint loc = [event locationInWindow];
+                        postMessage(reinterpret_cast<HANDLE>(targetHwnd), WM_MOUSEWHEEL, wParam,
+                                    (intptr_t)((static_cast<int>(loc.y) << 16) | (static_cast<int>(loc.x) & 0xFFFF)));
+                    }
+                }
+                break;
+            }
+            default:
+                break;
             }
 
             [NSApp sendEvent:event];
@@ -425,7 +473,9 @@ void WindowManager::pumpEvents() {
 }
 
 BOOL WindowManager::getMessage(MSG* lpMsg, HANDLE hWnd, UINT wMsgFilterMin, UINT wMsgFilterMax) {
-    (void)hWnd; (void)wMsgFilterMin; (void)wMsgFilterMax;
+    (void)hWnd;
+    (void)wMsgFilterMin;
+    (void)wMsgFilterMax;
 
     while (!m_quitReceived) {
         pumpEvents();
@@ -462,7 +512,9 @@ BOOL WindowManager::getMessage(MSG* lpMsg, HANDLE hWnd, UINT wMsgFilterMin, UINT
 }
 
 BOOL WindowManager::peekMessage(MSG* lpMsg, HANDLE hWnd, UINT wMsgFilterMin, UINT wMsgFilterMax, UINT wRemoveMsg) {
-    (void)hWnd; (void)wMsgFilterMin; (void)wMsgFilterMax;
+    (void)hWnd;
+    (void)wMsgFilterMin;
+    (void)wMsgFilterMax;
 
     pumpEvents();
 
@@ -470,14 +522,16 @@ BOOL WindowManager::peekMessage(MSG* lpMsg, HANDLE hWnd, UINT wMsgFilterMin, UIN
 
     if (!m_globalQueue.empty()) {
         *lpMsg = m_globalQueue.front();
-        if (wRemoveMsg & 0x0001) m_globalQueue.pop();
+        if (wRemoveMsg & 0x0001)
+            m_globalQueue.pop();
         return lpMsg->message != WM_QUIT ? 1 : 0;
     }
 
     for (auto& [hwnd, queue] : m_messageQueues) {
         if (!queue.empty()) {
             *lpMsg = queue.front();
-            if (wRemoveMsg & 0x0001) queue.pop();
+            if (wRemoveMsg & 0x0001)
+                queue.pop();
             return 1;
         }
     }
@@ -491,7 +545,8 @@ BOOL WindowManager::translateMessage(const MSG* lpMsg) {
 }
 
 intptr_t WindowManager::dispatchMessage(const MSG* lpMsg) {
-    if (!lpMsg) return 0;
+    if (!lpMsg)
+        return 0;
 
     uintptr_t h = reinterpret_cast<uintptr_t>(lpMsg->hwnd);
     auto it = m_wndProcs.find(h);
@@ -549,25 +604,26 @@ void WindowManager::postQuitMessage(int nExitCode) {
 
 intptr_t WindowManager::defWindowProc(HANDLE hWnd, UINT Msg, uintptr_t wParam, intptr_t lParam) {
     switch (Msg) {
-        case WM_DESTROY:
-            postQuitMessage(0);
-            return 0;
-        case WM_CLOSE:
-            destroyWindow(hWnd);
-            return 0;
-        case WM_ERASEBKGND:
-            return 1;
-        default:
-            return 0;
+    case WM_DESTROY:
+        postQuitMessage(0);
+        return 0;
+    case WM_CLOSE:
+        destroyWindow(hWnd);
+        return 0;
+    case WM_ERASEBKGND:
+        return 1;
+    default:
+        return 0;
     }
 }
 
 void* WindowManager::getNSWindow(HANDLE hWnd) {
     uintptr_t h = reinterpret_cast<uintptr_t>(hWnd);
     auto it = m_hwndToNSWindow.find(h);
-    if (it != m_hwndToNSWindow.end()) return it->second;
+    if (it != m_hwndToNSWindow.end())
+        return it->second;
     return nullptr;
 }
 
-}
-}
+} // namespace win32
+} // namespace metalsharp

--- a/src/wine/d3d11_pe.cpp
+++ b/src/wine/d3d11_pe.cpp
@@ -1,14 +1,15 @@
 /// @file d3d11_pe.cpp
 /// @brief Wine D3D11 PE module with COM interface forwarding.
 ///
-/// Standalone Wine PE-side d3d11.dll that implements ID3D11Device and ID3D11DeviceContext COM interfaces. Forwards create/execute calls through Wine's unixlib mechanism to a platform-specific rendering backend.
+/// Standalone Wine PE-side d3d11.dll that implements ID3D11Device and ID3D11DeviceContext COM interfaces. Forwards
+/// create/execute calls through Wine's unixlib mechanism to a platform-specific rendering backend.
 #include <d3d11.h>
 #include <dxgi.h>
-#include <string.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <windows.h>
+#include <string.h>
 #include <unordered_map>
+#include <windows.h>
 #include <winternl.h>
 
 #pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
@@ -17,7 +18,7 @@
 
 typedef long NTSTATUS;
 typedef unsigned long long unixlib_handle_t;
-typedef NTSTATUS (WINAPI *unix_call_dispatcher_t)(unixlib_handle_t, unsigned int, void*);
+typedef NTSTATUS(WINAPI* unix_call_dispatcher_t)(unixlib_handle_t, unsigned int, void*);
 typedef NTSTATUS (*unixlib_entry_t)(void*);
 
 #ifndef STATUS_SUCCESS
@@ -35,28 +36,30 @@ static NTSTATUS unix_call(unsigned int code, void* args) {
 }
 
 static bool init_unix_call() {
-    if (g_unixlib_handle && g_unix_call_dispatcher) return true;
+    if (g_unixlib_handle && g_unix_call_dispatcher)
+        return true;
 
     HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
-    if (!ntdll) { fprintf(stderr, "[metalsharp] no ntdll\n"); return false; }
+    if (!ntdll) {
+        fprintf(stderr, "[metalsharp] no ntdll\n");
+        return false;
+    }
 
-    typedef NTSTATUS (NTAPI *pNtQVM)(HANDLE, const void*, ULONG, void*, SIZE_T, SIZE_T*);
+    typedef NTSTATUS(NTAPI * pNtQVM)(HANDLE, const void*, ULONG, void*, SIZE_T, SIZE_T*);
     pNtQVM pNtQueryVirtualMemory = (pNtQVM)GetProcAddress(ntdll, "NtQueryVirtualMemory");
-    if (!pNtQueryVirtualMemory) { fprintf(stderr, "[metalsharp] no NtQueryVirtualMemory\n"); return false; }
+    if (!pNtQueryVirtualMemory) {
+        fprintf(stderr, "[metalsharp] no NtQueryVirtualMemory\n");
+        return false;
+    }
 
     unixlib_handle_t handle = 0;
-    NTSTATUS status = pNtQueryVirtualMemory(
-        (HANDLE)(LONG_PTR)-1,
-        (const void*)g_hModule,
-        1000,
-        &handle,
-        sizeof(handle),
-        nullptr
-    );
-    fprintf(stderr, "[metalsharp] NtQueryVirtualMemory(1000) status=%ld handle=%llu\n",
-        status, (unsigned long long)handle);
+    NTSTATUS status =
+        pNtQueryVirtualMemory((HANDLE)(LONG_PTR)-1, (const void*)g_hModule, 1000, &handle, sizeof(handle), nullptr);
+    fprintf(stderr, "[metalsharp] NtQueryVirtualMemory(1000) status=%ld handle=%llu\n", status,
+            (unsigned long long)handle);
 
-    if (status < 0) return false;
+    if (status < 0)
+        return false;
     g_unixlib_handle = handle;
 
     void** ptr = (void**)GetProcAddress(ntdll, "__wine_unix_call_dispatcher");
@@ -68,38 +71,54 @@ static bool init_unix_call() {
         g_unix_call_dispatcher = (unix_call_dispatcher_t)GetProcAddress(ntdll, "__wine_unix_call_dispatcher");
     }
 
-    if (!g_unix_call_dispatcher) return false;
+    if (!g_unix_call_dispatcher)
+        return false;
 
     fprintf(stderr, "[metalsharp] unix call initialized: handle=%llu dispatch=%p\n",
-        (unsigned long long)g_unixlib_handle, (void*)g_unix_call_dispatcher);
+            (unsigned long long)g_unixlib_handle, (void*)g_unix_call_dispatcher);
     return true;
 }
 
 static std::unordered_map<void*, uint64_t> g_handles;
 
 static uint64_t obj_handle(void* obj) {
-    if (!obj) return 0;
+    if (!obj)
+        return 0;
     auto it = g_handles.find(obj);
     return it != g_handles.end() ? it->second : 0;
 }
 
 static void set_handle(void* obj, uint64_t h) {
-    if (obj) g_handles[obj] = h;
+    if (obj)
+        g_handles[obj] = h;
 }
 
-#define MS_QI \
-    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override { if(ppv)*ppv=nullptr; return E_NOINTERFACE; } \
-    ULONG WINAPI AddRef() override { return InterlockedIncrement(&m_ref); } \
-    ULONG WINAPI Release() override { ULONG r = InterlockedDecrement(&m_ref); return r ? r : 1; }
+#define MS_QI                                                                                                          \
+    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override {                                                       \
+        if (ppv)                                                                                                       \
+            *ppv = nullptr;                                                                                            \
+        return E_NOINTERFACE;                                                                                          \
+    }                                                                                                                  \
+    ULONG WINAPI AddRef() override {                                                                                   \
+        return InterlockedIncrement(&m_ref);                                                                           \
+    }                                                                                                                  \
+    ULONG WINAPI Release() override {                                                                                  \
+        ULONG r = InterlockedDecrement(&m_ref);                                                                        \
+        return r ? r : 1;                                                                                              \
+    }
 
 class MSDeviceContext;
 static MSDeviceContext* g_ctx = nullptr;
 
 class MSDeviceChildStub : public ID3D11DeviceChild {
     LONG m_ref = 1;
-public:
+
+  public:
     MS_QI
-    void WINAPI GetDevice(ID3D11Device** pp) override { if(pp) *pp = nullptr; }
+    void WINAPI GetDevice(ID3D11Device** pp) override {
+        if (pp)
+            *pp = nullptr;
+    }
     HRESULT WINAPI GetPrivateData(REFGUID, UINT*, void*) override { return E_NOTIMPL; }
     HRESULT WINAPI SetPrivateData(REFGUID, UINT, const void*) override { return S_OK; }
     HRESULT WINAPI SetPrivateDataInterface(REFGUID, const IUnknown*) override { return S_OK; }
@@ -107,61 +126,99 @@ public:
 
 class MSResourceStub : public ID3D11Resource {
     LONG m_ref = 1;
-public:
+
+  public:
     MS_QI
-    void WINAPI GetDevice(ID3D11Device** pp) override { if(pp) *pp = nullptr; }
+    void WINAPI GetDevice(ID3D11Device** pp) override {
+        if (pp)
+            *pp = nullptr;
+    }
     HRESULT WINAPI GetPrivateData(REFGUID, UINT*, void*) override { return E_NOTIMPL; }
     HRESULT WINAPI SetPrivateData(REFGUID, UINT, const void*) override { return S_OK; }
     HRESULT WINAPI SetPrivateDataInterface(REFGUID, const IUnknown*) override { return S_OK; }
-    void WINAPI GetType(D3D11_RESOURCE_DIMENSION* r) override { if(r) *r = D3D11_RESOURCE_DIMENSION_UNKNOWN; }
+    void WINAPI GetType(D3D11_RESOURCE_DIMENSION* r) override {
+        if (r)
+            *r = D3D11_RESOURCE_DIMENSION_UNKNOWN;
+    }
     void WINAPI SetEvictionPriority(UINT) override {}
     UINT WINAPI GetEvictionPriority() override { return 0; }
 };
 
 class MSBuffer : public ID3D11Buffer {
     LONG m_ref = 1;
-public:
+
+  public:
     MS_QI
-    void WINAPI GetDevice(ID3D11Device** pp) override { if(pp) *pp = nullptr; }
+    void WINAPI GetDevice(ID3D11Device** pp) override {
+        if (pp)
+            *pp = nullptr;
+    }
     HRESULT WINAPI GetPrivateData(REFGUID, UINT*, void*) override { return E_NOTIMPL; }
     HRESULT WINAPI SetPrivateData(REFGUID, UINT, const void*) override { return S_OK; }
     HRESULT WINAPI SetPrivateDataInterface(REFGUID, const IUnknown*) override { return S_OK; }
-    void WINAPI GetType(D3D11_RESOURCE_DIMENSION* r) override { if(r) *r = D3D11_RESOURCE_DIMENSION_BUFFER; }
+    void WINAPI GetType(D3D11_RESOURCE_DIMENSION* r) override {
+        if (r)
+            *r = D3D11_RESOURCE_DIMENSION_BUFFER;
+    }
     void WINAPI SetEvictionPriority(UINT) override {}
     UINT WINAPI GetEvictionPriority() override { return 0; }
-    void WINAPI GetDesc(D3D11_BUFFER_DESC* pDesc) override { if(pDesc) memset(pDesc, 0, sizeof(*pDesc)); }
+    void WINAPI GetDesc(D3D11_BUFFER_DESC* pDesc) override {
+        if (pDesc)
+            memset(pDesc, 0, sizeof(*pDesc));
+    }
 };
 
 class MSTexture2D : public ID3D11Texture2D {
     LONG m_ref = 1;
-public:
+
+  public:
     MS_QI
-    void WINAPI GetDevice(ID3D11Device** pp) override { if(pp) *pp = nullptr; }
+    void WINAPI GetDevice(ID3D11Device** pp) override {
+        if (pp)
+            *pp = nullptr;
+    }
     HRESULT WINAPI GetPrivateData(REFGUID, UINT*, void*) override { return E_NOTIMPL; }
     HRESULT WINAPI SetPrivateData(REFGUID, UINT, const void*) override { return S_OK; }
     HRESULT WINAPI SetPrivateDataInterface(REFGUID, const IUnknown*) override { return S_OK; }
-    void WINAPI GetType(D3D11_RESOURCE_DIMENSION* r) override { if(r) *r = D3D11_RESOURCE_DIMENSION_TEXTURE2D; }
+    void WINAPI GetType(D3D11_RESOURCE_DIMENSION* r) override {
+        if (r)
+            *r = D3D11_RESOURCE_DIMENSION_TEXTURE2D;
+    }
     void WINAPI SetEvictionPriority(UINT) override {}
     UINT WINAPI GetEvictionPriority() override { return 0; }
-    void WINAPI GetDesc(D3D11_TEXTURE2D_DESC* pDesc) override { if(pDesc) memset(pDesc, 0, sizeof(*pDesc)); }
+    void WINAPI GetDesc(D3D11_TEXTURE2D_DESC* pDesc) override {
+        if (pDesc)
+            memset(pDesc, 0, sizeof(*pDesc));
+    }
 };
 
 class MSView : public ID3D11View {
     LONG m_ref = 1;
-public:
+
+  public:
     MS_QI
-    void WINAPI GetDevice(ID3D11Device** pp) override { if(pp) *pp = nullptr; }
+    void WINAPI GetDevice(ID3D11Device** pp) override {
+        if (pp)
+            *pp = nullptr;
+    }
     HRESULT WINAPI GetPrivateData(REFGUID, UINT*, void*) override { return E_NOTIMPL; }
     HRESULT WINAPI SetPrivateData(REFGUID, UINT, const void*) override { return S_OK; }
     HRESULT WINAPI SetPrivateDataInterface(REFGUID, const IUnknown*) override { return S_OK; }
-    void WINAPI GetResource(ID3D11Resource** pp) override { if(pp) *pp = nullptr; }
+    void WINAPI GetResource(ID3D11Resource** pp) override {
+        if (pp)
+            *pp = nullptr;
+    }
 };
 
 class MSDeviceContext : public ID3D11DeviceContext {
     LONG m_ref = 1;
-public:
+
+  public:
     MS_QI
-    void WINAPI GetDevice(ID3D11Device** pp) override { if(pp) *pp = nullptr; }
+    void WINAPI GetDevice(ID3D11Device** pp) override {
+        if (pp)
+            *pp = nullptr;
+    }
     D3D11_DEVICE_CONTEXT_TYPE WINAPI GetType() override { return D3D11_DEVICE_CONTEXT_IMMEDIATE; }
     UINT WINAPI GetContextFlags() override { return 0; }
     HRESULT WINAPI GetPrivateData(REFGUID, UINT*, void*) override { return E_NOTIMPL; }
@@ -169,7 +226,8 @@ public:
     HRESULT WINAPI SetPrivateDataInterface(REFGUID, const IUnknown*) override { return S_OK; }
 
     void WINAPI IASetInputLayout(ID3D11InputLayout*) override {}
-    void WINAPI IASetVertexBuffers(UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppVB, const UINT* pStrides, const UINT* pOffsets) override {
+    void WINAPI IASetVertexBuffers(UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppVB, const UINT* pStrides,
+                                   const UINT* pOffsets) override {
         struct ms_set_vertex_buffers_params p = {};
         p.start_slot = StartSlot;
         p.num_buffers = NumBuffers;
@@ -199,11 +257,11 @@ public:
         struct ms_draw_params p = {VertexCount, StartVertex};
         unix_call(MS_FUNC_DRAW, &p);
     }
-    void WINAPI DrawInstanced(UINT,UINT,UINT,UINT) override {}
-    void WINAPI DrawIndexedInstanced(UINT,UINT,UINT,INT,UINT) override {}
+    void WINAPI DrawInstanced(UINT, UINT, UINT, UINT) override {}
+    void WINAPI DrawIndexedInstanced(UINT, UINT, UINT, INT, UINT) override {}
     void WINAPI DrawAuto() override {}
-    void WINAPI DrawIndexedInstancedIndirect(ID3D11Buffer*,UINT) override {}
-    void WINAPI DrawInstancedIndirect(ID3D11Buffer*,UINT) override {}
+    void WINAPI DrawIndexedInstancedIndirect(ID3D11Buffer*, UINT) override {}
+    void WINAPI DrawInstancedIndirect(ID3D11Buffer*, UINT) override {}
     void WINAPI VSSetShader(ID3D11VertexShader* pShader, ID3D11ClassInstance* const*, UINT) override {
         uint64_t h = obj_handle(pShader);
         unix_call(MS_FUNC_VS_SET_SHADER, &h);
@@ -216,8 +274,8 @@ public:
             p.buffer_handles[i] = obj_handle(ppB[i]);
         unix_call(MS_FUNC_VS_SET_CONSTANT_BUFFERS, &p);
     }
-    void WINAPI VSSetShaderResources(UINT,UINT,ID3D11ShaderResourceView*const*) override {}
-    void WINAPI VSSetSamplers(UINT,UINT,ID3D11SamplerState*const*) override {}
+    void WINAPI VSSetShaderResources(UINT, UINT, ID3D11ShaderResourceView* const*) override {}
+    void WINAPI VSSetSamplers(UINT, UINT, ID3D11SamplerState* const*) override {}
     void WINAPI PSSetShader(ID3D11PixelShader* pShader, ID3D11ClassInstance* const*, UINT) override {
         uint64_t h = obj_handle(pShader);
         unix_call(MS_FUNC_PS_SET_SHADER, &h);
@@ -230,28 +288,29 @@ public:
             p.buffer_handles[i] = obj_handle(ppB[i]);
         unix_call(MS_FUNC_PS_SET_CONSTANT_BUFFERS, &p);
     }
-    void WINAPI PSSetShaderResources(UINT,UINT,ID3D11ShaderResourceView*const*) override {}
-    void WINAPI PSSetSamplers(UINT,UINT,ID3D11SamplerState*const*) override {}
-    void WINAPI GSSetShader(ID3D11GeometryShader*,ID3D11ClassInstance*const*,UINT) override {}
-    void WINAPI GSSetConstantBuffers(UINT,UINT,ID3D11Buffer*const*) override {}
-    void WINAPI GSSetShaderResources(UINT,UINT,ID3D11ShaderResourceView*const*) override {}
-    void WINAPI GSSetSamplers(UINT,UINT,ID3D11SamplerState*const*) override {}
-    void WINAPI CSSetShader(ID3D11ComputeShader*,ID3D11ClassInstance*const*,UINT) override {}
-    void WINAPI CSSetConstantBuffers(UINT,UINT,ID3D11Buffer*const*) override {}
-    void WINAPI CSSetShaderResources(UINT,UINT,ID3D11ShaderResourceView*const*) override {}
-    void WINAPI CSSetSamplers(UINT,UINT,ID3D11SamplerState*const*) override {}
-    void WINAPI CSSetUnorderedAccessViews(UINT,UINT,ID3D11UnorderedAccessView*const*,const UINT*) override {}
-    void WINAPI Dispatch(UINT,UINT,UINT) override {}
-    void WINAPI DispatchIndirect(ID3D11Buffer*,UINT) override {}
-    void WINAPI HSSetShader(ID3D11HullShader*,ID3D11ClassInstance*const*,UINT) override {}
-    void WINAPI HSSetShaderResources(UINT,UINT,ID3D11ShaderResourceView*const*) override {}
-    void WINAPI HSSetSamplers(UINT,UINT,ID3D11SamplerState*const*) override {}
-    void WINAPI HSSetConstantBuffers(UINT,UINT,ID3D11Buffer*const*) override {}
-    void WINAPI DSSetShader(ID3D11DomainShader*,ID3D11ClassInstance*const*,UINT) override {}
-    void WINAPI DSSetShaderResources(UINT,UINT,ID3D11ShaderResourceView*const*) override {}
-    void WINAPI DSSetSamplers(UINT,UINT,ID3D11SamplerState*const*) override {}
-    void WINAPI DSSetConstantBuffers(UINT,UINT,ID3D11Buffer*const*) override {}
-    void WINAPI OMSetRenderTargets(UINT NumViews, ID3D11RenderTargetView* const* ppRTV, ID3D11DepthStencilView* pDSV) override {
+    void WINAPI PSSetShaderResources(UINT, UINT, ID3D11ShaderResourceView* const*) override {}
+    void WINAPI PSSetSamplers(UINT, UINT, ID3D11SamplerState* const*) override {}
+    void WINAPI GSSetShader(ID3D11GeometryShader*, ID3D11ClassInstance* const*, UINT) override {}
+    void WINAPI GSSetConstantBuffers(UINT, UINT, ID3D11Buffer* const*) override {}
+    void WINAPI GSSetShaderResources(UINT, UINT, ID3D11ShaderResourceView* const*) override {}
+    void WINAPI GSSetSamplers(UINT, UINT, ID3D11SamplerState* const*) override {}
+    void WINAPI CSSetShader(ID3D11ComputeShader*, ID3D11ClassInstance* const*, UINT) override {}
+    void WINAPI CSSetConstantBuffers(UINT, UINT, ID3D11Buffer* const*) override {}
+    void WINAPI CSSetShaderResources(UINT, UINT, ID3D11ShaderResourceView* const*) override {}
+    void WINAPI CSSetSamplers(UINT, UINT, ID3D11SamplerState* const*) override {}
+    void WINAPI CSSetUnorderedAccessViews(UINT, UINT, ID3D11UnorderedAccessView* const*, const UINT*) override {}
+    void WINAPI Dispatch(UINT, UINT, UINT) override {}
+    void WINAPI DispatchIndirect(ID3D11Buffer*, UINT) override {}
+    void WINAPI HSSetShader(ID3D11HullShader*, ID3D11ClassInstance* const*, UINT) override {}
+    void WINAPI HSSetShaderResources(UINT, UINT, ID3D11ShaderResourceView* const*) override {}
+    void WINAPI HSSetSamplers(UINT, UINT, ID3D11SamplerState* const*) override {}
+    void WINAPI HSSetConstantBuffers(UINT, UINT, ID3D11Buffer* const*) override {}
+    void WINAPI DSSetShader(ID3D11DomainShader*, ID3D11ClassInstance* const*, UINT) override {}
+    void WINAPI DSSetShaderResources(UINT, UINT, ID3D11ShaderResourceView* const*) override {}
+    void WINAPI DSSetSamplers(UINT, UINT, ID3D11SamplerState* const*) override {}
+    void WINAPI DSSetConstantBuffers(UINT, UINT, ID3D11Buffer* const*) override {}
+    void WINAPI OMSetRenderTargets(UINT NumViews, ID3D11RenderTargetView* const* ppRTV,
+                                   ID3D11DepthStencilView* pDSV) override {
         struct ms_set_render_targets_params p = {};
         p.num_views = NumViews;
         for (UINT i = 0; i < NumViews && i < 8; i++)
@@ -259,9 +318,11 @@ public:
         p.dsv_handle = obj_handle(pDSV);
         unix_call(MS_FUNC_OM_SET_RENDER_TARGETS, &p);
     }
-    void WINAPI OMSetRenderTargetsAndUnorderedAccessViews(UINT,ID3D11RenderTargetView*const*,ID3D11DepthStencilView*,UINT,UINT,ID3D11UnorderedAccessView*const*,const UINT*) override {}
-    void WINAPI OMSetBlendState(ID3D11BlendState*,const FLOAT[4],UINT) override {}
-    void WINAPI OMSetDepthStencilState(ID3D11DepthStencilState*,UINT) override {}
+    void WINAPI OMSetRenderTargetsAndUnorderedAccessViews(UINT, ID3D11RenderTargetView* const*, ID3D11DepthStencilView*,
+                                                          UINT, UINT, ID3D11UnorderedAccessView* const*,
+                                                          const UINT*) override {}
+    void WINAPI OMSetBlendState(ID3D11BlendState*, const FLOAT[4], UINT) override {}
+    void WINAPI OMSetDepthStencilState(ID3D11DepthStencilState*, UINT) override {}
     void WINAPI RSSetState(ID3D11RasterizerState*) override {}
     void WINAPI RSSetViewports(UINT, const D3D11_VIEWPORT* pVP) override {
         struct ms_viewport vp = {};
@@ -275,19 +336,25 @@ public:
         }
         unix_call(MS_FUNC_SET_VIEWPORTS, &vp);
     }
-    void WINAPI RSSetScissorRects(UINT,const D3D11_RECT*) override {}
-    void WINAPI SOSetTargets(UINT,ID3D11Buffer*const*,const UINT*) override {}
+    void WINAPI RSSetScissorRects(UINT, const D3D11_RECT*) override {}
+    void WINAPI SOSetTargets(UINT, ID3D11Buffer* const*, const UINT*) override {}
     void WINAPI ClearRenderTargetView(ID3D11RenderTargetView* pRTV, const FLOAT c[4]) override {
         struct ms_clear_params p = {};
         p.view_handle = obj_handle(pRTV);
-        if (c) { p.r=c[0]; p.g=c[1]; p.b=c[2]; p.a=c[3]; }
+        if (c) {
+            p.r = c[0];
+            p.g = c[1];
+            p.b = c[2];
+            p.a = c[3];
+        }
         unix_call(MS_FUNC_CLEAR_RENDER_TARGET_VIEW, &p);
     }
-    void WINAPI ClearDepthStencilView(ID3D11DepthStencilView*,UINT,FLOAT,UINT8) override {}
-    void WINAPI ClearUnorderedAccessViewUint(ID3D11UnorderedAccessView*,const UINT[4]) override {}
-    void WINAPI ClearUnorderedAccessViewFloat(ID3D11UnorderedAccessView*,const FLOAT[4]) override {}
+    void WINAPI ClearDepthStencilView(ID3D11DepthStencilView*, UINT, FLOAT, UINT8) override {}
+    void WINAPI ClearUnorderedAccessViewUint(ID3D11UnorderedAccessView*, const UINT[4]) override {}
+    void WINAPI ClearUnorderedAccessViewFloat(ID3D11UnorderedAccessView*, const FLOAT[4]) override {}
     void WINAPI ClearState() override {}
-    void WINAPI UpdateSubresource(ID3D11Resource* pRes, UINT Sub, const D3D11_BOX*, const void* pData, UINT RowPitch, UINT DepthPitch) override {
+    void WINAPI UpdateSubresource(ID3D11Resource* pRes, UINT Sub, const D3D11_BOX*, const void* pData, UINT RowPitch,
+                                  UINT DepthPitch) override {
         struct ms_update_subresource_params p = {};
         p.resource_handle = obj_handle(pRes);
         p.subresource = Sub;
@@ -296,60 +363,62 @@ public:
         p.depth_pitch = DepthPitch;
         unix_call(MS_FUNC_UPDATE_SUBRESOURCE, &p);
     }
-    void WINAPI CopyResource(ID3D11Resource*,ID3D11Resource*) override {}
-    void WINAPI CopySubresourceRegion(ID3D11Resource*,UINT,UINT,UINT,UINT,ID3D11Resource*,UINT,const D3D11_BOX*) override {}
-    void WINAPI ResolveSubresource(ID3D11Resource*,UINT,ID3D11Resource*,UINT,DXGI_FORMAT) override {}
+    void WINAPI CopyResource(ID3D11Resource*, ID3D11Resource*) override {}
+    void WINAPI CopySubresourceRegion(ID3D11Resource*, UINT, UINT, UINT, UINT, ID3D11Resource*, UINT,
+                                      const D3D11_BOX*) override {}
+    void WINAPI ResolveSubresource(ID3D11Resource*, UINT, ID3D11Resource*, UINT, DXGI_FORMAT) override {}
     void WINAPI GenerateMips(ID3D11ShaderResourceView*) override {}
-    void WINAPI CopyStructureCount(ID3D11Buffer*,UINT,ID3D11UnorderedAccessView*) override {}
-    void WINAPI SetResourceMinLOD(ID3D11Resource*,FLOAT) override {}
+    void WINAPI CopyStructureCount(ID3D11Buffer*, UINT, ID3D11UnorderedAccessView*) override {}
+    void WINAPI SetResourceMinLOD(ID3D11Resource*, FLOAT) override {}
     FLOAT WINAPI GetResourceMinLOD(ID3D11Resource*) override { return 0.0f; }
-    HRESULT WINAPI Map(ID3D11Resource*,UINT,D3D11_MAP,UINT,D3D11_MAPPED_SUBRESOURCE*) override { return E_NOTIMPL; }
-    void WINAPI Unmap(ID3D11Resource*,UINT) override {}
+    HRESULT WINAPI Map(ID3D11Resource*, UINT, D3D11_MAP, UINT, D3D11_MAPPED_SUBRESOURCE*) override { return E_NOTIMPL; }
+    void WINAPI Unmap(ID3D11Resource*, UINT) override {}
     void WINAPI Flush() override { unix_call(MS_FUNC_FLUSH, nullptr); }
     void WINAPI Begin(ID3D11Asynchronous*) override {}
     void WINAPI End(ID3D11Asynchronous*) override {}
-    HRESULT WINAPI GetData(ID3D11Asynchronous*,void*,UINT,UINT) override { return S_FALSE; }
-    void WINAPI SetPredication(ID3D11Predicate*,BOOL) override {}
-    void WINAPI GetPredication(ID3D11Predicate**,BOOL*) override {}
-    void WINAPI ExecuteCommandList(ID3D11CommandList*,BOOL) override {}
-    HRESULT WINAPI FinishCommandList(BOOL,ID3D11CommandList**) override { return S_OK; }
-    void WINAPI VSGetShader(ID3D11VertexShader**,ID3D11ClassInstance**,UINT*) override {}
-    void WINAPI VSGetConstantBuffers(UINT,UINT,ID3D11Buffer**) override {}
-    void WINAPI VSGetShaderResources(UINT,UINT,ID3D11ShaderResourceView**) override {}
-    void WINAPI VSGetSamplers(UINT,UINT,ID3D11SamplerState**) override {}
-    void WINAPI PSGetShader(ID3D11PixelShader**,ID3D11ClassInstance**,UINT*) override {}
-    void WINAPI PSGetConstantBuffers(UINT,UINT,ID3D11Buffer**) override {}
-    void WINAPI PSGetShaderResources(UINT,UINT,ID3D11ShaderResourceView**) override {}
-    void WINAPI PSGetSamplers(UINT,UINT,ID3D11SamplerState**) override {}
-    void WINAPI GSGetShader(ID3D11GeometryShader**,ID3D11ClassInstance**,UINT*) override {}
-    void WINAPI GSGetConstantBuffers(UINT,UINT,ID3D11Buffer**) override {}
-    void WINAPI GSGetShaderResources(UINT,UINT,ID3D11ShaderResourceView**) override {}
-    void WINAPI GSGetSamplers(UINT,UINT,ID3D11SamplerState**) override {}
-    void WINAPI HSGetShader(ID3D11HullShader**,ID3D11ClassInstance**,UINT*) override {}
-    void WINAPI HSGetConstantBuffers(UINT,UINT,ID3D11Buffer**) override {}
-    void WINAPI HSGetShaderResources(UINT,UINT,ID3D11ShaderResourceView**) override {}
-    void WINAPI HSGetSamplers(UINT,UINT,ID3D11SamplerState**) override {}
-    void WINAPI DSGetShader(ID3D11DomainShader**,ID3D11ClassInstance**,UINT*) override {}
-    void WINAPI DSGetConstantBuffers(UINT,UINT,ID3D11Buffer**) override {}
-    void WINAPI DSGetShaderResources(UINT,UINT,ID3D11ShaderResourceView**) override {}
-    void WINAPI DSGetSamplers(UINT,UINT,ID3D11SamplerState**) override {}
-    void WINAPI CSGetShader(ID3D11ComputeShader**,ID3D11ClassInstance**,UINT*) override {}
-    void WINAPI CSGetConstantBuffers(UINT,UINT,ID3D11Buffer**) override {}
-    void WINAPI CSGetShaderResources(UINT,UINT,ID3D11ShaderResourceView**) override {}
-    void WINAPI CSGetSamplers(UINT,UINT,ID3D11SamplerState**) override {}
-    void WINAPI CSGetUnorderedAccessViews(UINT,UINT,ID3D11UnorderedAccessView**) override {}
+    HRESULT WINAPI GetData(ID3D11Asynchronous*, void*, UINT, UINT) override { return S_FALSE; }
+    void WINAPI SetPredication(ID3D11Predicate*, BOOL) override {}
+    void WINAPI GetPredication(ID3D11Predicate**, BOOL*) override {}
+    void WINAPI ExecuteCommandList(ID3D11CommandList*, BOOL) override {}
+    HRESULT WINAPI FinishCommandList(BOOL, ID3D11CommandList**) override { return S_OK; }
+    void WINAPI VSGetShader(ID3D11VertexShader**, ID3D11ClassInstance**, UINT*) override {}
+    void WINAPI VSGetConstantBuffers(UINT, UINT, ID3D11Buffer**) override {}
+    void WINAPI VSGetShaderResources(UINT, UINT, ID3D11ShaderResourceView**) override {}
+    void WINAPI VSGetSamplers(UINT, UINT, ID3D11SamplerState**) override {}
+    void WINAPI PSGetShader(ID3D11PixelShader**, ID3D11ClassInstance**, UINT*) override {}
+    void WINAPI PSGetConstantBuffers(UINT, UINT, ID3D11Buffer**) override {}
+    void WINAPI PSGetShaderResources(UINT, UINT, ID3D11ShaderResourceView**) override {}
+    void WINAPI PSGetSamplers(UINT, UINT, ID3D11SamplerState**) override {}
+    void WINAPI GSGetShader(ID3D11GeometryShader**, ID3D11ClassInstance**, UINT*) override {}
+    void WINAPI GSGetConstantBuffers(UINT, UINT, ID3D11Buffer**) override {}
+    void WINAPI GSGetShaderResources(UINT, UINT, ID3D11ShaderResourceView**) override {}
+    void WINAPI GSGetSamplers(UINT, UINT, ID3D11SamplerState**) override {}
+    void WINAPI HSGetShader(ID3D11HullShader**, ID3D11ClassInstance**, UINT*) override {}
+    void WINAPI HSGetConstantBuffers(UINT, UINT, ID3D11Buffer**) override {}
+    void WINAPI HSGetShaderResources(UINT, UINT, ID3D11ShaderResourceView**) override {}
+    void WINAPI HSGetSamplers(UINT, UINT, ID3D11SamplerState**) override {}
+    void WINAPI DSGetShader(ID3D11DomainShader**, ID3D11ClassInstance**, UINT*) override {}
+    void WINAPI DSGetConstantBuffers(UINT, UINT, ID3D11Buffer**) override {}
+    void WINAPI DSGetShaderResources(UINT, UINT, ID3D11ShaderResourceView**) override {}
+    void WINAPI DSGetSamplers(UINT, UINT, ID3D11SamplerState**) override {}
+    void WINAPI CSGetShader(ID3D11ComputeShader**, ID3D11ClassInstance**, UINT*) override {}
+    void WINAPI CSGetConstantBuffers(UINT, UINT, ID3D11Buffer**) override {}
+    void WINAPI CSGetShaderResources(UINT, UINT, ID3D11ShaderResourceView**) override {}
+    void WINAPI CSGetSamplers(UINT, UINT, ID3D11SamplerState**) override {}
+    void WINAPI CSGetUnorderedAccessViews(UINT, UINT, ID3D11UnorderedAccessView**) override {}
     void WINAPI IAGetInputLayout(ID3D11InputLayout**) override {}
-    void WINAPI IAGetVertexBuffers(UINT,UINT,ID3D11Buffer**,UINT*,UINT*) override {}
-    void WINAPI IAGetIndexBuffer(ID3D11Buffer**,DXGI_FORMAT*,UINT*) override {}
+    void WINAPI IAGetVertexBuffers(UINT, UINT, ID3D11Buffer**, UINT*, UINT*) override {}
+    void WINAPI IAGetIndexBuffer(ID3D11Buffer**, DXGI_FORMAT*, UINT*) override {}
     void WINAPI IAGetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY*) override {}
-    void WINAPI OMGetRenderTargets(UINT,ID3D11RenderTargetView**,ID3D11DepthStencilView**) override {}
-    void WINAPI OMGetRenderTargetsAndUnorderedAccessViews(UINT,ID3D11RenderTargetView**,ID3D11DepthStencilView**,UINT,UINT,ID3D11UnorderedAccessView**) override {}
-    void WINAPI OMGetBlendState(ID3D11BlendState**,FLOAT[4],UINT*) override {}
-    void WINAPI OMGetDepthStencilState(ID3D11DepthStencilState**,UINT*) override {}
+    void WINAPI OMGetRenderTargets(UINT, ID3D11RenderTargetView**, ID3D11DepthStencilView**) override {}
+    void WINAPI OMGetRenderTargetsAndUnorderedAccessViews(UINT, ID3D11RenderTargetView**, ID3D11DepthStencilView**,
+                                                          UINT, UINT, ID3D11UnorderedAccessView**) override {}
+    void WINAPI OMGetBlendState(ID3D11BlendState**, FLOAT[4], UINT*) override {}
+    void WINAPI OMGetDepthStencilState(ID3D11DepthStencilState**, UINT*) override {}
     void WINAPI RSGetState(ID3D11RasterizerState**) override {}
-    void WINAPI RSGetViewports(UINT*,D3D11_VIEWPORT*) override {}
-    void WINAPI RSGetScissorRects(UINT*,D3D11_RECT*) override {}
-    void WINAPI SOGetTargets(UINT,ID3D11Buffer**) override {}
+    void WINAPI RSGetViewports(UINT*, D3D11_VIEWPORT*) override {}
+    void WINAPI RSGetScissorRects(UINT*, D3D11_RECT*) override {}
+    void WINAPI SOGetTargets(UINT, ID3D11Buffer**) override {}
 };
 
 static MSDeviceContext g_ctx_impl;
@@ -357,45 +426,62 @@ static MSDeviceContext g_ctx_impl;
 class MSCPSwapChain : public IDXGISwapChain {
     LONG m_ref = 1;
     DXGI_SWAP_CHAIN_DESC m_desc;
-public:
+
+  public:
     MSCPSwapChain() { memset(&m_desc, 0, sizeof(m_desc)); }
-    
+
     HRESULT WINAPI QueryInterface(REFIID riid, void** ppv) override {
-        if (ppv) *ppv = nullptr;
+        if (ppv)
+            *ppv = nullptr;
         return E_NOINTERFACE;
     }
     ULONG WINAPI AddRef() override { return InterlockedIncrement(&m_ref); }
-    ULONG WINAPI Release() override { LONG r = InterlockedDecrement(&m_ref); return r ? r : 1; }
+    ULONG WINAPI Release() override {
+        LONG r = InterlockedDecrement(&m_ref);
+        return r ? r : 1;
+    }
     HRESULT WINAPI SetPrivateDataInterface(REFGUID, const IUnknown*) override { return S_OK; }
     HRESULT WINAPI GetPrivateData(REFGUID, UINT*, void*) override { return E_NOTIMPL; }
     HRESULT WINAPI SetPrivateData(REFGUID, UINT, const void*) override { return S_OK; }
-    HRESULT WINAPI GetParent(REFIID, void** pp) override { if(pp)*pp=nullptr; return E_NOINTERFACE; }
-    HRESULT WINAPI GetDevice(REFIID, void** pp) override { if(pp)*pp=nullptr; return E_NOINTERFACE; }
-    
+    HRESULT WINAPI GetParent(REFIID, void** pp) override {
+        if (pp)
+            *pp = nullptr;
+        return E_NOINTERFACE;
+    }
+    HRESULT WINAPI GetDevice(REFIID, void** pp) override {
+        if (pp)
+            *pp = nullptr;
+        return E_NOINTERFACE;
+    }
+
     HRESULT WINAPI Present(UINT SyncInterval, UINT Flags) override {
         unix_call(MS_FUNC_PRESENT, nullptr);
         return S_OK;
     }
-    
+
     HRESULT WINAPI GetBuffer(UINT Buffer, REFIID riid, void** ppSurface) override {
-        if (!ppSurface) return E_POINTER;
+        if (!ppSurface)
+            return E_POINTER;
         struct ms_get_buffer_params p = {};
         p.buffer_index = Buffer;
         NTSTATUS r = unix_call(MS_FUNC_GET_BUFFER, &p);
-        if (r < 0) return E_FAIL;
-        
+        if (r < 0)
+            return E_FAIL;
+
         auto* tex = new MSTexture2D();
         set_handle(tex, p.out_handle);
         *ppSurface = tex;
         return S_OK;
     }
-    
+
     HRESULT WINAPI GetDesc(DXGI_SWAP_CHAIN_DESC* pDesc) override {
-        if (pDesc) *pDesc = m_desc;
+        if (pDesc)
+            *pDesc = m_desc;
         return S_OK;
     }
-    
-    HRESULT WINAPI ResizeBuffers(UINT BufferCount, UINT Width, UINT Height, DXGI_FORMAT NewFormat, UINT SwapChainFlags) override {
+
+    HRESULT WINAPI ResizeBuffers(UINT BufferCount, UINT Width, UINT Height, DXGI_FORMAT NewFormat,
+                                 UINT SwapChainFlags) override {
         struct ms_resize_params p = {};
         p.width = Width;
         p.height = Height;
@@ -403,16 +489,35 @@ public:
         unix_call(MS_FUNC_RESIZE_BUFFERS, &p);
         return S_OK;
     }
-    
+
     HRESULT WINAPI ResizeTarget(const DXGI_MODE_DESC* pNewTargetParameters) override { return S_OK; }
-    HRESULT WINAPI GetContainingOutput(IDXGIOutput** ppOutput) override { if(ppOutput)*ppOutput=nullptr; return E_NOTIMPL; }
-    HRESULT WINAPI GetFrameStatistics(DXGI_FRAME_STATISTICS* pStats) override { if(pStats) memset(pStats,0,sizeof(*pStats)); return S_OK; }
-    HRESULT WINAPI GetLastPresentCount(UINT* pLastPresentCount) override { if(pLastPresentCount)*pLastPresentCount=0; return S_OK; }
+    HRESULT WINAPI GetContainingOutput(IDXGIOutput** ppOutput) override {
+        if (ppOutput)
+            *ppOutput = nullptr;
+        return E_NOTIMPL;
+    }
+    HRESULT WINAPI GetFrameStatistics(DXGI_FRAME_STATISTICS* pStats) override {
+        if (pStats)
+            memset(pStats, 0, sizeof(*pStats));
+        return S_OK;
+    }
+    HRESULT WINAPI GetLastPresentCount(UINT* pLastPresentCount) override {
+        if (pLastPresentCount)
+            *pLastPresentCount = 0;
+        return S_OK;
+    }
     HRESULT WINAPI SetFullscreenState(BOOL Fullscreen, IDXGIOutput* pTarget) override { return S_OK; }
-    HRESULT WINAPI GetFullscreenState(BOOL* pFullscreen, IDXGIOutput** ppTarget) override { if(pFullscreen)*pFullscreen=FALSE; if(ppTarget)*ppTarget=nullptr; return S_OK; }
-    
+    HRESULT WINAPI GetFullscreenState(BOOL* pFullscreen, IDXGIOutput** ppTarget) override {
+        if (pFullscreen)
+            *pFullscreen = FALSE;
+        if (ppTarget)
+            *ppTarget = nullptr;
+        return S_OK;
+    }
+
     void InitDesc(const DXGI_SWAP_CHAIN_DESC* pDesc) {
-        if (pDesc) m_desc = *pDesc;
+        if (pDesc)
+            m_desc = *pDesc;
     }
 };
 
@@ -440,25 +545,38 @@ void InitSwapChain(const DXGI_SWAP_CHAIN_DESC* pDesc) {
 
 class MSDevice : public ID3D11Device {
     LONG m_ref = 1;
-public:
+
+  public:
     MS_QI
-    void WINAPI GetImmediateContext(ID3D11DeviceContext** pp) override { if(pp) *pp = g_ctx; }
-    HRESULT WINAPI CheckFeatureSupport(D3D11_FEATURE,void*,UINT) override { return E_NOTIMPL; }
-    HRESULT WINAPI CheckMultisampleQualityLevels(DXGI_FORMAT,UINT,UINT*) override { return E_NOTIMPL; }
+    void WINAPI GetImmediateContext(ID3D11DeviceContext** pp) override {
+        if (pp)
+            *pp = g_ctx;
+    }
+    HRESULT WINAPI CheckFeatureSupport(D3D11_FEATURE, void*, UINT) override { return E_NOTIMPL; }
+    HRESULT WINAPI CheckMultisampleQualityLevels(DXGI_FORMAT, UINT, UINT*) override { return E_NOTIMPL; }
     void WINAPI CheckCounterInfo(D3D11_COUNTER_INFO*) override {}
-    HRESULT WINAPI CheckCounter(const D3D11_COUNTER_DESC*,D3D11_COUNTER_TYPE*,UINT*,LPSTR,UINT*,LPSTR,UINT*,LPSTR,UINT*) override { return E_NOTIMPL; }
-    HRESULT WINAPI CheckFormatSupport(DXGI_FORMAT,UINT* pS) override { if(pS)*pS=0x3FFF; return S_OK; }
-    HRESULT WINAPI GetPrivateData(REFGUID,UINT*,void*) override { return E_NOTIMPL; }
-    HRESULT WINAPI SetPrivateData(REFGUID,UINT,const void*) override { return S_OK; }
-    HRESULT WINAPI SetPrivateDataInterface(REFGUID,const IUnknown*) override { return S_OK; }
+    HRESULT WINAPI CheckCounter(const D3D11_COUNTER_DESC*, D3D11_COUNTER_TYPE*, UINT*, LPSTR, UINT*, LPSTR, UINT*,
+                                LPSTR, UINT*) override {
+        return E_NOTIMPL;
+    }
+    HRESULT WINAPI CheckFormatSupport(DXGI_FORMAT, UINT* pS) override {
+        if (pS)
+            *pS = 0x3FFF;
+        return S_OK;
+    }
+    HRESULT WINAPI GetPrivateData(REFGUID, UINT*, void*) override { return E_NOTIMPL; }
+    HRESULT WINAPI SetPrivateData(REFGUID, UINT, const void*) override { return S_OK; }
+    HRESULT WINAPI SetPrivateDataInterface(REFGUID, const IUnknown*) override { return S_OK; }
     D3D_FEATURE_LEVEL WINAPI GetFeatureLevel() override { return D3D_FEATURE_LEVEL_11_0; }
     UINT WINAPI GetCreationFlags() override { return 0; }
     HRESULT WINAPI GetDeviceRemovedReason() override { return S_OK; }
     UINT WINAPI GetExceptionMode() override { return 0; }
     HRESULT WINAPI SetExceptionMode(UINT) override { return S_OK; }
 
-    HRESULT WINAPI CreateBuffer(const D3D11_BUFFER_DESC* pDesc, const D3D11_SUBRESOURCE_DATA* pInit, ID3D11Buffer** ppOut) override {
-        if (!ppOut) return S_OK;
+    HRESULT WINAPI CreateBuffer(const D3D11_BUFFER_DESC* pDesc, const D3D11_SUBRESOURCE_DATA* pInit,
+                                ID3D11Buffer** ppOut) override {
+        if (!ppOut)
+            return S_OK;
         auto* obj = new MSBuffer();
         struct ms_create_buffer_params p = {};
         if (pDesc) {
@@ -474,13 +592,19 @@ public:
             p.initial_data_size = pDesc ? pDesc->ByteWidth : 0;
         }
         NTSTATUS ret = unix_call(MS_FUNC_CREATE_BUFFER, &p);
-        if (ret >= 0) set_handle(obj, p.out_handle);
+        if (ret >= 0)
+            set_handle(obj, p.out_handle);
         *ppOut = obj;
         return S_OK;
     }
-    HRESULT WINAPI CreateTexture1D(const D3D11_TEXTURE1D_DESC*,const D3D11_SUBRESOURCE_DATA*,ID3D11Texture1D**) override { return S_OK; }
-    HRESULT WINAPI CreateTexture2D(const D3D11_TEXTURE2D_DESC* pDesc, const D3D11_SUBRESOURCE_DATA*, ID3D11Texture2D** ppOut) override {
-        if (!ppOut) return S_OK;
+    HRESULT WINAPI CreateTexture1D(const D3D11_TEXTURE1D_DESC*, const D3D11_SUBRESOURCE_DATA*,
+                                   ID3D11Texture1D**) override {
+        return S_OK;
+    }
+    HRESULT WINAPI CreateTexture2D(const D3D11_TEXTURE2D_DESC* pDesc, const D3D11_SUBRESOURCE_DATA*,
+                                   ID3D11Texture2D** ppOut) override {
+        if (!ppOut)
+            return S_OK;
         auto* obj = new MSTexture2D();
         struct ms_create_texture_2d_params p = {};
         if (pDesc) {
@@ -497,67 +621,107 @@ public:
             p.misc_flags = (uint32_t)pDesc->MiscFlags;
         }
         NTSTATUS ret = unix_call(MS_FUNC_CREATE_TEXTURE_2D, &p);
-        if (ret >= 0) set_handle(obj, p.out_handle);
+        if (ret >= 0)
+            set_handle(obj, p.out_handle);
         *ppOut = obj;
         return S_OK;
     }
-    HRESULT WINAPI CreateTexture3D(const D3D11_TEXTURE3D_DESC*,const D3D11_SUBRESOURCE_DATA*,ID3D11Texture3D**) override { return S_OK; }
-    HRESULT WINAPI CreateShaderResourceView(ID3D11Resource*,const D3D11_SHADER_RESOURCE_VIEW_DESC*,ID3D11ShaderResourceView**) override { return S_OK; }
-    HRESULT WINAPI CreateUnorderedAccessView(ID3D11Resource*,const D3D11_UNORDERED_ACCESS_VIEW_DESC*,ID3D11UnorderedAccessView**) override { return S_OK; }
-    HRESULT WINAPI CreateRenderTargetView(ID3D11Resource* pRes, const D3D11_RENDER_TARGET_VIEW_DESC* pDesc, ID3D11RenderTargetView** ppOut) override {
-        if (!ppOut) return S_OK;
+    HRESULT WINAPI CreateTexture3D(const D3D11_TEXTURE3D_DESC*, const D3D11_SUBRESOURCE_DATA*,
+                                   ID3D11Texture3D**) override {
+        return S_OK;
+    }
+    HRESULT WINAPI CreateShaderResourceView(ID3D11Resource*, const D3D11_SHADER_RESOURCE_VIEW_DESC*,
+                                            ID3D11ShaderResourceView**) override {
+        return S_OK;
+    }
+    HRESULT WINAPI CreateUnorderedAccessView(ID3D11Resource*, const D3D11_UNORDERED_ACCESS_VIEW_DESC*,
+                                             ID3D11UnorderedAccessView**) override {
+        return S_OK;
+    }
+    HRESULT WINAPI CreateRenderTargetView(ID3D11Resource* pRes, const D3D11_RENDER_TARGET_VIEW_DESC* pDesc,
+                                          ID3D11RenderTargetView** ppOut) override {
+        if (!ppOut)
+            return S_OK;
         auto* obj = new MSDeviceChildStub();
         struct ms_create_rt_view_params p = {};
         p.texture_handle = obj_handle(pRes);
         p.format = pDesc ? (uint32_t)pDesc->Format : 0;
         p.mip_slice = 0;
         NTSTATUS ret = unix_call(MS_FUNC_CREATE_RENDER_TARGET_VIEW, &p);
-        if (ret >= 0) set_handle(obj, p.out_handle);
+        if (ret >= 0)
+            set_handle(obj, p.out_handle);
         *ppOut = (ID3D11RenderTargetView*)obj;
         return S_OK;
     }
-    HRESULT WINAPI CreateDepthStencilView(ID3D11Resource*,const D3D11_DEPTH_STENCIL_VIEW_DESC*,ID3D11DepthStencilView**) override { return S_OK; }
-    HRESULT WINAPI CreateInputLayout(const D3D11_INPUT_ELEMENT_DESC*,UINT,const void*,SIZE_T,ID3D11InputLayout** ppOut) override {
-        if (ppOut) *ppOut = (ID3D11InputLayout*)new MSDeviceChildStub();
+    HRESULT WINAPI CreateDepthStencilView(ID3D11Resource*, const D3D11_DEPTH_STENCIL_VIEW_DESC*,
+                                          ID3D11DepthStencilView**) override {
         return S_OK;
     }
-    HRESULT WINAPI CreateVertexShader(const void* pBC, SIZE_T Len, ID3D11ClassLinkage*, ID3D11VertexShader** ppOut) override {
-        if (!ppOut) return S_OK;
+    HRESULT WINAPI CreateInputLayout(const D3D11_INPUT_ELEMENT_DESC*, UINT, const void*, SIZE_T,
+                                     ID3D11InputLayout** ppOut) override {
+        if (ppOut)
+            *ppOut = (ID3D11InputLayout*)new MSDeviceChildStub();
+        return S_OK;
+    }
+    HRESULT WINAPI CreateVertexShader(const void* pBC, SIZE_T Len, ID3D11ClassLinkage*,
+                                      ID3D11VertexShader** ppOut) override {
+        if (!ppOut)
+            return S_OK;
         auto* obj = new MSDeviceChildStub();
         struct ms_create_shader_params p = {};
         p.bytecode = pBC;
         p.bytecode_size = (uint32_t)Len;
         NTSTATUS ret = unix_call(MS_FUNC_CREATE_VERTEX_SHADER, &p);
-        if (ret >= 0) set_handle(obj, p.out_handle);
+        if (ret >= 0)
+            set_handle(obj, p.out_handle);
         *ppOut = (ID3D11VertexShader*)obj;
         return S_OK;
     }
-    HRESULT WINAPI CreateGeometryShader(const void*,SIZE_T,ID3D11ClassLinkage*,ID3D11GeometryShader**) override { return S_OK; }
-    HRESULT WINAPI CreateGeometryShaderWithStreamOutput(const void*,SIZE_T,const D3D11_SO_DECLARATION_ENTRY*,UINT,const UINT*,UINT,UINT,ID3D11ClassLinkage*,ID3D11GeometryShader**) override { return S_OK; }
-    HRESULT WINAPI CreatePixelShader(const void* pBC, SIZE_T Len, ID3D11ClassLinkage*, ID3D11PixelShader** ppOut) override {
-        if (!ppOut) return S_OK;
+    HRESULT WINAPI CreateGeometryShader(const void*, SIZE_T, ID3D11ClassLinkage*, ID3D11GeometryShader**) override {
+        return S_OK;
+    }
+    HRESULT WINAPI CreateGeometryShaderWithStreamOutput(const void*, SIZE_T, const D3D11_SO_DECLARATION_ENTRY*, UINT,
+                                                        const UINT*, UINT, UINT, ID3D11ClassLinkage*,
+                                                        ID3D11GeometryShader**) override {
+        return S_OK;
+    }
+    HRESULT WINAPI CreatePixelShader(const void* pBC, SIZE_T Len, ID3D11ClassLinkage*,
+                                     ID3D11PixelShader** ppOut) override {
+        if (!ppOut)
+            return S_OK;
         auto* obj = new MSDeviceChildStub();
         struct ms_create_shader_params p = {};
         p.bytecode = pBC;
         p.bytecode_size = (uint32_t)Len;
         NTSTATUS ret = unix_call(MS_FUNC_CREATE_PIXEL_SHADER, &p);
-        if (ret >= 0) set_handle(obj, p.out_handle);
+        if (ret >= 0)
+            set_handle(obj, p.out_handle);
         *ppOut = (ID3D11PixelShader*)obj;
         return S_OK;
     }
-    HRESULT WINAPI CreateHullShader(const void*,SIZE_T,ID3D11ClassLinkage*,ID3D11HullShader**) override { return S_OK; }
-    HRESULT WINAPI CreateDomainShader(const void*,SIZE_T,ID3D11ClassLinkage*,ID3D11DomainShader**) override { return S_OK; }
-    HRESULT WINAPI CreateComputeShader(const void*,SIZE_T,ID3D11ClassLinkage*,ID3D11ComputeShader**) override { return S_OK; }
+    HRESULT WINAPI CreateHullShader(const void*, SIZE_T, ID3D11ClassLinkage*, ID3D11HullShader**) override {
+        return S_OK;
+    }
+    HRESULT WINAPI CreateDomainShader(const void*, SIZE_T, ID3D11ClassLinkage*, ID3D11DomainShader**) override {
+        return S_OK;
+    }
+    HRESULT WINAPI CreateComputeShader(const void*, SIZE_T, ID3D11ClassLinkage*, ID3D11ComputeShader**) override {
+        return S_OK;
+    }
     HRESULT WINAPI CreateClassLinkage(ID3D11ClassLinkage**) override { return S_OK; }
-    HRESULT WINAPI CreateBlendState(const D3D11_BLEND_DESC*,ID3D11BlendState**) override { return S_OK; }
-    HRESULT WINAPI CreateDepthStencilState(const D3D11_DEPTH_STENCIL_DESC*,ID3D11DepthStencilState**) override { return S_OK; }
-    HRESULT WINAPI CreateRasterizerState(const D3D11_RASTERIZER_DESC*,ID3D11RasterizerState**) override { return S_OK; }
-    HRESULT WINAPI CreateSamplerState(const D3D11_SAMPLER_DESC*,ID3D11SamplerState**) override { return S_OK; }
-    HRESULT WINAPI CreateQuery(const D3D11_QUERY_DESC*,ID3D11Query**) override { return S_OK; }
-    HRESULT WINAPI CreatePredicate(const D3D11_QUERY_DESC*,ID3D11Predicate**) override { return S_OK; }
-    HRESULT WINAPI CreateCounter(const D3D11_COUNTER_DESC*,ID3D11Counter**) override { return E_NOTIMPL; }
-    HRESULT WINAPI CreateDeferredContext(UINT,ID3D11DeviceContext**) override { return E_NOTIMPL; }
-    HRESULT WINAPI OpenSharedResource(HANDLE,REFIID,void**) override { return E_NOTIMPL; }
+    HRESULT WINAPI CreateBlendState(const D3D11_BLEND_DESC*, ID3D11BlendState**) override { return S_OK; }
+    HRESULT WINAPI CreateDepthStencilState(const D3D11_DEPTH_STENCIL_DESC*, ID3D11DepthStencilState**) override {
+        return S_OK;
+    }
+    HRESULT WINAPI CreateRasterizerState(const D3D11_RASTERIZER_DESC*, ID3D11RasterizerState**) override {
+        return S_OK;
+    }
+    HRESULT WINAPI CreateSamplerState(const D3D11_SAMPLER_DESC*, ID3D11SamplerState**) override { return S_OK; }
+    HRESULT WINAPI CreateQuery(const D3D11_QUERY_DESC*, ID3D11Query**) override { return S_OK; }
+    HRESULT WINAPI CreatePredicate(const D3D11_QUERY_DESC*, ID3D11Predicate**) override { return S_OK; }
+    HRESULT WINAPI CreateCounter(const D3D11_COUNTER_DESC*, ID3D11Counter**) override { return E_NOTIMPL; }
+    HRESULT WINAPI CreateDeferredContext(UINT, ID3D11DeviceContext**) override { return E_NOTIMPL; }
+    HRESULT WINAPI OpenSharedResource(HANDLE, REFIID, void**) override { return E_NOTIMPL; }
 };
 
 static MSDevice g_dev_impl;
@@ -574,14 +738,12 @@ BOOL WINAPI DllMain(HINSTANCE inst, DWORD reason, LPVOID reserved) {
 
 extern "C" {
 
-__declspec(dllexport)
-HRESULT WINAPI D3D11CreateDeviceAndSwapChain(
-    IDXGIAdapter*, D3D_DRIVER_TYPE, HMODULE, UINT,
-    const D3D_FEATURE_LEVEL*, UINT, UINT,
-    const DXGI_SWAP_CHAIN_DESC* pSwapChainDesc, IDXGISwapChain** ppSwapChain,
-    ID3D11Device** ppDevice, D3D_FEATURE_LEVEL* pFL,
-    ID3D11DeviceContext** ppCtx)
-{
+__declspec(dllexport) HRESULT WINAPI D3D11CreateDeviceAndSwapChain(IDXGIAdapter*, D3D_DRIVER_TYPE, HMODULE, UINT,
+                                                                   const D3D_FEATURE_LEVEL*, UINT, UINT,
+                                                                   const DXGI_SWAP_CHAIN_DESC* pSwapChainDesc,
+                                                                   IDXGISwapChain** ppSwapChain,
+                                                                   ID3D11Device** ppDevice, D3D_FEATURE_LEVEL* pFL,
+                                                                   ID3D11DeviceContext** ppCtx) {
     fprintf(stderr, "[metalsharp] D3D11CreateDevice called\n");
     if (!init_unix_call()) {
         fprintf(stderr, "[metalsharp] FAILED to init unix call bridge\n");
@@ -589,38 +751,36 @@ HRESULT WINAPI D3D11CreateDeviceAndSwapChain(
     }
     NTSTATUS r = unix_call(MS_FUNC_INIT, nullptr);
     fprintf(stderr, "[metalsharp] INIT returned %ld\n", r);
-    if (r < 0) return E_FAIL;
+    if (r < 0)
+        return E_FAIL;
     unix_call(MS_FUNC_CREATE_DEVICE, nullptr);
-    if (ppDevice) *ppDevice = &g_dev_impl;
-    if (ppCtx) *ppCtx = g_ctx;
-    if (pFL) *pFL = D3D_FEATURE_LEVEL_11_0;
-    
+    if (ppDevice)
+        *ppDevice = &g_dev_impl;
+    if (ppCtx)
+        *ppCtx = g_ctx;
+    if (pFL)
+        *pFL = D3D_FEATURE_LEVEL_11_0;
+
     if (pSwapChainDesc && ppSwapChain) {
         InitSwapChain(pSwapChainDesc);
         *ppSwapChain = &g_swapchain;
     }
-    
+
     return S_OK;
 }
 
-__declspec(dllexport)
-HRESULT WINAPI D3D11CreateDevice(
-    IDXGIAdapter* a, D3D_DRIVER_TYPE dt, HMODULE sw, UINT f,
-    const D3D_FEATURE_LEVEL* fl, UINT nfl, UINT sdk,
-    ID3D11Device** ppDev, D3D_FEATURE_LEVEL* pFL2,
-    ID3D11DeviceContext** ppCtx)
-{
+__declspec(dllexport) HRESULT WINAPI D3D11CreateDevice(IDXGIAdapter* a, D3D_DRIVER_TYPE dt, HMODULE sw, UINT f,
+                                                       const D3D_FEATURE_LEVEL* fl, UINT nfl, UINT sdk,
+                                                       ID3D11Device** ppDev, D3D_FEATURE_LEVEL* pFL2,
+                                                       ID3D11DeviceContext** ppCtx) {
     return D3D11CreateDeviceAndSwapChain(a, dt, sw, f, fl, nfl, sdk, NULL, NULL, ppDev, pFL2, ppCtx);
 }
 
-__declspec(dllexport)
-long MetalSharpUnixCall(unsigned int code, void* args) {
+__declspec(dllexport) long MetalSharpUnixCall(unsigned int code, void* args) {
     return unix_call(code, args);
 }
 
-__declspec(dllexport)
-void* MetalSharpGetSwapChain() {
+__declspec(dllexport) void* MetalSharpGetSwapChain() {
     return &g_swapchain;
 }
-
 }

--- a/src/wine/d3d9_pe.cpp
+++ b/src/wine/d3d9_pe.cpp
@@ -1,14 +1,16 @@
 /// @file d3d9_pe.cpp
 /// @brief Wine D3D9 PE module with COM interface forwarding.
 ///
-/// Standalone Wine PE-side d3d9.dll that implements IDirect3D9 and IDirect3DDevice9 COM interfaces. Forwards create/execute calls through Wine's unixlib mechanism to a platform-specific rendering backend for legacy D3D9 games.
+/// Standalone Wine PE-side d3d9.dll that implements IDirect3D9 and IDirect3DDevice9 COM interfaces. Forwards
+/// create/execute calls through Wine's unixlib mechanism to a platform-specific rendering backend for legacy D3D9
+/// games.
 #include <d3d9.h>
 #include <d3d9caps.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include <stdint.h>
-#include <windows.h>
 #include <unordered_map>
+#include <windows.h>
 #include <winternl.h>
 
 #pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
@@ -17,45 +19,73 @@
 
 typedef long NTSTATUS;
 typedef unsigned long long unixlib_handle_t;
-typedef NTSTATUS (WINAPI *unix_call_dispatcher_t)(unixlib_handle_t, unsigned int, void*);
+typedef NTSTATUS(WINAPI* unix_call_dispatcher_t)(unixlib_handle_t, unsigned int, void*);
 
 static unixlib_handle_t g_unixlib_handle = 0;
 static unix_call_dispatcher_t g_unix_call_dispatcher = nullptr;
 static HMODULE g_hModule = nullptr;
 
 static NTSTATUS unix_call(unsigned int code, void* args) {
-    if (!g_unix_call_dispatcher || !g_unixlib_handle) return (NTSTATUS)0xC000000E;
+    if (!g_unix_call_dispatcher || !g_unixlib_handle)
+        return (NTSTATUS)0xC000000E;
     return g_unix_call_dispatcher(g_unixlib_handle, code, args);
 }
 
 static bool init_unix_call() {
-    if (g_unixlib_handle && g_unix_call_dispatcher) return true;
+    if (g_unixlib_handle && g_unix_call_dispatcher)
+        return true;
     HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
-    if (!ntdll) return false;
-    typedef NTSTATUS (NTAPI *pNtQVM)(HANDLE, const void*, ULONG, void*, SIZE_T, SIZE_T*);
+    if (!ntdll)
+        return false;
+    typedef NTSTATUS(NTAPI * pNtQVM)(HANDLE, const void*, ULONG, void*, SIZE_T, SIZE_T*);
     auto pNtQueryVirtualMemory = (pNtQVM)GetProcAddress(ntdll, "NtQueryVirtualMemory");
-    if (!pNtQueryVirtualMemory) return false;
+    if (!pNtQueryVirtualMemory)
+        return false;
     unixlib_handle_t handle = 0;
-    NTSTATUS status = pNtQueryVirtualMemory((HANDLE)(LONG_PTR)-1, (const void*)g_hModule, 1000, &handle, sizeof(handle), nullptr);
-    if (status < 0) return false;
+    NTSTATUS status =
+        pNtQueryVirtualMemory((HANDLE)(LONG_PTR)-1, (const void*)g_hModule, 1000, &handle, sizeof(handle), nullptr);
+    if (status < 0)
+        return false;
     g_unixlib_handle = handle;
     void** ptr = (void**)GetProcAddress(ntdll, "__wine_unix_call_dispatcher");
-    if (ptr && *ptr) g_unix_call_dispatcher = (unix_call_dispatcher_t)*ptr;
-    else g_unix_call_dispatcher = (unix_call_dispatcher_t)GetProcAddress(ntdll, "__wine_unix_call_dispatcher");
+    if (ptr && *ptr)
+        g_unix_call_dispatcher = (unix_call_dispatcher_t)*ptr;
+    else
+        g_unix_call_dispatcher = (unix_call_dispatcher_t)GetProcAddress(ntdll, "__wine_unix_call_dispatcher");
     return g_unix_call_dispatcher != nullptr;
 }
 
 static std::unordered_map<void*, uint64_t> g_handles;
-static uint64_t obj_handle(void* obj) { if(!obj) return 0; auto it=g_handles.find(obj); return it!=g_handles.end()?it->second:0; }
-static void set_handle(void* obj, uint64_t h) { if(obj) g_handles[obj]=h; }
+static uint64_t obj_handle(void* obj) {
+    if (!obj)
+        return 0;
+    auto it = g_handles.find(obj);
+    return it != g_handles.end() ? it->second : 0;
+}
+static void set_handle(void* obj, uint64_t h) {
+    if (obj)
+        g_handles[obj] = h;
+}
 
 class MSD3DSurface : public IDirect3DSurface9 {
     LONG m_ref = 1;
-public:
-    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override { if(ppv)*ppv=nullptr; return E_NOINTERFACE; }
+
+  public:
+    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override {
+        if (ppv)
+            *ppv = nullptr;
+        return E_NOINTERFACE;
+    }
     ULONG WINAPI AddRef() override { return InterlockedIncrement(&m_ref); }
-    ULONG WINAPI Release() override { ULONG r = InterlockedDecrement(&m_ref); return r ? r : 0; }
-    HRESULT WINAPI GetDevice(IDirect3DDevice9** pp) override { if(pp)*pp=nullptr; return S_OK; }
+    ULONG WINAPI Release() override {
+        ULONG r = InterlockedDecrement(&m_ref);
+        return r ? r : 0;
+    }
+    HRESULT WINAPI GetDevice(IDirect3DDevice9** pp) override {
+        if (pp)
+            *pp = nullptr;
+        return S_OK;
+    }
     HRESULT WINAPI SetPrivateData(REFGUID, const void*, DWORD, DWORD) override { return S_OK; }
     HRESULT WINAPI GetPrivateData(REFGUID, void*, DWORD*) override { return E_NOTIMPL; }
     HRESULT WINAPI FreePrivateData(REFGUID) override { return S_OK; }
@@ -64,7 +94,11 @@ public:
     void WINAPI PreLoad() override {}
     D3DRESOURCETYPE WINAPI GetType() override { return D3DRTYPE_SURFACE; }
     HRESULT WINAPI GetContainer(REFIID, void**) override { return E_NOTIMPL; }
-    HRESULT WINAPI GetDesc(D3DSURFACE_DESC* pDesc) override { if(pDesc) memset(pDesc,0,sizeof(*pDesc)); return S_OK; }
+    HRESULT WINAPI GetDesc(D3DSURFACE_DESC* pDesc) override {
+        if (pDesc)
+            memset(pDesc, 0, sizeof(*pDesc));
+        return S_OK;
+    }
     HRESULT WINAPI LockRect(D3DLOCKED_RECT*, const RECT*, DWORD) override { return E_NOTIMPL; }
     HRESULT WINAPI UnlockRect() override { return S_OK; }
     HRESULT WINAPI GetDC(HDC*) override { return E_NOTIMPL; }
@@ -73,11 +107,23 @@ public:
 
 class MSD3DVertexBuffer : public IDirect3DVertexBuffer9 {
     LONG m_ref = 1;
-public:
-    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override { if(ppv)*ppv=nullptr; return E_NOINTERFACE; }
+
+  public:
+    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override {
+        if (ppv)
+            *ppv = nullptr;
+        return E_NOINTERFACE;
+    }
     ULONG WINAPI AddRef() override { return InterlockedIncrement(&m_ref); }
-    ULONG WINAPI Release() override { ULONG r = InterlockedDecrement(&m_ref); return r ? r : 0; }
-    HRESULT WINAPI GetDevice(IDirect3DDevice9** pp) override { if(pp)*pp=nullptr; return S_OK; }
+    ULONG WINAPI Release() override {
+        ULONG r = InterlockedDecrement(&m_ref);
+        return r ? r : 0;
+    }
+    HRESULT WINAPI GetDevice(IDirect3DDevice9** pp) override {
+        if (pp)
+            *pp = nullptr;
+        return S_OK;
+    }
     HRESULT WINAPI SetPrivateData(REFGUID, const void*, DWORD, DWORD) override { return S_OK; }
     HRESULT WINAPI GetPrivateData(REFGUID, void*, DWORD*) override { return E_NOTIMPL; }
     HRESULT WINAPI FreePrivateData(REFGUID) override { return S_OK; }
@@ -86,20 +132,40 @@ public:
     void WINAPI PreLoad() override {}
     D3DRESOURCETYPE WINAPI GetType() override { return D3DRTYPE_VERTEXBUFFER; }
     HRESULT WINAPI Lock(UINT, UINT, void** ppbData, DWORD) override {
-        struct d3d9_map_params p = {}; p.resource_handle = obj_handle(this); unix_call(D3D9_FUNC_MAP, &p);
-        if(p.out_data && ppbData) *ppbData = p.out_data; return S_OK;
+        struct d3d9_map_params p = {};
+        p.resource_handle = obj_handle(this);
+        unix_call(D3D9_FUNC_MAP, &p);
+        if (p.out_data && ppbData)
+            *ppbData = p.out_data;
+        return S_OK;
     }
     HRESULT WINAPI Unlock() override { return S_OK; }
-    HRESULT WINAPI GetDesc(D3DVERTEXBUFFER_DESC* pDesc) override { if(pDesc) memset(pDesc,0,sizeof(*pDesc)); return S_OK; }
+    HRESULT WINAPI GetDesc(D3DVERTEXBUFFER_DESC* pDesc) override {
+        if (pDesc)
+            memset(pDesc, 0, sizeof(*pDesc));
+        return S_OK;
+    }
 };
 
 class MSD3DIndexBuffer : public IDirect3DIndexBuffer9 {
     LONG m_ref = 1;
-public:
-    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override { if(ppv)*ppv=nullptr; return E_NOINTERFACE; }
+
+  public:
+    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override {
+        if (ppv)
+            *ppv = nullptr;
+        return E_NOINTERFACE;
+    }
     ULONG WINAPI AddRef() override { return InterlockedIncrement(&m_ref); }
-    ULONG WINAPI Release() override { ULONG r = InterlockedDecrement(&m_ref); return r ? r : 0; }
-    HRESULT WINAPI GetDevice(IDirect3DDevice9** pp) override { if(pp)*pp=nullptr; return S_OK; }
+    ULONG WINAPI Release() override {
+        ULONG r = InterlockedDecrement(&m_ref);
+        return r ? r : 0;
+    }
+    HRESULT WINAPI GetDevice(IDirect3DDevice9** pp) override {
+        if (pp)
+            *pp = nullptr;
+        return S_OK;
+    }
     HRESULT WINAPI SetPrivateData(REFGUID, const void*, DWORD, DWORD) override { return S_OK; }
     HRESULT WINAPI GetPrivateData(REFGUID, void*, DWORD*) override { return E_NOTIMPL; }
     HRESULT WINAPI FreePrivateData(REFGUID) override { return S_OK; }
@@ -108,20 +174,40 @@ public:
     void WINAPI PreLoad() override {}
     D3DRESOURCETYPE WINAPI GetType() override { return D3DRTYPE_INDEXBUFFER; }
     HRESULT WINAPI Lock(UINT, UINT, void** ppbData, DWORD) override {
-        struct d3d9_map_params p = {}; p.resource_handle = obj_handle(this); unix_call(D3D9_FUNC_MAP, &p);
-        if(p.out_data && ppbData) *ppbData = p.out_data; return S_OK;
+        struct d3d9_map_params p = {};
+        p.resource_handle = obj_handle(this);
+        unix_call(D3D9_FUNC_MAP, &p);
+        if (p.out_data && ppbData)
+            *ppbData = p.out_data;
+        return S_OK;
     }
     HRESULT WINAPI Unlock() override { return S_OK; }
-    HRESULT WINAPI GetDesc(D3DINDEXBUFFER_DESC* pDesc) override { if(pDesc) memset(pDesc,0,sizeof(*pDesc)); return S_OK; }
+    HRESULT WINAPI GetDesc(D3DINDEXBUFFER_DESC* pDesc) override {
+        if (pDesc)
+            memset(pDesc, 0, sizeof(*pDesc));
+        return S_OK;
+    }
 };
 
 class MSD3DTexture : public IDirect3DTexture9 {
     LONG m_ref = 1;
-public:
-    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override { if(ppv)*ppv=nullptr; return E_NOINTERFACE; }
+
+  public:
+    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override {
+        if (ppv)
+            *ppv = nullptr;
+        return E_NOINTERFACE;
+    }
     ULONG WINAPI AddRef() override { return InterlockedIncrement(&m_ref); }
-    ULONG WINAPI Release() override { ULONG r = InterlockedDecrement(&m_ref); return r ? r : 0; }
-    HRESULT WINAPI GetDevice(IDirect3DDevice9** pp) override { if(pp)*pp=nullptr; return S_OK; }
+    ULONG WINAPI Release() override {
+        ULONG r = InterlockedDecrement(&m_ref);
+        return r ? r : 0;
+    }
+    HRESULT WINAPI GetDevice(IDirect3DDevice9** pp) override {
+        if (pp)
+            *pp = nullptr;
+        return S_OK;
+    }
     HRESULT WINAPI SetPrivateData(REFGUID, const void*, DWORD, DWORD) override { return S_OK; }
     HRESULT WINAPI GetPrivateData(REFGUID, void*, DWORD*) override { return E_NOTIMPL; }
     HRESULT WINAPI FreePrivateData(REFGUID) override { return S_OK; }
@@ -135,8 +221,16 @@ public:
     HRESULT WINAPI SetAutoGenFilterType(D3DTEXTUREFILTERTYPE) override { return S_OK; }
     D3DTEXTUREFILTERTYPE WINAPI GetAutoGenFilterType() override { return D3DTEXF_LINEAR; }
     void WINAPI GenerateMipSubLevels() override {}
-    HRESULT WINAPI GetLevelDesc(UINT, D3DSURFACE_DESC* pDesc) override { if(pDesc) memset(pDesc,0,sizeof(*pDesc)); return S_OK; }
-    HRESULT WINAPI GetSurfaceLevel(UINT, IDirect3DSurface9** pp) override { if(pp) *pp = new MSD3DSurface(); return S_OK; }
+    HRESULT WINAPI GetLevelDesc(UINT, D3DSURFACE_DESC* pDesc) override {
+        if (pDesc)
+            memset(pDesc, 0, sizeof(*pDesc));
+        return S_OK;
+    }
+    HRESULT WINAPI GetSurfaceLevel(UINT, IDirect3DSurface9** pp) override {
+        if (pp)
+            *pp = new MSD3DSurface();
+        return S_OK;
+    }
     HRESULT WINAPI LockRect(UINT, D3DLOCKED_RECT*, const RECT*, DWORD) override { return E_NOTIMPL; }
     HRESULT WINAPI UnlockRect(UINT) override { return S_OK; }
     HRESULT WINAPI AddDirtyRect(const RECT*) override { return S_OK; }
@@ -144,41 +238,89 @@ public:
 
 class MSD3DVertexDeclaration : public IDirect3DVertexDeclaration9 {
     LONG m_ref = 1;
-public:
-    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override { if(ppv)*ppv=nullptr; return E_NOINTERFACE; }
+
+  public:
+    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override {
+        if (ppv)
+            *ppv = nullptr;
+        return E_NOINTERFACE;
+    }
     ULONG WINAPI AddRef() override { return InterlockedIncrement(&m_ref); }
-    ULONG WINAPI Release() override { ULONG r = InterlockedDecrement(&m_ref); return r ? r : 0; }
-    HRESULT WINAPI GetDevice(IDirect3DDevice9** pp) override { if(pp)*pp=nullptr; return S_OK; }
+    ULONG WINAPI Release() override {
+        ULONG r = InterlockedDecrement(&m_ref);
+        return r ? r : 0;
+    }
+    HRESULT WINAPI GetDevice(IDirect3DDevice9** pp) override {
+        if (pp)
+            *pp = nullptr;
+        return S_OK;
+    }
     HRESULT WINAPI GetDeclaration(D3DVERTEXELEMENT9*, UINT*) override { return E_NOTIMPL; }
 };
 
 class MSD3DVertexShader : public IDirect3DVertexShader9 {
     LONG m_ref = 1;
-public:
-    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override { if(ppv)*ppv=nullptr; return E_NOINTERFACE; }
+
+  public:
+    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override {
+        if (ppv)
+            *ppv = nullptr;
+        return E_NOINTERFACE;
+    }
     ULONG WINAPI AddRef() override { return InterlockedIncrement(&m_ref); }
-    ULONG WINAPI Release() override { ULONG r = InterlockedDecrement(&m_ref); return r ? r : 0; }
-    HRESULT WINAPI GetDevice(IDirect3DDevice9** pp) override { if(pp)*pp=nullptr; return S_OK; }
+    ULONG WINAPI Release() override {
+        ULONG r = InterlockedDecrement(&m_ref);
+        return r ? r : 0;
+    }
+    HRESULT WINAPI GetDevice(IDirect3DDevice9** pp) override {
+        if (pp)
+            *pp = nullptr;
+        return S_OK;
+    }
     HRESULT WINAPI GetFunction(void*, UINT*) override { return S_OK; }
 };
 
 class MSD3DPixelShader : public IDirect3DPixelShader9 {
     LONG m_ref = 1;
-public:
-    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override { if(ppv)*ppv=nullptr; return E_NOINTERFACE; }
+
+  public:
+    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override {
+        if (ppv)
+            *ppv = nullptr;
+        return E_NOINTERFACE;
+    }
     ULONG WINAPI AddRef() override { return InterlockedIncrement(&m_ref); }
-    ULONG WINAPI Release() override { ULONG r = InterlockedDecrement(&m_ref); return r ? r : 0; }
-    HRESULT WINAPI GetDevice(IDirect3DDevice9** pp) override { if(pp)*pp=nullptr; return S_OK; }
+    ULONG WINAPI Release() override {
+        ULONG r = InterlockedDecrement(&m_ref);
+        return r ? r : 0;
+    }
+    HRESULT WINAPI GetDevice(IDirect3DDevice9** pp) override {
+        if (pp)
+            *pp = nullptr;
+        return S_OK;
+    }
     HRESULT WINAPI GetFunction(void*, UINT*) override { return S_OK; }
 };
 
 class MSD3DStateBlock : public IDirect3DStateBlock9 {
     LONG m_ref = 1;
-public:
-    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override { if(ppv)*ppv=nullptr; return E_NOINTERFACE; }
+
+  public:
+    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override {
+        if (ppv)
+            *ppv = nullptr;
+        return E_NOINTERFACE;
+    }
     ULONG WINAPI AddRef() override { return InterlockedIncrement(&m_ref); }
-    ULONG WINAPI Release() override { ULONG r = InterlockedDecrement(&m_ref); return r ? r : 0; }
-    HRESULT WINAPI GetDevice(IDirect3DDevice9** pp) override { if(pp)*pp=nullptr; return S_OK; }
+    ULONG WINAPI Release() override {
+        ULONG r = InterlockedDecrement(&m_ref);
+        return r ? r : 0;
+    }
+    HRESULT WINAPI GetDevice(IDirect3DDevice9** pp) override {
+        if (pp)
+            *pp = nullptr;
+        return S_OK;
+    }
     HRESULT WINAPI Capture() override { return S_OK; }
     HRESULT WINAPI Apply() override { return S_OK; }
 };
@@ -190,19 +332,18 @@ static void fill_caps(D3DCAPS9* pCaps) {
     pCaps->Caps2 = D3DCAPS2_DYNAMICTEXTURES | D3DCAPS2_FULLSCREENGAMMA;
     pCaps->Caps3 = D3DCAPS3_ALPHA_FULLSCREEN_FLIP_OR_DISCARD;
     pCaps->PresentationIntervals = D3DPRESENT_INTERVAL_IMMEDIATE | D3DPRESENT_INTERVAL_ONE;
-    pCaps->DevCaps = D3DDEVCAPS_HWTRANSFORMANDLIGHT | D3DDEVCAPS_PUREDEVICE |
-                     D3DDEVCAPS_DRAWPRIMITIVES2 | D3DDEVCAPS_DRAWPRIMITIVES2EX;
-    pCaps->PrimitiveMiscCaps = D3DPMISCCAPS_MASKZ | D3DPMISCCAPS_CULLNONE |
-                               D3DPMISCCAPS_CULLCW | D3DPMISCCAPS_CULLCCW |
-                               D3DPMISCCAPS_BLENDOP;
+    pCaps->DevCaps = D3DDEVCAPS_HWTRANSFORMANDLIGHT | D3DDEVCAPS_PUREDEVICE | D3DDEVCAPS_DRAWPRIMITIVES2 |
+                     D3DDEVCAPS_DRAWPRIMITIVES2EX;
+    pCaps->PrimitiveMiscCaps =
+        D3DPMISCCAPS_MASKZ | D3DPMISCCAPS_CULLNONE | D3DPMISCCAPS_CULLCW | D3DPMISCCAPS_CULLCCW | D3DPMISCCAPS_BLENDOP;
     pCaps->RasterCaps = D3DPRASTERCAPS_DITHER | D3DPRASTERCAPS_ZTEST | D3DPRASTERCAPS_SCISSORTEST;
     pCaps->ZCmpCaps = 0xFF;
     pCaps->SrcBlendCaps = 0x1FF;
     pCaps->DestBlendCaps = 0x1FF;
     pCaps->AlphaCmpCaps = 0xFF;
     pCaps->ShadeCaps = D3DPSHADECAPS_COLORGOURAUDRGB;
-    pCaps->TextureCaps = D3DPTEXTURECAPS_PERSPECTIVE | D3DPTEXTURECAPS_ALPHA |
-                         D3DPTEXTURECAPS_POW2 | D3DPTEXTURECAPS_CUBEMAP | D3DPTEXTURECAPS_MIPMAP;
+    pCaps->TextureCaps = D3DPTEXTURECAPS_PERSPECTIVE | D3DPTEXTURECAPS_ALPHA | D3DPTEXTURECAPS_POW2 |
+                         D3DPTEXTURECAPS_CUBEMAP | D3DPTEXTURECAPS_MIPMAP;
     pCaps->TextureFilterCaps = 0x3F;
     pCaps->CubeTextureFilterCaps = 0x3F;
     pCaps->VolumeTextureFilterCaps = 0x3F;
@@ -244,304 +385,567 @@ static void fill_caps(D3DCAPS9* pCaps) {
 class MSD3DDevice9 : public IDirect3DDevice9 {
     LONG m_ref = 1;
     IDirect3D9* m_parent;
-public:
+
+  public:
     MSD3DDevice9(IDirect3D9* parent) : m_parent(parent) {}
-    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override { if(ppv)*ppv=nullptr; return E_NOINTERFACE; }
-    ULONG WINAPI AddRef() override { return InterlockedIncrement(&m_ref); }
-    ULONG WINAPI Release() override { ULONG r = InterlockedDecrement(&m_ref); return r ? r : 0; }
-    HRESULT WINAPI TestCooperativeLevel() override { return D3D_OK; }
-    UINT WINAPI GetAvailableTextureMem() override { return 512*1024*1024; }
-    HRESULT WINAPI EvictManagedResources() override { return S_OK; }
-    HRESULT WINAPI GetDirect3D(IDirect3D9** pp) override { if(pp)*pp=m_parent; return S_OK; }
-    HRESULT WINAPI GetDeviceCaps(D3DCAPS9* p) override { if(!p) return E_POINTER; fill_caps(p); return S_OK; }
-    HRESULT WINAPI GetDisplayMode(UINT, D3DDISPLAYMODE* p) override {
-        if(p){p->Width=1920;p->Height=1080;p->RefreshRate=60;p->Format=D3DFMT_X8R8G8B8;} return S_OK;
+    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override {
+        if (ppv)
+            *ppv = nullptr;
+        return E_NOINTERFACE;
     }
-    HRESULT WINAPI GetCreationParameters(D3DDEVICE_CREATION_PARAMETERS* p) override { if(p)memset(p,0,sizeof(*p)); return S_OK; }
-    HRESULT WINAPI SetCursorProperties(UINT,UINT,IDirect3DSurface9*) override { return S_OK; }
-    void WINAPI SetCursorPosition(int,int,DWORD) override {}
+    ULONG WINAPI AddRef() override { return InterlockedIncrement(&m_ref); }
+    ULONG WINAPI Release() override {
+        ULONG r = InterlockedDecrement(&m_ref);
+        return r ? r : 0;
+    }
+    HRESULT WINAPI TestCooperativeLevel() override { return D3D_OK; }
+    UINT WINAPI GetAvailableTextureMem() override { return 512 * 1024 * 1024; }
+    HRESULT WINAPI EvictManagedResources() override { return S_OK; }
+    HRESULT WINAPI GetDirect3D(IDirect3D9** pp) override {
+        if (pp)
+            *pp = m_parent;
+        return S_OK;
+    }
+    HRESULT WINAPI GetDeviceCaps(D3DCAPS9* p) override {
+        if (!p)
+            return E_POINTER;
+        fill_caps(p);
+        return S_OK;
+    }
+    HRESULT WINAPI GetDisplayMode(UINT, D3DDISPLAYMODE* p) override {
+        if (p) {
+            p->Width = 1920;
+            p->Height = 1080;
+            p->RefreshRate = 60;
+            p->Format = D3DFMT_X8R8G8B8;
+        }
+        return S_OK;
+    }
+    HRESULT WINAPI GetCreationParameters(D3DDEVICE_CREATION_PARAMETERS* p) override {
+        if (p)
+            memset(p, 0, sizeof(*p));
+        return S_OK;
+    }
+    HRESULT WINAPI SetCursorProperties(UINT, UINT, IDirect3DSurface9*) override { return S_OK; }
+    void WINAPI SetCursorPosition(int, int, DWORD) override {}
     BOOL WINAPI ShowCursor(BOOL) override { return FALSE; }
-    HRESULT WINAPI CreateAdditionalSwapChain(D3DPRESENT_PARAMETERS*,IDirect3DSwapChain9**) override { return E_NOTIMPL; }
-    HRESULT WINAPI GetSwapChain(UINT,IDirect3DSwapChain9**) override { return E_NOTIMPL; }
+    HRESULT WINAPI CreateAdditionalSwapChain(D3DPRESENT_PARAMETERS*, IDirect3DSwapChain9**) override {
+        return E_NOTIMPL;
+    }
+    HRESULT WINAPI GetSwapChain(UINT, IDirect3DSwapChain9**) override { return E_NOTIMPL; }
     UINT WINAPI GetNumberOfSwapChains() override { return 1; }
     HRESULT WINAPI Reset(D3DPRESENT_PARAMETERS* pParams) override {
-        if(!pParams) return E_POINTER;
+        if (!pParams)
+            return E_POINTER;
         struct d3d9_reset_params p = {};
-        p.width=pParams->BackBufferWidth; p.height=pParams->BackBufferHeight;
-        p.back_buffer_format=(uint32_t)pParams->BackBufferFormat; p.windowed=pParams->Windowed;
-        p.back_buffer_count=pParams->BackBufferCount; p.enable_auto_depth_stencil=pParams->EnableAutoDepthStencil;
-        p.auto_depth_stencil_format=(uint32_t)pParams->AutoDepthStencilFormat;
-        unix_call(D3D9_FUNC_RESET, &p); return S_OK;
+        p.width = pParams->BackBufferWidth;
+        p.height = pParams->BackBufferHeight;
+        p.back_buffer_format = (uint32_t)pParams->BackBufferFormat;
+        p.windowed = pParams->Windowed;
+        p.back_buffer_count = pParams->BackBufferCount;
+        p.enable_auto_depth_stencil = pParams->EnableAutoDepthStencil;
+        p.auto_depth_stencil_format = (uint32_t)pParams->AutoDepthStencilFormat;
+        unix_call(D3D9_FUNC_RESET, &p);
+        return S_OK;
     }
-    HRESULT WINAPI Present(const RECT*, const RECT*, HWND, const RGNDATA*) override { unix_call(D3D9_FUNC_PRESENT, nullptr); return S_OK; }
-    HRESULT WINAPI GetBackBuffer(UINT,UINT,D3DBACKBUFFER_TYPE,IDirect3DSurface9** pp) override { if(pp)*pp=new MSD3DSurface(); return S_OK; }
-    HRESULT WINAPI GetRasterStatus(UINT,D3DRASTER_STATUS*) override { return E_NOTIMPL; }
+    HRESULT WINAPI Present(const RECT*, const RECT*, HWND, const RGNDATA*) override {
+        unix_call(D3D9_FUNC_PRESENT, nullptr);
+        return S_OK;
+    }
+    HRESULT WINAPI GetBackBuffer(UINT, UINT, D3DBACKBUFFER_TYPE, IDirect3DSurface9** pp) override {
+        if (pp)
+            *pp = new MSD3DSurface();
+        return S_OK;
+    }
+    HRESULT WINAPI GetRasterStatus(UINT, D3DRASTER_STATUS*) override { return E_NOTIMPL; }
     HRESULT WINAPI SetDialogBoxMode(BOOL) override { return S_OK; }
-    void WINAPI SetGammaRamp(UINT,DWORD,const D3DGAMMARAMP*) override {}
-    void WINAPI GetGammaRamp(UINT,D3DGAMMARAMP*) override {}
-    HRESULT WINAPI CreateTexture(UINT W,UINT H,UINT L,DWORD U,D3DFORMAT F,D3DPOOL P,IDirect3DTexture9** pp,HANDLE*) override {
-        if(!pp) return S_OK;
+    void WINAPI SetGammaRamp(UINT, DWORD, const D3DGAMMARAMP*) override {}
+    void WINAPI GetGammaRamp(UINT, D3DGAMMARAMP*) override {}
+    HRESULT WINAPI CreateTexture(UINT W, UINT H, UINT L, DWORD U, D3DFORMAT F, D3DPOOL P, IDirect3DTexture9** pp,
+                                 HANDLE*) override {
+        if (!pp)
+            return S_OK;
         auto* t = new MSD3DTexture();
-        struct d3d9_create_texture_params p = {W,H,L,(uint32_t)U,(uint32_t)F,(int)P,0};
+        struct d3d9_create_texture_params p = {W, H, L, (uint32_t)U, (uint32_t)F, (int)P, 0};
         NTSTATUS r = unix_call(D3D9_FUNC_CREATE_TEXTURE, &p);
-        if(r>=0) set_handle(t, p.out_handle);
-        *pp = t; return S_OK;
+        if (r >= 0)
+            set_handle(t, p.out_handle);
+        *pp = t;
+        return S_OK;
     }
-    HRESULT WINAPI CreateVolumeTexture(UINT,UINT,UINT,UINT,DWORD,D3DFORMAT,D3DPOOL,IDirect3DVolumeTexture9**,HANDLE*) override { return E_NOTIMPL; }
-    HRESULT WINAPI CreateCubeTexture(UINT,UINT,DWORD,D3DFORMAT,D3DPOOL,IDirect3DCubeTexture9**,HANDLE*) override { return E_NOTIMPL; }
-    HRESULT WINAPI CreateVertexBuffer(UINT L,DWORD U,DWORD F,D3DPOOL P,IDirect3DVertexBuffer9** pp,HANDLE*) override {
-        if(!pp) return S_OK;
+    HRESULT WINAPI CreateVolumeTexture(UINT, UINT, UINT, UINT, DWORD, D3DFORMAT, D3DPOOL, IDirect3DVolumeTexture9**,
+                                       HANDLE*) override {
+        return E_NOTIMPL;
+    }
+    HRESULT WINAPI CreateCubeTexture(UINT, UINT, DWORD, D3DFORMAT, D3DPOOL, IDirect3DCubeTexture9**, HANDLE*) override {
+        return E_NOTIMPL;
+    }
+    HRESULT WINAPI CreateVertexBuffer(UINT L, DWORD U, DWORD F, D3DPOOL P, IDirect3DVertexBuffer9** pp,
+                                      HANDLE*) override {
+        if (!pp)
+            return S_OK;
         auto* b = new MSD3DVertexBuffer();
-        struct d3d9_create_buffer_params p = {L,(uint32_t)U,F,(int)P,0};
+        struct d3d9_create_buffer_params p = {L, (uint32_t)U, F, (int)P, 0};
         NTSTATUS r = unix_call(D3D9_FUNC_CREATE_VERTEX_BUFFER, &p);
-        if(r>=0) set_handle(b, p.out_handle);
-        *pp = b; return S_OK;
+        if (r >= 0)
+            set_handle(b, p.out_handle);
+        *pp = b;
+        return S_OK;
     }
-    HRESULT WINAPI CreateIndexBuffer(UINT L,DWORD U,D3DFORMAT,D3DPOOL P,IDirect3DIndexBuffer9** pp,HANDLE*) override {
-        if(!pp) return S_OK;
+    HRESULT WINAPI CreateIndexBuffer(UINT L, DWORD U, D3DFORMAT, D3DPOOL P, IDirect3DIndexBuffer9** pp,
+                                     HANDLE*) override {
+        if (!pp)
+            return S_OK;
         auto* b = new MSD3DIndexBuffer();
-        struct d3d9_create_buffer_params p = {L,(uint32_t)U,0,(int)P,0};
+        struct d3d9_create_buffer_params p = {L, (uint32_t)U, 0, (int)P, 0};
         NTSTATUS r = unix_call(D3D9_FUNC_CREATE_INDEX_BUFFER, &p);
-        if(r>=0) set_handle(b, p.out_handle);
-        *pp = b; return S_OK;
+        if (r >= 0)
+            set_handle(b, p.out_handle);
+        *pp = b;
+        return S_OK;
     }
-    HRESULT WINAPI CreateRenderTarget(UINT W,UINT H,D3DFORMAT F,D3DMULTISAMPLE_TYPE MS,DWORD MQ,BOOL,IDirect3DSurface9** pp,HANDLE*) override {
-        if(!pp) return S_OK;
+    HRESULT WINAPI CreateRenderTarget(UINT W, UINT H, D3DFORMAT F, D3DMULTISAMPLE_TYPE MS, DWORD MQ, BOOL,
+                                      IDirect3DSurface9** pp, HANDLE*) override {
+        if (!pp)
+            return S_OK;
         auto* s = new MSD3DSurface();
-        struct d3d9_create_surface_params p = {W,H,(uint32_t)F,(uint32_t)MS,MQ,0,0};
+        struct d3d9_create_surface_params p = {W, H, (uint32_t)F, (uint32_t)MS, MQ, 0, 0};
         NTSTATUS r = unix_call(D3D9_FUNC_CREATE_RENDER_TARGET, &p);
-        if(r>=0) set_handle(s, p.out_handle);
-        *pp = s; return S_OK;
+        if (r >= 0)
+            set_handle(s, p.out_handle);
+        *pp = s;
+        return S_OK;
     }
-    HRESULT WINAPI CreateDepthStencilSurface(UINT W,UINT H,D3DFORMAT F,D3DMULTISAMPLE_TYPE MS,DWORD MQ,BOOL,IDirect3DSurface9** pp,HANDLE*) override {
-        if(!pp) return S_OK;
+    HRESULT WINAPI CreateDepthStencilSurface(UINT W, UINT H, D3DFORMAT F, D3DMULTISAMPLE_TYPE MS, DWORD MQ, BOOL,
+                                             IDirect3DSurface9** pp, HANDLE*) override {
+        if (!pp)
+            return S_OK;
         auto* s = new MSD3DSurface();
-        struct d3d9_create_surface_params p = {W,H,(uint32_t)F,(uint32_t)MS,MQ,0,0};
+        struct d3d9_create_surface_params p = {W, H, (uint32_t)F, (uint32_t)MS, MQ, 0, 0};
         NTSTATUS r = unix_call(D3D9_FUNC_CREATE_DEPTH_STENCIL, &p);
-        if(r>=0) set_handle(s, p.out_handle);
-        *pp = s; return S_OK;
+        if (r >= 0)
+            set_handle(s, p.out_handle);
+        *pp = s;
+        return S_OK;
     }
-    HRESULT WINAPI UpdateSurface(IDirect3DSurface9*,const RECT*,IDirect3DSurface9*,const POINT*) override { return S_OK; }
-    HRESULT WINAPI UpdateTexture(IDirect3DBaseTexture9*,IDirect3DBaseTexture9*) override { return S_OK; }
-    HRESULT WINAPI GetRenderTargetData(IDirect3DSurface9*,IDirect3DSurface9*) override { return S_OK; }
-    HRESULT WINAPI GetFrontBufferData(UINT,IDirect3DSurface9*) override { return S_OK; }
-    HRESULT WINAPI StretchRect(IDirect3DSurface9*,const RECT*,IDirect3DSurface9*,const RECT*,D3DTEXTUREFILTERTYPE) override { return S_OK; }
-    HRESULT WINAPI ColorFill(IDirect3DSurface9*,const RECT*,D3DCOLOR) override { return S_OK; }
-    HRESULT WINAPI CreateOffscreenPlainSurface(UINT,UINT,D3DFORMAT,D3DPOOL,IDirect3DSurface9** pp,HANDLE*) override { if(pp)*pp=new MSD3DSurface(); return S_OK; }
-    HRESULT WINAPI SetRenderTarget(DWORD idx,IDirect3DSurface9* s) override {
-        uint64_t h[2] = {(uint64_t)idx, obj_handle(s)}; unix_call(D3D9_FUNC_SET_RENDER_TARGET, h); return S_OK;
+    HRESULT WINAPI UpdateSurface(IDirect3DSurface9*, const RECT*, IDirect3DSurface9*, const POINT*) override {
+        return S_OK;
     }
-    HRESULT WINAPI GetRenderTarget(DWORD,IDirect3DSurface9** pp) override { if(pp)*pp=nullptr; return D3DERR_NOTFOUND; }
-    HRESULT WINAPI SetDepthStencilSurface(IDirect3DSurface9* s) override { uint64_t h=obj_handle(s); unix_call(D3D9_FUNC_SET_DEPTH_STENCIL,&h); return S_OK; }
-    HRESULT WINAPI GetDepthStencilSurface(IDirect3DSurface9** pp) override { if(pp)*pp=nullptr; return D3DERR_NOTFOUND; }
-    HRESULT WINAPI BeginScene() override { unix_call(D3D9_FUNC_BEGIN_SCENE, nullptr); return S_OK; }
-    HRESULT WINAPI EndScene() override { unix_call(D3D9_FUNC_END_SCENE, nullptr); return S_OK; }
-    HRESULT WINAPI Clear(DWORD,const D3DRECT*,DWORD Flags,D3DCOLOR Color,float Z,DWORD Stencil) override {
-        struct d3d9_clear_params p = {(uint32_t)Flags,(uint32_t)Color,Z,(uint32_t)Stencil};
-        unix_call(D3D9_FUNC_CLEAR, &p); return S_OK;
+    HRESULT WINAPI UpdateTexture(IDirect3DBaseTexture9*, IDirect3DBaseTexture9*) override { return S_OK; }
+    HRESULT WINAPI GetRenderTargetData(IDirect3DSurface9*, IDirect3DSurface9*) override { return S_OK; }
+    HRESULT WINAPI GetFrontBufferData(UINT, IDirect3DSurface9*) override { return S_OK; }
+    HRESULT WINAPI StretchRect(IDirect3DSurface9*, const RECT*, IDirect3DSurface9*, const RECT*,
+                               D3DTEXTUREFILTERTYPE) override {
+        return S_OK;
     }
-    HRESULT WINAPI SetTransform(D3DTRANSFORMSTATETYPE,const D3DMATRIX*) override { return S_OK; }
-    HRESULT WINAPI GetTransform(D3DTRANSFORMSTATETYPE,D3DMATRIX*) override { return E_NOTIMPL; }
-    HRESULT WINAPI MultiplyTransform(D3DTRANSFORMSTATETYPE,const D3DMATRIX*) override { return S_OK; }
+    HRESULT WINAPI ColorFill(IDirect3DSurface9*, const RECT*, D3DCOLOR) override { return S_OK; }
+    HRESULT WINAPI CreateOffscreenPlainSurface(UINT, UINT, D3DFORMAT, D3DPOOL, IDirect3DSurface9** pp,
+                                               HANDLE*) override {
+        if (pp)
+            *pp = new MSD3DSurface();
+        return S_OK;
+    }
+    HRESULT WINAPI SetRenderTarget(DWORD idx, IDirect3DSurface9* s) override {
+        uint64_t h[2] = {(uint64_t)idx, obj_handle(s)};
+        unix_call(D3D9_FUNC_SET_RENDER_TARGET, h);
+        return S_OK;
+    }
+    HRESULT WINAPI GetRenderTarget(DWORD, IDirect3DSurface9** pp) override {
+        if (pp)
+            *pp = nullptr;
+        return D3DERR_NOTFOUND;
+    }
+    HRESULT WINAPI SetDepthStencilSurface(IDirect3DSurface9* s) override {
+        uint64_t h = obj_handle(s);
+        unix_call(D3D9_FUNC_SET_DEPTH_STENCIL, &h);
+        return S_OK;
+    }
+    HRESULT WINAPI GetDepthStencilSurface(IDirect3DSurface9** pp) override {
+        if (pp)
+            *pp = nullptr;
+        return D3DERR_NOTFOUND;
+    }
+    HRESULT WINAPI BeginScene() override {
+        unix_call(D3D9_FUNC_BEGIN_SCENE, nullptr);
+        return S_OK;
+    }
+    HRESULT WINAPI EndScene() override {
+        unix_call(D3D9_FUNC_END_SCENE, nullptr);
+        return S_OK;
+    }
+    HRESULT WINAPI Clear(DWORD, const D3DRECT*, DWORD Flags, D3DCOLOR Color, float Z, DWORD Stencil) override {
+        struct d3d9_clear_params p = {(uint32_t)Flags, (uint32_t)Color, Z, (uint32_t)Stencil};
+        unix_call(D3D9_FUNC_CLEAR, &p);
+        return S_OK;
+    }
+    HRESULT WINAPI SetTransform(D3DTRANSFORMSTATETYPE, const D3DMATRIX*) override { return S_OK; }
+    HRESULT WINAPI GetTransform(D3DTRANSFORMSTATETYPE, D3DMATRIX*) override { return E_NOTIMPL; }
+    HRESULT WINAPI MultiplyTransform(D3DTRANSFORMSTATETYPE, const D3DMATRIX*) override { return S_OK; }
     HRESULT WINAPI SetViewport(const D3DVIEWPORT9* vp) override {
-        if(!vp) return E_POINTER;
-        struct d3d9_viewport v = {vp->X,vp->Y,vp->Width,vp->Height,vp->MinZ,vp->MaxZ};
-        unix_call(D3D9_FUNC_SET_VIEWPORT, &v); return S_OK;
+        if (!vp)
+            return E_POINTER;
+        struct d3d9_viewport v = {vp->X, vp->Y, vp->Width, vp->Height, vp->MinZ, vp->MaxZ};
+        unix_call(D3D9_FUNC_SET_VIEWPORT, &v);
+        return S_OK;
     }
-    HRESULT WINAPI GetViewport(D3DVIEWPORT9* vp) override { if(vp)memset(vp,0,sizeof(*vp)); return S_OK; }
+    HRESULT WINAPI GetViewport(D3DVIEWPORT9* vp) override {
+        if (vp)
+            memset(vp, 0, sizeof(*vp));
+        return S_OK;
+    }
     HRESULT WINAPI SetMaterial(const D3DMATERIAL9*) override { return S_OK; }
     HRESULT WINAPI GetMaterial(D3DMATERIAL9*) override { return E_NOTIMPL; }
-    HRESULT WINAPI SetLight(DWORD,const D3DLIGHT9*) override { return S_OK; }
-    HRESULT WINAPI GetLight(DWORD,D3DLIGHT9*) override { return E_NOTIMPL; }
-    HRESULT WINAPI LightEnable(DWORD,BOOL) override { return S_OK; }
-    HRESULT WINAPI GetLightEnable(DWORD,BOOL*) override { return E_NOTIMPL; }
-    HRESULT WINAPI SetClipPlane(DWORD,const float*) override { return S_OK; }
-    HRESULT WINAPI GetClipPlane(DWORD,float*) override { return E_NOTIMPL; }
-    HRESULT WINAPI SetRenderState(D3DRENDERSTATETYPE s,DWORD v) override {
-        struct d3d9_set_render_state_params p = {(uint32_t)s,(uint32_t)v}; unix_call(D3D9_FUNC_SET_RENDER_STATE,&p); return S_OK;
+    HRESULT WINAPI SetLight(DWORD, const D3DLIGHT9*) override { return S_OK; }
+    HRESULT WINAPI GetLight(DWORD, D3DLIGHT9*) override { return E_NOTIMPL; }
+    HRESULT WINAPI LightEnable(DWORD, BOOL) override { return S_OK; }
+    HRESULT WINAPI GetLightEnable(DWORD, BOOL*) override { return E_NOTIMPL; }
+    HRESULT WINAPI SetClipPlane(DWORD, const float*) override { return S_OK; }
+    HRESULT WINAPI GetClipPlane(DWORD, float*) override { return E_NOTIMPL; }
+    HRESULT WINAPI SetRenderState(D3DRENDERSTATETYPE s, DWORD v) override {
+        struct d3d9_set_render_state_params p = {(uint32_t)s, (uint32_t)v};
+        unix_call(D3D9_FUNC_SET_RENDER_STATE, &p);
+        return S_OK;
     }
-    HRESULT WINAPI GetRenderState(D3DRENDERSTATETYPE,DWORD* p) override { if(p)*p=0; return S_OK; }
-    HRESULT WINAPI CreateStateBlock(D3DSTATEBLOCKTYPE,IDirect3DStateBlock9** pp) override { if(pp)*pp=new MSD3DStateBlock(); return S_OK; }
+    HRESULT WINAPI GetRenderState(D3DRENDERSTATETYPE, DWORD* p) override {
+        if (p)
+            *p = 0;
+        return S_OK;
+    }
+    HRESULT WINAPI CreateStateBlock(D3DSTATEBLOCKTYPE, IDirect3DStateBlock9** pp) override {
+        if (pp)
+            *pp = new MSD3DStateBlock();
+        return S_OK;
+    }
     HRESULT WINAPI BeginStateBlock() override { return S_OK; }
-    HRESULT WINAPI EndStateBlock(IDirect3DStateBlock9** pp) override { if(pp)*pp=new MSD3DStateBlock(); return S_OK; }
+    HRESULT WINAPI EndStateBlock(IDirect3DStateBlock9** pp) override {
+        if (pp)
+            *pp = new MSD3DStateBlock();
+        return S_OK;
+    }
     HRESULT WINAPI SetClipStatus(const D3DCLIPSTATUS9*) override { return S_OK; }
     HRESULT WINAPI GetClipStatus(D3DCLIPSTATUS9*) override { return E_NOTIMPL; }
-    HRESULT WINAPI GetTexture(DWORD,IDirect3DBaseTexture9** pp) override { if(pp)*pp=nullptr; return S_OK; }
-    HRESULT WINAPI SetTexture(DWORD Stage,IDirect3DBaseTexture9* t) override {
-        struct d3d9_set_texture_params p = {(uint32_t)Stage,obj_handle(t)}; unix_call(D3D9_FUNC_SET_TEXTURE,&p); return S_OK;
+    HRESULT WINAPI GetTexture(DWORD, IDirect3DBaseTexture9** pp) override {
+        if (pp)
+            *pp = nullptr;
+        return S_OK;
     }
-    HRESULT WINAPI GetTextureStageState(DWORD,D3DTEXTURESTAGESTATETYPE,DWORD*) override { return E_NOTIMPL; }
-    HRESULT WINAPI SetTextureStageState(DWORD,D3DTEXTURESTAGESTATETYPE,DWORD) override { return S_OK; }
-    HRESULT WINAPI GetSamplerState(DWORD,D3DSAMPLERSTATETYPE,DWORD*) override { return E_NOTIMPL; }
-    HRESULT WINAPI SetSamplerState(DWORD s,D3DSAMPLERSTATETYPE t,DWORD v) override {
-        struct d3d9_set_sampler_state_params p = {(uint32_t)s,(uint32_t)t,(uint32_t)v}; unix_call(D3D9_FUNC_SET_SAMPLER_STATE,&p); return S_OK;
+    HRESULT WINAPI SetTexture(DWORD Stage, IDirect3DBaseTexture9* t) override {
+        struct d3d9_set_texture_params p = {(uint32_t)Stage, obj_handle(t)};
+        unix_call(D3D9_FUNC_SET_TEXTURE, &p);
+        return S_OK;
+    }
+    HRESULT WINAPI GetTextureStageState(DWORD, D3DTEXTURESTAGESTATETYPE, DWORD*) override { return E_NOTIMPL; }
+    HRESULT WINAPI SetTextureStageState(DWORD, D3DTEXTURESTAGESTATETYPE, DWORD) override { return S_OK; }
+    HRESULT WINAPI GetSamplerState(DWORD, D3DSAMPLERSTATETYPE, DWORD*) override { return E_NOTIMPL; }
+    HRESULT WINAPI SetSamplerState(DWORD s, D3DSAMPLERSTATETYPE t, DWORD v) override {
+        struct d3d9_set_sampler_state_params p = {(uint32_t)s, (uint32_t)t, (uint32_t)v};
+        unix_call(D3D9_FUNC_SET_SAMPLER_STATE, &p);
+        return S_OK;
     }
     HRESULT WINAPI ValidateDevice(DWORD*) override { return S_OK; }
-    HRESULT WINAPI SetPaletteEntries(UINT,const PALETTEENTRY*) override { return S_OK; }
-    HRESULT WINAPI GetPaletteEntries(UINT,PALETTEENTRY*) override { return E_NOTIMPL; }
+    HRESULT WINAPI SetPaletteEntries(UINT, const PALETTEENTRY*) override { return S_OK; }
+    HRESULT WINAPI GetPaletteEntries(UINT, PALETTEENTRY*) override { return E_NOTIMPL; }
     HRESULT WINAPI SetCurrentTexturePalette(UINT) override { return S_OK; }
     HRESULT WINAPI GetCurrentTexturePalette(UINT*) override { return E_NOTIMPL; }
     HRESULT WINAPI SetScissorRect(const RECT* r) override {
-        if(!r) return E_POINTER;
-        struct d3d9_scissor_rect s = {r->left,r->top,r->right,r->bottom};
-        unix_call(D3D9_FUNC_SET_SCISSOR_RECT, &s); return S_OK;
+        if (!r)
+            return E_POINTER;
+        struct d3d9_scissor_rect s = {r->left, r->top, r->right, r->bottom};
+        unix_call(D3D9_FUNC_SET_SCISSOR_RECT, &s);
+        return S_OK;
     }
-    HRESULT WINAPI GetScissorRect(RECT* r) override { if(r)memset(r,0,sizeof(*r)); return S_OK; }
+    HRESULT WINAPI GetScissorRect(RECT* r) override {
+        if (r)
+            memset(r, 0, sizeof(*r));
+        return S_OK;
+    }
     HRESULT WINAPI SetSoftwareVertexProcessing(BOOL) override { return S_OK; }
     BOOL WINAPI GetSoftwareVertexProcessing() override { return FALSE; }
     HRESULT WINAPI SetNPatchMode(float) override { return S_OK; }
     float WINAPI GetNPatchMode() override { return 0.0f; }
-    HRESULT WINAPI DrawPrimitive(D3DPRIMITIVETYPE pt,UINT sv,UINT pc) override {
-        struct d3d9_draw_params p = {(uint32_t)pt,sv,pc}; unix_call(D3D9_FUNC_DRAW_PRIMITIVE,&p); return S_OK;
+    HRESULT WINAPI DrawPrimitive(D3DPRIMITIVETYPE pt, UINT sv, UINT pc) override {
+        struct d3d9_draw_params p = {(uint32_t)pt, sv, pc};
+        unix_call(D3D9_FUNC_DRAW_PRIMITIVE, &p);
+        return S_OK;
     }
-    HRESULT WINAPI DrawIndexedPrimitive(D3DPRIMITIVETYPE pt,INT bvi,UINT mvi,UINT nv,UINT si,UINT pc) override {
-        struct d3d9_draw_indexed_params p = {(uint32_t)pt,bvi,mvi,nv,si,pc};
-        unix_call(D3D9_FUNC_DRAW_INDEXED_PRIMITIVE,&p); return S_OK;
+    HRESULT WINAPI DrawIndexedPrimitive(D3DPRIMITIVETYPE pt, INT bvi, UINT mvi, UINT nv, UINT si, UINT pc) override {
+        struct d3d9_draw_indexed_params p = {(uint32_t)pt, bvi, mvi, nv, si, pc};
+        unix_call(D3D9_FUNC_DRAW_INDEXED_PRIMITIVE, &p);
+        return S_OK;
     }
-    HRESULT WINAPI DrawPrimitiveUP(D3DPRIMITIVETYPE,UINT,const void*,UINT) override { return E_NOTIMPL; }
-    HRESULT WINAPI DrawIndexedPrimitiveUP(D3DPRIMITIVETYPE,UINT,UINT,UINT,const void*,D3DFORMAT,const void*,UINT) override { return E_NOTIMPL; }
-    HRESULT WINAPI ProcessVertices(UINT,UINT,UINT,IDirect3DVertexBuffer9*,IDirect3DVertexDeclaration9*,DWORD) override { return E_NOTIMPL; }
-    HRESULT WINAPI CreateVertexDeclaration(const D3DVERTEXELEMENT9* els,IDirect3DVertexDeclaration9** pp) override {
-        if(!pp) return S_OK;
+    HRESULT WINAPI DrawPrimitiveUP(D3DPRIMITIVETYPE, UINT, const void*, UINT) override { return E_NOTIMPL; }
+    HRESULT WINAPI DrawIndexedPrimitiveUP(D3DPRIMITIVETYPE, UINT, UINT, UINT, const void*, D3DFORMAT, const void*,
+                                          UINT) override {
+        return E_NOTIMPL;
+    }
+    HRESULT WINAPI ProcessVertices(UINT, UINT, UINT, IDirect3DVertexBuffer9*, IDirect3DVertexDeclaration9*,
+                                   DWORD) override {
+        return E_NOTIMPL;
+    }
+    HRESULT WINAPI CreateVertexDeclaration(const D3DVERTEXELEMENT9* els, IDirect3DVertexDeclaration9** pp) override {
+        if (!pp)
+            return S_OK;
         auto* d = new MSD3DVertexDeclaration();
-        struct d3d9_create_vertex_decl_params p = {}; p.num_elements = 0;
+        struct d3d9_create_vertex_decl_params p = {};
+        p.num_elements = 0;
         struct d3d9_vertex_element elems[64];
-        if(els) {
-            for(UINT i=0;i<64;i++) {
-                if(els[i].Stream==0xFF && els[i].Type==D3DDECLTYPE_UNUSED) break;
-                elems[i].stream=els[i].Stream; elems[i].offset=els[i].Offset;
-                elems[i].type=els[i].Type; elems[i].method=els[i].Method;
-                elems[i].usage=els[i].Usage; elems[i].usage_index=els[i].UsageIndex;
+        if (els) {
+            for (UINT i = 0; i < 64; i++) {
+                if (els[i].Stream == 0xFF && els[i].Type == D3DDECLTYPE_UNUSED)
+                    break;
+                elems[i].stream = els[i].Stream;
+                elems[i].offset = els[i].Offset;
+                elems[i].type = els[i].Type;
+                elems[i].method = els[i].Method;
+                elems[i].usage = els[i].Usage;
+                elems[i].usage_index = els[i].UsageIndex;
                 p.num_elements++;
             }
             p.elements = elems;
         }
         NTSTATUS r = unix_call(D3D9_FUNC_CREATE_VERTEX_DECLARATION, &p);
-        if(r>=0) set_handle(d, p.out_handle);
-        *pp = d; return S_OK;
+        if (r >= 0)
+            set_handle(d, p.out_handle);
+        *pp = d;
+        return S_OK;
     }
-    HRESULT WINAPI SetVertexDeclaration(IDirect3DVertexDeclaration9* d) override { uint64_t h=obj_handle(d); unix_call(D3D9_FUNC_SET_VERTEX_DECLARATION,&h); return S_OK; }
-    HRESULT WINAPI GetVertexDeclaration(IDirect3DVertexDeclaration9** pp) override { if(pp)*pp=nullptr; return D3DERR_NOTFOUND; }
+    HRESULT WINAPI SetVertexDeclaration(IDirect3DVertexDeclaration9* d) override {
+        uint64_t h = obj_handle(d);
+        unix_call(D3D9_FUNC_SET_VERTEX_DECLARATION, &h);
+        return S_OK;
+    }
+    HRESULT WINAPI GetVertexDeclaration(IDirect3DVertexDeclaration9** pp) override {
+        if (pp)
+            *pp = nullptr;
+        return D3DERR_NOTFOUND;
+    }
     HRESULT WINAPI SetFVF(DWORD) override { return S_OK; }
     HRESULT WINAPI GetFVF(DWORD*) override { return E_NOTIMPL; }
-    HRESULT WINAPI CreateVertexShader(const DWORD* fn,IDirect3DVertexShader9** pp) override {
-        if(!pp) return S_OK;
+    HRESULT WINAPI CreateVertexShader(const DWORD* fn, IDirect3DVertexShader9** pp) override {
+        if (!pp)
+            return S_OK;
         auto* s = new MSD3DVertexShader();
         struct d3d9_create_shader_params p = {};
-        if(fn) {
-            const uint8_t* ptr=(const uint8_t*)fn; uint32_t sz=0;
-            if(ptr[0]=='D'&&ptr[1]=='X'&&ptr[2]=='B'&&ptr[3]=='C') { sz=*(const uint32_t*)(ptr+16); }
-            else { while(*(const uint32_t*)(ptr+sz)!=0x0000FFFF && sz<65536) sz+=4; sz+=4; }
-            p.bytecode=fn; p.bytecode_size=sz;
+        if (fn) {
+            const uint8_t* ptr = (const uint8_t*)fn;
+            uint32_t sz = 0;
+            if (ptr[0] == 'D' && ptr[1] == 'X' && ptr[2] == 'B' && ptr[3] == 'C') {
+                sz = *(const uint32_t*)(ptr + 16);
+            } else {
+                while (*(const uint32_t*)(ptr + sz) != 0x0000FFFF && sz < 65536)
+                    sz += 4;
+                sz += 4;
+            }
+            p.bytecode = fn;
+            p.bytecode_size = sz;
         }
         NTSTATUS r = unix_call(D3D9_FUNC_CREATE_VERTEX_SHADER, &p);
-        if(r>=0) set_handle(s, p.out_handle);
-        *pp = s; return S_OK;
+        if (r >= 0)
+            set_handle(s, p.out_handle);
+        *pp = s;
+        return S_OK;
     }
-    HRESULT WINAPI SetVertexShader(IDirect3DVertexShader9* s) override { uint64_t h=obj_handle(s); unix_call(D3D9_FUNC_SET_VERTEX_SHADER,&h); return S_OK; }
-    HRESULT WINAPI GetVertexShader(IDirect3DVertexShader9** pp) override { if(pp)*pp=nullptr; return D3DERR_NOTFOUND; }
-    HRESULT WINAPI SetVertexShaderConstantF(UINT sr,const float* d,UINT c) override {
-        struct d3d9_set_constants_f_params p = {}; p.start_register=sr; p.count=c*4;
-        if(p.count>256) p.count=256; if(d) memcpy(p.values,d,p.count*sizeof(float));
-        unix_call(D3D9_FUNC_SET_VS_CONSTANTS_F,&p); return S_OK;
+    HRESULT WINAPI SetVertexShader(IDirect3DVertexShader9* s) override {
+        uint64_t h = obj_handle(s);
+        unix_call(D3D9_FUNC_SET_VERTEX_SHADER, &h);
+        return S_OK;
     }
-    HRESULT WINAPI GetVertexShaderConstantF(UINT,float*,UINT) override { return E_NOTIMPL; }
-    HRESULT WINAPI SetVertexShaderConstantI(UINT,const int*,UINT) override { return S_OK; }
-    HRESULT WINAPI GetVertexShaderConstantI(UINT,int*,UINT) override { return E_NOTIMPL; }
-    HRESULT WINAPI SetVertexShaderConstantB(UINT,const BOOL*,UINT) override { return S_OK; }
-    HRESULT WINAPI GetVertexShaderConstantB(UINT,BOOL*,UINT) override { return E_NOTIMPL; }
-    HRESULT WINAPI SetStreamSource(UINT sn,IDirect3DVertexBuffer9* b,UINT off,UINT stride) override {
-        struct d3d9_set_stream_source_params p = {sn,obj_handle(b),off,stride};
-        unix_call(D3D9_FUNC_SET_STREAM_SOURCE,&p); return S_OK;
+    HRESULT WINAPI GetVertexShader(IDirect3DVertexShader9** pp) override {
+        if (pp)
+            *pp = nullptr;
+        return D3DERR_NOTFOUND;
     }
-    HRESULT WINAPI GetStreamSource(UINT,IDirect3DVertexBuffer9**,UINT*,UINT*) override { return E_NOTIMPL; }
-    HRESULT WINAPI SetStreamSourceFreq(UINT,UINT) override { return S_OK; }
-    HRESULT WINAPI GetStreamSourceFreq(UINT,UINT*) override { return E_NOTIMPL; }
-    HRESULT WINAPI SetIndices(IDirect3DIndexBuffer9* b) override { uint64_t h=obj_handle(b); unix_call(D3D9_FUNC_SET_INDICES,&h); return S_OK; }
-    HRESULT WINAPI GetIndices(IDirect3DIndexBuffer9** pp) override { if(pp)*pp=nullptr; return D3DERR_NOTFOUND; }
-    HRESULT WINAPI CreatePixelShader(const DWORD* fn,IDirect3DPixelShader9** pp) override {
-        if(!pp) return S_OK;
+    HRESULT WINAPI SetVertexShaderConstantF(UINT sr, const float* d, UINT c) override {
+        struct d3d9_set_constants_f_params p = {};
+        p.start_register = sr;
+        p.count = c * 4;
+        if (p.count > 256)
+            p.count = 256;
+        if (d)
+            memcpy(p.values, d, p.count * sizeof(float));
+        unix_call(D3D9_FUNC_SET_VS_CONSTANTS_F, &p);
+        return S_OK;
+    }
+    HRESULT WINAPI GetVertexShaderConstantF(UINT, float*, UINT) override { return E_NOTIMPL; }
+    HRESULT WINAPI SetVertexShaderConstantI(UINT, const int*, UINT) override { return S_OK; }
+    HRESULT WINAPI GetVertexShaderConstantI(UINT, int*, UINT) override { return E_NOTIMPL; }
+    HRESULT WINAPI SetVertexShaderConstantB(UINT, const BOOL*, UINT) override { return S_OK; }
+    HRESULT WINAPI GetVertexShaderConstantB(UINT, BOOL*, UINT) override { return E_NOTIMPL; }
+    HRESULT WINAPI SetStreamSource(UINT sn, IDirect3DVertexBuffer9* b, UINT off, UINT stride) override {
+        struct d3d9_set_stream_source_params p = {sn, obj_handle(b), off, stride};
+        unix_call(D3D9_FUNC_SET_STREAM_SOURCE, &p);
+        return S_OK;
+    }
+    HRESULT WINAPI GetStreamSource(UINT, IDirect3DVertexBuffer9**, UINT*, UINT*) override { return E_NOTIMPL; }
+    HRESULT WINAPI SetStreamSourceFreq(UINT, UINT) override { return S_OK; }
+    HRESULT WINAPI GetStreamSourceFreq(UINT, UINT*) override { return E_NOTIMPL; }
+    HRESULT WINAPI SetIndices(IDirect3DIndexBuffer9* b) override {
+        uint64_t h = obj_handle(b);
+        unix_call(D3D9_FUNC_SET_INDICES, &h);
+        return S_OK;
+    }
+    HRESULT WINAPI GetIndices(IDirect3DIndexBuffer9** pp) override {
+        if (pp)
+            *pp = nullptr;
+        return D3DERR_NOTFOUND;
+    }
+    HRESULT WINAPI CreatePixelShader(const DWORD* fn, IDirect3DPixelShader9** pp) override {
+        if (!pp)
+            return S_OK;
         auto* s = new MSD3DPixelShader();
         struct d3d9_create_shader_params p = {};
-        if(fn) {
-            const uint8_t* ptr=(const uint8_t*)fn; uint32_t sz=0;
-            if(ptr[0]=='D'&&ptr[1]=='X'&&ptr[2]=='B'&&ptr[3]=='C') { sz=*(const uint32_t*)(ptr+16); }
-            else { while(*(const uint32_t*)(ptr+sz)!=0x0000FFFF && sz<65536) sz+=4; sz+=4; }
-            p.bytecode=fn; p.bytecode_size=sz;
+        if (fn) {
+            const uint8_t* ptr = (const uint8_t*)fn;
+            uint32_t sz = 0;
+            if (ptr[0] == 'D' && ptr[1] == 'X' && ptr[2] == 'B' && ptr[3] == 'C') {
+                sz = *(const uint32_t*)(ptr + 16);
+            } else {
+                while (*(const uint32_t*)(ptr + sz) != 0x0000FFFF && sz < 65536)
+                    sz += 4;
+                sz += 4;
+            }
+            p.bytecode = fn;
+            p.bytecode_size = sz;
         }
         NTSTATUS r = unix_call(D3D9_FUNC_CREATE_PIXEL_SHADER, &p);
-        if(r>=0) set_handle(s, p.out_handle);
-        *pp = s; return S_OK;
+        if (r >= 0)
+            set_handle(s, p.out_handle);
+        *pp = s;
+        return S_OK;
     }
-    HRESULT WINAPI SetPixelShader(IDirect3DPixelShader9* s) override { uint64_t h=obj_handle(s); unix_call(D3D9_FUNC_SET_PIXEL_SHADER,&h); return S_OK; }
-    HRESULT WINAPI GetPixelShader(IDirect3DPixelShader9** pp) override { if(pp)*pp=nullptr; return D3DERR_NOTFOUND; }
-    HRESULT WINAPI SetPixelShaderConstantF(UINT sr,const float* d,UINT c) override {
-        struct d3d9_set_constants_f_params p = {}; p.start_register=sr; p.count=c*4;
-        if(p.count>256) p.count=256; if(d) memcpy(p.values,d,p.count*sizeof(float));
-        unix_call(D3D9_FUNC_SET_PS_CONSTANTS_F,&p); return S_OK;
+    HRESULT WINAPI SetPixelShader(IDirect3DPixelShader9* s) override {
+        uint64_t h = obj_handle(s);
+        unix_call(D3D9_FUNC_SET_PIXEL_SHADER, &h);
+        return S_OK;
     }
-    HRESULT WINAPI GetPixelShaderConstantF(UINT,float*,UINT) override { return E_NOTIMPL; }
-    HRESULT WINAPI SetPixelShaderConstantI(UINT,const int*,UINT) override { return S_OK; }
-    HRESULT WINAPI GetPixelShaderConstantI(UINT,int*,UINT) override { return E_NOTIMPL; }
-    HRESULT WINAPI SetPixelShaderConstantB(UINT,const BOOL*,UINT) override { return S_OK; }
-    HRESULT WINAPI GetPixelShaderConstantB(UINT,BOOL*,UINT) override { return E_NOTIMPL; }
-    HRESULT WINAPI DrawRectPatch(UINT,const float*,const D3DRECTPATCH_INFO*) override { return E_NOTIMPL; }
-    HRESULT WINAPI DrawTriPatch(UINT,const float*,const D3DTRIPATCH_INFO*) override { return E_NOTIMPL; }
+    HRESULT WINAPI GetPixelShader(IDirect3DPixelShader9** pp) override {
+        if (pp)
+            *pp = nullptr;
+        return D3DERR_NOTFOUND;
+    }
+    HRESULT WINAPI SetPixelShaderConstantF(UINT sr, const float* d, UINT c) override {
+        struct d3d9_set_constants_f_params p = {};
+        p.start_register = sr;
+        p.count = c * 4;
+        if (p.count > 256)
+            p.count = 256;
+        if (d)
+            memcpy(p.values, d, p.count * sizeof(float));
+        unix_call(D3D9_FUNC_SET_PS_CONSTANTS_F, &p);
+        return S_OK;
+    }
+    HRESULT WINAPI GetPixelShaderConstantF(UINT, float*, UINT) override { return E_NOTIMPL; }
+    HRESULT WINAPI SetPixelShaderConstantI(UINT, const int*, UINT) override { return S_OK; }
+    HRESULT WINAPI GetPixelShaderConstantI(UINT, int*, UINT) override { return E_NOTIMPL; }
+    HRESULT WINAPI SetPixelShaderConstantB(UINT, const BOOL*, UINT) override { return S_OK; }
+    HRESULT WINAPI GetPixelShaderConstantB(UINT, BOOL*, UINT) override { return E_NOTIMPL; }
+    HRESULT WINAPI DrawRectPatch(UINT, const float*, const D3DRECTPATCH_INFO*) override { return E_NOTIMPL; }
+    HRESULT WINAPI DrawTriPatch(UINT, const float*, const D3DTRIPATCH_INFO*) override { return E_NOTIMPL; }
     HRESULT WINAPI DeletePatch(UINT) override { return S_OK; }
-    HRESULT WINAPI CreateQuery(D3DQUERYTYPE,IDirect3DQuery9**) override { return E_NOTIMPL; }
+    HRESULT WINAPI CreateQuery(D3DQUERYTYPE, IDirect3DQuery9**) override { return E_NOTIMPL; }
 };
 
 static MSD3DDevice9* g_device = nullptr;
 
 class MSD3D9 : public IDirect3D9 {
     LONG m_ref = 1;
-public:
-    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override { if(ppv)*ppv=nullptr; return E_NOINTERFACE; }
+
+  public:
+    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override {
+        if (ppv)
+            *ppv = nullptr;
+        return E_NOINTERFACE;
+    }
     ULONG WINAPI AddRef() override { return InterlockedIncrement(&m_ref); }
-    ULONG WINAPI Release() override { ULONG r = InterlockedDecrement(&m_ref); return r ? r : 0; }
+    ULONG WINAPI Release() override {
+        ULONG r = InterlockedDecrement(&m_ref);
+        return r ? r : 0;
+    }
     HRESULT WINAPI RegisterSoftwareDevice(void*) override { return S_OK; }
     UINT WINAPI GetAdapterCount() override { return 1; }
-    HRESULT WINAPI GetAdapterIdentifier(UINT,DWORD,D3DADAPTER_IDENTIFIER9* p) override {
-        if(!p) return E_POINTER; memset(p,0,sizeof(*p));
-        strncpy(p->Driver,"metalsharp_d3d9",sizeof(p->Driver)-1);
-        strncpy(p->Description,"MetalSharp D3D9",sizeof(p->Description)-1);
-        p->VendorId=0x106B; p->DeviceId=1; p->WHQLLevel=1; return S_OK;
+    HRESULT WINAPI GetAdapterIdentifier(UINT, DWORD, D3DADAPTER_IDENTIFIER9* p) override {
+        if (!p)
+            return E_POINTER;
+        memset(p, 0, sizeof(*p));
+        strncpy(p->Driver, "metalsharp_d3d9", sizeof(p->Driver) - 1);
+        strncpy(p->Description, "MetalSharp D3D9", sizeof(p->Description) - 1);
+        p->VendorId = 0x106B;
+        p->DeviceId = 1;
+        p->WHQLLevel = 1;
+        return S_OK;
     }
-    UINT WINAPI GetAdapterModeCount(UINT,D3DFORMAT) override { return 1; }
-    HRESULT WINAPI EnumAdapterModes(UINT,D3DFORMAT,UINT,D3DDISPLAYMODE* p) override {
-        if(p){p->Width=1920;p->Height=1080;p->RefreshRate=60;p->Format=D3DFMT_X8R8G8B8;} return S_OK;
+    UINT WINAPI GetAdapterModeCount(UINT, D3DFORMAT) override { return 1; }
+    HRESULT WINAPI EnumAdapterModes(UINT, D3DFORMAT, UINT, D3DDISPLAYMODE* p) override {
+        if (p) {
+            p->Width = 1920;
+            p->Height = 1080;
+            p->RefreshRate = 60;
+            p->Format = D3DFMT_X8R8G8B8;
+        }
+        return S_OK;
     }
-    HRESULT WINAPI GetAdapterDisplayMode(UINT,D3DDISPLAYMODE* p) override {
-        if(p){p->Width=1920;p->Height=1080;p->RefreshRate=60;p->Format=D3DFMT_X8R8G8B8;} return S_OK;
+    HRESULT WINAPI GetAdapterDisplayMode(UINT, D3DDISPLAYMODE* p) override {
+        if (p) {
+            p->Width = 1920;
+            p->Height = 1080;
+            p->RefreshRate = 60;
+            p->Format = D3DFMT_X8R8G8B8;
+        }
+        return S_OK;
     }
-    HRESULT WINAPI CheckDeviceType(UINT,D3DDEVTYPE,D3DFORMAT,D3DFORMAT,BOOL) override { return D3D_OK; }
-    HRESULT WINAPI CheckDeviceFormat(UINT,D3DDEVTYPE,D3DFORMAT,DWORD,D3DRESOURCETYPE,D3DFORMAT) override { return D3D_OK; }
-    HRESULT WINAPI CheckDeviceMultiSampleType(UINT,D3DDEVTYPE,D3DFORMAT,BOOL,D3DMULTISAMPLE_TYPE,DWORD*) override { return D3D_OK; }
-    HRESULT WINAPI CheckDepthStencilMatch(UINT,D3DDEVTYPE,D3DFORMAT,D3DFORMAT,D3DFORMAT) override { return D3D_OK; }
-    HRESULT WINAPI CheckDeviceFormatConversion(UINT,D3DDEVTYPE,D3DFORMAT,D3DFORMAT) override { return D3D_OK; }
-    HRESULT WINAPI GetDeviceCaps(UINT,D3DDEVTYPE,D3DCAPS9* p) override { if(!p) return E_POINTER; fill_caps(p); return S_OK; }
+    HRESULT WINAPI CheckDeviceType(UINT, D3DDEVTYPE, D3DFORMAT, D3DFORMAT, BOOL) override { return D3D_OK; }
+    HRESULT WINAPI CheckDeviceFormat(UINT, D3DDEVTYPE, D3DFORMAT, DWORD, D3DRESOURCETYPE, D3DFORMAT) override {
+        return D3D_OK;
+    }
+    HRESULT WINAPI CheckDeviceMultiSampleType(UINT, D3DDEVTYPE, D3DFORMAT, BOOL, D3DMULTISAMPLE_TYPE, DWORD*) override {
+        return D3D_OK;
+    }
+    HRESULT WINAPI CheckDepthStencilMatch(UINT, D3DDEVTYPE, D3DFORMAT, D3DFORMAT, D3DFORMAT) override { return D3D_OK; }
+    HRESULT WINAPI CheckDeviceFormatConversion(UINT, D3DDEVTYPE, D3DFORMAT, D3DFORMAT) override { return D3D_OK; }
+    HRESULT WINAPI GetDeviceCaps(UINT, D3DDEVTYPE, D3DCAPS9* p) override {
+        if (!p)
+            return E_POINTER;
+        fill_caps(p);
+        return S_OK;
+    }
     HMONITOR WINAPI GetAdapterMonitor(UINT) override { return (HMONITOR)1; }
-    HRESULT WINAPI CreateDevice(UINT,D3DDEVTYPE,HWND hw,DWORD,D3DPRESENT_PARAMETERS* pp,IDirect3DDevice9** ppd) override {
+    HRESULT WINAPI CreateDevice(UINT, D3DDEVTYPE, HWND hw, DWORD, D3DPRESENT_PARAMETERS* pp,
+                                IDirect3DDevice9** ppd) override {
         fprintf(stderr, "[d3d9] CreateDevice called\n");
-        if(!ppd) return E_POINTER;
-        if(!init_unix_call()) return E_FAIL;
+        if (!ppd)
+            return E_POINTER;
+        if (!init_unix_call())
+            return E_FAIL;
         NTSTATUS r = unix_call(D3D9_FUNC_INIT, nullptr);
-        if(r<0) return E_FAIL;
+        if (r < 0)
+            return E_FAIL;
         struct d3d9_create_device_params p = {};
-        if(pp) {
-            p.width=pp->BackBufferWidth; p.height=pp->BackBufferHeight;
-            p.back_buffer_format=(uint32_t)pp->BackBufferFormat; p.windowed=pp->Windowed;
-            p.back_buffer_count=pp->BackBufferCount; p.enable_auto_depth_stencil=pp->EnableAutoDepthStencil;
-            p.auto_depth_stencil_format=(uint32_t)pp->AutoDepthStencilFormat;
-            p.presentation_interval=(uint32_t)pp->PresentationInterval;
-            p.multisample_type=(uint32_t)pp->MultiSampleType; p.multisample_quality=pp->MultiSampleQuality;
-        } else { p.width=1280; p.height=720; p.windowed=1; p.back_buffer_count=1; p.back_buffer_format=22; }
-        p.hwnd=(uint64_t)(uintptr_t)hw;
+        if (pp) {
+            p.width = pp->BackBufferWidth;
+            p.height = pp->BackBufferHeight;
+            p.back_buffer_format = (uint32_t)pp->BackBufferFormat;
+            p.windowed = pp->Windowed;
+            p.back_buffer_count = pp->BackBufferCount;
+            p.enable_auto_depth_stencil = pp->EnableAutoDepthStencil;
+            p.auto_depth_stencil_format = (uint32_t)pp->AutoDepthStencilFormat;
+            p.presentation_interval = (uint32_t)pp->PresentationInterval;
+            p.multisample_type = (uint32_t)pp->MultiSampleType;
+            p.multisample_quality = pp->MultiSampleQuality;
+        } else {
+            p.width = 1280;
+            p.height = 720;
+            p.windowed = 1;
+            p.back_buffer_count = 1;
+            p.back_buffer_format = 22;
+        }
+        p.hwnd = (uint64_t)(uintptr_t)hw;
         r = unix_call(D3D9_FUNC_CREATE_DEVICE, &p);
-        if(r<0) return E_FAIL;
+        if (r < 0)
+            return E_FAIL;
         auto* dev = new MSD3DDevice9(this);
         g_device = dev;
-        *ppd = dev; return S_OK;
+        *ppd = dev;
+        return S_OK;
     }
 };
 
@@ -549,16 +953,17 @@ static MSD3D9 g_d3d9_impl;
 
 BOOL WINAPI DllMain(HINSTANCE inst, DWORD reason, LPVOID reserved) {
     (void)reserved;
-    if(reason == DLL_PROCESS_ATTACH) { g_hModule = (HMODULE)inst; DisableThreadLibraryCalls(inst); }
+    if (reason == DLL_PROCESS_ATTACH) {
+        g_hModule = (HMODULE)inst;
+        DisableThreadLibraryCalls(inst);
+    }
     return TRUE;
 }
 
 extern "C" {
 
-__declspec(dllexport)
-IDirect3D9* WINAPI Direct3DCreate9(UINT SDKVersion) {
+__declspec(dllexport) IDirect3D9* WINAPI Direct3DCreate9(UINT SDKVersion) {
     fprintf(stderr, "[d3d9] Direct3DCreate9(%u)\n", SDKVersion);
     return &g_d3d9_impl;
 }
-
 }

--- a/src/wine/d3d9_unix.h
+++ b/src/wine/d3d9_unix.h
@@ -1,12 +1,14 @@
 /// @file d3d9_unix.h
 /// @brief Shared header for Wine D3D9 PE/Unix interface.
 ///
-/// Defines the unixlib dispatch table, shared structures, and callback types used by the PE-side D3D9 shim to communicate with the Unix-side Metal backend. Covers D3D9 device creation, swap chain, and resource management calls.
+/// Defines the unixlib dispatch table, shared structures, and callback types used by the PE-side D3D9 shim to
+/// communicate with the Unix-side Metal backend. Covers D3D9 device creation, swap chain, and resource management
+/// calls.
 #ifndef METALSHARP_D3D9_UNIX_H
 #define METALSHARP_D3D9_UNIX_H
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/wine/d3d9_unix.mm
+++ b/src/wine/d3d9_unix.mm
@@ -1,18 +1,19 @@
 /// @file d3d9_unix.mm
 /// @brief Unix-side D3D9 Metal backend (Objective-C++ Metal implementation).
 ///
-/// Implements the Metal backend for D3D9 calls received from the PE side. Handles IDirect3DDevice9 draw calls, texture management, fixed-function pipeline emulation via Metal shaders, and swap chain presentation through CAMetalLayer.
+/// Implements the Metal backend for D3D9 calls received from the PE side. Handles IDirect3DDevice9 draw calls, texture
+/// management, fixed-function pipeline emulation via Metal shaders, and swap chain presentation through CAMetalLayer.
+#import <AppKit/AppKit.h>
 #import <Metal/Metal.h>
 #import <QuartzCore/CAMetalLayer.h>
-#import <AppKit/AppKit.h>
 
+#include <mutex>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdint.h>
 #include <unordered_map>
 #include <vector>
-#include <mutex>
 
 extern "C" {
 #include "mojoshader/mojoshader.h"
@@ -29,13 +30,8 @@ static id<MTLFunction> mojo_translate_to_metal(const uint8_t* bytecode, uint32_t
     char func_name[64];
     snprintf(func_name, sizeof(func_name), "%s_main", stage);
 
-    const MOJOSHADER_parseData* pd = MOJOSHADER_parse(
-        MOJOSHADER_PROFILE_METAL,
-        func_name,
-        bytecode, size,
-        NULL, 0, NULL, 0,
-        NULL, NULL, NULL
-    );
+    const MOJOSHADER_parseData* pd =
+        MOJOSHADER_parse(MOJOSHADER_PROFILE_METAL, func_name, bytecode, size, NULL, 0, NULL, 0, NULL, NULL, NULL);
 
     if (!pd || pd->error_count > 0) {
         if (pd && pd->errors) {
@@ -43,7 +39,8 @@ static id<MTLFunction> mojo_translate_to_metal(const uint8_t* bytecode, uint32_t
         } else {
             fprintf(stderr, "[mojo] %s parse returned NULL\n", stage);
         }
-        if (pd) MOJOSHADER_freeParseData(pd);
+        if (pd)
+            MOJOSHADER_freeParseData(pd);
         return nil;
     }
 
@@ -56,17 +53,20 @@ static id<MTLFunction> mojo_translate_to_metal(const uint8_t* bytecode, uint32_t
     fprintf(stderr, "[mojo] %s translated %u bytes bytecode -> %d bytes MSL\n", stage, size, pd->output_len);
 
     @autoreleasepool {
-        NSString* source = [[NSString alloc] initWithBytes:pd->output length:pd->output_len encoding:NSUTF8StringEncoding];
+        NSString* source = [[NSString alloc] initWithBytes:pd->output
+                                                    length:pd->output_len
+                                                  encoding:NSUTF8StringEncoding];
         NSError* error = nil;
         id<MTLLibrary> library = [g_device newLibraryWithSource:source options:nil error:&error];
         if (error || !library) {
             fprintf(stderr, "[mojo] %s Metal compile error: %s\n", stage,
-                error ? [[error localizedDescription] UTF8String] : "unknown");
+                    error ? [[error localizedDescription] UTF8String] : "unknown");
             MOJOSHADER_freeParseData(pd);
             return nil;
         }
 
-        NSString* funcName = pd->mainfn ? [NSString stringWithUTF8String:pd->mainfn] : [NSString stringWithUTF8String:func_name];
+        NSString* funcName =
+            pd->mainfn ? [NSString stringWithUTF8String:pd->mainfn] : [NSString stringWithUTF8String:func_name];
         id<MTLFunction> func = [library newFunctionWithName:funcName];
         if (!func) {
             func = [library newFunctionWithName:@"main"];
@@ -78,7 +78,9 @@ static id<MTLFunction> mojo_translate_to_metal(const uint8_t* bytecode, uint32_t
 
 static std::mutex g_mutex;
 static uint64_t g_next_handle = 0x2000;
-static uint64_t new_handle() { return ++g_next_handle; }
+static uint64_t new_handle() {
+    return ++g_next_handle;
+}
 
 struct D3D9Buffer {
     id<MTLBuffer> buffer;
@@ -150,94 +152,157 @@ static std::unordered_map<uint64_t, D3D9VertexDecl> g_vertex_decls;
 
 static MTLPixelFormat d3dformat_to_mtl(uint32_t fmt) {
     switch (fmt) {
-        case 21: return MTLPixelFormatBGRA8Unorm;
-        case 22: return MTLPixelFormatBGRA8Unorm;
-        case 23: return MTLPixelFormatB5G6R5Unorm;
-        case 28: return MTLPixelFormatA8Unorm;
-        case 75: return MTLPixelFormatDepth24Unorm_Stencil8;
-        case 80: return MTLPixelFormatDepth16Unorm;
-        case 82: return MTLPixelFormatDepth32Float;
-        case 83: return MTLPixelFormatDepth32Float_Stencil8;
-        case 111: return MTLPixelFormatR16Float;
-        case 112: return MTLPixelFormatRG16Float;
-        case 113: return MTLPixelFormatRGBA16Float;
-        case 114: return MTLPixelFormatR32Float;
-        case 115: return MTLPixelFormatRG32Float;
-        case 116: return MTLPixelFormatRGBA32Float;
-        case 50: return MTLPixelFormatA8Unorm;
-        case 51: return MTLPixelFormatRG8Unorm;
-        default: return MTLPixelFormatBGRA8Unorm;
+    case 21:
+        return MTLPixelFormatBGRA8Unorm;
+    case 22:
+        return MTLPixelFormatBGRA8Unorm;
+    case 23:
+        return MTLPixelFormatB5G6R5Unorm;
+    case 28:
+        return MTLPixelFormatA8Unorm;
+    case 75:
+        return MTLPixelFormatDepth24Unorm_Stencil8;
+    case 80:
+        return MTLPixelFormatDepth16Unorm;
+    case 82:
+        return MTLPixelFormatDepth32Float;
+    case 83:
+        return MTLPixelFormatDepth32Float_Stencil8;
+    case 111:
+        return MTLPixelFormatR16Float;
+    case 112:
+        return MTLPixelFormatRG16Float;
+    case 113:
+        return MTLPixelFormatRGBA16Float;
+    case 114:
+        return MTLPixelFormatR32Float;
+    case 115:
+        return MTLPixelFormatRG32Float;
+    case 116:
+        return MTLPixelFormatRGBA32Float;
+    case 50:
+        return MTLPixelFormatA8Unorm;
+    case 51:
+        return MTLPixelFormatRG8Unorm;
+    default:
+        return MTLPixelFormatBGRA8Unorm;
     }
 }
 
 static MTLVertexFormat d3ddecltype_to_mtl(uint8_t type) {
     switch (type) {
-        case 0: return MTLVertexFormatFloat;
-        case 1: return MTLVertexFormatFloat2;
-        case 2: return MTLVertexFormatFloat3;
-        case 3: return MTLVertexFormatFloat4;
-        case 4: return MTLVertexFormatUChar4Normalized;
-        case 5: return MTLVertexFormatUChar4;
-        case 6: return MTLVertexFormatShort2;
-        case 7: return MTLVertexFormatShort4;
-        case 8: return MTLVertexFormatUChar4Normalized;
-        case 9: return MTLVertexFormatShort2Normalized;
-        case 10: return MTLVertexFormatShort4Normalized;
-        case 11: return MTLVertexFormatUShort2Normalized;
-        case 12: return MTLVertexFormatUShort4Normalized;
-        case 15: return MTLVertexFormatHalf2;
-        case 16: return MTLVertexFormatHalf4;
-        default: return MTLVertexFormatFloat4;
+    case 0:
+        return MTLVertexFormatFloat;
+    case 1:
+        return MTLVertexFormatFloat2;
+    case 2:
+        return MTLVertexFormatFloat3;
+    case 3:
+        return MTLVertexFormatFloat4;
+    case 4:
+        return MTLVertexFormatUChar4Normalized;
+    case 5:
+        return MTLVertexFormatUChar4;
+    case 6:
+        return MTLVertexFormatShort2;
+    case 7:
+        return MTLVertexFormatShort4;
+    case 8:
+        return MTLVertexFormatUChar4Normalized;
+    case 9:
+        return MTLVertexFormatShort2Normalized;
+    case 10:
+        return MTLVertexFormatShort4Normalized;
+    case 11:
+        return MTLVertexFormatUShort2Normalized;
+    case 12:
+        return MTLVertexFormatUShort4Normalized;
+    case 15:
+        return MTLVertexFormatHalf2;
+    case 16:
+        return MTLVertexFormatHalf4;
+    default:
+        return MTLVertexFormatFloat4;
     }
 }
 
 static uint32_t d3ddecltype_size(uint8_t type) {
     switch (type) {
-        case 0: return 4;
-        case 1: return 8;
-        case 2: return 12;
-        case 3: return 16;
-        case 4: return 4;
-        case 5: return 4;
-        case 6: return 4;
-        case 7: return 8;
-        case 8: return 4;
-        case 9: return 4;
-        case 10: return 8;
-        case 11: return 4;
-        case 12: return 8;
-        case 15: return 4;
-        case 16: return 8;
-        default: return 16;
+    case 0:
+        return 4;
+    case 1:
+        return 8;
+    case 2:
+        return 12;
+    case 3:
+        return 16;
+    case 4:
+        return 4;
+    case 5:
+        return 4;
+    case 6:
+        return 4;
+    case 7:
+        return 8;
+    case 8:
+        return 4;
+    case 9:
+        return 4;
+    case 10:
+        return 8;
+    case 11:
+        return 4;
+    case 12:
+        return 8;
+    case 15:
+        return 4;
+    case 16:
+        return 8;
+    default:
+        return 16;
     }
 }
 
 static MTLPrimitiveType d3dprim_to_mtl(uint32_t prim) {
     switch (prim) {
-        case 1: return MTLPrimitiveTypePoint;
-        case 2: return MTLPrimitiveTypeLine;
-        case 3: return MTLPrimitiveTypeLineStrip;
-        case 4: return MTLPrimitiveTypeTriangle;
-        case 5: return MTLPrimitiveTypeTriangleStrip;
-        default: return MTLPrimitiveTypeTriangle;
+    case 1:
+        return MTLPrimitiveTypePoint;
+    case 2:
+        return MTLPrimitiveTypeLine;
+    case 3:
+        return MTLPrimitiveTypeLineStrip;
+    case 4:
+        return MTLPrimitiveTypeTriangle;
+    case 5:
+        return MTLPrimitiveTypeTriangleStrip;
+    default:
+        return MTLPrimitiveTypeTriangle;
     }
 }
 
 static uint32_t prim_vertex_count(uint32_t prim_type, uint32_t prim_count) {
     switch (prim_type) {
-        case 1: return prim_count;
-        case 2: return prim_count * 2;
-        case 3: return prim_count + 1;
-        case 4: return prim_count * 3;
-        case 5: return prim_count + 2;
-        default: return prim_count * 3;
+    case 1:
+        return prim_count;
+    case 2:
+        return prim_count * 2;
+    case 3:
+        return prim_count + 1;
+    case 4:
+        return prim_count * 3;
+    case 5:
+        return prim_count + 2;
+    default:
+        return prim_count * 3;
     }
 }
 
 static NTSTATUS d3d9_init(void*) {
-    if (g_device) return 0;
+    if (g_device)
+        return 0;
     g_device = MTLCreateSystemDefaultDevice();
-    if (!g_device) return -1;
+    if (!g_device)
+        return -1;
     g_queue = [g_device newCommandQueue];
     memset((void*)&g_state, 0, sizeof(g_state));
     fprintf(stderr, "[d3d9] Metal device: %s\n", [[g_device name] UTF8String]);
@@ -246,10 +311,12 @@ static NTSTATUS d3d9_init(void*) {
 
 static NTSTATUS d3d9_create_device(void* p) {
     auto* params = (struct d3d9_create_device_params*)p;
-    if (!g_device) d3d9_init(nullptr);
+    if (!g_device)
+        d3d9_init(nullptr);
 
     if (g_swapchain) {
-        if (g_swapchain->window) [g_swapchain->window close];
+        if (g_swapchain->window)
+            [g_swapchain->window close];
         delete g_swapchain;
     }
     g_swapchain = new D3D9SwapChain();
@@ -257,42 +324,42 @@ static NTSTATUS d3d9_create_device(void* p) {
     g_swapchain->height = params->height > 0 ? params->height : 720;
 
     dispatch_async(dispatch_get_main_queue(), ^{
-        NSRect frame = NSMakeRect(0, 0, g_swapchain->width, g_swapchain->height);
-        NSUInteger style = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable |
-                           NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable;
-        g_swapchain->window = [[NSWindow alloc] initWithContentRect:frame
-                                                          styleMask:style
-                                                            backing:NSBackingStoreBuffered
-                                                              defer:NO];
-        [g_swapchain->window setTitle:@"MetalSharp D3D9"];
-        [g_swapchain->window makeKeyAndOrderFront:nil];
+      NSRect frame = NSMakeRect(0, 0, g_swapchain->width, g_swapchain->height);
+      NSUInteger style = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable |
+                         NSWindowStyleMaskResizable;
+      g_swapchain->window = [[NSWindow alloc] initWithContentRect:frame
+                                                        styleMask:style
+                                                          backing:NSBackingStoreBuffered
+                                                            defer:NO];
+      [g_swapchain->window setTitle:@"MetalSharp D3D9"];
+      [g_swapchain->window makeKeyAndOrderFront:nil];
 
-        g_swapchain->layer = [CAMetalLayer layer];
-        g_swapchain->layer.device = g_device;
-        g_swapchain->layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
-        g_swapchain->layer.framebufferOnly = NO;
-        g_swapchain->layer.drawableSize = CGSizeMake(g_swapchain->width, g_swapchain->height);
+      g_swapchain->layer = [CAMetalLayer layer];
+      g_swapchain->layer.device = g_device;
+      g_swapchain->layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
+      g_swapchain->layer.framebufferOnly = NO;
+      g_swapchain->layer.drawableSize = CGSizeMake(g_swapchain->width, g_swapchain->height);
 
-        NSView* cv = [g_swapchain->window contentView];
-        cv.wantsLayer = YES;
-        cv.layer = g_swapchain->layer;
+      NSView* cv = [g_swapchain->window contentView];
+      cv.wantsLayer = YES;
+      cv.layer = g_swapchain->layer;
     });
 
-    fprintf(stderr, "[d3d9] Device created: %ux%u windowed=%d\n",
-        g_swapchain->width, g_swapchain->height, params->windowed);
+    fprintf(stderr, "[d3d9] Device created: %ux%u windowed=%d\n", g_swapchain->width, g_swapchain->height,
+            params->windowed);
     return 0;
 }
 
 static NTSTATUS d3d9_create_vertex_buffer(void* p) {
     auto* params = (struct d3d9_create_buffer_params*)p;
-    if (!g_device) d3d9_init(nullptr);
+    if (!g_device)
+        d3d9_init(nullptr);
 
     uint64_t handle = new_handle();
     auto& buf = g_buffers[handle];
     buf.size = params->length;
 
-    buf.buffer = [g_device newBufferWithLength:params->length
-                                       options:MTLResourceStorageModeShared];
+    buf.buffer = [g_device newBufferWithLength:params->length options:MTLResourceStorageModeShared];
 
     if (!buf.buffer) {
         g_buffers.erase(handle);
@@ -306,14 +373,14 @@ static NTSTATUS d3d9_create_vertex_buffer(void* p) {
 
 static NTSTATUS d3d9_create_index_buffer(void* p) {
     auto* params = (struct d3d9_create_buffer_params*)p;
-    if (!g_device) d3d9_init(nullptr);
+    if (!g_device)
+        d3d9_init(nullptr);
 
     uint64_t handle = new_handle();
     auto& buf = g_buffers[handle];
     buf.size = params->length;
 
-    buf.buffer = [g_device newBufferWithLength:params->length
-                                       options:MTLResourceStorageModeShared];
+    buf.buffer = [g_device newBufferWithLength:params->length options:MTLResourceStorageModeShared];
 
     if (!buf.buffer) {
         g_buffers.erase(handle);
@@ -327,7 +394,8 @@ static NTSTATUS d3d9_create_index_buffer(void* p) {
 
 static NTSTATUS d3d9_create_texture(void* p) {
     auto* params = (struct d3d9_create_texture_params*)p;
-    if (!g_device) d3d9_init(nullptr);
+    if (!g_device)
+        d3d9_init(nullptr);
 
     uint64_t handle = new_handle();
     auto& tex = g_textures[handle];
@@ -356,7 +424,8 @@ static NTSTATUS d3d9_create_texture(void* p) {
 
 static NTSTATUS d3d9_create_render_target(void* p) {
     auto* params = (struct d3d9_create_surface_params*)p;
-    if (!g_device) d3d9_init(nullptr);
+    if (!g_device)
+        d3d9_init(nullptr);
 
     uint64_t handle = new_handle();
     auto& tex = g_textures[handle];
@@ -385,7 +454,8 @@ static NTSTATUS d3d9_create_render_target(void* p) {
 
 static NTSTATUS d3d9_create_depth_stencil(void* p) {
     auto* params = (struct d3d9_create_surface_params*)p;
-    if (!g_device) d3d9_init(nullptr);
+    if (!g_device)
+        d3d9_init(nullptr);
 
     uint64_t handle = new_handle();
     auto& tex = g_textures[handle];
@@ -414,7 +484,8 @@ static NTSTATUS d3d9_create_depth_stencil(void* p) {
 
 static NTSTATUS d3d9_create_vertex_shader(void* p) {
     auto* params = (struct d3d9_create_shader_params*)p;
-    if (!g_device) d3d9_init(nullptr);
+    if (!g_device)
+        d3d9_init(nullptr);
 
     uint64_t handle = new_handle();
     auto& shader = g_shaders[handle];
@@ -431,12 +502,14 @@ static NTSTATUS d3d9_create_vertex_shader(void* p) {
             size_t source_len = remaining - name_len - 1;
 
             @autoreleasepool {
-                NSString* nsSource = [[NSString alloc] initWithBytes:source length:source_len encoding:NSUTF8StringEncoding];
+                NSString* nsSource = [[NSString alloc] initWithBytes:source
+                                                              length:source_len
+                                                            encoding:NSUTF8StringEncoding];
                 NSError* error = nil;
                 id<MTLLibrary> library = [g_device newLibraryWithSource:nsSource options:nil error:&error];
                 if (error || !library) {
                     fprintf(stderr, "[d3d9] VS compile error: %s\n",
-                        error ? [[error localizedDescription] UTF8String] : "unknown");
+                            error ? [[error localizedDescription] UTF8String] : "unknown");
                 } else {
                     NSString* nsFunc = [NSString stringWithUTF8String:func_name];
                     shader.function = [library newFunctionWithName:nsFunc];
@@ -459,7 +532,8 @@ static NTSTATUS d3d9_create_vertex_shader(void* p) {
 
 static NTSTATUS d3d9_create_pixel_shader(void* p) {
     auto* params = (struct d3d9_create_shader_params*)p;
-    if (!g_device) d3d9_init(nullptr);
+    if (!g_device)
+        d3d9_init(nullptr);
 
     uint64_t handle = new_handle();
     auto& shader = g_shaders[handle];
@@ -476,12 +550,14 @@ static NTSTATUS d3d9_create_pixel_shader(void* p) {
             size_t source_len = remaining - name_len - 1;
 
             @autoreleasepool {
-                NSString* nsSource = [[NSString alloc] initWithBytes:source length:source_len encoding:NSUTF8StringEncoding];
+                NSString* nsSource = [[NSString alloc] initWithBytes:source
+                                                              length:source_len
+                                                            encoding:NSUTF8StringEncoding];
                 NSError* error = nil;
                 id<MTLLibrary> library = [g_device newLibraryWithSource:nsSource options:nil error:&error];
                 if (error || !library) {
                     fprintf(stderr, "[d3d9] PS compile error: %s\n",
-                        error ? [[error localizedDescription] UTF8String] : "unknown");
+                            error ? [[error localizedDescription] UTF8String] : "unknown");
                 } else {
                     NSString* nsFunc = [NSString stringWithUTF8String:func_name];
                     shader.function = [library newFunctionWithName:nsFunc];
@@ -516,8 +592,8 @@ static NTSTATUS d3d9_create_vertex_declaration(void* p) {
     }
 
     params->out_handle = handle;
-    fprintf(stderr, "[d3d9] Vertex declaration created: %u elements handle=%llu\n",
-        params->num_elements, (unsigned long long)handle);
+    fprintf(stderr, "[d3d9] Vertex declaration created: %u elements handle=%llu\n", params->num_elements,
+            (unsigned long long)handle);
     return 0;
 }
 
@@ -562,13 +638,15 @@ static NTSTATUS d3d9_set_pixel_shader(void* p) {
 
 static NTSTATUS d3d9_set_vs_constants_f(void* p) {
     auto* params = (struct d3d9_set_constants_f_params*)p;
-    if (!g_state.command_buffer || !g_state.in_render_pass) return 0;
+    if (!g_state.command_buffer || !g_state.in_render_pass)
+        return 0;
     uint32_t byte_count = params->count * sizeof(float);
-    if (byte_count == 0) return 0;
+    if (byte_count == 0)
+        return 0;
 
     id<MTLBuffer> const_buf = [g_device newBufferWithBytes:params->values
-                                                     length:byte_count
-                                                    options:MTLResourceStorageModeShared];
+                                                    length:byte_count
+                                                   options:MTLResourceStorageModeShared];
     if (const_buf && g_state.encoder) {
         uint32_t base_idx = params->start_register + 20;
         [g_state.encoder setVertexBuffer:const_buf offset:0 atIndex:base_idx];
@@ -578,13 +656,15 @@ static NTSTATUS d3d9_set_vs_constants_f(void* p) {
 
 static NTSTATUS d3d9_set_ps_constants_f(void* p) {
     auto* params = (struct d3d9_set_constants_f_params*)p;
-    if (!g_state.command_buffer || !g_state.in_render_pass) return 0;
+    if (!g_state.command_buffer || !g_state.in_render_pass)
+        return 0;
     uint32_t byte_count = params->count * sizeof(float);
-    if (byte_count == 0) return 0;
+    if (byte_count == 0)
+        return 0;
 
     id<MTLBuffer> const_buf = [g_device newBufferWithBytes:params->values
-                                                     length:byte_count
-                                                    options:MTLResourceStorageModeShared];
+                                                    length:byte_count
+                                                   options:MTLResourceStorageModeShared];
     if (const_buf && g_state.encoder) {
         uint32_t base_idx = params->start_register + 20;
         [g_state.encoder setFragmentBuffer:const_buf offset:0 atIndex:base_idx];
@@ -623,7 +703,8 @@ static NTSTATUS d3d9_set_render_state(void* p) {
 }
 
 static void ensure_render_pass() {
-    if (g_state.in_render_pass) return;
+    if (g_state.in_render_pass)
+        return;
     if (!g_state.command_buffer) {
         g_state.command_buffer = [g_queue commandBuffer];
     }
@@ -668,8 +749,7 @@ static void ensure_render_pass() {
     if (g_state.needs_pipeline_update && g_state.vertex_shader_handle && g_state.pixel_shader_handle) {
         auto vs_it = g_shaders.find(g_state.vertex_shader_handle);
         auto ps_it = g_shaders.find(g_state.pixel_shader_handle);
-        if (vs_it != g_shaders.end() && ps_it != g_shaders.end() &&
-            vs_it->second.function && ps_it->second.function) {
+        if (vs_it != g_shaders.end() && ps_it != g_shaders.end() && vs_it->second.function && ps_it->second.function) {
 
             @autoreleasepool {
                 MTLRenderPipelineDescriptor* pdesc = [[MTLRenderPipelineDescriptor alloc] init];
@@ -695,7 +775,7 @@ static void ensure_render_pass() {
                 g_state.current_pipeline = [g_device newRenderPipelineStateWithDescriptor:pdesc error:&error];
                 if (error || !g_state.current_pipeline) {
                     fprintf(stderr, "[d3d9] Pipeline error: %s\n",
-                        error ? [[error localizedDescription] UTF8String] : "unknown");
+                            error ? [[error localizedDescription] UTF8String] : "unknown");
                 }
                 g_state.needs_pipeline_update = false;
             }
@@ -707,9 +787,8 @@ static void ensure_render_pass() {
     }
 
     if (g_state.has_viewport) {
-        MTLViewport vp = { (double)g_state.viewport_x, (double)g_state.viewport_y,
-                           (double)g_state.viewport_w, (double)g_state.viewport_h,
-                           (double)g_state.viewport_min_z, (double)g_state.viewport_max_z };
+        MTLViewport vp = {(double)g_state.viewport_x, (double)g_state.viewport_y,     (double)g_state.viewport_w,
+                          (double)g_state.viewport_h, (double)g_state.viewport_min_z, (double)g_state.viewport_max_z};
         [g_state.encoder setViewport:vp];
     }
 
@@ -717,9 +796,7 @@ static void ensure_render_pass() {
         if (g_state.vertex_buffer_handles[i]) {
             auto it = g_buffers.find(g_state.vertex_buffer_handles[i]);
             if (it != g_buffers.end() && it->second.buffer) {
-                [g_state.encoder setVertexBuffer:it->second.buffer
-                                          offset:g_state.vertex_offsets[i]
-                                         atIndex:i];
+                [g_state.encoder setVertexBuffer:it->second.buffer offset:g_state.vertex_offsets[i] atIndex:i];
             }
         }
     }
@@ -728,7 +805,8 @@ static void ensure_render_pass() {
 static NTSTATUS d3d9_draw_primitive(void* p) {
     auto* params = (struct d3d9_draw_params*)p;
     ensure_render_pass();
-    if (!g_state.encoder) return -1;
+    if (!g_state.encoder)
+        return -1;
 
     uint32_t vertex_count = prim_vertex_count(params->primitive_type, params->primitive_count);
     [g_state.encoder drawPrimitives:d3dprim_to_mtl(params->primitive_type)
@@ -740,7 +818,8 @@ static NTSTATUS d3d9_draw_primitive(void* p) {
 static NTSTATUS d3d9_draw_indexed_primitive(void* p) {
     auto* params = (struct d3d9_draw_indexed_params*)p;
     ensure_render_pass();
-    if (!g_state.encoder) return -1;
+    if (!g_state.encoder)
+        return -1;
 
     if (g_state.index_buffer_handle) {
         auto it = g_buffers.find(g_state.index_buffer_handle);
@@ -775,10 +854,14 @@ static NTSTATUS d3d9_clear(void* p) {
         for (int i = 0; i < 4; i++) {
             if (g_state.render_targets[i]) {
                 auto it = g_textures.find(g_state.render_targets[i]);
-                if (it != g_textures.end()) { target = it->second.texture; break; }
+                if (it != g_textures.end()) {
+                    target = it->second.texture;
+                    break;
+                }
             }
         }
-        if (!target && g_swapchain && g_swapchain->back_buffer) target = g_swapchain->back_buffer;
+        if (!target && g_swapchain && g_swapchain->back_buffer)
+            target = g_swapchain->back_buffer;
 
         if (target) {
             auto* attachment = desc.colorAttachments[0];
@@ -819,7 +902,8 @@ static NTSTATUS d3d9_clear(void* p) {
 }
 
 static NTSTATUS d3d9_present(void*) {
-    if (!g_swapchain || !g_swapchain->layer) return -1;
+    if (!g_swapchain || !g_swapchain->layer)
+        return -1;
 
     @autoreleasepool {
         if (g_state.in_render_pass && g_state.encoder) {
@@ -833,16 +917,21 @@ static NTSTATUS d3d9_present(void*) {
         }
 
         id<CAMetalDrawable> drawable = [g_swapchain->layer nextDrawable];
-        if (!drawable) return 0;
+        if (!drawable)
+            return 0;
 
         if (g_swapchain->back_buffer) {
             id<MTLCommandBuffer> blit = [g_queue commandBuffer];
             id<MTLBlitCommandEncoder> blitEnc = [blit blitCommandEncoder];
             [blitEnc copyFromTexture:g_swapchain->back_buffer
-                         sourceSlice:0 sourceLevel:0 sourceOrigin:MTLOriginMake(0,0,0)
-                           sourceSize:MTLSizeMake(g_swapchain->width, g_swapchain->height, 1)
-                            toTexture:drawable.texture
-                     destinationSlice:0 destinationLevel:0 destinationOrigin:MTLOriginMake(0,0,0)];
+                         sourceSlice:0
+                         sourceLevel:0
+                        sourceOrigin:MTLOriginMake(0, 0, 0)
+                          sourceSize:MTLSizeMake(g_swapchain->width, g_swapchain->height, 1)
+                           toTexture:drawable.texture
+                    destinationSlice:0
+                    destinationLevel:0
+                   destinationOrigin:MTLOriginMake(0, 0, 0)];
             [blitEnc endEncoding];
             [blit presentDrawable:drawable];
             [blit commit];
@@ -883,9 +972,8 @@ static NTSTATUS d3d9_set_viewport(void* p) {
     g_state.has_viewport = true;
 
     if (g_state.encoder) {
-        MTLViewport mtlvp = { (double)vp->x, (double)vp->y,
-                              (double)vp->width, (double)vp->height,
-                              (double)vp->min_z, (double)vp->max_z };
+        MTLViewport mtlvp = {(double)vp->x,      (double)vp->y,     (double)vp->width,
+                             (double)vp->height, (double)vp->min_z, (double)vp->max_z};
         [g_state.encoder setViewport:mtlvp];
     }
     return 0;
@@ -894,9 +982,8 @@ static NTSTATUS d3d9_set_viewport(void* p) {
 static NTSTATUS d3d9_set_scissor_rect(void* p) {
     auto* r = (struct d3d9_scissor_rect*)p;
     if (g_state.encoder) {
-        MTLScissorRect scissor = { (NSUInteger)r->left, (NSUInteger)r->top,
-                                   (NSUInteger)(r->right - r->left),
-                                   (NSUInteger)(r->bottom - r->top) };
+        MTLScissorRect scissor = {(NSUInteger)r->left, (NSUInteger)r->top, (NSUInteger)(r->right - r->left),
+                                  (NSUInteger)(r->bottom - r->top)};
         [g_state.encoder setScissorRect:scissor];
     }
     return 0;
@@ -938,14 +1025,15 @@ static NTSTATUS d3d9_map(void* p) {
     return -1;
 }
 
-static NTSTATUS d3d9_stub(void*) { return 0; }
+static NTSTATUS d3d9_stub(void*) {
+    return 0;
+}
 
 extern "C" {
 
 typedef NTSTATUS (*unixlib_entry_t)(void*);
 
-__attribute__((used, visibility("default")))
-unixlib_entry_t __wine_unix_call_funcs[] = {
+__attribute__((used, visibility("default"))) unixlib_entry_t __wine_unix_call_funcs[] = {
     d3d9_init,
     d3d9_create_device,
     d3d9_create_vertex_buffer,
@@ -982,8 +1070,7 @@ unixlib_entry_t __wine_unix_call_funcs[] = {
     d3d9_stub,
 };
 
-__attribute__((used, visibility("default")))
-unixlib_entry_t __wine_unix_call_wow64_funcs[] = {
+__attribute__((used, visibility("default"))) unixlib_entry_t __wine_unix_call_wow64_funcs[] = {
     d3d9_init,
     d3d9_create_device,
     d3d9_create_vertex_buffer,
@@ -1020,6 +1107,7 @@ unixlib_entry_t __wine_unix_call_wow64_funcs[] = {
     d3d9_stub,
 };
 
-NTSTATUS __attribute__((visibility("default"))) __wine_unix_lib_init(void) { return 0; }
-
+NTSTATUS __attribute__((visibility("default"))) __wine_unix_lib_init(void) {
+    return 0;
+}
 }

--- a/src/wine/dxgi_pe.cpp
+++ b/src/wine/dxgi_pe.cpp
@@ -1,11 +1,12 @@
 /// @file dxgi_pe.cpp
 /// @brief Wine DXGI PE module for swap chain and adapter enumeration.
 ///
-/// Implements IDXGIFactory, IDXGIAdapter, and IDXGISwapChain COM interfaces. Enumerates real display modes via the unixlib backend and manages swap chain presentation against the game's window (HWND→CAMetalLayer).
+/// Implements IDXGIFactory, IDXGIAdapter, and IDXGISwapChain COM interfaces. Enumerates real display modes via the
+/// unixlib backend and manages swap chain presentation against the game's window (HWND→CAMetalLayer).
 #include <dxgi.h>
-#include <string.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 #include <windows.h>
 
 typedef long (*MetalSharpUnixCall_t)(unsigned int, void*);
@@ -40,38 +41,67 @@ struct ms_get_buffer_params {
 };
 
 static bool load_d3d11() {
-    if (g_unix_call) return true;
+    if (g_unix_call)
+        return true;
     HMODULE d3d11 = GetModuleHandleA("d3d11.dll");
-    if (!d3d11) d3d11 = LoadLibraryA("d3d11.dll");
-    if (!d3d11) { fprintf(stderr, "[metalsharp-dxgi] cannot load d3d11.dll\n"); return false; }
-    
+    if (!d3d11)
+        d3d11 = LoadLibraryA("d3d11.dll");
+    if (!d3d11) {
+        fprintf(stderr, "[metalsharp-dxgi] cannot load d3d11.dll\n");
+        return false;
+    }
+
     g_unix_call = (MetalSharpUnixCall_t)GetProcAddress(d3d11, "MetalSharpUnixCall");
-    g_get_swapchain = (void*(*)())GetProcAddress(d3d11, "MetalSharpGetSwapChain");
-    
-    if (!g_unix_call) { fprintf(stderr, "[metalsharp-dxgi] MetalSharpUnixCall not found\n"); return false; }
+    g_get_swapchain = (void* (*)())GetProcAddress(d3d11, "MetalSharpGetSwapChain");
+
+    if (!g_unix_call) {
+        fprintf(stderr, "[metalsharp-dxgi] MetalSharpUnixCall not found\n");
+        return false;
+    }
     fprintf(stderr, "[metalsharp-dxgi] bridge to d3d11.dll OK\n");
     return true;
 }
 
 class MSCPSwapChain : public IDXGISwapChain {
     LONG m_ref = 1;
-public:
-    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override { if(ppv)*ppv=NULL; return E_NOINTERFACE; }
+
+  public:
+    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override {
+        if (ppv)
+            *ppv = NULL;
+        return E_NOINTERFACE;
+    }
     ULONG WINAPI AddRef() override { return InterlockedIncrement(&m_ref); }
-    ULONG WINAPI Release() override { LONG r = InterlockedDecrement(&m_ref); return r?r:1; }
+    ULONG WINAPI Release() override {
+        LONG r = InterlockedDecrement(&m_ref);
+        return r ? r : 1;
+    }
     HRESULT WINAPI SetPrivateDataInterface(REFGUID, const IUnknown*) override { return S_OK; }
     HRESULT WINAPI GetPrivateData(REFGUID, UINT*, void*) override { return E_NOTIMPL; }
     HRESULT WINAPI SetPrivateData(REFGUID, UINT, const void*) override { return S_OK; }
-    HRESULT WINAPI GetParent(REFIID, void** pp) override { if(pp)*pp=NULL; return E_NOINTERFACE; }
-    HRESULT WINAPI GetDevice(REFIID, void** pp) override { if(pp)*pp=NULL; return E_NOINTERFACE; }
-    
+    HRESULT WINAPI GetParent(REFIID, void** pp) override {
+        if (pp)
+            *pp = NULL;
+        return E_NOINTERFACE;
+    }
+    HRESULT WINAPI GetDevice(REFIID, void** pp) override {
+        if (pp)
+            *pp = NULL;
+        return E_NOINTERFACE;
+    }
+
     HRESULT WINAPI Present(UINT, UINT) override {
-        if (g_unix_call) g_unix_call(MS_FUNC_PRESENT, nullptr);
+        if (g_unix_call)
+            g_unix_call(MS_FUNC_PRESENT, nullptr);
         return S_OK;
     }
-    
+
     HRESULT WINAPI GetBuffer(UINT idx, REFIID, void** pp) override {
-        if (!g_unix_call || !pp) { if(pp)*pp=NULL; return E_FAIL; }
+        if (!g_unix_call || !pp) {
+            if (pp)
+                *pp = NULL;
+            return E_FAIL;
+        }
         struct ms_get_buffer_params p = {};
         p.buffer_index = idx;
         g_unix_call(MS_FUNC_GET_BUFFER, &p);
@@ -82,8 +112,11 @@ public:
         *pp = NULL;
         return E_FAIL;
     }
-    
-    HRESULT WINAPI GetDesc(DXGI_SWAP_CHAIN_DESC* p) override { memset(p,0,sizeof(*p)); return S_OK; }
+
+    HRESULT WINAPI GetDesc(DXGI_SWAP_CHAIN_DESC* p) override {
+        memset(p, 0, sizeof(*p));
+        return S_OK;
+    }
     HRESULT WINAPI ResizeBuffers(UINT, UINT w, UINT h, DXGI_FORMAT, UINT) override {
         if (g_unix_call) {
             struct ms_resize_params p = {w, h, 2};
@@ -92,9 +125,20 @@ public:
         return S_OK;
     }
     HRESULT WINAPI ResizeTarget(const DXGI_MODE_DESC*) override { return S_OK; }
-    HRESULT WINAPI GetContainingOutput(IDXGIOutput** pp) override { if(pp)*pp=NULL; return E_NOTIMPL; }
-    HRESULT WINAPI GetFrameStatistics(DXGI_FRAME_STATISTICS* p) override { memset(p,0,sizeof(*p)); return S_OK; }
-    HRESULT WINAPI GetLastPresentCount(UINT* p) override { if(p)*p=0; return S_OK; }
+    HRESULT WINAPI GetContainingOutput(IDXGIOutput** pp) override {
+        if (pp)
+            *pp = NULL;
+        return E_NOTIMPL;
+    }
+    HRESULT WINAPI GetFrameStatistics(DXGI_FRAME_STATISTICS* p) override {
+        memset(p, 0, sizeof(*p));
+        return S_OK;
+    }
+    HRESULT WINAPI GetLastPresentCount(UINT* p) override {
+        if (p)
+            *p = 0;
+        return S_OK;
+    }
     HRESULT WINAPI SetFullscreenState(BOOL, IDXGIOutput*) override { return S_OK; }
     HRESULT WINAPI GetFullscreenState(BOOL*, IDXGIOutput**) override { return S_OK; }
 };
@@ -103,46 +147,90 @@ static MSCPSwapChain g_swapchain;
 
 class MSCPADapter : public IDXGIAdapter {
     LONG m_ref = 1;
-public:
-    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override { if(ppv)*ppv=NULL; return E_NOINTERFACE; }
+
+  public:
+    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override {
+        if (ppv)
+            *ppv = NULL;
+        return E_NOINTERFACE;
+    }
     ULONG WINAPI AddRef() override { return InterlockedIncrement(&m_ref); }
-    ULONG WINAPI Release() override { LONG r = InterlockedDecrement(&m_ref); return r?r:1; }
+    ULONG WINAPI Release() override {
+        LONG r = InterlockedDecrement(&m_ref);
+        return r ? r : 1;
+    }
     HRESULT WINAPI SetPrivateDataInterface(REFGUID, const IUnknown*) override { return S_OK; }
     HRESULT WINAPI GetPrivateData(REFGUID, UINT*, void*) override { return E_NOTIMPL; }
     HRESULT WINAPI SetPrivateData(REFGUID, UINT, const void*) override { return S_OK; }
-    HRESULT WINAPI GetParent(REFIID, void** pp) override { if(pp)*pp=NULL; return E_NOINTERFACE; }
-    HRESULT WINAPI EnumOutputs(UINT idx, IDXGIOutput** pp) override { if(pp)*pp=NULL; return DXGI_ERROR_NOT_FOUND; }
+    HRESULT WINAPI GetParent(REFIID, void** pp) override {
+        if (pp)
+            *pp = NULL;
+        return E_NOINTERFACE;
+    }
+    HRESULT WINAPI EnumOutputs(UINT idx, IDXGIOutput** pp) override {
+        if (pp)
+            *pp = NULL;
+        return DXGI_ERROR_NOT_FOUND;
+    }
     HRESULT WINAPI GetDesc(DXGI_ADAPTER_DESC* p) override {
-        memset(p,0,sizeof(*p));
+        memset(p, 0, sizeof(*p));
         p->VendorId = 0x106B;
-        p->DedicatedVideoMemory = 512*1024*1024;
+        p->DedicatedVideoMemory = 512 * 1024 * 1024;
         return S_OK;
     }
-    HRESULT WINAPI CheckInterfaceSupport(REFGUID, LARGE_INTEGER* pv) override { if(pv)pv->QuadPart=1; return S_OK; }
+    HRESULT WINAPI CheckInterfaceSupport(REFGUID, LARGE_INTEGER* pv) override {
+        if (pv)
+            pv->QuadPart = 1;
+        return S_OK;
+    }
 };
 
 static MSCPADapter g_adapter;
 
 class MSCPGIFactory : public IDXGIFactory {
     LONG m_ref = 1;
-public:
-    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override { if(ppv)*ppv=NULL; return E_NOINTERFACE; }
+
+  public:
+    HRESULT WINAPI QueryInterface(REFIID, void** ppv) override {
+        if (ppv)
+            *ppv = NULL;
+        return E_NOINTERFACE;
+    }
     ULONG WINAPI AddRef() override { return InterlockedIncrement(&m_ref); }
-    ULONG WINAPI Release() override { LONG r = InterlockedDecrement(&m_ref); return r?r:1; }
+    ULONG WINAPI Release() override {
+        LONG r = InterlockedDecrement(&m_ref);
+        return r ? r : 1;
+    }
     HRESULT WINAPI SetPrivateDataInterface(REFGUID, const IUnknown*) override { return S_OK; }
     HRESULT WINAPI GetPrivateData(REFGUID, UINT*, void*) override { return E_NOTIMPL; }
     HRESULT WINAPI SetPrivateData(REFGUID, UINT, const void*) override { return S_OK; }
-    HRESULT WINAPI GetParent(REFIID, void** pp) override { if(pp)*pp=NULL; return E_NOINTERFACE; }
+    HRESULT WINAPI GetParent(REFIID, void** pp) override {
+        if (pp)
+            *pp = NULL;
+        return E_NOINTERFACE;
+    }
     HRESULT WINAPI EnumAdapters(UINT idx, IDXGIAdapter** pp) override {
-        if(idx==0){if(pp)*pp=&g_adapter; return S_OK;}
-        if(pp)*pp=NULL; return DXGI_ERROR_NOT_FOUND;
+        if (idx == 0) {
+            if (pp)
+                *pp = &g_adapter;
+            return S_OK;
+        }
+        if (pp)
+            *pp = NULL;
+        return DXGI_ERROR_NOT_FOUND;
     }
     HRESULT WINAPI MakeWindowAssociation(HWND, UINT) override { return S_OK; }
-    HRESULT WINAPI GetWindowAssociation(HWND* p) override { if(p)*p=NULL; return S_OK; }
-    HRESULT WINAPI CreateSwapChain(IUnknown* pDevice, DXGI_SWAP_CHAIN_DESC* pDesc, IDXGISwapChain** ppSwapChain) override {
-        if (!ppSwapChain) return E_POINTER;
+    HRESULT WINAPI GetWindowAssociation(HWND* p) override {
+        if (p)
+            *p = NULL;
+        return S_OK;
+    }
+    HRESULT WINAPI CreateSwapChain(IUnknown* pDevice, DXGI_SWAP_CHAIN_DESC* pDesc,
+                                   IDXGISwapChain** ppSwapChain) override {
+        if (!ppSwapChain)
+            return E_POINTER;
         load_d3d11();
-        
+
         if (g_unix_call && pDesc) {
             struct ms_create_swap_chain_params p = {};
             p.width = pDesc->BufferDesc.Width;
@@ -153,37 +241,42 @@ public:
             p.hwnd = (uint64_t)(uintptr_t)pDesc->OutputWindow;
             g_unix_call(MS_FUNC_CREATE_SWAP_CHAIN, &p);
         }
-        
+
         *ppSwapChain = &g_swapchain;
         return S_OK;
     }
     HRESULT WINAPI CreateSoftwareAdapter(HMODULE, IDXGIAdapter** pp) override {
-        if(pp)*pp=&g_adapter; return S_OK;
+        if (pp)
+            *pp = &g_adapter;
+        return S_OK;
     }
 };
 
 static MSCPGIFactory g_factory;
 
 BOOL WINAPI DllMain(HINSTANCE, DWORD reason, LPVOID) {
-    if (reason == DLL_PROCESS_ATTACH) load_d3d11();
+    if (reason == DLL_PROCESS_ATTACH)
+        load_d3d11();
     return TRUE;
 }
 
 extern "C" {
 
 __declspec(dllexport) HRESULT WINAPI CreateDXGIFactory(REFIID, void** pp) {
-    if(pp) *pp = &g_factory;
+    if (pp)
+        *pp = &g_factory;
     return S_OK;
 }
 
 __declspec(dllexport) HRESULT WINAPI CreateDXGIFactory1(REFIID, void** pp) {
-    if(pp) *pp = &g_factory;
+    if (pp)
+        *pp = &g_factory;
     return S_OK;
 }
 
 __declspec(dllexport) HRESULT WINAPI CreateDXGIFactory2(UINT, REFIID, void** pp) {
-    if(pp) *pp = &g_factory;
+    if (pp)
+        *pp = &g_factory;
     return S_OK;
 }
-
 }

--- a/src/wine/metalsharp_d3d11_pe.cpp
+++ b/src/wine/metalsharp_d3d11_pe.cpp
@@ -1,7 +1,9 @@
 /// @file metalsharp_d3d11_pe.cpp
 /// @brief Wine PE-side D3D11 DLL entry point for MetalSharp.
 ///
-/// Implements the Windows-side D3D11 COM class factory (DllGetClassObject, DllCanUnloadNow) that Wine loads as d3d11.dll. Marshals D3D11 interface calls across the PE/Unix boundary to the MetalSharp Metal backend via the unixlib thunk.
+/// Implements the Windows-side D3D11 COM class factory (DllGetClassObject, DllCanUnloadNow) that Wine loads as
+/// d3d11.dll. Marshals D3D11 interface calls across the PE/Unix boundary to the MetalSharp Metal backend via the
+/// unixlib thunk.
 #include "metalsharp_unix.h"
 #include <wine/debug.h>
 
@@ -10,13 +12,16 @@ WINE_DEFAULT_DEBUG_CHANNEL(metalsharp);
 static ms_unix_call_func unix_call = NULL;
 
 static BOOL init_unix_lib(void) {
-    if (unix_call) return TRUE;
+    if (unix_call)
+        return TRUE;
 
     HMODULE mod = GetModuleHandleA("metalsharp_unix.dll");
-    if (!mod) return FALSE;
+    if (!mod)
+        return FALSE;
 
     unix_call = (ms_unix_call_func)GetProcAddress(mod, "__wine_unix_call_funcs");
-    if (!unix_call) return FALSE;
+    if (!unix_call)
+        return FALSE;
 
     unix_call(MS_FUNC_INIT, NULL);
     return TRUE;
@@ -48,26 +53,36 @@ typedef struct IDXGIAdapter {
     const struct IDXGIAdapterVtbl* lpVtbl;
 } IDXGIAdapter;
 
-static ULONG STDMETHODCALLTYPE device_AddRef(ID3D11Device* This) { return 1; }
-static ULONG STDMETHODCALLTYPE device_Release(ID3D11Device* This) { return 0; }
+static ULONG STDMETHODCALLTYPE device_AddRef(ID3D11Device* This) {
+    return 1;
+}
+static ULONG STDMETHODCALLTYPE device_Release(ID3D11Device* This) {
+    return 0;
+}
 static HRESULT STDMETHODCALLTYPE device_QueryInterface(ID3D11Device* This, REFIID riid, void** ppv) {
     *ppv = NULL;
     return E_NOINTERFACE;
 }
 
-static HRESULT STDMETHODCALLTYPE device_CheckFeatureSupport(ID3D11Device* This, int Feature, void* pFeatureSupportData, UINT FeatureSupportDataSize) {
+static HRESULT STDMETHODCALLTYPE device_CheckFeatureSupport(ID3D11Device* This, int Feature, void* pFeatureSupportData,
+                                                            UINT FeatureSupportDataSize) {
     return E_NOTIMPL;
 }
 
-static HRESULT STDMETHODCALLTYPE device_CreateTexture2D(ID3D11Device* This, const void* pDesc, const void* pInitialData, void** ppTexture2D) {
-    if (!ppTexture2D) return E_POINTER;
+static HRESULT STDMETHODCALLTYPE device_CreateTexture2D(ID3D11Device* This, const void* pDesc, const void* pInitialData,
+                                                        void** ppTexture2D) {
+    if (!ppTexture2D)
+        return E_POINTER;
     *ppTexture2D = (void*)0x1;
     return S_OK;
 }
 
-static HRESULT STDMETHODCALLTYPE device_CreateBuffer(ID3D11Device* This, const void* pDesc, const void* pInitialData, void** ppBuffer) {
-    if (!ppTexture2D) return E_POINTER;
-    if (!init_unix_lib()) return E_FAIL;
+static HRESULT STDMETHODCALLTYPE device_CreateBuffer(ID3D11Device* This, const void* pDesc, const void* pInitialData,
+                                                     void** ppBuffer) {
+    if (!ppTexture2D)
+        return E_POINTER;
+    if (!init_unix_lib())
+        return E_FAIL;
     struct ms_create_buffer_params params = {0};
     params.initial_data = pInitialData;
     unix_call(MS_FUNC_CREATE_BUFFER, &params);
@@ -75,83 +90,113 @@ static HRESULT STDMETHODCALLTYPE device_CreateBuffer(ID3D11Device* This, const v
     return S_OK;
 }
 
-static HRESULT STDMETHODCALLTYPE device_CreateVertexShader(ID3D11Device* This, const void* pShaderBytecode, SIZE_T BytecodeLength, void* pClassLinkage, void** ppVertexShader) {
-    if (!ppVertexShader) return E_POINTER;
+static HRESULT STDMETHODCALLTYPE device_CreateVertexShader(ID3D11Device* This, const void* pShaderBytecode,
+                                                           SIZE_T BytecodeLength, void* pClassLinkage,
+                                                           void** ppVertexShader) {
+    if (!ppVertexShader)
+        return E_POINTER;
     *ppVertexShader = (void*)0x3;
     return S_OK;
 }
 
-static HRESULT STDMETHODCALLTYPE device_CreatePixelShader(ID3D11Device* This, const void* pShaderBytecode, SIZE_T BytecodeLength, void* pClassLinkage, void** ppPixelShader) {
-    if (!ppPixelShader) return E_POINTER;
+static HRESULT STDMETHODCALLTYPE device_CreatePixelShader(ID3D11Device* This, const void* pShaderBytecode,
+                                                          SIZE_T BytecodeLength, void* pClassLinkage,
+                                                          void** ppPixelShader) {
+    if (!ppPixelShader)
+        return E_POINTER;
     *ppPixelShader = (void*)0x4;
     return S_OK;
 }
 
-static HRESULT STDMETHODCALLTYPE device_CreateInputLayout(ID3D11Device* This, const void* pInputElementDescs, UINT NumElements, const void* pShaderBytecodeWithInputSignature, SIZE_T BytecodeLength, void** ppInputLayout) {
-    if (!ppInputLayout) return E_POINTER;
+static HRESULT STDMETHODCALLTYPE device_CreateInputLayout(ID3D11Device* This, const void* pInputElementDescs,
+                                                          UINT NumElements,
+                                                          const void* pShaderBytecodeWithInputSignature,
+                                                          SIZE_T BytecodeLength, void** ppInputLayout) {
+    if (!ppInputLayout)
+        return E_POINTER;
     *ppInputLayout = (void*)0x5;
     return S_OK;
 }
 
-static HRESULT STDMETHODCALLTYPE device_CreateRenderTargetView(ID3D11Device* This, void* pResource, const void* pDesc, void** ppRTView) {
-    if (!ppRTView) return E_POINTER;
+static HRESULT STDMETHODCALLTYPE device_CreateRenderTargetView(ID3D11Device* This, void* pResource, const void* pDesc,
+                                                               void** ppRTView) {
+    if (!ppRTView)
+        return E_POINTER;
     *ppRTView = (void*)0x6;
     return S_OK;
 }
 
-static HRESULT STDMETHODCALLTYPE device_CreateDepthStencilView(ID3D11Device* This, void* pResource, const void* pDesc, void** ppDepthStencilView) {
-    if (!ppDepthStencilView) return E_POINTER;
+static HRESULT STDMETHODCALLTYPE device_CreateDepthStencilView(ID3D11Device* This, void* pResource, const void* pDesc,
+                                                               void** ppDepthStencilView) {
+    if (!ppDepthStencilView)
+        return E_POINTER;
     *ppDepthStencilView = (void*)0x7;
     return S_OK;
 }
 
-static HRESULT STDMETHODCALLTYPE device_CreateSamplerState(ID3D11Device* This, const void* pSamplerDesc, void** ppSamplerState) {
-    if (!ppSamplerState) return E_POINTER;
+static HRESULT STDMETHODCALLTYPE device_CreateSamplerState(ID3D11Device* This, const void* pSamplerDesc,
+                                                           void** ppSamplerState) {
+    if (!ppSamplerState)
+        return E_POINTER;
     *ppSamplerState = (void*)0x8;
     return S_OK;
 }
 
-static HRESULT STDMETHODCALLTYPE device_CreateBlendState(ID3D11Device* This, const void* pBlendStateDesc, void** ppBlendState) {
-    if (!ppBlendState) return E_POINTER;
+static HRESULT STDMETHODCALLTYPE device_CreateBlendState(ID3D11Device* This, const void* pBlendStateDesc,
+                                                         void** ppBlendState) {
+    if (!ppBlendState)
+        return E_POINTER;
     *ppBlendState = (void*)0x9;
     return S_OK;
 }
 
-static HRESULT STDMETHODCALLTYPE device_CreateRasterizerState(ID3D11Device* This, const void* pRasterizerDesc, void** ppRasterizerState) {
-    if (!ppRasterizerState) return E_POINTER;
+static HRESULT STDMETHODCALLTYPE device_CreateRasterizerState(ID3D11Device* This, const void* pRasterizerDesc,
+                                                              void** ppRasterizerState) {
+    if (!ppRasterizerState)
+        return E_POINTER;
     *ppRasterizerState = (void*)0xA;
     return S_OK;
 }
 
-static HRESULT STDMETHODCALLTYPE device_CreateDepthStencilState(ID3D11Device* This, const void* pDepthStencilDesc, void** ppDepthStencilState) {
-    if (!ppDepthStencilState) return E_POINTER;
+static HRESULT STDMETHODCALLTYPE device_CreateDepthStencilState(ID3D11Device* This, const void* pDepthStencilDesc,
+                                                                void** ppDepthStencilState) {
+    if (!ppDepthStencilState)
+        return E_POINTER;
     *ppDepthStencilState = (void*)0xB;
     return S_OK;
 }
 
 static void STDMETHODCALLTYPE device_GetImmediateContext(ID3D11Device* This, ID3D11DeviceContext** ppImmediateContext);
 
-static HRESULT STDMETHODCALLTYPE device_CreateShaderResourceView(ID3D11Device* This, void* pResource, const void* pDesc, void** ppSRView) {
-    if (!ppSRView) return E_POINTER;
+static HRESULT STDMETHODCALLTYPE device_CreateShaderResourceView(ID3D11Device* This, void* pResource, const void* pDesc,
+                                                                 void** ppSRView) {
+    if (!ppSRView)
+        return E_POINTER;
     *ppSRView = (void*)0xC;
     return S_OK;
 }
 
-static HRESULT STDMETHODCALLTYPE device_CreateComputeShader(ID3D11Device* This, const void* pShaderBytecode, SIZE_T BytecodeLength, void* pClassLinkage, void** ppComputeShader) {
-    if (!ppComputeShader) return E_POINTER;
+static HRESULT STDMETHODCALLTYPE device_CreateComputeShader(ID3D11Device* This, const void* pShaderBytecode,
+                                                            SIZE_T BytecodeLength, void* pClassLinkage,
+                                                            void** ppComputeShader) {
+    if (!ppComputeShader)
+        return E_POINTER;
     *ppComputeShader = (void*)0xD;
     return S_OK;
 }
 
-static HRESULT STDMETHODCALLTYPE device_CreateUnorderedAccessView(ID3D11Device* This, void* pResource, const void* pDesc, void** ppUAView) {
-    if (!ppUAView) return E_POINTER;
+static HRESULT STDMETHODCALLTYPE device_CreateUnorderedAccessView(ID3D11Device* This, void* pResource,
+                                                                  const void* pDesc, void** ppUAView) {
+    if (!ppUAView)
+        return E_POINTER;
     *ppUAView = (void*)0xE;
     return S_OK;
 }
 
 static void STDMETHODCALLTYPE device_GetFeatureLevel(ID3D11Device* This, void* pFeatureLevel) {
     static const int level = 0xb000;
-    if (pFeatureLevel) memcpy(pFeatureLevel, &level, sizeof(int));
+    if (pFeatureLevel)
+        memcpy(pFeatureLevel, &level, sizeof(int));
 }
 
 static const struct ID3D11DeviceVtbl device_vtbl = {
@@ -219,62 +264,88 @@ static const struct ID3D11DeviceVtbl device_vtbl = {
     device_GetFeatureLevel,
 };
 
-static ID3D11Device g_device = { &device_vtbl };
+static ID3D11Device g_device = {&device_vtbl};
 static ID3D11DeviceContext g_context;
 
-static void STDMETHODCALLTYPE ctx_QueryInterface(ID3D11DeviceContext* This, REFIID riid, void** ppv) { *ppv = NULL; }
-static ULONG STDMETHODCALLTYPE ctx_AddRef(ID3D11DeviceContext* This) { return 1; }
-static ULONG STDMETHODCALLTYPE ctx_Release(ID3D11DeviceContext* This) { return 0; }
+static void STDMETHODCALLTYPE ctx_QueryInterface(ID3D11DeviceContext* This, REFIID riid, void** ppv) {
+    *ppv = NULL;
+}
+static ULONG STDMETHODCALLTYPE ctx_AddRef(ID3D11DeviceContext* This) {
+    return 1;
+}
+static ULONG STDMETHODCALLTYPE ctx_Release(ID3D11DeviceContext* This) {
+    return 0;
+}
 
-static void STDMETHODCALLTYPE ctx_IASetVertexBuffers(ID3D11DeviceContext* This, UINT StartSlot, UINT NumBuffers, void* const* ppVertexBuffers, const UINT* pStrides, const UINT* pOffsets) {}
+static void STDMETHODCALLTYPE ctx_IASetVertexBuffers(ID3D11DeviceContext* This, UINT StartSlot, UINT NumBuffers,
+                                                     void* const* ppVertexBuffers, const UINT* pStrides,
+                                                     const UINT* pOffsets) {}
 static void STDMETHODCALLTYPE ctx_IASetIndexBuffer(ID3D11DeviceContext* This, void* pBuffer, int Format, UINT Offset) {}
 static void STDMETHODCALLTYPE ctx_IASetPrimitiveTopology(ID3D11DeviceContext* This, int Topology) {}
-static void STDMETHODCALLTYPE ctx_DrawIndexed(ID3D11DeviceContext* This, UINT IndexCount, UINT StartIndexLocation, INT BaseVertexLocation) {}
+static void STDMETHODCALLTYPE ctx_DrawIndexed(ID3D11DeviceContext* This, UINT IndexCount, UINT StartIndexLocation,
+                                              INT BaseVertexLocation) {}
 static void STDMETHODCALLTYPE ctx_Draw(ID3D11DeviceContext* This, UINT VertexCount, UINT StartVertexLocation) {}
-static void STDMETHODCALLTYPE ctx_VSSetShader(ID3D11DeviceContext* This, void* pVertexShader, void* const* ppClassInstances, UINT NumClassInstances) {}
-static void STDMETHODCALLTYPE ctx_PSSetShader(ID3D11DeviceContext* This, void* pPixelShader, void* const* ppClassInstances, UINT NumClassInstances) {}
-static void STDMETHODCALLTYPE ctx_VSSetConstantBuffers(ID3D11DeviceContext* This, UINT StartSlot, UINT NumBuffers, void* const* ppConstantBuffers) {}
-static void STDMETHODCALLTYPE ctx_PSSetConstantBuffers(ID3D11DeviceContext* This, UINT StartSlot, UINT NumBuffers, void* const* ppConstantBuffers) {}
-static void STDMETHODCALLTYPE ctx_VSSetShaderResources(ID3D11DeviceContext* This, UINT StartSlot, UINT NumViews, void* const* ppShaderResourceViews) {}
-static void STDMETHODCALLTYPE ctx_PSSetShaderResources(ID3D11DeviceContext* This, UINT StartSlot, UINT NumViews, void* const* ppShaderResourceViews) {}
-static void STDMETHODCALLTYPE ctx_VSSetSamplers(ID3D11DeviceContext* This, UINT StartSlot, UINT NumSamplers, void* const* ppSamplers) {}
-static void STDMETHODCALLTYPE ctx_PSSetSamplers(ID3D11DeviceContext* This, UINT StartSlot, UINT NumSamplers, void* const* ppSamplers) {}
-static void STDMETHODCALLTYPE ctx_OMSetRenderTargets(ID3D11DeviceContext* This, UINT NumViews, void* const* ppRenderTargetViews, void* pDepthStencilView) {}
-static void STDMETHODCALLTYPE ctx_OMSetBlendState(ID3D11DeviceContext* This, void* pBlendState, const float BlendFactor[4], UINT SampleMask) {}
-static void STDMETHODCALLTYPE ctx_OMSetDepthStencilState(ID3D11DeviceContext* This, void* pDepthStencilState, UINT StencilRef) {}
+static void STDMETHODCALLTYPE ctx_VSSetShader(ID3D11DeviceContext* This, void* pVertexShader,
+                                              void* const* ppClassInstances, UINT NumClassInstances) {}
+static void STDMETHODCALLTYPE ctx_PSSetShader(ID3D11DeviceContext* This, void* pPixelShader,
+                                              void* const* ppClassInstances, UINT NumClassInstances) {}
+static void STDMETHODCALLTYPE ctx_VSSetConstantBuffers(ID3D11DeviceContext* This, UINT StartSlot, UINT NumBuffers,
+                                                       void* const* ppConstantBuffers) {}
+static void STDMETHODCALLTYPE ctx_PSSetConstantBuffers(ID3D11DeviceContext* This, UINT StartSlot, UINT NumBuffers,
+                                                       void* const* ppConstantBuffers) {}
+static void STDMETHODCALLTYPE ctx_VSSetShaderResources(ID3D11DeviceContext* This, UINT StartSlot, UINT NumViews,
+                                                       void* const* ppShaderResourceViews) {}
+static void STDMETHODCALLTYPE ctx_PSSetShaderResources(ID3D11DeviceContext* This, UINT StartSlot, UINT NumViews,
+                                                       void* const* ppShaderResourceViews) {}
+static void STDMETHODCALLTYPE ctx_VSSetSamplers(ID3D11DeviceContext* This, UINT StartSlot, UINT NumSamplers,
+                                                void* const* ppSamplers) {}
+static void STDMETHODCALLTYPE ctx_PSSetSamplers(ID3D11DeviceContext* This, UINT StartSlot, UINT NumSamplers,
+                                                void* const* ppSamplers) {}
+static void STDMETHODCALLTYPE ctx_OMSetRenderTargets(ID3D11DeviceContext* This, UINT NumViews,
+                                                     void* const* ppRenderTargetViews, void* pDepthStencilView) {}
+static void STDMETHODCALLTYPE ctx_OMSetBlendState(ID3D11DeviceContext* This, void* pBlendState,
+                                                  const float BlendFactor[4], UINT SampleMask) {}
+static void STDMETHODCALLTYPE ctx_OMSetDepthStencilState(ID3D11DeviceContext* This, void* pDepthStencilState,
+                                                         UINT StencilRef) {}
 static void STDMETHODCALLTYPE ctx_RSSetState(ID3D11DeviceContext* This, void* pRasterizerState) {}
-static void STDMETHODCALLTYPE ctx_RSSetViewports(ID3D11DeviceContext* This, UINT NumViewports, const void* pViewports) {}
+static void STDMETHODCALLTYPE ctx_RSSetViewports(ID3D11DeviceContext* This, UINT NumViewports, const void* pViewports) {
+}
 static void STDMETHODCALLTYPE ctx_RSSetScissorRects(ID3D11DeviceContext* This, UINT NumRects, const void* pRects) {}
-static void STDMETHODCALLTYPE ctx_ClearRenderTargetView(ID3D11DeviceContext* This, void* pRenderTargetView, const float ColorRGBA[4]) {}
-static void STDMETHODCALLTYPE ctx_ClearDepthStencilView(ID3D11DeviceContext* This, void* pDepthStencilView, UINT ClearFlags, float Depth, UINT8 Stencil) {}
-static void STDMETHODCALLTYPE ctx_UpdateSubresource(ID3D11DeviceContext* This, void* pDstResource, UINT DstSubresource, const void* pDstBox, const void* pSrcData, UINT SrcRowPitch, UINT SrcDepthPitch) {}
+static void STDMETHODCALLTYPE ctx_ClearRenderTargetView(ID3D11DeviceContext* This, void* pRenderTargetView,
+                                                        const float ColorRGBA[4]) {}
+static void STDMETHODCALLTYPE ctx_ClearDepthStencilView(ID3D11DeviceContext* This, void* pDepthStencilView,
+                                                        UINT ClearFlags, float Depth, UINT8 Stencil) {}
+static void STDMETHODCALLTYPE ctx_UpdateSubresource(ID3D11DeviceContext* This, void* pDstResource, UINT DstSubresource,
+                                                    const void* pDstBox, const void* pSrcData, UINT SrcRowPitch,
+                                                    UINT SrcDepthPitch) {}
 static void STDMETHODCALLTYPE ctx_CopyResource(ID3D11DeviceContext* This, void* pDstResource, void* pSrcResource) {}
-static void STDMETHODCALLTYPE ctx_Map(ID3D11DeviceContext* This, void* pResource, UINT Subresource, int MapType, UINT MapFlags, void* pMappedResource) {
+static void STDMETHODCALLTYPE ctx_Map(ID3D11DeviceContext* This, void* pResource, UINT Subresource, int MapType,
+                                      UINT MapFlags, void* pMappedResource) {
     memset(pMappedResource, 0, sizeof(struct ms_mapped_subresource));
 }
 static void STDMETHODCALLTYPE ctx_Unmap(ID3D11DeviceContext* This, void* pResource, UINT Subresource) {}
 static void STDMETHODCALLTYPE ctx_Flush(ID3D11DeviceContext* This) {}
 
 static void STDMETHODCALLTYPE device_GetImmediateContext(ID3D11Device* This, ID3D11DeviceContext** ppImmediateContext) {
-    if (ppImmediateContext) *ppImmediateContext = &g_context;
+    if (ppImmediateContext)
+        *ppImmediateContext = &g_context;
 }
 
 BOOL WINAPI DllMain(HINSTANCE inst, DWORD reason, LPVOID reserved) {
-    (void)inst; (void)reserved;
+    (void)inst;
+    (void)reserved;
     if (reason == DLL_PROCESS_ATTACH) {
         init_unix_lib();
     }
     return TRUE;
 }
 
-__declspec(dllexport)
-HRESULT WINAPI D3D11CreateDeviceAndSwapChain(
-    void* pAdapter, int DriverType, HMODULE Software, UINT Flags,
-    const void* pFeatureLevels, UINT FeatureLevels, UINT SDKVersion,
-    const void* pSwapChainDesc, void** ppSwapChain,
-    ID3D11Device** ppDevice, void* pFeatureLevel,
-    ID3D11DeviceContext** ppImmediateContext)
-{
+__declspec(dllexport) HRESULT WINAPI D3D11CreateDeviceAndSwapChain(void* pAdapter, int DriverType, HMODULE Software,
+                                                                   UINT Flags, const void* pFeatureLevels,
+                                                                   UINT FeatureLevels, UINT SDKVersion,
+                                                                   const void* pSwapChainDesc, void** ppSwapChain,
+                                                                   ID3D11Device** ppDevice, void* pFeatureLevel,
+                                                                   ID3D11DeviceContext** ppImmediateContext) {
     TRACE("D3D11CreateDeviceAndSwapChain adapter=%p\n", pAdapter);
 
     if (!init_unix_lib()) {
@@ -299,21 +370,18 @@ HRESULT WINAPI D3D11CreateDeviceAndSwapChain(
         *ppSwapChain = (void*)0x10;
     }
 
-    if (ppDevice) *ppDevice = &g_device;
-    if (ppImmediateContext) *ppImmediateContext = &g_context;
+    if (ppDevice)
+        *ppDevice = &g_device;
+    if (ppImmediateContext)
+        *ppImmediateContext = &g_context;
 
     return S_OK;
 }
 
-__declspec(dllexport)
-HRESULT WINAPI D3D11CreateDevice(
-    void* pAdapter, int DriverType, HMODULE Software, UINT Flags,
-    const void* pFeatureLevels, UINT FeatureLevels, UINT SDKVersion,
-    ID3D11Device** ppDevice, void* pFeatureLevel,
-    ID3D11DeviceContext** ppImmediateContext)
-{
-    return D3D11CreateDeviceAndSwapChain(
-        pAdapter, DriverType, Software, Flags,
-        pFeatureLevels, FeatureLevels, SDKVersion,
-        NULL, NULL, ppDevice, pFeatureLevel, ppImmediateContext);
+__declspec(dllexport) HRESULT WINAPI D3D11CreateDevice(void* pAdapter, int DriverType, HMODULE Software, UINT Flags,
+                                                       const void* pFeatureLevels, UINT FeatureLevels, UINT SDKVersion,
+                                                       ID3D11Device** ppDevice, void* pFeatureLevel,
+                                                       ID3D11DeviceContext** ppImmediateContext) {
+    return D3D11CreateDeviceAndSwapChain(pAdapter, DriverType, Software, Flags, pFeatureLevels, FeatureLevels,
+                                         SDKVersion, NULL, NULL, ppDevice, pFeatureLevel, ppImmediateContext);
 }

--- a/src/wine/metalsharp_unix.h
+++ b/src/wine/metalsharp_unix.h
@@ -1,12 +1,14 @@
 /// @file metalsharp_unix.h
 /// @brief Shared header for MetalSharp Wine PE/Unix D3D11 interface.
 ///
-/// Defines the unixlib dispatch table, shared structures, and callback types used by the PE-side D3D11 shim to communicate with the Unix-side Metal backend. Bridges Wine's PE/Unix split architecture for D3D11 device and context calls.
+/// Defines the unixlib dispatch table, shared structures, and callback types used by the PE-side D3D11 shim to
+/// communicate with the Unix-side Metal backend. Bridges Wine's PE/Unix split architecture for D3D11 device and context
+/// calls.
 #ifndef METALSHARP_UNIX_H
 #define METALSHARP_UNIX_H
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/wine/metalsharp_unix.mm
+++ b/src/wine/metalsharp_unix.mm
@@ -1,18 +1,20 @@
 /// @file metalsharp_unix.mm
 /// @brief Unix-side MetalSharp D3D11 backend (Objective-C++ Metal implementation).
 ///
-/// Implements the Metal backend that receives D3D11 calls from the PE side via unixlib thunks. Creates MTLDevice, MTLCommandQueue, MTLRenderPipelineState, and MTLTexture objects to fulfill D3D11 device, context, and resource requests.
+/// Implements the Metal backend that receives D3D11 calls from the PE side via unixlib thunks. Creates MTLDevice,
+/// MTLCommandQueue, MTLRenderPipelineState, and MTLTexture objects to fulfill D3D11 device, context, and resource
+/// requests.
+#import <AppKit/AppKit.h>
 #import <Metal/Metal.h>
 #import <QuartzCore/CAMetalLayer.h>
-#import <AppKit/AppKit.h>
 
+#include <mutex>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdint.h>
 #include <unordered_map>
 #include <vector>
-#include <mutex>
 
 typedef long NTSTATUS;
 
@@ -21,7 +23,9 @@ typedef long NTSTATUS;
 static std::mutex g_mutex;
 static uint64_t g_next_handle = 0x1000;
 
-static uint64_t new_handle() { return ++g_next_handle; }
+static uint64_t new_handle() {
+    return ++g_next_handle;
+}
 
 struct MetalBuffer {
     id<MTLBuffer> buffer;
@@ -66,31 +70,31 @@ struct SwapChain {
 struct FrameState {
     id<MTLRenderPipelineState> pipeline;
     id<MTLDepthStencilState> depth_state;
-    
+
     id<MTLBuffer> vertex_buffers[16];
     uint32_t vertex_strides[16];
     uint32_t vertex_offsets[16];
     id<MTLBuffer> index_buffer;
     uint32_t index_format;
     uint32_t index_offset;
-    
+
     id<MTLBuffer> vs_constants[14];
     id<MTLBuffer> ps_constants[14];
     id<MTLTexture> vs_resources[128];
     id<MTLTexture> ps_resources[128];
     id<MTLSamplerState> vs_samplers[16];
     id<MTLSamplerState> ps_samplers[16];
-    
+
     id<MTLTexture> render_targets[8];
     id<MTLTexture> depth_target;
-    
+
     id<MTLFunction> vs_function;
     id<MTLFunction> ps_function;
     bool needs_pipeline_update;
-    
+
     float viewport_x, viewport_y, viewport_w, viewport_h, viewport_min, viewport_max;
     bool has_viewport;
-    
+
     uint32_t primitive_topology;
     bool in_render_pass;
     id<MTLCommandBuffer> command_buffer;
@@ -110,43 +114,70 @@ static std::unordered_map<uint64_t, MetalPipeline> g_pipelines;
 
 static MTLPrimitiveType to_mtl_primitive(uint32_t topo) {
     switch (topo) {
-        case 1: return MTLPrimitiveTypePoint;
-        case 2: return MTLPrimitiveTypeLine;
-        case 3: return MTLPrimitiveTypeLineStrip;
-        case 4: return MTLPrimitiveTypeTriangle;
-        case 5: return MTLPrimitiveTypeTriangleStrip;
-        default: return MTLPrimitiveTypeTriangle;
+    case 1:
+        return MTLPrimitiveTypePoint;
+    case 2:
+        return MTLPrimitiveTypeLine;
+    case 3:
+        return MTLPrimitiveTypeLineStrip;
+    case 4:
+        return MTLPrimitiveTypeTriangle;
+    case 5:
+        return MTLPrimitiveTypeTriangleStrip;
+    default:
+        return MTLPrimitiveTypeTriangle;
     }
 }
 
 static MTLPixelFormat dxgi_to_mtl(uint32_t format) {
     switch (format) {
-        case 28: return MTLPixelFormatBGRA8Unorm;
-        case 87: return MTLPixelFormatRGBA8Unorm;
-        case 2:  return MTLPixelFormatR32Float;
-        case 6:  return MTLPixelFormatR16Float;
-        case 11: return MTLPixelFormatRG16Float;
-        case 16: return MTLPixelFormatRG32Float;
-        case 24: return MTLPixelFormatR8Unorm;
-        case 49: return MTLPixelFormatBC1_RGBA;
-        case 50: return MTLPixelFormatBC2_RGBA;
-        case 51: return MTLPixelFormatBC3_RGBA;
-        case 70: return MTLPixelFormatBC7_RGBAUnorm;
-        case 71: return MTLPixelFormatBC7_RGBAUnorm_sRGB;
-        case 44: return MTLPixelFormatBC1_RGBA_sRGB;
-        case 55: return MTLPixelFormatDepth32Float;
-        case 40: return MTLPixelFormatDepth16Unorm;
-        case 45: return MTLPixelFormatDepth24Unorm_Stencil8;
-        case 62: return MTLPixelFormatRGB10A2Unorm;
-        case 12: return MTLPixelFormatRG11B10Float;
-        default: return MTLPixelFormatBGRA8Unorm;
+    case 28:
+        return MTLPixelFormatBGRA8Unorm;
+    case 87:
+        return MTLPixelFormatRGBA8Unorm;
+    case 2:
+        return MTLPixelFormatR32Float;
+    case 6:
+        return MTLPixelFormatR16Float;
+    case 11:
+        return MTLPixelFormatRG16Float;
+    case 16:
+        return MTLPixelFormatRG32Float;
+    case 24:
+        return MTLPixelFormatR8Unorm;
+    case 49:
+        return MTLPixelFormatBC1_RGBA;
+    case 50:
+        return MTLPixelFormatBC2_RGBA;
+    case 51:
+        return MTLPixelFormatBC3_RGBA;
+    case 70:
+        return MTLPixelFormatBC7_RGBAUnorm;
+    case 71:
+        return MTLPixelFormatBC7_RGBAUnorm_sRGB;
+    case 44:
+        return MTLPixelFormatBC1_RGBA_sRGB;
+    case 55:
+        return MTLPixelFormatDepth32Float;
+    case 40:
+        return MTLPixelFormatDepth16Unorm;
+    case 45:
+        return MTLPixelFormatDepth24Unorm_Stencil8;
+    case 62:
+        return MTLPixelFormatRGB10A2Unorm;
+    case 12:
+        return MTLPixelFormatRG11B10Float;
+    default:
+        return MTLPixelFormatBGRA8Unorm;
     }
 }
 
 static NTSTATUS ms_init(void*) {
-    if (g_device) return 0;
+    if (g_device)
+        return 0;
     g_device = MTLCreateSystemDefaultDevice();
-    if (!g_device) return -1;
+    if (!g_device)
+        return -1;
     g_queue = [g_device newCommandQueue];
     memset((void*)&g_frame, 0, sizeof(g_frame));
     fprintf(stderr, "[metalsharp] Metal device: %s\n", [[g_device name] UTF8String]);
@@ -159,45 +190,48 @@ static NTSTATUS ms_create_device(void*) {
 
 static NTSTATUS ms_create_swap_chain(void* p) {
     auto* params = (struct ms_create_swap_chain_params*)p;
-    if (!g_device) ms_init(nullptr);
-    
+    if (!g_device)
+        ms_init(nullptr);
+
     if (g_swapchain) {
-        if (g_swapchain->window) [g_swapchain->window close];
+        if (g_swapchain->window)
+            [g_swapchain->window close];
         delete g_swapchain;
     }
     g_swapchain = new SwapChain();
     g_swapchain->width = params->width > 0 ? params->width : 1280;
     g_swapchain->height = params->height > 0 ? params->height : 720;
-    
+
     dispatch_async(dispatch_get_main_queue(), ^{
-        NSRect frame = NSMakeRect(0, 0, g_swapchain->width, g_swapchain->height);
-        NSUInteger style = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable |
-                           NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable;
-        g_swapchain->window = [[NSWindow alloc] initWithContentRect:frame
-                                                          styleMask:style
-                                                            backing:NSBackingStoreBuffered
-                                                              defer:NO];
-        [g_swapchain->window setTitle:@"MetalSharp"];
-        [g_swapchain->window makeKeyAndOrderFront:nil];
-        
-        g_swapchain->layer = [CAMetalLayer layer];
-        g_swapchain->layer.device = g_device;
-        g_swapchain->layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
-        g_swapchain->layer.framebufferOnly = NO;
-        g_swapchain->layer.drawableSize = CGSizeMake(g_swapchain->width, g_swapchain->height);
-        
-        NSView* cv = [g_swapchain->window contentView];
-        cv.wantsLayer = YES;
-        cv.layer = g_swapchain->layer;
+      NSRect frame = NSMakeRect(0, 0, g_swapchain->width, g_swapchain->height);
+      NSUInteger style = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable |
+                         NSWindowStyleMaskResizable;
+      g_swapchain->window = [[NSWindow alloc] initWithContentRect:frame
+                                                        styleMask:style
+                                                          backing:NSBackingStoreBuffered
+                                                            defer:NO];
+      [g_swapchain->window setTitle:@"MetalSharp"];
+      [g_swapchain->window makeKeyAndOrderFront:nil];
+
+      g_swapchain->layer = [CAMetalLayer layer];
+      g_swapchain->layer.device = g_device;
+      g_swapchain->layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
+      g_swapchain->layer.framebufferOnly = NO;
+      g_swapchain->layer.drawableSize = CGSizeMake(g_swapchain->width, g_swapchain->height);
+
+      NSView* cv = [g_swapchain->window contentView];
+      cv.wantsLayer = YES;
+      cv.layer = g_swapchain->layer;
     });
-    
+
     fprintf(stderr, "[metalsharp] Swap chain %ux%u\n", g_swapchain->width, g_swapchain->height);
     return 0;
 }
 
 static NTSTATUS ms_present(void*) {
-    if (!g_swapchain || !g_swapchain->layer) return -1;
-    
+    if (!g_swapchain || !g_swapchain->layer)
+        return -1;
+
     @autoreleasepool {
         if (g_frame.in_render_pass && g_frame.encoder) {
             [g_frame.encoder endEncoding];
@@ -208,18 +242,23 @@ static NTSTATUS ms_present(void*) {
             [g_frame.command_buffer commit];
             g_frame.command_buffer = nil;
         }
-        
+
         id<CAMetalDrawable> drawable = [g_swapchain->layer nextDrawable];
-        if (!drawable) return 0;
-        
+        if (!drawable)
+            return 0;
+
         if (g_swapchain->back_buffer) {
             id<MTLCommandBuffer> blit = [g_queue commandBuffer];
             id<MTLBlitCommandEncoder> blitEnc = [blit blitCommandEncoder];
             [blitEnc copyFromTexture:g_swapchain->back_buffer
-                         sourceSlice:0 sourceLevel:0 sourceOrigin:MTLOriginMake(0,0,0)
-                           sourceSize:MTLSizeMake(g_swapchain->width, g_swapchain->height, 1)
-                            toTexture:drawable.texture
-                     destinationSlice:0 destinationLevel:0 destinationOrigin:MTLOriginMake(0,0,0)];
+                         sourceSlice:0
+                         sourceLevel:0
+                        sourceOrigin:MTLOriginMake(0, 0, 0)
+                          sourceSize:MTLSizeMake(g_swapchain->width, g_swapchain->height, 1)
+                           toTexture:drawable.texture
+                    destinationSlice:0
+                    destinationLevel:0
+                   destinationOrigin:MTLOriginMake(0, 0, 0)];
             [blitEnc endEncoding];
             [blit presentDrawable:drawable];
             [blit commit];
@@ -229,60 +268,61 @@ static NTSTATUS ms_present(void*) {
             [cmd commit];
         }
     }
-    
+
     @autoreleasepool {
         id<MTLRenderPipelineState> saved_pipeline = g_frame.pipeline;
         id<MTLFunction> saved_vs = g_frame.vs_function;
         id<MTLFunction> saved_ps = g_frame.ps_function;
-        
+
         memset((void*)&g_frame, 0, sizeof(g_frame));
-        
+
         g_frame.pipeline = saved_pipeline;
         g_frame.vs_function = saved_vs;
         g_frame.ps_function = saved_ps;
     }
-    
+
     return 0;
 }
 
 static NTSTATUS ms_create_buffer(void* p) {
     auto* params = (struct ms_create_buffer_params*)p;
-    if (!g_device) ms_init(nullptr);
-    
+    if (!g_device)
+        ms_init(nullptr);
+
     uint64_t handle = new_handle();
     auto& buf = g_buffers[handle];
     buf.size = params->byte_width;
     buf.mapped = nullptr;
-    
+
     if (params->initial_data && params->initial_data_size > 0) {
         buf.buffer = [g_device newBufferWithBytes:params->initial_data
                                            length:params->byte_width
                                           options:MTLResourceStorageModeShared];
     } else {
-        buf.buffer = [g_device newBufferWithLength:params->byte_width
-                                           options:MTLResourceStorageModeShared];
+        buf.buffer = [g_device newBufferWithLength:params->byte_width options:MTLResourceStorageModeShared];
     }
-    
+
     if (!buf.buffer) {
         g_buffers.erase(handle);
         return -1;
     }
-    
+
     params->out_handle = handle;
     return 0;
 }
 
 static NTSTATUS ms_create_texture_2d(void* p) {
     auto* params = (struct ms_create_texture_2d_params*)p;
-    if (!g_device) ms_init(nullptr);
-    
+    if (!g_device)
+        ms_init(nullptr);
+
     uint64_t handle = new_handle();
     auto& tex = g_textures[handle];
     tex.width = params->width;
     tex.height = params->height;
     tex.format = params->format;
     tex.mip_levels = params->mip_levels > 0 ? params->mip_levels : 1;
-    
+
     MTLTextureDescriptor* desc = [[MTLTextureDescriptor alloc] init];
     desc.textureType = MTLTextureType2D;
     desc.pixelFormat = dxgi_to_mtl(params->format);
@@ -290,33 +330,39 @@ static NTSTATUS ms_create_texture_2d(void* p) {
     desc.height = params->height;
     desc.mipmapLevelCount = tex.mip_levels;
     desc.sampleCount = params->sample_count > 0 ? params->sample_count : 1;
-    
+
     MTLTextureUsage usage = 0;
-    if (params->bind_flags & 0x1) usage |= MTLTextureUsageShaderRead;
-    if (params->bind_flags & 0x2) usage |= MTLTextureUsageRenderTarget;
-    if (params->bind_flags & 0x40) usage |= MTLTextureUsageShaderRead | MTLTextureUsageShaderWrite;
-    if (params->bind_flags & 0x20) usage |= MTLTextureUsagePixelFormatView;
-    if (usage == 0) usage = MTLTextureUsageShaderRead;
+    if (params->bind_flags & 0x1)
+        usage |= MTLTextureUsageShaderRead;
+    if (params->bind_flags & 0x2)
+        usage |= MTLTextureUsageRenderTarget;
+    if (params->bind_flags & 0x40)
+        usage |= MTLTextureUsageShaderRead | MTLTextureUsageShaderWrite;
+    if (params->bind_flags & 0x20)
+        usage |= MTLTextureUsagePixelFormatView;
+    if (usage == 0)
+        usage = MTLTextureUsageShaderRead;
     desc.usage = usage;
     desc.storageMode = (params->cpu_access_flags & 0x10000) ? MTLStorageModeShared : MTLStorageModePrivate;
-    
+
     tex.texture = [g_device newTextureWithDescriptor:desc];
     if (!tex.texture) {
         g_textures.erase(handle);
         return -1;
     }
-    
+
     params->out_handle = handle;
     return 0;
 }
 
 static NTSTATUS ms_create_render_target_view(void* p) {
     auto* params = (struct ms_create_rt_view_params*)p;
-    if (!g_device) ms_init(nullptr);
-    
+    if (!g_device)
+        ms_init(nullptr);
+
     uint64_t handle = new_handle();
     auto& rtv = g_rtvs[handle];
-    
+
     if (params->texture_handle) {
         auto it = g_textures.find(params->texture_handle);
         if (it != g_textures.end()) {
@@ -342,36 +388,38 @@ static NTSTATUS ms_create_render_target_view(void* p) {
             rtv.height = g_swapchain->height;
         }
     }
-    
+
     params->out_handle = handle;
     return 0;
 }
 
 static NTSTATUS ms_create_depth_stencil_view(void* p) {
     auto* params = (struct ms_create_rt_view_params*)p;
-    if (!g_device) ms_init(nullptr);
-    
+    if (!g_device)
+        ms_init(nullptr);
+
     uint64_t handle = new_handle();
     auto& dsv = g_rtvs[handle];
-    
+
     auto it = g_textures.find(params->texture_handle);
     if (it != g_textures.end()) {
         dsv.texture = it->second.texture;
         dsv.width = it->second.width;
         dsv.height = it->second.height;
     }
-    
+
     params->out_handle = handle;
     return 0;
 }
 
 static NTSTATUS ms_create_vertex_shader(void* p) {
     auto* params = (struct ms_create_shader_params*)p;
-    if (!g_device || !params->bytecode || params->bytecode_size == 0) return -1;
-    
+    if (!g_device || !params->bytecode || params->bytecode_size == 0)
+        return -1;
+
     uint64_t handle = new_handle();
     auto& shader = g_shaders[handle];
-    
+
     const uint8_t* ptr = (const uint8_t*)params->bytecode;
     if (params->bytecode_size > 5 && ptr[0] == 'M' && ptr[1] == 'S' && ptr[2] == 'L' && ptr[3] == '\0') {
         const char* func_name = (const char*)(ptr + 4);
@@ -383,14 +431,16 @@ static NTSTATUS ms_create_vertex_shader(void* p) {
         }
         const char* source = func_name + name_len + 1;
         size_t source_len = remaining - name_len - 1;
-        
+
         @autoreleasepool {
-            NSString* nsSource = [[NSString alloc] initWithBytes:source length:source_len encoding:NSUTF8StringEncoding];
+            NSString* nsSource = [[NSString alloc] initWithBytes:source
+                                                          length:source_len
+                                                        encoding:NSUTF8StringEncoding];
             NSError* error = nil;
             id<MTLLibrary> library = [g_device newLibraryWithSource:nsSource options:nil error:&error];
             if (error || !library) {
                 fprintf(stderr, "[metalsharp] VS compile error: %s\n",
-                    error ? [[error localizedDescription] UTF8String] : "unknown");
+                        error ? [[error localizedDescription] UTF8String] : "unknown");
                 g_shaders.erase(handle);
                 return -1;
             }
@@ -408,18 +458,19 @@ static NTSTATUS ms_create_vertex_shader(void* p) {
         auto* bc = (const uint8_t*)params->bytecode;
         shader.bytecode.assign(bc, bc + params->bytecode_size);
     }
-    
+
     params->out_handle = handle;
     return 0;
 }
 
 static NTSTATUS ms_create_pixel_shader(void* p) {
     auto* params = (struct ms_create_shader_params*)p;
-    if (!g_device || !params->bytecode || params->bytecode_size == 0) return -1;
-    
+    if (!g_device || !params->bytecode || params->bytecode_size == 0)
+        return -1;
+
     uint64_t handle = new_handle();
     auto& shader = g_shaders[handle];
-    
+
     const uint8_t* ptr = (const uint8_t*)params->bytecode;
     if (params->bytecode_size > 5 && ptr[0] == 'M' && ptr[1] == 'S' && ptr[2] == 'L' && ptr[3] == '\0') {
         const char* func_name = (const char*)(ptr + 4);
@@ -431,14 +482,16 @@ static NTSTATUS ms_create_pixel_shader(void* p) {
         }
         const char* source = func_name + name_len + 1;
         size_t source_len = remaining - name_len - 1;
-        
+
         @autoreleasepool {
-            NSString* nsSource = [[NSString alloc] initWithBytes:source length:source_len encoding:NSUTF8StringEncoding];
+            NSString* nsSource = [[NSString alloc] initWithBytes:source
+                                                          length:source_len
+                                                        encoding:NSUTF8StringEncoding];
             NSError* error = nil;
             id<MTLLibrary> library = [g_device newLibraryWithSource:nsSource options:nil error:&error];
             if (error || !library) {
                 fprintf(stderr, "[metalsharp] PS compile error: %s\n",
-                    error ? [[error localizedDescription] UTF8String] : "unknown");
+                        error ? [[error localizedDescription] UTF8String] : "unknown");
                 g_shaders.erase(handle);
                 return -1;
             }
@@ -456,26 +509,39 @@ static NTSTATUS ms_create_pixel_shader(void* p) {
         auto* bc = (const uint8_t*)params->bytecode;
         shader.bytecode.assign(bc, bc + params->bytecode_size);
     }
-    
+
     params->out_handle = handle;
     return 0;
 }
 
-static NTSTATUS ms_create_input_layout(void*) { return 0; }
-static NTSTATUS ms_create_blend_state(void*) { return 0; }
-static NTSTATUS ms_create_rasterizer_state(void*) { return 0; }
-static NTSTATUS ms_create_depth_stencil_state(void*) { return 0; }
-static NTSTATUS ms_create_sampler_state(void*) { return 0; }
-static NTSTATUS ms_create_shader_resource_view(void*) { return 0; }
+static NTSTATUS ms_create_input_layout(void*) {
+    return 0;
+}
+static NTSTATUS ms_create_blend_state(void*) {
+    return 0;
+}
+static NTSTATUS ms_create_rasterizer_state(void*) {
+    return 0;
+}
+static NTSTATUS ms_create_depth_stencil_state(void*) {
+    return 0;
+}
+static NTSTATUS ms_create_sampler_state(void*) {
+    return 0;
+}
+static NTSTATUS ms_create_shader_resource_view(void*) {
+    return 0;
+}
 
 static void ensure_render_pass() {
-    if (g_frame.in_render_pass) return;
+    if (g_frame.in_render_pass)
+        return;
     if (!g_frame.command_buffer) {
         g_frame.command_buffer = [g_queue commandBuffer];
     }
-    
+
     MTLRenderPassDescriptor* desc = [[MTLRenderPassDescriptor alloc] init];
-    
+
     bool has_target = false;
     for (int i = 0; i < 8; i++) {
         if (g_frame.render_targets[i]) {
@@ -486,7 +552,7 @@ static void ensure_render_pass() {
             has_target = true;
         }
     }
-    
+
     if (!has_target && g_swapchain && g_swapchain->back_buffer) {
         auto* attachment = desc.colorAttachments[0];
         attachment.texture = g_swapchain->back_buffer;
@@ -494,23 +560,23 @@ static void ensure_render_pass() {
         attachment.clearColor = MTLClearColorMake(0, 0, 0, 1);
         attachment.storeAction = MTLStoreActionStore;
     }
-    
+
     if (g_frame.depth_target) {
         desc.depthAttachment.texture = g_frame.depth_target;
         desc.depthAttachment.loadAction = MTLLoadActionClear;
         desc.depthAttachment.clearDepth = 1.0;
         desc.depthAttachment.storeAction = MTLStoreActionStore;
     }
-    
+
     g_frame.encoder = [g_frame.command_buffer renderCommandEncoderWithDescriptor:desc];
     g_frame.in_render_pass = true;
-    
+
     if (g_frame.needs_pipeline_update && g_frame.vs_function && g_frame.ps_function) {
         @autoreleasepool {
             MTLRenderPipelineDescriptor* pdesc = [[MTLRenderPipelineDescriptor alloc] init];
             pdesc.vertexFunction = g_frame.vs_function;
             pdesc.fragmentFunction = g_frame.ps_function;
-            
+
             MTLPixelFormat rt_format = MTLPixelFormatBGRA8Unorm;
             for (int i = 0; i < 8; i++) {
                 if (g_frame.render_targets[i]) {
@@ -519,26 +585,25 @@ static void ensure_render_pass() {
                 }
             }
             pdesc.colorAttachments[0].pixelFormat = rt_format;
-            
+
             NSError* error = nil;
             g_frame.pipeline = [g_device newRenderPipelineStateWithDescriptor:pdesc error:&error];
             if (error || !g_frame.pipeline) {
                 fprintf(stderr, "[metalsharp] Pipeline error: %s\n",
-                    error ? [[error localizedDescription] UTF8String] : "unknown");
+                        error ? [[error localizedDescription] UTF8String] : "unknown");
             } else {
                 fprintf(stderr, "[metalsharp] Pipeline created\n");
             }
             g_frame.needs_pipeline_update = false;
         }
     }
-    
+
     if (g_frame.pipeline) {
         [g_frame.encoder setRenderPipelineState:g_frame.pipeline];
     }
     if (g_frame.has_viewport) {
-        MTLViewport vp = { g_frame.viewport_x, g_frame.viewport_y,
-                           g_frame.viewport_w, g_frame.viewport_h,
-                           g_frame.viewport_min, g_frame.viewport_max };
+        MTLViewport vp = {g_frame.viewport_x, g_frame.viewport_y,   g_frame.viewport_w,
+                          g_frame.viewport_h, g_frame.viewport_min, g_frame.viewport_max};
         [g_frame.encoder setViewport:vp];
     }
 }
@@ -550,7 +615,7 @@ static NTSTATUS ms_om_set_render_targets(void* p) {
         g_frame.in_render_pass = false;
         g_frame.encoder = nil;
     }
-    
+
     memset(g_frame.render_targets, 0, sizeof(g_frame.render_targets));
     for (uint32_t i = 0; i < params->num_views && i < 8; i++) {
         if (params->rtv_handles[i]) {
@@ -573,8 +638,9 @@ static NTSTATUS ms_om_set_render_targets(void* p) {
 static NTSTATUS ms_clear_render_target_view(void* p) {
     auto* params = (struct ms_clear_params*)p;
     auto it = g_rtvs.find(params->view_handle);
-    if (it == g_rtvs.end()) return -1;
-    
+    if (it == g_rtvs.end())
+        return -1;
+
     if (g_frame.in_render_pass) {
         [g_frame.encoder endEncoding];
         g_frame.in_render_pass = false;
@@ -582,14 +648,14 @@ static NTSTATUS ms_clear_render_target_view(void* p) {
     if (!g_frame.command_buffer) {
         g_frame.command_buffer = [g_queue commandBuffer];
     }
-    
+
     MTLRenderPassDescriptor* desc = [[MTLRenderPassDescriptor alloc] init];
     auto* attachment = desc.colorAttachments[0];
     attachment.texture = it->second.texture;
     attachment.loadAction = MTLLoadActionClear;
     attachment.clearColor = MTLClearColorMake(params->r, params->g, params->b, params->a);
     attachment.storeAction = MTLStoreActionStore;
-    
+
     id<MTLRenderCommandEncoder> enc = [g_frame.command_buffer renderCommandEncoderWithDescriptor:desc];
     [enc endEncoding];
     return 0;
@@ -604,9 +670,9 @@ static NTSTATUS ms_set_viewports(void* p) {
     g_frame.viewport_min = vp->min_depth;
     g_frame.viewport_max = vp->max_depth;
     g_frame.has_viewport = true;
-    
+
     if (g_frame.encoder) {
-        MTLViewport mtlvp = { vp->top_left_x, vp->top_left_y, vp->width, vp->height, vp->min_depth, vp->max_depth };
+        MTLViewport mtlvp = {vp->top_left_x, vp->top_left_y, vp->width, vp->height, vp->min_depth, vp->max_depth};
         [g_frame.encoder setViewport:mtlvp];
     }
     return 0;
@@ -622,11 +688,9 @@ static NTSTATUS ms_ia_set_vertex_buffers(void* p) {
                 g_frame.vertex_buffers[slot] = it->second.buffer;
                 g_frame.vertex_strides[slot] = params->strides[i];
                 g_frame.vertex_offsets[slot] = params->offsets[i];
-                
+
                 if (g_frame.encoder) {
-                    [g_frame.encoder setVertexBuffer:it->second.buffer
-                                             offset:params->offsets[i]
-                                            atIndex:slot];
+                    [g_frame.encoder setVertexBuffer:it->second.buffer offset:params->offsets[i] atIndex:slot];
                 }
             }
         }
@@ -721,15 +785,17 @@ static NTSTATUS ms_ps_set_constant_buffers(void* p) {
 static NTSTATUS ms_draw_indexed(void* p) {
     auto* params = (struct ms_draw_indexed_params*)p;
     ensure_render_pass();
-    if (!g_frame.encoder) return -1;
-    
+    if (!g_frame.encoder)
+        return -1;
+
     if (g_frame.index_buffer) {
         MTLIndexType indexType = (g_frame.index_format == 1) ? MTLIndexTypeUInt16 : MTLIndexTypeUInt32;
-        [g_frame.encoder drawIndexedPrimitives:to_mtl_primitive(g_frame.primitive_topology)
-                                    indexCount:params->index_count
-                                     indexType:indexType
-                                   indexBuffer:g_frame.index_buffer
-                             indexBufferOffset:g_frame.index_offset + params->start_index * (g_frame.index_format == 1 ? 2 : 4)];
+        [g_frame.encoder
+            drawIndexedPrimitives:to_mtl_primitive(g_frame.primitive_topology)
+                       indexCount:params->index_count
+                        indexType:indexType
+                      indexBuffer:g_frame.index_buffer
+                indexBufferOffset:g_frame.index_offset + params->start_index * (g_frame.index_format == 1 ? 2 : 4)];
     }
     return 0;
 }
@@ -737,8 +803,9 @@ static NTSTATUS ms_draw_indexed(void* p) {
 static NTSTATUS ms_draw(void* p) {
     auto* params = (struct ms_draw_params*)p;
     ensure_render_pass();
-    if (!g_frame.encoder) return -1;
-    
+    if (!g_frame.encoder)
+        return -1;
+
     [g_frame.encoder drawPrimitives:to_mtl_primitive(g_frame.primitive_topology)
                         vertexStart:params->start_vertex
                         vertexCount:params->vertex_count];
@@ -823,7 +890,7 @@ static NTSTATUS ms_get_buffer(void* p) {
             g_swapchain->back_buffer = [g_device newTextureWithDescriptor:desc];
         }
     }
-    
+
     uint64_t handle = new_handle();
     auto& tex = g_textures[handle];
     if (g_swapchain && g_swapchain->back_buffer) {
@@ -848,7 +915,8 @@ static NTSTATUS ms_shutdown(void*) {
     g_rtvs.clear();
     g_pipelines.clear();
     if (g_swapchain) {
-        if (g_swapchain->window) [g_swapchain->window close];
+        if (g_swapchain->window)
+            [g_swapchain->window close];
         delete g_swapchain;
         g_swapchain = nullptr;
     }
@@ -857,14 +925,15 @@ static NTSTATUS ms_shutdown(void*) {
     return 0;
 }
 
-static NTSTATUS ms_stub(void*) { return 0; }
+static NTSTATUS ms_stub(void*) {
+    return 0;
+}
 
 extern "C" {
 
 typedef NTSTATUS (*unixlib_entry_t)(void*);
 
-__attribute__((used, visibility("default")))
-unixlib_entry_t __wine_unix_call_funcs[] = {
+__attribute__((used, visibility("default"))) unixlib_entry_t __wine_unix_call_funcs[] = {
     ms_init,
     ms_create_device,
     ms_create_swap_chain,
@@ -929,8 +998,7 @@ unixlib_entry_t __wine_unix_call_funcs[] = {
     ms_stub,
 };
 
-__attribute__((used, visibility("default")))
-unixlib_entry_t __wine_unix_call_wow64_funcs[] = {
+__attribute__((used, visibility("default"))) unixlib_entry_t __wine_unix_call_wow64_funcs[] = {
     ms_init,
     ms_create_device,
     ms_create_swap_chain,
@@ -996,6 +1064,7 @@ unixlib_entry_t __wine_unix_call_wow64_funcs[] = {
     ms_stub,
 };
 
-NTSTATUS __attribute__((visibility("default"))) __wine_unix_lib_init(void) { return 0; }
-
+NTSTATUS __attribute__((visibility("default"))) __wine_unix_lib_init(void) {
+    return 0;
+}
 }

--- a/src/wine/mscoree_pe.cpp
+++ b/src/wine/mscoree_pe.cpp
@@ -1,14 +1,15 @@
 /// @file mscoree_pe.cpp
 /// @brief Wine mscoree PE module for .NET CLR hosting shim.
 ///
-/// Implements CorBindToRuntimeEx and CLRCreateInstance to satisfy .NET executable loading. Routes actual CLR initialization to the unixlib backend which loads the system Mono runtime for running managed game assemblies.
-#include <windows.h>
+/// Implements CorBindToRuntimeEx and CLRCreateInstance to satisfy .NET executable loading. Routes actual CLR
+/// initialization to the unixlib backend which loads the system Mono runtime for running managed game assemblies.
 #include <stdio.h>
 #include <string.h>
+#include <windows.h>
 
 typedef long NTSTATUS;
 typedef unsigned long long unixlib_handle_t;
-typedef NTSTATUS (WINAPI *unix_call_dispatcher_t)(unixlib_handle_t, unsigned int, void*);
+typedef NTSTATUS(WINAPI* unix_call_dispatcher_t)(unixlib_handle_t, unsigned int, void*);
 
 #ifndef STATUS_SUCCESS
 #define STATUS_SUCCESS ((NTSTATUS)0)
@@ -21,38 +22,52 @@ static unix_call_dispatcher_t g_unix_call_dispatcher = NULL;
 static HMODULE g_hModule = NULL;
 static int g_unix_initialized = 0;
 
-static NTSTATUS unix_call(unsigned int code, void *args) {
+static NTSTATUS unix_call(unsigned int code, void* args) {
     if (!g_unix_call_dispatcher || !g_unixlib_handle)
         return (NTSTATUS)0xC000000E;
     return g_unix_call_dispatcher(g_unixlib_handle, code, args);
 }
 
 static int init_unix_call(void) {
-    if (g_unix_initialized) return 1;
+    if (g_unix_initialized)
+        return 1;
     fprintf(stderr, "[mscoree] init_unix_call starting...\n");
 
     HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
-    if (!ntdll) { fprintf(stderr, "[mscoree] no ntdll\n"); return 0; }
+    if (!ntdll) {
+        fprintf(stderr, "[mscoree] no ntdll\n");
+        return 0;
+    }
 
-    typedef NTSTATUS (NTAPI *pNtQVM)(HANDLE, const void*, ULONG, void*, SIZE_T, SIZE_T*);
+    typedef NTSTATUS(NTAPI * pNtQVM)(HANDLE, const void*, ULONG, void*, SIZE_T, SIZE_T*);
     pNtQVM pNtQueryVirtualMemory = (pNtQVM)GetProcAddress(ntdll, "NtQueryVirtualMemory");
-    if (!pNtQueryVirtualMemory) { fprintf(stderr, "[mscoree] no NtQueryVirtualMemory\n"); return 0; }
+    if (!pNtQueryVirtualMemory) {
+        fprintf(stderr, "[mscoree] no NtQueryVirtualMemory\n");
+        return 0;
+    }
 
     unixlib_handle_t handle = 0;
-    NTSTATUS status = pNtQueryVirtualMemory(
-        (HANDLE)(LONG_PTR)-1, (const void*)g_hModule, 1000,
-        &handle, sizeof(handle), NULL);
-    fprintf(stderr, "[mscoree] NtQueryVirtualMemory(1000) status=%ld handle=%llu\n", status, (unsigned long long)handle);
-    if (status < 0) return 0;
+    NTSTATUS status =
+        pNtQueryVirtualMemory((HANDLE)(LONG_PTR)-1, (const void*)g_hModule, 1000, &handle, sizeof(handle), NULL);
+    fprintf(stderr, "[mscoree] NtQueryVirtualMemory(1000) status=%ld handle=%llu\n", status,
+            (unsigned long long)handle);
+    if (status < 0)
+        return 0;
     g_unixlib_handle = handle;
 
-    void **ptr = (void**)GetProcAddress(ntdll, "__wine_unix_call_dispatcher");
+    void** ptr = (void**)GetProcAddress(ntdll, "__wine_unix_call_dispatcher");
     fprintf(stderr, "[mscoree] __wine_unix_call_dispatcher ptr=%p val=%p\n", ptr, ptr ? *ptr : NULL);
-    if (ptr && *ptr) g_unix_call_dispatcher = (unix_call_dispatcher_t)*ptr;
-    else g_unix_call_dispatcher = (unix_call_dispatcher_t)GetProcAddress(ntdll, "__wine_unix_call_dispatcher");
+    if (ptr && *ptr)
+        g_unix_call_dispatcher = (unix_call_dispatcher_t)*ptr;
+    else
+        g_unix_call_dispatcher = (unix_call_dispatcher_t)GetProcAddress(ntdll, "__wine_unix_call_dispatcher");
 
-    if (!g_unix_call_dispatcher) { fprintf(stderr, "[mscoree] no unix_call_dispatcher\n"); return 0; }
-    fprintf(stderr, "[mscoree] unix bridge initialized: dispatcher=%p handle=%llu\n", (void*)g_unix_call_dispatcher, (unsigned long long)handle);
+    if (!g_unix_call_dispatcher) {
+        fprintf(stderr, "[mscoree] no unix_call_dispatcher\n");
+        return 0;
+    }
+    fprintf(stderr, "[mscoree] unix bridge initialized: dispatcher=%p handle=%llu\n", (void*)g_unix_call_dispatcher,
+            (unsigned long long)handle);
     g_unix_initialized = 1;
     return 1;
 }
@@ -80,14 +95,15 @@ static void (*p_mono_domain_set_config)(MonoDomain*, const char*, const char*);
 static void (*p_mono_thread_attach)(MonoDomain*);
 static void (*p_mono_thread_detach)(void);
 
-#define LOAD_MONO_FUNC(name) \
-    p_##name = (decltype(p_##name))GetProcAddress(g_mono_handle, #name); \
-    if (!p_##name) { \
-        fprintf(stderr, "[mscoree] FAILED to resolve " #name "\n"); \
+#define LOAD_MONO_FUNC(name)                                                                                           \
+    p_##name = (decltype(p_##name))GetProcAddress(g_mono_handle, #name);                                               \
+    if (!p_##name) {                                                                                                   \
+        fprintf(stderr, "[mscoree] FAILED to resolve " #name "\n");                                                    \
     }
 
 static int load_wine_mono(void) {
-    if (g_mono_handle) return 1;
+    if (g_mono_handle)
+        return 1;
 
     char mono_dll_path[MAX_PATH];
     GetWindowsDirectoryA(mono_dll_path, MAX_PATH);
@@ -104,7 +120,7 @@ static int load_wine_mono(void) {
     LOAD_MONO_FUNC(mono_get_version);
     LOAD_MONO_FUNC(mono_set_assemblies_path);
 
-    const char *ver = p_mono_get_version ? p_mono_get_version() : "unknown";
+    const char* ver = p_mono_get_version ? p_mono_get_version() : "unknown";
     fprintf(stderr, "[mscoree] mono version: %s\n", ver);
 
     LOAD_MONO_FUNC(mono_jit_init_version);
@@ -125,7 +141,7 @@ static int load_wine_mono(void) {
 
     if (!p_mono_jit_init_version || !p_mono_set_dirs || !p_mono_config_parse) {
         fprintf(stderr, "[mscoree] Missing critical: jit_init=%p set_dirs=%p config_parse=%p\n",
-            (void*)p_mono_jit_init_version, (void*)p_mono_set_dirs, (void*)p_mono_config_parse);
+                (void*)p_mono_jit_init_version, (void*)p_mono_set_dirs, (void*)p_mono_config_parse);
         return 0;
     }
     return 1;
@@ -145,18 +161,21 @@ static int launch_embedded_mono(void) {
     char exe_dir[1024] = {0};
     GetModuleFileNameA(NULL, exe_path, sizeof(exe_path));
     strncpy(exe_dir, exe_path, sizeof(exe_dir) - 1);
-    char *last_slash = strrchr(exe_dir, '\\');
-    if (last_slash) *last_slash = 0;
+    char* last_slash = strrchr(exe_dir, '\\');
+    if (last_slash)
+        *last_slash = 0;
 
     char unix_exe[1024];
     char unix_dir[1024];
-    const char *real_path = exe_path;
-    if (real_path[0] && real_path[1] == ':') real_path += 2;
-    const char *real_dir = exe_dir;
-    if (real_dir[0] && real_dir[1] == ':') real_dir += 2;
+    const char* real_path = exe_path;
+    if (real_path[0] && real_path[1] == ':')
+        real_path += 2;
+    const char* real_dir = exe_dir;
+    if (real_dir[0] && real_dir[1] == ':')
+        real_dir += 2;
 
-    const char *src = real_path;
-    char *dst = unix_exe;
+    const char* src = real_path;
+    char* dst = unix_exe;
     while (*src && dst < unix_exe + sizeof(unix_exe) - 1) {
         *dst++ = (*src == '\\') ? '/' : *src;
         src++;
@@ -181,7 +200,7 @@ static int launch_embedded_mono(void) {
     fprintf(stderr, "[mscoree] [2] typedef done\n");
     mono_jit_init_t p_jit_init = (mono_jit_init_t)GetProcAddress(g_mono_handle, "mono_jit_init");
     fprintf(stderr, "[mscoree] [3] GetProcAddress returned %p\n", (void*)p_jit_init);
-    MonoDomain *domain = NULL;
+    MonoDomain* domain = NULL;
     if (p_jit_init) {
         fprintf(stderr, "[mscoree] [4] calling mono_jit_init...\n");
         domain = p_jit_init("metalsharp");
@@ -201,13 +220,13 @@ static int launch_embedded_mono(void) {
 
     fprintf(stderr, "[mscoree] mono_image_open: %s\n", unix_exe);
     MonoImageOpenStatus status;
-    MonoImage *image = p_mono_image_open(unix_exe, &status);
+    MonoImage* image = p_mono_image_open(unix_exe, &status);
     if (!image) {
         fprintf(stderr, "[mscoree] mono_image_open failed: %d\n", status);
         return -1;
     }
 
-    MonoAssembly *assembly = p_mono_assembly_load_from(image, unix_exe, &status);
+    MonoAssembly* assembly = p_mono_assembly_load_from(image, unix_exe, &status);
     if (!assembly) {
         fprintf(stderr, "[mscoree] mono_assembly_load_from failed: %d\n", status);
         return -1;
@@ -216,9 +235,9 @@ static int launch_embedded_mono(void) {
 
     LPWSTR cmdLineW = GetCommandLineW();
     int argc = 0;
-    LPWSTR *argvW = CommandLineToArgvW(cmdLineW, &argc);
+    LPWSTR* argvW = CommandLineToArgvW(cmdLineW, &argc);
 
-    char **argv = (char**)malloc(argc * sizeof(char*));
+    char** argv = (char**)malloc(argc * sizeof(char*));
     for (int i = 0; i < argc; i++) {
         argv[i] = (char*)malloc(512);
         WideCharToMultiByte(CP_UTF8, 0, argvW[i], -1, argv[i], 512, NULL, NULL);
@@ -228,7 +247,8 @@ static int launch_embedded_mono(void) {
     int exit_code = p_mono_jit_exec(domain, assembly, argc, argv);
     fprintf(stderr, "[mscoree] mono_jit_exec returned %d\n", exit_code);
 
-    for (int i = 0; i < argc; i++) free(argv[i]);
+    for (int i = 0; i < argc; i++)
+        free(argv[i]);
     free(argv);
 
     p_mono_thread_manage();
@@ -249,23 +269,32 @@ void WINAPI _CorExeMain(void) {
     char exe_dir[1024] = {0};
     GetModuleFileNameA(NULL, exe_path, sizeof(exe_path));
     strncpy(exe_dir, exe_path, sizeof(exe_dir) - 1);
-    char *last_slash = strrchr(exe_dir, '\\');
-    if (last_slash) *last_slash = 0;
+    char* last_slash = strrchr(exe_dir, '\\');
+    if (last_slash)
+        *last_slash = 0;
 
-    const char *real_path = exe_path;
-    if (real_path[0] && real_path[1] == ':') real_path += 2;
-    const char *real_dir = exe_dir;
-    if (real_dir[0] && real_dir[1] == ':') real_dir += 2;
+    const char* real_path = exe_path;
+    if (real_path[0] && real_path[1] == ':')
+        real_path += 2;
+    const char* real_dir = exe_dir;
+    if (real_dir[0] && real_dir[1] == ':')
+        real_dir += 2;
 
     char unix_exe[1024];
     char unix_dir[1024];
-    const char *src = real_path;
-    char *dst = unix_exe;
-    while (*src && dst < unix_exe + sizeof(unix_exe) - 1) { *dst++ = (*src == '\\') ? '/' : *src; src++; }
+    const char* src = real_path;
+    char* dst = unix_exe;
+    while (*src && dst < unix_exe + sizeof(unix_exe) - 1) {
+        *dst++ = (*src == '\\') ? '/' : *src;
+        src++;
+    }
     *dst = 0;
     src = real_dir;
     dst = unix_dir;
-    while (*src && dst < unix_dir + sizeof(unix_dir) - 1) { *dst++ = (*src == '\\') ? '/' : *src; src++; }
+    while (*src && dst < unix_dir + sizeof(unix_dir) - 1) {
+        *dst++ = (*src == '\\') ? '/' : *src;
+        src++;
+    }
     *dst = 0;
 
     struct mscoree_cor_exe_main_params params;
@@ -291,67 +320,157 @@ __int32 WINAPI _CorExeMain2(PBYTE, DWORD, LPWSTR, LPWSTR, LPWSTR) {
     return -1;
 }
 
-BOOL WINAPI _CorDllMain(HINSTANCE, DWORD, LPVOID) { return TRUE; }
-void WINAPI CorExitProcess(int exitCode) { ExitProcess(exitCode); }
+BOOL WINAPI _CorDllMain(HINSTANCE, DWORD, LPVOID) {
+    return TRUE;
+}
+void WINAPI CorExitProcess(int exitCode) {
+    ExitProcess(exitCode);
+}
 VOID WINAPI _CorImageUnloading(PVOID) {}
-HRESULT WINAPI _CorValidateImage(PVOID*, LPCWSTR) { return E_FAIL; }
+HRESULT WINAPI _CorValidateImage(PVOID*, LPCWSTR) {
+    return E_FAIL;
+}
 
-HRESULT WINAPI CorBindToRuntimeEx(LPWSTR, LPWSTR, DWORD, REFCLSID, REFIID, LPVOID *ppv) { *ppv = NULL; return E_FAIL; }
-HRESULT WINAPI CorBindToRuntime(LPWSTR, LPWSTR, DWORD, REFCLSID, REFIID, LPVOID *ppv) { *ppv = NULL; return E_FAIL; }
-HRESULT WINAPI CorBindToRuntimeHost(LPCWSTR, LPCWSTR, LPCWSTR, VOID*, DWORD, REFCLSID, REFIID, LPVOID *ppv) { *ppv = NULL; return E_FAIL; }
-HRESULT WINAPI CorBindToCurrentRuntime(LPCWSTR, REFCLSID, REFIID, LPVOID *ppv) { *ppv = NULL; return E_FAIL; }
-HRESULT WINAPI CLRCreateInstance(REFCLSID, REFIID, LPVOID*) { return CLASS_E_CLASSNOTAVAILABLE; }
-HRESULT WINAPI CreateInterface(REFCLSID, REFIID, LPVOID*) { return CLASS_E_CLASSNOTAVAILABLE; }
-HRESULT WINAPI DllGetClassObject(REFCLSID, REFIID, LPVOID*) { return CLASS_E_CLASSNOTAVAILABLE; }
-HRESULT WINAPI DllCanUnloadNow() { return S_FALSE; }
-HRESULT WINAPI DllRegisterServer() { return S_OK; }
-HRESULT WINAPI DllUnregisterServer() { return S_OK; }
-
-HRESULT WINAPI GetCORVersion(LPWSTR pBuffer, DWORD cchBuffer, DWORD *dwLength) {
-    const char *ver = "v4.0.30319";
-    if (dwLength) *dwLength = 10;
-    if (pBuffer && cchBuffer > 10) MultiByteToWideChar(CP_ACP, 0, ver, -1, pBuffer, cchBuffer);
+HRESULT WINAPI CorBindToRuntimeEx(LPWSTR, LPWSTR, DWORD, REFCLSID, REFIID, LPVOID* ppv) {
+    *ppv = NULL;
+    return E_FAIL;
+}
+HRESULT WINAPI CorBindToRuntime(LPWSTR, LPWSTR, DWORD, REFCLSID, REFIID, LPVOID* ppv) {
+    *ppv = NULL;
+    return E_FAIL;
+}
+HRESULT WINAPI CorBindToRuntimeHost(LPCWSTR, LPCWSTR, LPCWSTR, VOID*, DWORD, REFCLSID, REFIID, LPVOID* ppv) {
+    *ppv = NULL;
+    return E_FAIL;
+}
+HRESULT WINAPI CorBindToCurrentRuntime(LPCWSTR, REFCLSID, REFIID, LPVOID* ppv) {
+    *ppv = NULL;
+    return E_FAIL;
+}
+HRESULT WINAPI CLRCreateInstance(REFCLSID, REFIID, LPVOID*) {
+    return CLASS_E_CLASSNOTAVAILABLE;
+}
+HRESULT WINAPI CreateInterface(REFCLSID, REFIID, LPVOID*) {
+    return CLASS_E_CLASSNOTAVAILABLE;
+}
+HRESULT WINAPI DllGetClassObject(REFCLSID, REFIID, LPVOID*) {
+    return CLASS_E_CLASSNOTAVAILABLE;
+}
+HRESULT WINAPI DllCanUnloadNow() {
+    return S_FALSE;
+}
+HRESULT WINAPI DllRegisterServer() {
+    return S_OK;
+}
+HRESULT WINAPI DllUnregisterServer() {
     return S_OK;
 }
 
-HRESULT WINAPI GetCORSystemDirectory(LPWSTR pBuffer, DWORD cchBuffer, DWORD *dwLength) {
-    const char *dir = "C:\\windows\\Microsoft.NET\\Framework\\v4.0.30319";
-    if (dwLength) *dwLength = (DWORD)strlen(dir);
-    if (pBuffer && cchBuffer > (DWORD)strlen(dir)) MultiByteToWideChar(CP_ACP, 0, dir, -1, pBuffer, cchBuffer);
+HRESULT WINAPI GetCORVersion(LPWSTR pBuffer, DWORD cchBuffer, DWORD* dwLength) {
+    const char* ver = "v4.0.30319";
+    if (dwLength)
+        *dwLength = 10;
+    if (pBuffer && cchBuffer > 10)
+        MultiByteToWideChar(CP_ACP, 0, ver, -1, pBuffer, cchBuffer);
     return S_OK;
 }
 
-HRESULT WINAPI GetFileVersion(LPCWSTR, LPWSTR, DWORD, DWORD *dwLength) { if (dwLength) *dwLength = 0; return S_OK; }
-HRESULT WINAPI CoInitializeCor(DWORD) { return S_OK; }
+HRESULT WINAPI GetCORSystemDirectory(LPWSTR pBuffer, DWORD cchBuffer, DWORD* dwLength) {
+    const char* dir = "C:\\windows\\Microsoft.NET\\Framework\\v4.0.30319";
+    if (dwLength)
+        *dwLength = (DWORD)strlen(dir);
+    if (pBuffer && cchBuffer > (DWORD)strlen(dir))
+        MultiByteToWideChar(CP_ACP, 0, dir, -1, pBuffer, cchBuffer);
+    return S_OK;
+}
+
+HRESULT WINAPI GetFileVersion(LPCWSTR, LPWSTR, DWORD, DWORD* dwLength) {
+    if (dwLength)
+        *dwLength = 0;
+    return S_OK;
+}
+HRESULT WINAPI CoInitializeCor(DWORD) {
+    return S_OK;
+}
 void WINAPI CoUninitializeCor(DWORD) {}
-HRESULT WINAPI CoInitializeEE(DWORD) { return E_FAIL; }
+HRESULT WINAPI CoInitializeEE(DWORD) {
+    return E_FAIL;
+}
 void WINAPI CoUninitializeEE(BOOL) {}
 void WINAPI CoEEShutDownCOM(void) {}
 void WINAPI CorMarkThreadInThreadPool(void) {}
-HRESULT WINAPI CorGetSvc(void) { return E_NOTIMPL; }
-HRESULT WINAPI CorIsLatestSvc(int *a, int *b) { if(a) *a=1; if(b) *b=1; return S_OK; }
-HRESULT WINAPI GetRealProcAddress(LPCSTR, void**) { return 0x80131073; }
-HRESULT WINAPI LockClrVersion(void*, void**, void**) { return S_OK; }
-HRESULT WINAPI ClrCreateManagedInstance(LPCWSTR, REFIID, void**) { return E_FAIL; }
+HRESULT WINAPI CorGetSvc(void) {
+    return E_NOTIMPL;
+}
+HRESULT WINAPI CorIsLatestSvc(int* a, int* b) {
+    if (a)
+        *a = 1;
+    if (b)
+        *b = 1;
+    return S_OK;
+}
+HRESULT WINAPI GetRealProcAddress(LPCSTR, void**) {
+    return 0x80131073;
+}
+HRESULT WINAPI LockClrVersion(void*, void**, void**) {
+    return S_OK;
+}
+HRESULT WINAPI ClrCreateManagedInstance(LPCWSTR, REFIID, void**) {
+    return E_FAIL;
+}
 void WINAPI CorDllMainWorker(void*) {}
-HRESULT WINAPI LoadLibraryShim(LPCWSTR, LPCWSTR, LPVOID, HMODULE *ph) { if(ph) *ph=NULL; return E_HANDLE; }
-HRESULT WINAPI GetRequestedRuntimeInfo(LPCWSTR,LPCWSTR,LPCWSTR,DWORD,DWORD,LPWSTR,DWORD,DWORD*,LPWSTR,DWORD,DWORD*) { return E_NOTIMPL; }
-HRESULT WINAPI GetRequestedRuntimeVersion(LPWSTR,LPWSTR,DWORD,DWORD*) { return E_NOTIMPL; }
-void WINAPI CallFunctionShim(void*,char*,void*,void**) {}
-HRESULT WINAPI CloseCtrs() { return S_OK; }
-HRESULT WINAPI CollectCtrs() { return S_OK; }
-HRESULT WINAPI CorBindToRuntimeByCfg(void*,DWORD,DWORD,REFCLSID,REFIID,LPVOID*) { return E_FAIL; }
-HRESULT WINAPI CorBindToRuntimeByPath(LPCWSTR,LPCWSTR,DWORD,REFCLSID,REFIID,LPVOID*) { return E_FAIL; }
-HRESULT WINAPI CorBindToRuntimeByPathEx(LPCWSTR,DWORD,DWORD,REFCLSID,REFIID,LPVOID*) { return E_FAIL; }
-HRESULT WINAPI CorTickleSvc() { return S_OK; }
-HRESULT WINAPI CreateConfigStream(LPCWSTR,void**) { return E_NOTIMPL; }
-HRESULT WINAPI CreateDebuggingInterfaceFromVersion(DWORD,LPCWSTR,void**) { return E_NOTIMPL; }
-HRESULT WINAPI GetCORRequiredVersion(LPWSTR,DWORD,DWORD*) { return S_OK; }
-HRESULT WINAPI GetCORRootDirectory(LPWSTR,DWORD,DWORD*) { return S_OK; }
-HRESULT WINAPI GetCompileInfo(DWORD*,DWORD*) { return S_OK; }
-HRESULT WINAPI MetahostGetRuntime(LPCWSTR,REFCLSID,REFIID,LPVOID*) { return E_FAIL; }
-HRESULT WINAPI RunDll32Shim() { return S_OK; }
-
+HRESULT WINAPI LoadLibraryShim(LPCWSTR, LPCWSTR, LPVOID, HMODULE* ph) {
+    if (ph)
+        *ph = NULL;
+    return E_HANDLE;
+}
+HRESULT WINAPI GetRequestedRuntimeInfo(LPCWSTR, LPCWSTR, LPCWSTR, DWORD, DWORD, LPWSTR, DWORD, DWORD*, LPWSTR, DWORD,
+                                       DWORD*) {
+    return E_NOTIMPL;
+}
+HRESULT WINAPI GetRequestedRuntimeVersion(LPWSTR, LPWSTR, DWORD, DWORD*) {
+    return E_NOTIMPL;
+}
+void WINAPI CallFunctionShim(void*, char*, void*, void**) {}
+HRESULT WINAPI CloseCtrs() {
+    return S_OK;
+}
+HRESULT WINAPI CollectCtrs() {
+    return S_OK;
+}
+HRESULT WINAPI CorBindToRuntimeByCfg(void*, DWORD, DWORD, REFCLSID, REFIID, LPVOID*) {
+    return E_FAIL;
+}
+HRESULT WINAPI CorBindToRuntimeByPath(LPCWSTR, LPCWSTR, DWORD, REFCLSID, REFIID, LPVOID*) {
+    return E_FAIL;
+}
+HRESULT WINAPI CorBindToRuntimeByPathEx(LPCWSTR, DWORD, DWORD, REFCLSID, REFIID, LPVOID*) {
+    return E_FAIL;
+}
+HRESULT WINAPI CorTickleSvc() {
+    return S_OK;
+}
+HRESULT WINAPI CreateConfigStream(LPCWSTR, void**) {
+    return E_NOTIMPL;
+}
+HRESULT WINAPI CreateDebuggingInterfaceFromVersion(DWORD, LPCWSTR, void**) {
+    return E_NOTIMPL;
+}
+HRESULT WINAPI GetCORRequiredVersion(LPWSTR, DWORD, DWORD*) {
+    return S_OK;
+}
+HRESULT WINAPI GetCORRootDirectory(LPWSTR, DWORD, DWORD*) {
+    return S_OK;
+}
+HRESULT WINAPI GetCompileInfo(DWORD*, DWORD*) {
+    return S_OK;
+}
+HRESULT WINAPI MetahostGetRuntime(LPCWSTR, REFCLSID, REFIID, LPVOID*) {
+    return E_FAIL;
+}
+HRESULT WINAPI RunDll32Shim() {
+    return S_OK;
+}
 }
 
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID) {

--- a/src/wine/mscoree_unix.c
+++ b/src/wine/mscoree_unix.c
@@ -1,32 +1,31 @@
 /// @file mscoree_unix.c
 /// @brief Unix-side mscoree backend for Mono runtime loading.
 ///
-/// Loads the system Mono runtime via dlopen and creates an application domain for executing managed .NET assemblies. Handles assembly resolution, P/Invoke marshaling setup, and entry point invocation for managed game executables.
+/// Loads the system Mono runtime via dlopen and creates an application domain for executing managed .NET assemblies.
+/// Handles assembly resolution, P/Invoke marshaling setup, and entry point invocation for managed game executables.
+#include <dlfcn.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <dlfcn.h>
 
 #include "mscoree_unix.h"
 
 typedef long NTSTATUS;
 #define STATUS_SUCCESS ((NTSTATUS)0)
 
-static NTSTATUS mscoree_unix_dispatch(unsigned int code, void *args);
+static NTSTATUS mscoree_unix_dispatch(unsigned int code, void* args);
 
 typedef NTSTATUS (*unixlib_call_t)(unsigned int, void*);
 
 __attribute__((visibility("default")))
-__attribute__((used))
-unixlib_call_t __wine_unix_call_funcs[2] = { mscoree_unix_dispatch, mscoree_unix_dispatch };
+__attribute__((used)) unixlib_call_t __wine_unix_call_funcs[2] = {mscoree_unix_dispatch, mscoree_unix_dispatch};
 
 __attribute__((visibility("default")))
-__attribute__((used))
-unixlib_call_t __wine_unix_call_wow64_funcs[2] = { mscoree_unix_dispatch, mscoree_unix_dispatch };
+__attribute__((used)) unixlib_call_t __wine_unix_call_wow64_funcs[2] = {mscoree_unix_dispatch, mscoree_unix_dispatch};
 
 #define WINE_MONO_LIB "@loader_path/libmonosgen-2.0.dylib"
 
-static void *g_mono_handle = NULL;
+static void* g_mono_handle = NULL;
 static int g_mono_initialized = 0;
 
 typedef struct _MonoDomain MonoDomain;
@@ -40,28 +39,29 @@ typedef enum {
     MONO_IMAGE_IMAGE_INVALID
 } MonoImageOpenStatus;
 
-static MonoDomain* (*p_mono_jit_init_version)(const char *domain_name, const char *runtime_version);
-static int (*p_mono_jit_exec)(MonoDomain *domain, MonoAssembly *assembly, int argc, char *argv[]);
-static MonoAssembly* (*p_mono_assembly_open)(const char *filename, MonoImageOpenStatus *status);
-static MonoImage* (*p_mono_assembly_get_image)(MonoAssembly *assembly);
-static MonoAssembly* (*p_mono_assembly_load_from)(MonoImage *image, const char *fname, MonoImageOpenStatus *status);
-static MonoImage* (*p_mono_image_open)(const char *fname, MonoImageOpenStatus *status);
-static void (*p_mono_set_dirs)(const char *assembly_dir, const char *config_dir);
-static void (*p_mono_config_parse)(const char *filename);
+static MonoDomain* (*p_mono_jit_init_version)(const char* domain_name, const char* runtime_version);
+static int (*p_mono_jit_exec)(MonoDomain* domain, MonoAssembly* assembly, int argc, char* argv[]);
+static MonoAssembly* (*p_mono_assembly_open)(const char* filename, MonoImageOpenStatus* status);
+static MonoImage* (*p_mono_assembly_get_image)(MonoAssembly* assembly);
+static MonoAssembly* (*p_mono_assembly_load_from)(MonoImage* image, const char* fname, MonoImageOpenStatus* status);
+static MonoImage* (*p_mono_image_open)(const char* fname, MonoImageOpenStatus* status);
+static void (*p_mono_set_dirs)(const char* assembly_dir, const char* config_dir);
+static void (*p_mono_config_parse)(const char* filename);
 static MonoDomain* (*p_mono_domain_get)(void);
-static void (*p_mono_thread_attach)(MonoDomain *domain);
+static void (*p_mono_thread_attach)(MonoDomain* domain);
 static void (*p_mono_runtime_quit)(void);
 static void (*p_mono_thread_manage)(void);
 
-#define LOAD_FUNC(name) \
-    p_##name = dlsym(g_mono_handle, #name); \
-    if (!p_##name) { \
-        fprintf(stderr, "[mscoree-unix] FAILED to load " #name ": %s\n", dlerror()); \
-        return -1; \
+#define LOAD_FUNC(name)                                                                                                \
+    p_##name = dlsym(g_mono_handle, #name);                                                                            \
+    if (!p_##name) {                                                                                                   \
+        fprintf(stderr, "[mscoree-unix] FAILED to load " #name ": %s\n", dlerror());                                   \
+        return -1;                                                                                                     \
     }
 
 static int load_mono(void) {
-    if (g_mono_handle) return 0;
+    if (g_mono_handle)
+        return 0;
 
     fprintf(stderr, "[mscoree-unix] Loading mono from %s\n", WINE_MONO_LIB);
     g_mono_handle = dlopen(WINE_MONO_LIB, RTLD_NOW | RTLD_GLOBAL);
@@ -89,20 +89,21 @@ static int load_mono(void) {
 
 #undef LOAD_FUNC
 
-static int do_init(void *args) {
+static int do_init(void* args) {
     (void)args;
     fprintf(stderr, "[mscoree-unix] INIT\n");
-    if (load_mono() < 0) return -1;
+    if (load_mono() < 0)
+        return -1;
 
     p_mono_set_dirs("/Users/alexmondello/.metalsharp/wine-dlls/mono-x86_64-lib/mono",
-                     "/Users/alexmondello/.metalsharp/wine-dlls/mono-x86_64-etc/mono");
+                    "/Users/alexmondello/.metalsharp/wine-dlls/mono-x86_64-etc/mono");
     p_mono_config_parse(NULL);
 
     fprintf(stderr, "[mscoree-unix] mono dirs configured\n");
     return 0;
 }
 
-static int do_cor_exe_main(void *args) {
+static int do_cor_exe_main(void* args) {
     (void)args;
     fprintf(stderr, "[mscoree-unix] do_cor_exe_main ENTRY\n");
     fflush(stderr);
@@ -112,15 +113,16 @@ static int do_cor_exe_main(void *args) {
         return -1;
     }
 
-    extern char **environ;
+    extern char** environ;
     char exe_path[1024] = {0};
     int found = 0;
 
     for (int i = 0; environ[i]; i++) {
-        if (strncmp(environ[i], "WINELOADERNOEXEC=", 17) == 0) continue;
+        if (strncmp(environ[i], "WINELOADERNOEXEC=", 17) == 0)
+            continue;
     }
 
-    for (char **env = environ; *env; env++) {
+    for (char** env = environ; *env; env++) {
         if (strncmp(*env, "_=", 2) == 0) {
             strncpy(exe_path, *env + 2, sizeof(exe_path) - 1);
             found = 1;
@@ -129,9 +131,9 @@ static int do_cor_exe_main(void *args) {
     }
 
     if (!found) {
-        char *path = getenv("PATH");
+        char* path = getenv("PATH");
         (void)path;
-        FILE *f = fopen("/proc/self/cmdline", "r");
+        FILE* f = fopen("/proc/self/cmdline", "r");
         if (f) {
             fgets(exe_path, sizeof(exe_path), f);
             fclose(f);
@@ -142,7 +144,7 @@ static int do_cor_exe_main(void *args) {
     fprintf(stderr, "[mscoree-unix] about to call mono_jit_init_version...\n");
     fflush(stderr);
 
-    MonoDomain *domain = NULL;
+    MonoDomain* domain = NULL;
 
     typedef MonoDomain* (*jit_init_t)(const char*);
     jit_init_t p_init = (jit_init_t)dlsym(g_mono_handle, "mono_jit_init");
@@ -172,15 +174,15 @@ static int do_cor_exe_main(void *args) {
 
     MonoImageOpenStatus status;
 
-    const char *exe_to_load = found ? exe_path : getenv("_");
+    const char* exe_to_load = found ? exe_path : getenv("_");
     if (!exe_to_load || !exe_to_load[0]) {
         fprintf(stderr, "[mscoree-unix] no exe path found\n");
         return -1;
     }
 
     char unix_path[1024];
-    const char *src = exe_to_load;
-    char *dst = unix_path;
+    const char* src = exe_to_load;
+    char* dst = unix_path;
     while (*src && dst < unix_path + sizeof(unix_path) - 1) {
         *dst++ = (*src == '\\') ? '/' : *src;
         src++;
@@ -188,13 +190,13 @@ static int do_cor_exe_main(void *args) {
     *dst = 0;
 
     fprintf(stderr, "[mscoree-unix] opening image: %s\n", unix_path);
-    MonoImage *image = p_mono_image_open(unix_path, &status);
+    MonoImage* image = p_mono_image_open(unix_path, &status);
     if (!image) {
         fprintf(stderr, "[mscoree-unix] mono_image_open failed: %d\n", status);
         return -1;
     }
 
-    MonoAssembly *assembly = p_mono_assembly_load_from(image, unix_path, &status);
+    MonoAssembly* assembly = p_mono_assembly_load_from(image, unix_path, &status);
     if (!assembly) {
         fprintf(stderr, "[mscoree-unix] mono_assembly_load_from failed: %d\n", status);
         return -1;
@@ -202,7 +204,7 @@ static int do_cor_exe_main(void *args) {
     fprintf(stderr, "[mscoree-unix] assembly loaded, calling mono_jit_exec\n");
 
     g_mono_initialized = 1;
-    char *argv[] = { unix_path, NULL };
+    char* argv[] = {unix_path, NULL};
     int exit_code = p_mono_jit_exec(domain, assembly, 1, argv);
     fprintf(stderr, "[mscoree-unix] mono_jit_exec returned %d\n", exit_code);
 
@@ -212,9 +214,9 @@ static int do_cor_exe_main(void *args) {
     return exit_code;
 }
 
-static int do_get_cor_version(void *args) {
-    struct mscoree_cor_version_params *p = (struct mscoree_cor_version_params *)args;
-    const char *ver = "v4.0.30319";
+static int do_get_cor_version(void* args) {
+    struct mscoree_cor_version_params* p = (struct mscoree_cor_version_params*)args;
+    const char* ver = "v4.0.30319";
     strncpy(p->version, ver, sizeof(p->version) - 1);
     p->version_len = (int32_t)strlen(ver);
     return 0;
@@ -222,7 +224,7 @@ static int do_get_cor_version(void *args) {
 
 static int g_state = 0;
 
-static NTSTATUS mscoree_unix_dispatch(unsigned int code, void *args) {
+static NTSTATUS mscoree_unix_dispatch(unsigned int code, void* args) {
     fprintf(stderr, "[mscoree-unix] dispatch: code=%u args=%p state=%d\n", code, args, g_state);
     fflush(stderr);
 

--- a/src/wine/mscoree_unix.h
+++ b/src/wine/mscoree_unix.h
@@ -1,12 +1,13 @@
 /// @file mscoree_unix.h
 /// @brief Shared header for Wine mscoree PE/Unix interface.
 ///
-/// Defines the unixlib dispatch table and shared structures for .NET CLR hosting calls that cross the PE/Unix boundary. Covers runtime loading, assembly execution, and AppDomain management.
+/// Defines the unixlib dispatch table and shared structures for .NET CLR hosting calls that cross the PE/Unix boundary.
+/// Covers runtime loading, assembly execution, and AppDomain management.
 #ifndef MSCOREE_UNIX_H
 #define MSCOREE_UNIX_H
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -22,7 +23,7 @@ struct mscoree_cor_exe_main_params {
     char exe_path[1024];
     char exe_dir[1024];
     int argc;
-    char *argv[64];
+    char* argv[64];
     int exit_code;
 };
 

--- a/src/wine/test_d3d11.cpp
+++ b/src/wine/test_d3d11.cpp
@@ -1,17 +1,23 @@
 /// @file test_d3d11.cpp
 /// @brief Integration test for D3D11 device creation and basic rendering.
 ///
-/// Creates a D3D11 device and swap chain, renders test primitives, and validates output against expected results. Runs under Wine with the MetalSharp D3D11 shim to verify end-to-end D3D11→Metal translation.
-#include <windows.h>
+/// Creates a D3D11 device and swap chain, renders test primitives, and validates output against expected results. Runs
+/// under Wine with the MetalSharp D3D11 shim to verify end-to-end D3D11→Metal translation.
 #include <d3d11.h>
 #include <stdio.h>
+#include <windows.h>
 
 static int g_pass = 0;
 static int g_fail = 0;
 
 static void check(const char* name, BOOL cond) {
-    if (cond) { printf("  PASS: %s\n", name); g_pass++; }
-    else      { printf("  FAIL: %s\n", name); g_fail++; }
+    if (cond) {
+        printf("  PASS: %s\n", name);
+        g_pass++;
+    } else {
+        printf("  FAIL: %s\n", name);
+        g_fail++;
+    }
 }
 
 int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR cmdline, int show) {
@@ -21,8 +27,8 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR cmdline, int show) {
     ID3D11DeviceContext* context = NULL;
     D3D_FEATURE_LEVEL featureLevel;
 
-    HRESULT hr = D3D11CreateDevice(NULL, D3D_DRIVER_TYPE_HARDWARE, NULL, 0, NULL, 0,
-                                    D3D11_SDK_VERSION, &device, &featureLevel, &context);
+    HRESULT hr = D3D11CreateDevice(NULL, D3D_DRIVER_TYPE_HARDWARE, NULL, 0, NULL, 0, D3D11_SDK_VERSION, &device,
+                                   &featureLevel, &context);
     printf("[Device] hr=0x%08X device=%p ctx=%p fl=0x%X\n", (unsigned)hr, device, context, featureLevel);
     check("D3D11CreateDevice", SUCCEEDED(hr) && device && context);
 
@@ -34,7 +40,7 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR cmdline, int show) {
     // --- Test 1: CreateBuffer with initial data ---
     printf("\n--- Test 1: CreateBuffer ---\n");
     {
-        float verts[] = { 0.0f, 0.5f, 0.5f, -0.5f, -0.5f, -0.5f };
+        float verts[] = {0.0f, 0.5f, 0.5f, -0.5f, -0.5f, -0.5f};
         D3D11_BUFFER_DESC desc = {};
         desc.ByteWidth = sizeof(verts);
         desc.Usage = D3D11_USAGE_DEFAULT;
@@ -69,7 +75,8 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR cmdline, int show) {
         printf("  hr=0x%08X buffer=%p\n", (unsigned)hr, buf);
         check("CreateBuffer (dynamic const) returns S_OK", SUCCEEDED(hr));
         check("Buffer pointer non-NULL", buf != NULL);
-        if (buf) buf->Release();
+        if (buf)
+            buf->Release();
     }
 
     // --- Test 3: CreateBuffer large ---
@@ -84,7 +91,8 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR cmdline, int show) {
         hr = device->CreateBuffer(&desc, NULL, &buf);
         printf("  hr=0x%08X buffer=%p\n", (unsigned)hr, buf);
         check("CreateBuffer (1MB) returns S_OK", SUCCEEDED(hr));
-        if (buf) buf->Release();
+        if (buf)
+            buf->Release();
     }
 
     // --- Test 4: CreateTexture2D (render target) ---
@@ -105,7 +113,8 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR cmdline, int show) {
         printf("  hr=0x%08X texture=%p\n", (unsigned)hr, tex);
         check("CreateTexture2D (RT) returns S_OK", SUCCEEDED(hr));
         check("Texture pointer non-NULL", tex != NULL);
-        if (tex) tex->Release();
+        if (tex)
+            tex->Release();
     }
 
     // --- Test 5: CreateTexture2D (depth stencil) ---
@@ -125,7 +134,8 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR cmdline, int show) {
         hr = device->CreateTexture2D(&desc, NULL, &tex);
         printf("  hr=0x%08X texture=%p\n", (unsigned)hr, tex);
         check("CreateTexture2D (DS) returns S_OK", SUCCEEDED(hr));
-        if (tex) tex->Release();
+        if (tex)
+            tex->Release();
     }
 
     // --- Test 6: CreateTexture2D (staging / CPU access) ---
@@ -145,7 +155,8 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR cmdline, int show) {
         hr = device->CreateTexture2D(&desc, NULL, &tex);
         printf("  hr=0x%08X texture=%p\n", (unsigned)hr, tex);
         check("CreateTexture2D (staging) returns S_OK", SUCCEEDED(hr));
-        if (tex) tex->Release();
+        if (tex)
+            tex->Release();
     }
 
     // --- Test 7: CreateRenderTargetView ---
@@ -169,7 +180,8 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR cmdline, int show) {
             printf("  hr=0x%08X rtv=%p\n", (unsigned)hr, rtv);
             check("CreateRenderTargetView returns S_OK", SUCCEEDED(hr));
             check("RTV pointer non-NULL", rtv != NULL);
-            if (rtv) rtv->Release();
+            if (rtv)
+                rtv->Release();
             tex->Release();
         } else {
             check("CreateRenderTargetView (no texture)", FALSE);
@@ -188,10 +200,13 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR cmdline, int show) {
             desc.BindFlags = D3D11_BIND_VERTEX_BUFFER;
             hr = device->CreateBuffer(&desc, NULL, &bufs[i]);
             printf("  buf[%d]=%p hr=0x%08X\n", i, bufs[i], (unsigned)hr);
-            if (FAILED(hr) || !bufs[i]) all_ok = FALSE;
+            if (FAILED(hr) || !bufs[i])
+                all_ok = FALSE;
         }
         check("All 4 buffers created", all_ok);
-        for (int i = 0; i < 4; i++) if (bufs[i]) bufs[i]->Release();
+        for (int i = 0; i < 4; i++)
+            if (bufs[i])
+                bufs[i]->Release();
     }
 
     context->Release();

--- a/src/wine/test_d3d9.cpp
+++ b/src/wine/test_d3d9.cpp
@@ -1,35 +1,52 @@
 /// @file test_d3d9.cpp
 /// @brief Integration test for D3D9 device creation and basic rendering.
 ///
-/// Creates a Direct3D 9 device and renders a test scene to verify the D3D9→Metal translation pipeline. Validates device capabilities, texture creation, and swap chain presentation under Wine.
-#include <windows.h>
+/// Creates a Direct3D 9 device and renders a test scene to verify the D3D9→Metal translation pipeline. Validates device
+/// capabilities, texture creation, and swap chain presentation under Wine.
 #include <d3d9.h>
 #include <stdio.h>
+#include <windows.h>
 
 int WINAPI WinMain(HINSTANCE h, HINSTANCE p, LPSTR cmd, int show) {
     fprintf(stderr, "=== D3D9 Bridge Test ===\n");
 
     IDirect3D9* d3d = Direct3DCreate9(D3D_SDK_VERSION);
-    if (!d3d) { fprintf(stderr, "  FAIL: Direct3DCreate9\n"); return 1; }
+    if (!d3d) {
+        fprintf(stderr, "  FAIL: Direct3DCreate9\n");
+        return 1;
+    }
     fprintf(stderr, "  PASS: Direct3DCreate9\n");
 
     D3DADAPTER_IDENTIFIER9 id = {};
     HRESULT hr = d3d->GetAdapterIdentifier(0, 0, &id);
-    if (FAILED(hr)) { fprintf(stderr, "  FAIL: GetAdapterIdentifier (0x%08x)\n", hr); return 1; }
+    if (FAILED(hr)) {
+        fprintf(stderr, "  FAIL: GetAdapterIdentifier (0x%08x)\n", hr);
+        return 1;
+    }
     fprintf(stderr, "  PASS: GetAdapterIdentifier: %s\n", id.Description);
 
     D3DCAPS9 caps = {};
     hr = d3d->GetDeviceCaps(0, D3DDEVTYPE_HAL, &caps);
-    if (FAILED(hr)) { fprintf(stderr, "  FAIL: GetDeviceCaps (0x%08x)\n", hr); return 1; }
+    if (FAILED(hr)) {
+        fprintf(stderr, "  FAIL: GetDeviceCaps (0x%08x)\n", hr);
+        return 1;
+    }
     fprintf(stderr, "  PASS: GetDeviceCaps: VS=%u PS=%u\n", caps.VertexShaderVersion, caps.PixelShaderVersion);
 
     D3DDISPLAYMODE dm = {};
     hr = d3d->GetAdapterDisplayMode(0, &dm);
-    if (FAILED(hr)) { fprintf(stderr, "  FAIL: GetAdapterDisplayMode (0x%08x)\n", hr); return 1; }
-    fprintf(stderr, "  PASS: GetAdapterDisplayMode: %ux%u @ %uHz fmt=%u\n", dm.Width, dm.Height, dm.RefreshRate, dm.Format);
+    if (FAILED(hr)) {
+        fprintf(stderr, "  FAIL: GetAdapterDisplayMode (0x%08x)\n", hr);
+        return 1;
+    }
+    fprintf(stderr, "  PASS: GetAdapterDisplayMode: %ux%u @ %uHz fmt=%u\n", dm.Width, dm.Height, dm.RefreshRate,
+            dm.Format);
 
     HWND wnd = CreateWindowExA(0, "STATIC", "d3d9test", 0, 0, 0, 800, 600, NULL, NULL, h, NULL);
-    if (!wnd) { fprintf(stderr, "  FAIL: CreateWindow\n"); return 1; }
+    if (!wnd) {
+        fprintf(stderr, "  FAIL: CreateWindow\n");
+        return 1;
+    }
 
     D3DPRESENT_PARAMETERS pp = {};
     pp.Windowed = TRUE;
@@ -40,50 +57,80 @@ int WINAPI WinMain(HINSTANCE h, HINSTANCE p, LPSTR cmd, int show) {
 
     IDirect3DDevice9* dev = NULL;
     hr = d3d->CreateDevice(0, D3DDEVTYPE_HAL, wnd, D3DCREATE_HARDWARE_VERTEXPROCESSING, &pp, &dev);
-    if (FAILED(hr)) { fprintf(stderr, "  FAIL: CreateDevice (0x%08x)\n", hr); return 1; }
+    if (FAILED(hr)) {
+        fprintf(stderr, "  FAIL: CreateDevice (0x%08x)\n", hr);
+        return 1;
+    }
     fprintf(stderr, "  PASS: CreateDevice\n");
 
-    struct Vertex { float x, y, z; DWORD color; };
+    struct Vertex {
+        float x, y, z;
+        DWORD color;
+    };
     Vertex tri[] = {
-        { 0.0f,  0.5f, 0.0f, 0x00ff0000 },
-        { 0.5f, -0.5f, 0.0f, 0x0000ff00 },
-        {-0.5f, -0.5f, 0.0f, 0x000000ff },
+        {0.0f, 0.5f, 0.0f, 0x00ff0000},
+        {0.5f, -0.5f, 0.0f, 0x0000ff00},
+        {-0.5f, -0.5f, 0.0f, 0x000000ff},
     };
 
     IDirect3DVertexBuffer9* vb = NULL;
     hr = dev->CreateVertexBuffer(sizeof(tri), 0, D3DFVF_XYZ | D3DFVF_DIFFUSE, D3DPOOL_DEFAULT, &vb, NULL);
-    if (FAILED(hr)) { fprintf(stderr, "  FAIL: CreateVertexBuffer (0x%08x)\n", hr); return 1; }
+    if (FAILED(hr)) {
+        fprintf(stderr, "  FAIL: CreateVertexBuffer (0x%08x)\n", hr);
+        return 1;
+    }
     fprintf(stderr, "  PASS: CreateVertexBuffer\n");
 
     void* data = NULL;
     hr = vb->Lock(0, 0, &data, 0);
-    if (FAILED(hr)) { fprintf(stderr, "  FAIL: Lock (0x%08x)\n", hr); return 1; }
+    if (FAILED(hr)) {
+        fprintf(stderr, "  FAIL: Lock (0x%08x)\n", hr);
+        return 1;
+    }
     memcpy(data, tri, sizeof(tri));
     vb->Unlock();
     fprintf(stderr, "  PASS: Lock/Unlock\n");
 
     hr = dev->SetStreamSource(0, vb, 0, sizeof(Vertex));
-    if (FAILED(hr)) { fprintf(stderr, "  FAIL: SetStreamSource (0x%08x)\n", hr); return 1; }
+    if (FAILED(hr)) {
+        fprintf(stderr, "  FAIL: SetStreamSource (0x%08x)\n", hr);
+        return 1;
+    }
     fprintf(stderr, "  PASS: SetStreamSource\n");
 
     hr = dev->SetFVF(D3DFVF_XYZ | D3DFVF_DIFFUSE);
-    if (FAILED(hr)) { fprintf(stderr, "  FAIL: SetFVF (0x%08x)\n", hr); return 1; }
+    if (FAILED(hr)) {
+        fprintf(stderr, "  FAIL: SetFVF (0x%08x)\n", hr);
+        return 1;
+    }
     fprintf(stderr, "  PASS: SetFVF\n");
 
     hr = dev->BeginScene();
-    if (FAILED(hr)) { fprintf(stderr, "  FAIL: BeginScene (0x%08x)\n", hr); return 1; }
+    if (FAILED(hr)) {
+        fprintf(stderr, "  FAIL: BeginScene (0x%08x)\n", hr);
+        return 1;
+    }
     fprintf(stderr, "  PASS: BeginScene\n");
 
     hr = dev->DrawPrimitive(D3DPT_TRIANGLELIST, 0, 1);
-    if (FAILED(hr)) { fprintf(stderr, "  FAIL: DrawPrimitive (0x%08x)\n", hr); return 1; }
+    if (FAILED(hr)) {
+        fprintf(stderr, "  FAIL: DrawPrimitive (0x%08x)\n", hr);
+        return 1;
+    }
     fprintf(stderr, "  PASS: DrawPrimitive\n");
 
     hr = dev->EndScene();
-    if (FAILED(hr)) { fprintf(stderr, "  FAIL: EndScene (0x%08x)\n", hr); return 1; }
+    if (FAILED(hr)) {
+        fprintf(stderr, "  FAIL: EndScene (0x%08x)\n", hr);
+        return 1;
+    }
     fprintf(stderr, "  PASS: EndScene\n");
 
     hr = dev->Present(NULL, NULL, NULL, NULL);
-    if (FAILED(hr)) { fprintf(stderr, "  FAIL: Present (0x%08x)\n", hr); return 1; }
+    if (FAILED(hr)) {
+        fprintf(stderr, "  FAIL: Present (0x%08x)\n", hr);
+        return 1;
+    }
     fprintf(stderr, "  PASS: Present\n");
 
     fprintf(stderr, "\n=== ALL D3D9 TESTS PASSED ===\n");

--- a/src/wine/test_mojoshader.cpp
+++ b/src/wine/test_mojoshader.cpp
@@ -1,31 +1,26 @@
 /// @file test_mojoshader.cpp
 /// @brief Test for MojoShader bytecode-to-MSL translation with D3D9.
 ///
-/// Compiles a simple vertex shader from HLSL bytecode through MojoShader's GLSL profile and verifies the translated output. Validates that fixed-function vertex processing fallbacks work correctly in the D3D9 pipeline.
-#include <windows.h>
+/// Compiles a simple vertex shader from HLSL bytecode through MojoShader's GLSL profile and verifies the translated
+/// output. Validates that fixed-function vertex processing fallbacks work correctly in the D3D9 pipeline.
 #include <d3d9.h>
 #include <stdio.h>
+#include <windows.h>
 
-static const DWORD vs_bytecode[] = {
-    0xFFFE0300,
-    0x0000004, 0xFFFE0002, 0x00000010, 0x00000001,
-    0x00000000, 0x800F0000, 0x90E40000,
-    0x00000000, 0x800F0001, 0x90E40001,
-    0x0000FFFF
-};
+static const DWORD vs_bytecode[] = {0xFFFE0300, 0x0000004,  0xFFFE0002, 0x00000010, 0x00000001, 0x00000000,
+                                    0x800F0000, 0x90E40000, 0x00000000, 0x800F0001, 0x90E40001, 0x0000FFFF};
 
-static const DWORD ps_bytecode[] = {
-    0xFFFF0300,
-    0x0000004, 0xFFFE0002, 0x00000010, 0x00000001,
-    0x00000000, 0x800F0000, 0x80E40001,
-    0x0000FFFF
-};
+static const DWORD ps_bytecode[] = {0xFFFF0300, 0x0000004,  0xFFFE0002, 0x00000010, 0x00000001,
+                                    0x00000000, 0x800F0000, 0x80E40001, 0x0000FFFF};
 
 int WINAPI WinMain(HINSTANCE h, HINSTANCE p, LPSTR cmd, int show) {
     fprintf(stderr, "=== D3D9 MojoShader Test ===\n");
 
     IDirect3D9* d3d = Direct3DCreate9(D3D_SDK_VERSION);
-    if (!d3d) { fprintf(stderr, "  FAIL: Direct3DCreate9\n"); return 1; }
+    if (!d3d) {
+        fprintf(stderr, "  FAIL: Direct3DCreate9\n");
+        return 1;
+    }
 
     HWND wnd = CreateWindowExA(0, "STATIC", "mojotest", 0, 0, 0, 400, 300, NULL, NULL, h, NULL);
 
@@ -38,25 +33,40 @@ int WINAPI WinMain(HINSTANCE h, HINSTANCE p, LPSTR cmd, int show) {
 
     IDirect3DDevice9* dev = NULL;
     HRESULT hr = d3d->CreateDevice(0, D3DDEVTYPE_HAL, wnd, D3DCREATE_HARDWARE_VERTEXPROCESSING, &pp, &dev);
-    if (FAILED(hr)) { fprintf(stderr, "  FAIL: CreateDevice (0x%08x)\n", hr); return 1; }
+    if (FAILED(hr)) {
+        fprintf(stderr, "  FAIL: CreateDevice (0x%08x)\n", hr);
+        return 1;
+    }
     fprintf(stderr, "  PASS: CreateDevice\n");
 
     IDirect3DVertexShader9* vs = NULL;
     hr = dev->CreateVertexShader(vs_bytecode, &vs);
-    if (FAILED(hr)) { fprintf(stderr, "  FAIL: CreateVertexShader (0x%08x)\n", hr); return 1; }
+    if (FAILED(hr)) {
+        fprintf(stderr, "  FAIL: CreateVertexShader (0x%08x)\n", hr);
+        return 1;
+    }
     fprintf(stderr, "  PASS: CreateVertexShader (SM3.0 bytecode)\n");
 
     IDirect3DPixelShader9* ps = NULL;
     hr = dev->CreatePixelShader(ps_bytecode, &ps);
-    if (FAILED(hr)) { fprintf(stderr, "  FAIL: CreatePixelShader (0x%08x)\n", hr); return 1; }
+    if (FAILED(hr)) {
+        fprintf(stderr, "  FAIL: CreatePixelShader (0x%08x)\n", hr);
+        return 1;
+    }
     fprintf(stderr, "  PASS: CreatePixelShader (SM3.0 bytecode)\n");
 
     hr = dev->SetVertexShader(vs);
-    if (FAILED(hr)) { fprintf(stderr, "  FAIL: SetVertexShader\n"); return 1; }
+    if (FAILED(hr)) {
+        fprintf(stderr, "  FAIL: SetVertexShader\n");
+        return 1;
+    }
     fprintf(stderr, "  PASS: SetVertexShader\n");
 
     hr = dev->SetPixelShader(ps);
-    if (FAILED(hr)) { fprintf(stderr, "  FAIL: SetPixelShader\n"); return 1; }
+    if (FAILED(hr)) {
+        fprintf(stderr, "  FAIL: SetPixelShader\n");
+        return 1;
+    }
     fprintf(stderr, "  PASS: SetPixelShader\n");
 
     fprintf(stderr, "\n=== ALL MOJOSHADER TESTS PASSED ===\n");

--- a/src/wine/test_mojoshader2.cpp
+++ b/src/wine/test_mojoshader2.cpp
@@ -1,31 +1,29 @@
 /// @file test_mojoshader2.cpp
 /// @brief Second MojoShader translation test with additional shader profiles.
 ///
-/// Tests MojoShader translation with pixel shader bytecode and validates sampler binding and constant table handling. Complements test_mojoshader.cpp with coverage for fragment-stage shader translation.
-#include <windows.h>
+/// Tests MojoShader translation with pixel shader bytecode and validates sampler binding and constant table handling.
+/// Complements test_mojoshader.cpp with coverage for fragment-stage shader translation.
 #include <d3d9.h>
 #include <stdio.h>
+#include <windows.h>
 
 static const DWORD vs_bytecode[] = {
-    0xFFFE0200,
-    0x0200001F, 0x80000000, 0x900F0000,
-    0x0200001F, 0x8000000A, 0x900F0001,
-    0x03000014, 0xC00F0000, 0x90E40000, 0xA0E40000,
-    0x02000001, 0xD00F0000, 0x90E40001,
-    0x0000FFFF,
+    0xFFFE0200, 0x0200001F, 0x80000000, 0x900F0000, 0x0200001F, 0x8000000A, 0x900F0001, 0x03000014,
+    0xC00F0000, 0x90E40000, 0xA0E40000, 0x02000001, 0xD00F0000, 0x90E40001, 0x0000FFFF,
 };
 
 static const DWORD ps_bytecode[] = {
-    0xFFFF0200,
-    0x02000001, 0x800F0000, 0x90E40001,
-    0x0000FFFF,
+    0xFFFF0200, 0x02000001, 0x800F0000, 0x90E40001, 0x0000FFFF,
 };
 
 int WINAPI WinMain(HINSTANCE h, HINSTANCE p, LPSTR cmd, int show) {
     fprintf(stderr, "=== D3D9 MojoShader Bytecode Test ===\n");
 
     IDirect3D9* d3d = Direct3DCreate9(D3D_SDK_VERSION);
-    if (!d3d) { fprintf(stderr, "  FAIL: Direct3DCreate9\n"); return 1; }
+    if (!d3d) {
+        fprintf(stderr, "  FAIL: Direct3DCreate9\n");
+        return 1;
+    }
 
     HWND wnd = CreateWindowExA(0, "STATIC", "mojotest", 0, 0, 0, 400, 300, NULL, NULL, h, NULL);
     D3DPRESENT_PARAMETERS pp = {};
@@ -37,25 +35,30 @@ int WINAPI WinMain(HINSTANCE h, HINSTANCE p, LPSTR cmd, int show) {
 
     IDirect3DDevice9* dev = NULL;
     HRESULT hr = d3d->CreateDevice(0, D3DDEVTYPE_HAL, wnd, D3DCREATE_HARDWARE_VERTEXPROCESSING, &pp, &dev);
-    if (FAILED(hr)) { fprintf(stderr, "  FAIL: CreateDevice (0x%08x)\n", hr); return 1; }
+    if (FAILED(hr)) {
+        fprintf(stderr, "  FAIL: CreateDevice (0x%08x)\n", hr);
+        return 1;
+    }
     fprintf(stderr, "  PASS: CreateDevice\n");
 
     IDirect3DVertexShader9* vs = NULL;
     hr = dev->CreateVertexShader(vs_bytecode, &vs);
-    fprintf(stderr, "  %s: CreateVertexShader -> 0x%08x (vs=%p)\n",
-        SUCCEEDED(hr) ? "PASS" : "FAIL", hr, (void*)vs);
+    fprintf(stderr, "  %s: CreateVertexShader -> 0x%08x (vs=%p)\n", SUCCEEDED(hr) ? "PASS" : "FAIL", hr, (void*)vs);
 
     IDirect3DPixelShader9* ps = NULL;
     hr = dev->CreatePixelShader(ps_bytecode, &ps);
-    fprintf(stderr, "  %s: CreatePixelShader -> 0x%08x (ps=%p)\n",
-        SUCCEEDED(hr) ? "PASS" : "FAIL", hr, (void*)ps);
+    fprintf(stderr, "  %s: CreatePixelShader -> 0x%08x (ps=%p)\n", SUCCEEDED(hr) ? "PASS" : "FAIL", hr, (void*)ps);
 
-    if (vs) dev->SetVertexShader(vs);
-    if (ps) dev->SetPixelShader(ps);
+    if (vs)
+        dev->SetVertexShader(vs);
+    if (ps)
+        dev->SetPixelShader(ps);
 
     fprintf(stderr, "\n=== DONE ===\n");
-    if (vs) vs->Release();
-    if (ps) ps->Release();
+    if (vs)
+        vs->Release();
+    if (ps)
+        ps->Release();
     dev->Release();
     d3d->Release();
     DestroyWindow(wnd);

--- a/src/wine/test_triangle.cpp
+++ b/src/wine/test_triangle.cpp
@@ -1,13 +1,14 @@
 /// @file test_triangle.cpp
 /// @brief End-to-end triangle rendering test via D3D11→Metal pipeline.
 ///
-/// The classic 'hello triangle' integration test that creates a D3D11 device, swap chain, vertex buffer, and simple shaders to render a colored triangle. Serves as the primary smoke test for the entire MetalSharp rendering stack.
-#include <windows.h>
+/// The classic 'hello triangle' integration test that creates a D3D11 device, swap chain, vertex buffer, and simple
+/// shaders to render a colored triangle. Serves as the primary smoke test for the entire MetalSharp rendering stack.
 #include <d3d11.h>
 #include <dxgi.h>
-#include <stdio.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
+#include <windows.h>
 
 static const char msl_source[] =
     "using namespace metal;\n"
@@ -27,16 +28,24 @@ static int g_pass = 0;
 static int g_fail = 0;
 
 static void check(const char* name, BOOL cond) {
-    if (cond) { printf("  PASS: %s\n", name); g_pass++; }
-    else      { printf("  FAIL: %s\n", name); g_fail++; }
+    if (cond) {
+        printf("  PASS: %s\n", name);
+        g_pass++;
+    } else {
+        printf("  FAIL: %s\n", name);
+        g_fail++;
+    }
 }
 
 static void build_shader_bytecode(const char* func_name, void* out, int* out_len) {
     uint8_t* p = (uint8_t*)out;
-    memcpy(p, "MSL", 4); p += 4;
+    memcpy(p, "MSL", 4);
+    p += 4;
     int name_len = (int)strlen(func_name);
-    memcpy(p, func_name, name_len + 1); p += name_len + 1;
-    memcpy(p, msl_source, sizeof(msl_source)); p += sizeof(msl_source);
+    memcpy(p, func_name, name_len + 1);
+    p += name_len + 1;
+    memcpy(p, msl_source, sizeof(msl_source));
+    p += sizeof(msl_source);
     *out_len = (int)(p - (uint8_t*)out);
 }
 
@@ -61,8 +70,8 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR cmdline, int show) {
     scDesc.Windowed = TRUE;
     scDesc.SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
 
-    HRESULT hr = D3D11CreateDeviceAndSwapChain(NULL, D3D_DRIVER_TYPE_HARDWARE, NULL, 0,
-        NULL, 0, D3D11_SDK_VERSION, &scDesc, &swapchain, &device, &fl, &ctx);
+    HRESULT hr = D3D11CreateDeviceAndSwapChain(NULL, D3D_DRIVER_TYPE_HARDWARE, NULL, 0, NULL, 0, D3D11_SDK_VERSION,
+                                               &scDesc, &swapchain, &device, &fl, &ctx);
     printf("[Device] hr=0x%08X dev=%p ctx=%p sc=%p fl=0x%X\n", (unsigned)hr, device, ctx, swapchain, fl);
     check("D3D11CreateDeviceAndSwapChain", SUCCEEDED(hr) && device && ctx && swapchain);
 
@@ -82,9 +91,7 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR cmdline, int show) {
     check("CreateRenderTargetView", SUCCEEDED(hr) && rtv);
 
     float vertices[] = {
-         0.0f,  0.5f, 0.0f,
-         0.5f, -0.5f, 0.0f,
-        -0.5f, -0.5f, 0.0f,
+        0.0f, 0.5f, 0.0f, 0.5f, -0.5f, 0.0f, -0.5f, -0.5f, 0.0f,
     };
 
     ID3D11Buffer* vertexBuffer = NULL;
@@ -98,14 +105,16 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR cmdline, int show) {
     printf("[VB] hr=0x%08X buf=%p\n", (unsigned)hr, vertexBuffer);
     check("CreateBuffer (vertex)", SUCCEEDED(hr) && vertexBuffer);
 
-    char vs_bc[4096]; int vs_len;
+    char vs_bc[4096];
+    int vs_len;
     build_shader_bytecode("vs_main", vs_bc, &vs_len);
     ID3D11VertexShader* vs = NULL;
     hr = device->CreateVertexShader(vs_bc, vs_len, NULL, &vs);
     printf("[VS] hr=0x%08X vs=%p\n", (unsigned)hr, vs);
     check("CreateVertexShader (MSL)", SUCCEEDED(hr) && vs);
 
-    char ps_bc[4096]; int ps_len;
+    char ps_bc[4096];
+    int ps_len;
     build_shader_bytecode("ps_main", ps_bc, &ps_len);
     ID3D11PixelShader* ps = NULL;
     hr = device->CreatePixelShader(ps_bc, ps_len, NULL, &ps);
@@ -113,14 +122,15 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR cmdline, int show) {
     check("CreatePixelShader (MSL)", SUCCEEDED(hr) && ps);
 
     ID3D11InputLayout* inputLayout = NULL;
-    D3D11_INPUT_ELEMENT_DESC layoutDesc = { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0 };
+    D3D11_INPUT_ELEMENT_DESC layoutDesc = {
+        "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0};
     hr = device->CreateInputLayout(&layoutDesc, 1, vs_bc, vs_len, &inputLayout);
     printf("[Layout] hr=0x%08X layout=%p\n", (unsigned)hr, inputLayout);
     check("CreateInputLayout", SUCCEEDED(hr));
 
     printf("\n--- Render Loop (60 frames) ---\n");
     for (int frame = 0; frame < 60; frame++) {
-        float clearColor[4] = { 0.1f, 0.1f, 0.15f, 1.0f };
+        float clearColor[4] = {0.1f, 0.1f, 0.15f, 1.0f};
         ctx->ClearRenderTargetView(rtv, clearColor);
 
         ctx->OMSetRenderTargets(1, &rtv, NULL);
@@ -134,7 +144,7 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR cmdline, int show) {
         ctx->VSSetShader(vs, NULL, 0);
         ctx->PSSetShader(ps, NULL, 0);
 
-        D3D11_VIEWPORT vp = { 0, 0, 800, 600, 0, 1 };
+        D3D11_VIEWPORT vp = {0, 0, 800, 600, 0, 1};
         ctx->RSSetViewports(1, &vp);
 
         ctx->Draw(3, 0);
@@ -152,15 +162,24 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR cmdline, int show) {
     }
 
     printf("\n--- Cleanup ---\n");
-    if (inputLayout) inputLayout->Release();
-    if (ps) ps->Release();
-    if (vs) vs->Release();
-    if (vertexBuffer) vertexBuffer->Release();
-    if (rtv) rtv->Release();
-    if (backBuffer) backBuffer->Release();
-    if (swapchain) swapchain->Release();
-    if (ctx) ctx->Release();
-    if (device) device->Release();
+    if (inputLayout)
+        inputLayout->Release();
+    if (ps)
+        ps->Release();
+    if (vs)
+        vs->Release();
+    if (vertexBuffer)
+        vertexBuffer->Release();
+    if (rtv)
+        rtv->Release();
+    if (backBuffer)
+        backBuffer->Release();
+    if (swapchain)
+        swapchain->Release();
+    if (ctx)
+        ctx->Release();
+    if (device)
+        device->Release();
 
     printf("\n=== Results: %d passed, %d failed ===\n", g_pass, g_fail);
     return g_fail > 0 ? 1 : 0;

--- a/tests/pe_tests/d3d11_triangle.cpp
+++ b/tests/pe_tests/d3d11_triangle.cpp
@@ -1,8 +1,8 @@
-#include <windows.h>
-#include <d3d11.h>
-#include <dxgi.h>
 #include <cstdio>
 #include <cstdlib>
+#include <d3d11.h>
+#include <dxgi.h>
+#include <windows.h>
 
 #pragma comment(lib, "d3d11.lib")
 #pragma comment(lib, "dxgi.lib")
@@ -17,25 +17,27 @@ static ID3D11PixelShader* g_ps = nullptr;
 static ID3D11InputLayout* g_layout = nullptr;
 static ID3D11Buffer* g_vb = nullptr;
 
-static const char vs_src[] =
-    "float4 VS(float3 pos : POSITION) : SV_POSITION {"
-    "  return float4(pos, 1.0);"
-    "}";
+static const char vs_src[] = "float4 VS(float3 pos : POSITION) : SV_POSITION {"
+                             "  return float4(pos, 1.0);"
+                             "}";
 
-static const char ps_src[] =
-    "float4 PS() : SV_TARGET {"
-    "  return float4(0.2, 0.6, 1.0, 1.0);"
-    "}";
+static const char ps_src[] = "float4 PS() : SV_TARGET {"
+                             "  return float4(0.2, 0.6, 1.0, 1.0);"
+                             "}";
 
 static float vertices[] = {
-     0.0f,  0.5f, 0.0f,
-     0.5f, -0.5f, 0.0f,
-    -0.5f, -0.5f, 0.0f,
+    0.0f, 0.5f, 0.0f, 0.5f, -0.5f, 0.0f, -0.5f, -0.5f, 0.0f,
 };
 
 static LRESULT WINAPI WndProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) {
-    if (msg == WM_DESTROY) { PostQuitMessage(0); return 0; }
-    if (msg == WM_KEYDOWN && wp == VK_ESCAPE) { PostQuitMessage(0); return 0; }
+    if (msg == WM_DESTROY) {
+        PostQuitMessage(0);
+        return 0;
+    }
+    if (msg == WM_KEYDOWN && wp == VK_ESCAPE) {
+        PostQuitMessage(0);
+        return 0;
+    }
     return DefWindowProcW(wnd, msg, wp, lp);
 }
 
@@ -58,9 +60,8 @@ int WINAPI WinMain(HINSTANCE inst, HINSTANCE prev, LPSTR cmdLine, int show) {
     wc.lpszClassName = L"MetalSharpTest";
     RegisterClassW(&wc);
 
-    HWND wnd = CreateWindowExW(0, L"MetalSharpTest", L"MetalSharp D3D11 Triangle",
-        WS_OVERLAPPEDWINDOW, 100, 100, 800, 600,
-        nullptr, nullptr, inst, nullptr);
+    HWND wnd = CreateWindowExW(0, L"MetalSharpTest", L"MetalSharp D3D11 Triangle", WS_OVERLAPPEDWINDOW, 100, 100, 800,
+                               600, nullptr, nullptr, inst, nullptr);
     ShowWindow(wnd, show);
     UpdateWindow(wnd);
 
@@ -83,9 +84,9 @@ int WINAPI WinMain(HINSTANCE inst, HINSTANCE prev, LPSTR cmdLine, int show) {
     scDesc.SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
 
     D3D_FEATURE_LEVEL featureLevel;
-    HRESULT hr = D3D11CreateDeviceAndSwapChain(nullptr, D3D_DRIVER_TYPE_HARDWARE,
-        nullptr, 0, nullptr, 0, D3D11_SDK_VERSION,
-        &scDesc, &g_swapChain, &g_device, &featureLevel, &g_context);
+    HRESULT hr =
+        D3D11CreateDeviceAndSwapChain(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, 0, nullptr, 0, D3D11_SDK_VERSION,
+                                      &scDesc, &g_swapChain, &g_device, &featureLevel, &g_context);
 
     if (FAILED(hr)) {
         char buf[256];
@@ -100,7 +101,7 @@ int WINAPI WinMain(HINSTANCE inst, HINSTANCE prev, LPSTR cmdLine, int show) {
     vbDesc.ByteWidth = sizeof(vertices);
     vbDesc.Usage = D3D11_USAGE_DEFAULT;
     vbDesc.BindFlags = D3D11_BIND_VERTEX_BUFFER;
-    D3D11_SUBRESOURCE_DATA vbData = { vertices, 0, 0 };
+    D3D11_SUBRESOURCE_DATA vbData = {vertices, 0, 0};
     g_device->CreateBuffer(&vbDesc, &vbData, &g_vb);
 
     UINT stride = 12;
@@ -108,10 +109,10 @@ int WINAPI WinMain(HINSTANCE inst, HINSTANCE prev, LPSTR cmdLine, int show) {
     g_context->IASetVertexBuffers(0, 1, &g_vb, &stride, &offset);
     g_context->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
 
-    D3D11_VIEWPORT vp = { 0.0f, 0.0f, (float)w, (float)h, 0.0f, 1.0f };
+    D3D11_VIEWPORT vp = {0.0f, 0.0f, (float)w, (float)h, 0.0f, 1.0f};
     g_context->RSSetViewports(1, &vp);
 
-    float clearColor[4] = { 0.05f, 0.05f, 0.1f, 1.0f };
+    float clearColor[4] = {0.05f, 0.05f, 0.1f, 1.0f};
 
     OutputDebugStringA("MetalSharp PE test: entering render loop\n");
 
@@ -137,14 +138,22 @@ int WINAPI WinMain(HINSTANCE inst, HINSTANCE prev, LPSTR cmdLine, int show) {
 
     OutputDebugStringA("MetalSharp PE test: shutting down\n");
 
-    if (g_rtView) g_rtView->Release();
-    if (g_vb) g_vb->Release();
-    if (g_layout) g_layout->Release();
-    if (g_vs) g_vs->Release();
-    if (g_ps) g_ps->Release();
-    if (g_swapChain) g_swapChain->Release();
-    if (g_context) g_context->Release();
-    if (g_device) g_device->Release();
+    if (g_rtView)
+        g_rtView->Release();
+    if (g_vb)
+        g_vb->Release();
+    if (g_layout)
+        g_layout->Release();
+    if (g_vs)
+        g_vs->Release();
+    if (g_ps)
+        g_ps->Release();
+    if (g_swapChain)
+        g_swapChain->Release();
+    if (g_context)
+        g_context->Release();
+    if (g_device)
+        g_device->Release();
 
     return 0;
 }

--- a/tests/test_audio.cpp
+++ b/tests/test_audio.cpp
@@ -1,18 +1,24 @@
-#include <metalsharp/CoreAudioBackend.h>
-#include <metalsharp/XAudio2Engine.h>
-#include <metalsharp/Platform.h>
 #include <cstdio>
 #include <cstring>
+#include <metalsharp/CoreAudioBackend.h>
+#include <metalsharp/Platform.h>
+#include <metalsharp/XAudio2Engine.h>
 
 extern "C" HRESULT XAudio2Create(void** ppXAudio2, UINT Flags, UINT XAudio2Processor);
 
 static int passed = 0;
 static int failed = 0;
 
-#define CHECK(cond, msg) do { \
-    if (cond) { printf("  [OK] %s\n", msg); passed++; } \
-    else { printf("  [FAIL] %s\n", msg); failed++; } \
-} while(0)
+#define CHECK(cond, msg)                                                                                               \
+    do {                                                                                                               \
+        if (cond) {                                                                                                    \
+            printf("  [OK] %s\n", msg);                                                                                \
+            passed++;                                                                                                  \
+        } else {                                                                                                       \
+            printf("  [FAIL] %s\n", msg);                                                                              \
+            failed++;                                                                                                  \
+        }                                                                                                              \
+    } while (0)
 
 int main() {
     printf("=== Audio Tests ===\n\n");

--- a/tests/test_d3d11_device.cpp
+++ b/tests/test_d3d11_device.cpp
@@ -1,19 +1,15 @@
-#include <d3d/D3D11.h>
 #include <cstdio>
 #include <cstring>
+#include <d3d/D3D11.h>
 
-extern "C" HRESULT D3D11CreateDevice(
-    void*, UINT, HMODULE, UINT, const void*, UINT, UINT,
-    ID3D11Device**, void*, ID3D11DeviceContext**);
+extern "C" HRESULT D3D11CreateDevice(void*, UINT, HMODULE, UINT, const void*, UINT, UINT, ID3D11Device**, void*,
+                                     ID3D11DeviceContext**);
 
 int main() {
     ID3D11Device* device = nullptr;
     ID3D11DeviceContext* context = nullptr;
 
-    HRESULT hr = D3D11CreateDevice(
-        nullptr, 0, nullptr, 0,
-        nullptr, 0, 7,
-        &device, nullptr, &context);
+    HRESULT hr = D3D11CreateDevice(nullptr, 0, nullptr, 0, nullptr, 0, 7, &device, nullptr, &context);
 
     if (FAILED(hr)) {
         fprintf(stderr, "FAIL: D3D11CreateDevice returned 0x%08x\n", hr);

--- a/tests/test_d3d12.cpp
+++ b/tests/test_d3d12.cpp
@@ -1,15 +1,21 @@
-#include <metalsharp/D3D12Device.h>
-#include <d3d/D3D12.h>
 #include <cstdio>
 #include <cstring>
+#include <d3d/D3D12.h>
+#include <metalsharp/D3D12Device.h>
 
 static int g_pass = 0;
 static int g_fail = 0;
 
-#define CHECK(cond, msg) do { \
-    if (cond) { printf("  [OK] %s\n", msg); g_pass++; } \
-    else { printf("  [FAIL] %s\n", msg); g_fail++; } \
-} while(0)
+#define CHECK(cond, msg)                                                                                               \
+    do {                                                                                                               \
+        if (cond) {                                                                                                    \
+            printf("  [OK] %s\n", msg);                                                                                \
+            g_pass++;                                                                                                  \
+        } else {                                                                                                       \
+            printf("  [FAIL] %s\n", msg);                                                                              \
+            g_fail++;                                                                                                  \
+        }                                                                                                              \
+    } while (0)
 
 int main() {
     printf("=== MetalSharp D3D12 Tests ===\n\n");
@@ -29,7 +35,8 @@ int main() {
     printf("\n--- Command Allocator ---\n");
     ID3D12CommandAllocator* cmdAlloc = nullptr;
     if (device) {
-        hr = device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_ID3D12CommandAllocator, (void**)&cmdAlloc);
+        hr = device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_ID3D12CommandAllocator,
+                                            (void**)&cmdAlloc);
         CHECK(SUCCEEDED(hr) && cmdAlloc, "CreateCommandAllocator");
         if (cmdAlloc) {
             hr = cmdAlloc->Reset();
@@ -40,7 +47,8 @@ int main() {
     printf("\n--- Command List ---\n");
     ID3D12GraphicsCommandList* cmdList = nullptr;
     if (device && cmdAlloc) {
-        hr = device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, cmdAlloc, nullptr, IID_ID3D12GraphicsCommandList, (void**)&cmdList);
+        hr = device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, cmdAlloc, nullptr,
+                                       IID_ID3D12GraphicsCommandList, (void**)&cmdList);
         CHECK(SUCCEEDED(hr) && cmdList, "CreateCommandList");
     }
 
@@ -82,7 +90,8 @@ int main() {
         bufDesc.Layout = 0;
         bufDesc.Flags = D3D12_RESOURCE_FLAG_NONE;
 
-        hr = device->CreateCommittedResource(&heapProps, 0, &bufDesc, D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, IID_ID3D12Resource, (void**)&uploadBuffer);
+        hr = device->CreateCommittedResource(&heapProps, 0, &bufDesc, D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
+                                             IID_ID3D12Resource, (void**)&uploadBuffer);
         CHECK(SUCCEEDED(hr) && uploadBuffer, "CreateCommittedResource (upload buffer)");
 
         if (uploadBuffer) {
@@ -126,12 +135,14 @@ int main() {
         texDesc.Layout = 0;
         texDesc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
 
-        hr = device->CreateCommittedResource(&heapProps, 0, &texDesc, D3D12_RESOURCE_STATE_RENDER_TARGET, nullptr, IID_ID3D12Resource, (void**)&rtTexture);
+        hr = device->CreateCommittedResource(&heapProps, 0, &texDesc, D3D12_RESOURCE_STATE_RENDER_TARGET, nullptr,
+                                             IID_ID3D12Resource, (void**)&rtTexture);
         CHECK(SUCCEEDED(hr) && rtTexture, "CreateCommittedResource (render target texture)");
 
         if (rtTexture) {
             CHECK(rtTexture->__metalTexturePtr() != nullptr, "Texture has Metal texture backing");
-            CHECK(rtTexture->__getResourceState() == D3D12_RESOURCE_STATE_RENDER_TARGET, "Initial resource state correct");
+            CHECK(rtTexture->__getResourceState() == D3D12_RESOURCE_STATE_RENDER_TARGET,
+                  "Initial resource state correct");
         }
     }
 
@@ -145,11 +156,13 @@ int main() {
         barrier.pResource = rtTexture;
 
         ID3D12GraphicsCommandList* freshList = nullptr;
-        device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, cmdAlloc, nullptr, IID_ID3D12GraphicsCommandList, (void**)&freshList);
+        device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, cmdAlloc, nullptr, IID_ID3D12GraphicsCommandList,
+                                  (void**)&freshList);
         if (freshList) {
             hr = freshList->ResourceBarrier(1, &barrier);
             CHECK(SUCCEEDED(hr), "ResourceBarrier");
-            CHECK(rtTexture->__getResourceState() == D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, "Resource state updated after barrier");
+            CHECK(rtTexture->__getResourceState() == D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+                  "Resource state updated after barrier");
             freshList->Close();
             freshList->Release();
         }
@@ -180,7 +193,8 @@ int main() {
 
         FLOAT clearColor[4] = {0.2f, 0.3f, 0.4f, 1.0f};
         ID3D12GraphicsCommandList* clearList = nullptr;
-        device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, cmdAlloc, nullptr, IID_ID3D12GraphicsCommandList, (void**)&clearList);
+        device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, cmdAlloc, nullptr, IID_ID3D12GraphicsCommandList,
+                                  (void**)&clearList);
         if (clearList) {
             hr = clearList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
             CHECK(SUCCEEDED(hr), "ClearRenderTargetView");
@@ -256,17 +270,28 @@ int main() {
         CHECK(inc == 1, "GetDescriptorHandleIncrementSize returns 1");
     }
 
-    if (pso) pso->Release();
-    if (cmdSig) cmdSig->Release();
-    if (fence) fence->Release();
-    if (rootSig) rootSig->Release();
-    if (rtvHeap) rtvHeap->Release();
-    if (rtTexture) rtTexture->Release();
-    if (uploadBuffer) uploadBuffer->Release();
-    if (cmdList) cmdList->Release();
-    if (cmdAlloc) cmdAlloc->Release();
-    if (cmdQueue) cmdQueue->Release();
-    if (device) device->Release();
+    if (pso)
+        pso->Release();
+    if (cmdSig)
+        cmdSig->Release();
+    if (fence)
+        fence->Release();
+    if (rootSig)
+        rootSig->Release();
+    if (rtvHeap)
+        rtvHeap->Release();
+    if (rtTexture)
+        rtTexture->Release();
+    if (uploadBuffer)
+        uploadBuffer->Release();
+    if (cmdList)
+        cmdList->Release();
+    if (cmdAlloc)
+        cmdAlloc->Release();
+    if (cmdQueue)
+        cmdQueue->Release();
+    if (device)
+        device->Release();
 
     printf("\n=== Results: %d passed, %d failed ===\n", g_pass, g_fail);
     return g_fail > 0 ? 1 : 0;

--- a/tests/test_deferred_context.cpp
+++ b/tests/test_deferred_context.cpp
@@ -1,17 +1,23 @@
+#include <cstdio>
+#include <cstring>
+#include <d3d/D3D11.h>
 #include <metalsharp/D3D11Device.h>
 #include <metalsharp/D3D11DeviceContext.h>
 #include <metalsharp/DeferredContext.h>
-#include <d3d/D3D11.h>
-#include <cstdio>
-#include <cstring>
 
 static int g_pass = 0;
 static int g_fail = 0;
 
-#define CHECK(cond, msg) do { \
-    if (cond) { printf("  [OK] %s\n", msg); g_pass++; } \
-    else { printf("  [FAIL] %s\n", msg); g_fail++; } \
-} while(0)
+#define CHECK(cond, msg)                                                                                               \
+    do {                                                                                                               \
+        if (cond) {                                                                                                    \
+            printf("  [OK] %s\n", msg);                                                                                \
+            g_pass++;                                                                                                  \
+        } else {                                                                                                       \
+            printf("  [FAIL] %s\n", msg);                                                                              \
+            g_fail++;                                                                                                  \
+        }                                                                                                              \
+    } while (0)
 
 static const char* kMSL = R"msl(
 #include <metal_stdlib>
@@ -154,12 +160,18 @@ int main() {
         }
     }
 
-    if (cmdList) cmdList->Release();
-    if (cmdList2) cmdList2->Release();
-    if (rtv) rtv->Release();
-    if (rtTexture) rtTexture->Release();
-    if (deferred) deferred->Release();
-    if (immediate) immediate->Release();
+    if (cmdList)
+        cmdList->Release();
+    if (cmdList2)
+        cmdList2->Release();
+    if (rtv)
+        rtv->Release();
+    if (rtTexture)
+        rtTexture->Release();
+    if (deferred)
+        deferred->Release();
+    if (immediate)
+        immediate->Release();
     device->Release();
 
     printf("\n=== Results: %d passed, %d failed ===\n", g_pass, g_fail);

--- a/tests/test_dxbc.cpp
+++ b/tests/test_dxbc.cpp
@@ -1,10 +1,16 @@
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <metalsharp/DXBCParser.h>
 #include <metalsharp/DXBCtoMSL.h>
-#include <cstdio>
-#include <cstring>
-#include <cstdlib>
 
-#define CHECK(cond, msg) do { if (!(cond)) { printf("FAIL: %s\n", msg); return 1; } } while(0)
+#define CHECK(cond, msg)                                                                                               \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            printf("FAIL: %s\n", msg);                                                                                 \
+            return 1;                                                                                                  \
+        }                                                                                                              \
+    } while (0)
 
 static void writeU32(std::vector<uint8_t>& out, uint32_t val) {
     out.push_back(val & 0xFF);
@@ -17,7 +23,7 @@ static std::vector<uint8_t> buildMinimalDXBC() {
     std::vector<uint8_t> shaderChunk;
 
     uint32_t versionToken = 0xFFFF0050; // ps_5_0 (major=5, minor=0)
-    uint32_t lengthToken = 3; // total tokens including version + length + ret
+    uint32_t lengthToken = 3;           // total tokens including version + length + ret
     uint32_t retToken = (22) | (1 << 24);
 
     writeU32(shaderChunk, versionToken);
@@ -34,14 +40,14 @@ static std::vector<uint8_t> buildMinimalDXBC() {
     const char* magic = "DXBC";
     dxbc.insert(dxbc.end(), magic, magic + 4);
     dxbc.insert(dxbc.end(), 16, 0); // checksum
-    writeU32(dxbc, 1); // version
+    writeU32(dxbc, 1);              // version
 
     uint32_t chunkCount = 1;
     uint32_t chunkDataOffset = 32 + chunkCount * 4; // 36
     uint32_t totalSize = chunkDataOffset + (uint32_t)chunk.size();
 
-    writeU32(dxbc, totalSize); // total file size
-    writeU32(dxbc, chunkCount); // chunk count
+    writeU32(dxbc, totalSize);       // total file size
+    writeU32(dxbc, chunkCount);      // chunk count
     writeU32(dxbc, chunkDataOffset); // offset to first chunk
 
     dxbc.insert(dxbc.end(), chunk.begin(), chunk.end());
@@ -80,7 +86,7 @@ static std::vector<uint8_t> buildShaderWithMov() {
     const char* magic = "DXBC";
     dxbc.insert(dxbc.end(), magic, magic + 4);
     dxbc.insert(dxbc.end(), 16, 0); // checksum
-    writeU32(dxbc, 1); // version
+    writeU32(dxbc, 1);              // version
 
     uint32_t chunkCount = 1;
     uint32_t chunkDataOffset = 32 + chunkCount * 4;

--- a/tests/test_format_translation.cpp
+++ b/tests/test_format_translation.cpp
@@ -1,6 +1,6 @@
-#include <metalsharp/FormatTranslation.h>
-#include <cstdio>
 #include <cassert>
+#include <cstdio>
+#include <metalsharp/FormatTranslation.h>
 
 int main() {
     using namespace metalsharp;

--- a/tests/test_input.cpp
+++ b/tests/test_input.cpp
@@ -1,14 +1,20 @@
-#include <metalsharp/GameControllerBridge.h>
 #include <cstdio>
 #include <cstring>
+#include <metalsharp/GameControllerBridge.h>
 
 static int passed = 0;
 static int failed = 0;
 
-#define CHECK(cond, msg) do { \
-    if (cond) { printf("  [OK] %s\n", msg); passed++; } \
-    else { printf("  [FAIL] %s\n", msg); failed++; } \
-} while(0)
+#define CHECK(cond, msg)                                                                                               \
+    do {                                                                                                               \
+        if (cond) {                                                                                                    \
+            printf("  [OK] %s\n", msg);                                                                                \
+            passed++;                                                                                                  \
+        } else {                                                                                                       \
+            printf("  [FAIL] %s\n", msg);                                                                              \
+            failed++;                                                                                                  \
+        }                                                                                                              \
+    } while (0)
 
 int main() {
     printf("=== Input Tests ===\n\n");

--- a/tests/test_metal_device.cpp
+++ b/tests/test_metal_device.cpp
@@ -1,5 +1,5 @@
-#include <metalsharp/MetalBackend.h>
 #include <cstdio>
+#include <metalsharp/MetalBackend.h>
 
 int main() {
     auto* device = metalsharp::MetalDevice::create();

--- a/tests/test_phase17.cpp
+++ b/tests/test_phase17.cpp
@@ -1,34 +1,41 @@
-#include <metalsharp/IRConverterBridge.h>
-#include <metalsharp/ShaderTranslator.h>
-#include <metalsharp/ArgumentBufferBinding.h>
-#include <metalsharp/ShaderCache.h>
+#include <cassert>
+#include <chrono>
 #include <cstdio>
 #include <cstring>
-#include <cassert>
+#include <metalsharp/ArgumentBufferBinding.h>
+#include <metalsharp/IRConverterBridge.h>
+#include <metalsharp/ShaderCache.h>
+#include <metalsharp/ShaderTranslator.h>
 #include <thread>
-#include <chrono>
 
 using namespace metalsharp;
 
 static int testsPassed = 0;
 static int testsFailed = 0;
 
-#define TEST(name) \
-    printf("  TEST: %-50s", #name); \
-    if (test_##name()) { printf("PASS\n"); testsPassed++; } \
-    else { printf("FAIL\n"); testsFailed++; }
+#define TEST(name)                                                                                                     \
+    printf("  TEST: %-50s", #name);                                                                                    \
+    if (test_##name()) {                                                                                               \
+        printf("PASS\n");                                                                                              \
+        testsPassed++;                                                                                                 \
+    } else {                                                                                                           \
+        printf("FAIL\n");                                                                                              \
+        testsFailed++;                                                                                                 \
+    }
 
 static bool test_irconverter_available() {
     auto& bridge = IRConverterBridge::instance();
     bool avail = bridge.isAvailable();
     printf("[%s] ", avail ? "available" : "not found");
-    if (!avail) printf("(SKIPPED — libmetalirconverter not installed) ");
+    if (!avail)
+        printf("(SKIPPED — libmetalirconverter not installed) ");
     return true;
 }
 
 static bool test_irconverter_detect_dxil_container() {
     auto& bridge = IRConverterBridge::instance();
-    if (!bridge.isAvailable()) return true;
+    if (!bridge.isAvailable())
+        return true;
 
     uint32_t fakeDXBC[16] = {};
     fakeDXBC[0] = 0x43425844;
@@ -41,7 +48,8 @@ static bool test_irconverter_detect_dxil_container() {
 
 static bool test_irconverter_detect_shader_model() {
     auto& bridge = IRConverterBridge::instance();
-    if (!bridge.isAvailable()) return true;
+    if (!bridge.isAvailable())
+        return true;
 
     uint8_t rawData[4] = {0x44, 0x58, 0x49, 0x4C};
     uint32_t sm = bridge.detectShaderModel(rawData, 4);
@@ -52,33 +60,21 @@ static bool test_shader_translator_fallback_dxbc() {
     ShaderTranslator translator;
 
     uint8_t minimalDXBC[] = {
-        0x44, 0x58, 0x42, 0x43,
-        0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00,
-        0x20, 0x00, 0x00, 0x00,
-        0x01, 0x00, 0x00, 0x00,
-        0x20, 0x00, 0x00, 0x00,
-        0x53, 0x48, 0x44, 0x52,
-        0x08, 0x00, 0x00, 0x00,
-        0xFE, 0xFF, 0x01, 0x00,
-        0x02, 0x00, 0x00, 0x00,
+        0x44, 0x58, 0x42, 0x43, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00,
+        0x53, 0x48, 0x44, 0x52, 0x08, 0x00, 0x00, 0x00, 0xFE, 0xFF, 0x01, 0x00, 0x02, 0x00, 0x00, 0x00,
     };
 
     CompiledShader shader = {};
-    bool result = translator.translateDXBC(
-        minimalDXBC, sizeof(minimalDXBC),
-        ShaderStage::Vertex, shader
-    );
+    bool result = translator.translateDXBC(minimalDXBC, sizeof(minimalDXBC), ShaderStage::Vertex, shader);
 
     return true;
 }
 
 static bool test_shader_compile_service_init() {
     auto& bridge = IRConverterBridge::instance();
-    if (!bridge.isAvailable()) return true;
+    if (!bridge.isAvailable())
+        return true;
     auto& service = ShaderCompileService::instance();
     bool ok = service.init(2);
     service.shutdown();
@@ -110,7 +106,8 @@ static bool test_argument_buffer_encode_constants() {
     uint32_t constants[4] = {0xDEADBEEF, 0xCAFEBABE, 0x12345678, 0x87654321};
 
     bool ok = mgr.encodeRootConstants(layout, 0, buffer, sizeof(buffer), constants, 4);
-    if (!ok) return false;
+    if (!ok)
+        return false;
 
     uint32_t val0, val1;
     memcpy(&val0, buffer, 4);
@@ -136,7 +133,8 @@ static bool test_argument_buffer_encode_descriptor_table() {
     uint64_t fakeGPUAddr = 0x12345678ABCDEF00ULL;
 
     bool ok = mgr.encodeDescriptorTable(layout, 0, buffer, sizeof(buffer), fakeGPUAddr);
-    if (!ok) return false;
+    if (!ok)
+        return false;
 
     uint64_t readback;
     memcpy(&readback, buffer, 8);
@@ -160,7 +158,8 @@ static bool test_argument_buffer_encode_root_descriptor() {
     uint64_t addr = 0xAABBCCDDEEFF0011ULL;
 
     bool ok = mgr.encodeRootDescriptor(layout, 0, buffer, sizeof(buffer), addr);
-    if (!ok) return false;
+    if (!ok)
+        return false;
 
     uint64_t readback;
     memcpy(&readback, buffer + 8, 8);
@@ -171,7 +170,8 @@ static bool test_shader_cache_hash_stability() {
     uint8_t data[] = {0x01, 0x02, 0x03, 0x04, 0x05};
     uint64_t h1 = ShaderCache::computeHash(data, sizeof(data));
     uint64_t h2 = ShaderCache::computeHash(data, sizeof(data));
-    if (h1 != h2) return false;
+    if (h1 != h2)
+        return false;
 
     uint8_t data2[] = {0x01, 0x02, 0x03, 0x04, 0x06};
     uint64_t h3 = ShaderCache::computeHash(data2, sizeof(data2));
@@ -179,16 +179,13 @@ static bool test_shader_cache_hash_stability() {
 }
 
 static bool test_shader_stage_enum_values() {
-    return ShaderStage::Vertex == ShaderStage::Vertex &&
-           ShaderStage::Pixel == ShaderStage::Pixel &&
+    return ShaderStage::Vertex == ShaderStage::Vertex && ShaderStage::Pixel == ShaderStage::Pixel &&
            ShaderStage::Compute == ShaderStage::Compute;
 }
 
 static bool test_compiled_shader_init() {
     CompiledShader shader = {};
-    return shader.library == nullptr &&
-           shader.vertexFunction == nullptr &&
-           shader.fragmentFunction == nullptr &&
+    return shader.library == nullptr && shader.vertexFunction == nullptr && shader.fragmentFunction == nullptr &&
            shader.computeFunction == nullptr;
 }
 
@@ -209,7 +206,8 @@ int main() {
     TEST(compiled_shader_init);
 
     printf("\n%d/%d passed", testsPassed, testsPassed + testsFailed);
-    if (testsFailed > 0) printf(" (%d FAILED)", testsFailed);
+    if (testsFailed > 0)
+        printf(" (%d FAILED)", testsFailed);
     printf("\n");
 
     return testsFailed > 0 ? 1 : 0;

--- a/tests/test_phase18.cpp
+++ b/tests/test_phase18.cpp
@@ -1,22 +1,28 @@
-#include <metalsharp/D3D12Device.h>
+#include <cassert>
 #include <cstdio>
 #include <cstring>
-#include <cassert>
+#include <metalsharp/D3D12Device.h>
 
 using namespace metalsharp;
 
 static int testsPassed = 0;
 static int testsFailed = 0;
 
-#define TEST(name) \
-    printf("  TEST: %-50s", #name); \
-    if (test_##name()) { printf("PASS\n"); testsPassed++; } \
-    else { printf("FAIL\n"); testsFailed++; }
+#define TEST(name)                                                                                                     \
+    printf("  TEST: %-50s", #name);                                                                                    \
+    if (test_##name()) {                                                                                               \
+        printf("PASS\n");                                                                                              \
+        testsPassed++;                                                                                                 \
+    } else {                                                                                                           \
+        printf("FAIL\n");                                                                                              \
+        testsFailed++;                                                                                                 \
+    }
 
 static bool test_d3d12_device_create() {
     D3D12DeviceImpl* device = nullptr;
     HRESULT hr = D3D12DeviceImpl::create(&device);
-    if (FAILED(hr) || !device) return false;
+    if (FAILED(hr) || !device)
+        return false;
     device->Release();
     return true;
 }
@@ -24,7 +30,8 @@ static bool test_d3d12_device_create() {
 static bool test_d3d12_create_command_queue() {
     D3D12DeviceImpl* device = nullptr;
     D3D12DeviceImpl::create(&device);
-    if (!device) return false;
+    if (!device)
+        return false;
 
     void* queue = nullptr;
     HRESULT hr = device->CreateCommandQueue(nullptr, IID_ID3D12CommandQueue, &queue);
@@ -35,7 +42,8 @@ static bool test_d3d12_create_command_queue() {
 static bool test_d3d12_create_command_allocator() {
     D3D12DeviceImpl* device = nullptr;
     D3D12DeviceImpl::create(&device);
-    if (!device) return false;
+    if (!device)
+        return false;
 
     void* alloc = nullptr;
     HRESULT hr = device->CreateCommandAllocator(0, IID_ID3D12CommandAllocator, &alloc);
@@ -46,7 +54,8 @@ static bool test_d3d12_create_command_allocator() {
 static bool test_d3d12_create_root_signature_empty() {
     D3D12DeviceImpl* device = nullptr;
     D3D12DeviceImpl::create(&device);
-    if (!device) return false;
+    if (!device)
+        return false;
 
     uint8_t blob[16] = {};
     uint32_t version = 1, numParams = 0, numStatic = 0, flags = 0;
@@ -64,7 +73,8 @@ static bool test_d3d12_create_root_signature_empty() {
 static bool test_d3d12_root_signature_parameters() {
     D3D12DeviceImpl* device = nullptr;
     D3D12DeviceImpl::create(&device);
-    if (!device) return false;
+    if (!device)
+        return false;
 
     struct {
         uint32_t version;
@@ -91,14 +101,15 @@ static bool test_d3d12_root_signature_parameters() {
 
     void* rsPtr = nullptr;
     HRESULT hr = device->CreateRootSignature(0, &blob, sizeof(blob), IID_ID3D12RootSignature, &rsPtr);
-    if (FAILED(hr)) { device->Release(); return false; }
+    if (FAILED(hr)) {
+        device->Release();
+        return false;
+    }
 
     auto* rs = static_cast<D3D12RootSignatureImpl*>(rsPtr);
-    bool ok = rs->numParameters == 1 &&
-              rs->parameters.size() == 1 &&
+    bool ok = rs->numParameters == 1 && rs->parameters.size() == 1 &&
               rs->parameters[0].ParameterType == D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS &&
-              rs->parameters[0].Constants.Num32BitValues == 4 &&
-              rs->argumentBufferSize > 0 &&
+              rs->parameters[0].Constants.Num32BitValues == 4 && rs->argumentBufferSize > 0 &&
               rs->parameterLayouts.size() == 1;
 
     rs->Release();
@@ -109,7 +120,8 @@ static bool test_d3d12_root_signature_parameters() {
 static bool test_d3d12_root_signature_layout_offsets() {
     D3D12DeviceImpl* device = nullptr;
     D3D12DeviceImpl::create(&device);
-    if (!device) return false;
+    if (!device)
+        return false;
 
     struct {
         uint32_t version;
@@ -140,10 +152,8 @@ static bool test_d3d12_root_signature_layout_offsets() {
     device->CreateRootSignature(0, &blob, sizeof(blob), IID_ID3D12RootSignature, &rsPtr);
     auto* rs = static_cast<D3D12RootSignatureImpl*>(rsPtr);
 
-    bool ok = rs->parameterLayouts.size() == 2 &&
-              rs->parameterLayouts[0].offset == 0 &&
-              rs->parameterLayouts[1].offset >= sizeof(uint64_t) &&
-              rs->parameterLayouts[1].offset % 16 == 0;
+    bool ok = rs->parameterLayouts.size() == 2 && rs->parameterLayouts[0].offset == 0 &&
+              rs->parameterLayouts[1].offset >= sizeof(uint64_t) && rs->parameterLayouts[1].offset % 16 == 0;
 
     rs->Release();
     device->Release();
@@ -153,7 +163,8 @@ static bool test_d3d12_root_signature_layout_offsets() {
 static bool test_d3d12_descriptor_heap_create() {
     D3D12DeviceImpl* device = nullptr;
     D3D12DeviceImpl::create(&device);
-    if (!device) return false;
+    if (!device)
+        return false;
 
     D3D12_DESCRIPTOR_HEAP_DESC desc = {};
     desc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
@@ -171,7 +182,8 @@ static bool test_d3d12_descriptor_heap_copy() {
     D3D12DescriptorHeapImpl heap(&heapDesc);
 
     auto* desc = heap.getDescriptorByIndex(0);
-    if (!desc) return false;
+    if (!desc)
+        return false;
     desc->gpuAddress = 0xDEADBEEF;
     desc->bufferSize = 256;
     desc->type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
@@ -187,13 +199,15 @@ static bool test_d3d12_descriptor_heap_copy() {
 static bool test_d3d12_create_command_list() {
     D3D12DeviceImpl* device = nullptr;
     D3D12DeviceImpl::create(&device);
-    if (!device) return false;
+    if (!device)
+        return false;
 
     void* alloc = nullptr;
     device->CreateCommandAllocator(0, IID_ID3D12CommandAllocator, &alloc);
 
     void* cmdList = nullptr;
-    HRESULT hr = device->CreateCommandList(0, 0, static_cast<ID3D12CommandAllocator*>(alloc), nullptr, IID_ID3D12GraphicsCommandList, &cmdList);
+    HRESULT hr = device->CreateCommandList(0, 0, static_cast<ID3D12CommandAllocator*>(alloc), nullptr,
+                                           IID_ID3D12GraphicsCommandList, &cmdList);
     device->Release();
     return SUCCEEDED(hr) && cmdList != nullptr;
 }
@@ -201,7 +215,8 @@ static bool test_d3d12_create_command_list() {
 static bool test_d3d12_root_binding_constants() {
     D3D12DeviceImpl* device = nullptr;
     D3D12DeviceImpl::create(&device);
-    if (!device) return false;
+    if (!device)
+        return false;
 
     struct {
         uint32_t version = 1;
@@ -224,7 +239,8 @@ static bool test_d3d12_root_binding_constants() {
     void* alloc = nullptr;
     device->CreateCommandAllocator(0, IID_ID3D12CommandAllocator, &alloc);
     void* cmdListPtr = nullptr;
-    device->CreateCommandList(0, 0, static_cast<ID3D12CommandAllocator*>(alloc), nullptr, IID_ID3D12GraphicsCommandList, &cmdListPtr);
+    device->CreateCommandList(0, 0, static_cast<ID3D12CommandAllocator*>(alloc), nullptr, IID_ID3D12GraphicsCommandList,
+                              &cmdListPtr);
     auto* cmdList = static_cast<ID3D12GraphicsCommandList*>(cmdListPtr);
 
     cmdList->SetGraphicsRootSignature(static_cast<ID3D12RootSignature*>(rs));
@@ -242,7 +258,8 @@ static bool test_d3d12_root_binding_constants() {
 static bool test_d3d12_root_binding_cbv() {
     D3D12DeviceImpl* device = nullptr;
     D3D12DeviceImpl::create(&device);
-    if (!device) return false;
+    if (!device)
+        return false;
 
     struct {
         uint32_t version = 1;
@@ -264,7 +281,8 @@ static bool test_d3d12_root_binding_cbv() {
     void* alloc = nullptr;
     device->CreateCommandAllocator(0, IID_ID3D12CommandAllocator, &alloc);
     void* cmdListPtr = nullptr;
-    device->CreateCommandList(0, 0, static_cast<ID3D12CommandAllocator*>(alloc), nullptr, IID_ID3D12GraphicsCommandList, &cmdListPtr);
+    device->CreateCommandList(0, 0, static_cast<ID3D12CommandAllocator*>(alloc), nullptr, IID_ID3D12GraphicsCommandList,
+                              &cmdListPtr);
     auto* cmdList = static_cast<ID3D12GraphicsCommandList*>(cmdListPtr);
 
     cmdList->SetGraphicsRootSignature(static_cast<ID3D12RootSignature*>(rs));
@@ -280,7 +298,8 @@ static bool test_d3d12_root_binding_cbv() {
 static bool test_d3d12_root_binding_descriptor_table() {
     D3D12DeviceImpl* device = nullptr;
     D3D12DeviceImpl::create(&device);
-    if (!device) return false;
+    if (!device)
+        return false;
 
     struct {
         uint32_t version = 1;
@@ -302,7 +321,8 @@ static bool test_d3d12_root_binding_descriptor_table() {
     void* alloc = nullptr;
     device->CreateCommandAllocator(0, IID_ID3D12CommandAllocator, &alloc);
     void* cmdListPtr = nullptr;
-    device->CreateCommandList(0, 0, static_cast<ID3D12CommandAllocator*>(alloc), nullptr, IID_ID3D12GraphicsCommandList, &cmdListPtr);
+    device->CreateCommandList(0, 0, static_cast<ID3D12CommandAllocator*>(alloc), nullptr, IID_ID3D12GraphicsCommandList,
+                              &cmdListPtr);
     auto* cmdList = static_cast<ID3D12GraphicsCommandList*>(cmdListPtr);
 
     cmdList->SetGraphicsRootSignature(static_cast<ID3D12RootSignature*>(rs));
@@ -318,7 +338,8 @@ static bool test_d3d12_root_binding_descriptor_table() {
 static bool test_d3d12_committed_resource_buffer() {
     D3D12DeviceImpl* device = nullptr;
     D3D12DeviceImpl::create(&device);
-    if (!device) return false;
+    if (!device)
+        return false;
 
     D3D12_HEAP_PROPERTIES heapProps = {D3D12_HEAP_TYPE_UPLOAD, 0, 0, 0, 0};
     D3D12_RESOURCE_DESC desc = {};
@@ -333,7 +354,8 @@ static bool test_d3d12_committed_resource_buffer() {
     desc.Flags = 0;
 
     void* resPtr = nullptr;
-    HRESULT hr = device->CreateCommittedResource(&heapProps, 0, &desc, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER, nullptr, IID_ID3D12Resource, &resPtr);
+    HRESULT hr = device->CreateCommittedResource(&heapProps, 0, &desc, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER,
+                                                 nullptr, IID_ID3D12Resource, &resPtr);
     device->Release();
     return SUCCEEDED(hr) && resPtr != nullptr;
 }
@@ -341,7 +363,8 @@ static bool test_d3d12_committed_resource_buffer() {
 static bool test_d3d12_buffer_map_unmap() {
     D3D12DeviceImpl* device = nullptr;
     D3D12DeviceImpl::create(&device);
-    if (!device) return false;
+    if (!device)
+        return false;
 
     D3D12_HEAP_PROPERTIES heapProps = {D3D12_HEAP_TYPE_UPLOAD, 0, 0, 0, 0};
     D3D12_RESOURCE_DESC desc = {};
@@ -353,7 +376,8 @@ static bool test_d3d12_buffer_map_unmap() {
     desc.SampleDesc = {1, 0};
 
     void* resPtr = nullptr;
-    device->CreateCommittedResource(&heapProps, 0, &desc, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER, nullptr, IID_ID3D12Resource, &resPtr);
+    device->CreateCommittedResource(&heapProps, 0, &desc, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER, nullptr,
+                                    IID_ID3D12Resource, &resPtr);
     auto* res = static_cast<ID3D12Resource*>(resPtr);
 
     void* data = nullptr;
@@ -371,7 +395,8 @@ static bool test_d3d12_buffer_map_unmap() {
 static bool test_d3d12_fence_signal() {
     D3D12DeviceImpl* device = nullptr;
     D3D12DeviceImpl::create(&device);
-    if (!device) return false;
+    if (!device)
+        return false;
 
     void* fencePtr = nullptr;
     device->CreateFence(0, 0, IID_ID3D12Fence, &fencePtr);
@@ -406,7 +431,8 @@ int main() {
     TEST(d3d12_fence_signal);
 
     printf("\n%d/%d passed", testsPassed, testsPassed + testsFailed);
-    if (testsFailed > 0) printf(" (%d FAILED)", testsFailed);
+    if (testsFailed > 0)
+        printf(" (%d FAILED)", testsFailed);
     printf("\n");
 
     return testsFailed > 0 ? 1 : 0;

--- a/tests/test_phase19.cpp
+++ b/tests/test_phase19.cpp
@@ -1,65 +1,71 @@
-#include <metalsharp/D3D12Device.h>
-#include <metalsharp/IRConverterBridge.h>
-#include <metalsharp/ShaderStage.h>
-#include <metalsharp/ShaderModelValidator.h>
-#include <d3d/D3D12.h>
+#include <cassert>
 #include <cstdio>
 #include <cstring>
-#include <cassert>
+#include <d3d/D3D12.h>
+#include <metalsharp/D3D12Device.h>
+#include <metalsharp/IRConverterBridge.h>
+#include <metalsharp/ShaderModelValidator.h>
+#include <metalsharp/ShaderStage.h>
 
 using namespace metalsharp;
 
 static int testsPassed = 0;
 static int testsFailed = 0;
 
-#define TEST(name) \
-    printf("  TEST: %-55s", #name); \
-    if (test_##name()) { printf("PASS\n"); testsPassed++; } \
-    else { printf("FAIL\n"); testsFailed++; }
+#define TEST(name)                                                                                                     \
+    printf("  TEST: %-55s", #name);                                                                                    \
+    if (test_##name()) {                                                                                               \
+        printf("PASS\n");                                                                                              \
+        testsPassed++;                                                                                                 \
+    } else {                                                                                                           \
+        printf("FAIL\n");                                                                                              \
+        testsFailed++;                                                                                                 \
+    }
 
 static bool test_shader_stage_new_values() {
-    return ShaderStage::Mesh != ShaderStage::Vertex &&
-           ShaderStage::Amplification != ShaderStage::Compute &&
-           ShaderStage::RayGeneration != ShaderStage::ClosestHit &&
-           ShaderStage::Miss != ShaderStage::Intersection &&
+    return ShaderStage::Mesh != ShaderStage::Vertex && ShaderStage::Amplification != ShaderStage::Compute &&
+           ShaderStage::RayGeneration != ShaderStage::ClosestHit && ShaderStage::Miss != ShaderStage::Intersection &&
            ShaderStage::AnyHit != ShaderStage::Callable;
 }
 
 static bool test_shader_model_60_capabilities() {
     auto& bridge = IRConverterBridge::instance();
-    if (!bridge.isAvailable()) return true;
+    if (!bridge.isAvailable())
+        return true;
     auto caps = bridge.getShaderModelCapabilities(60);
-    return caps.waveOps && caps.int64 &&
-           !caps.halfPrecision && !caps.barycentrics &&
-           !caps.rayTracing && !caps.meshShaders;
+    return caps.waveOps && caps.int64 && !caps.halfPrecision && !caps.barycentrics && !caps.rayTracing &&
+           !caps.meshShaders;
 }
 
 static bool test_shader_model_61_capabilities() {
     auto& bridge = IRConverterBridge::instance();
-    if (!bridge.isAvailable()) return true;
+    if (!bridge.isAvailable())
+        return true;
     auto caps = bridge.getShaderModelCapabilities(61);
-    return caps.waveOps && caps.int64 &&
-           caps.halfPrecision && caps.barycentrics &&
-           !caps.rayTracing && !caps.meshShaders;
+    return caps.waveOps && caps.int64 && caps.halfPrecision && caps.barycentrics && !caps.rayTracing &&
+           !caps.meshShaders;
 }
 
 static bool test_shader_model_63_raytracing() {
     auto& bridge = IRConverterBridge::instance();
-    if (!bridge.isAvailable()) return true;
+    if (!bridge.isAvailable())
+        return true;
     auto caps = bridge.getShaderModelCapabilities(63);
     return caps.rayTracing && caps.waveOps && caps.halfPrecision;
 }
 
 static bool test_shader_model_65_mesh() {
     auto& bridge = IRConverterBridge::instance();
-    if (!bridge.isAvailable()) return true;
+    if (!bridge.isAvailable())
+        return true;
     auto caps = bridge.getShaderModelCapabilities(65);
     return caps.meshShaders && caps.samplerFeedback && caps.rayTracing;
 }
 
 static bool test_shader_model_66_derivatives() {
     auto& bridge = IRConverterBridge::instance();
-    if (!bridge.isAvailable()) return true;
+    if (!bridge.isAvailable())
+        return true;
     auto caps = bridge.getShaderModelCapabilities(66);
     return caps.computeDerivatives && caps.meshShaders && caps.rayTracing;
 }
@@ -73,7 +79,8 @@ static bool test_shader_model_50_no_capabilities() {
 static bool test_create_state_object() {
     D3D12DeviceImpl* device = nullptr;
     D3D12DeviceImpl::create(&device);
-    if (!device) return false;
+    if (!device)
+        return false;
 
     D3D12_RAYTRACING_PIPELINE_CONFIG pipelineConfig = {2};
     D3D12_RAYTRACING_SHADER_CONFIG shaderConfig = {64, 32};
@@ -98,7 +105,8 @@ static bool test_create_state_object() {
 static bool test_state_object_with_library() {
     D3D12DeviceImpl* device = nullptr;
     D3D12DeviceImpl::create(&device);
-    if (!device) return false;
+    if (!device)
+        return false;
 
     uint8_t fakeDXIL[64] = {};
     memcpy(fakeDXIL, "DXIL", 4);
@@ -133,7 +141,8 @@ static bool test_state_object_with_library() {
 static bool test_rt_prebuild_info() {
     D3D12DeviceImpl* device = nullptr;
     D3D12DeviceImpl::create(&device);
-    if (!device) return false;
+    if (!device)
+        return false;
 
     D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS inputs = {};
     inputs.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
@@ -150,12 +159,14 @@ static bool test_rt_prebuild_info() {
 static bool test_dispatch_rays_command() {
     D3D12DeviceImpl* device = nullptr;
     D3D12DeviceImpl::create(&device);
-    if (!device) return false;
+    if (!device)
+        return false;
 
     void* alloc = nullptr;
     device->CreateCommandAllocator(0, IID_ID3D12CommandAllocator, &alloc);
     void* cmdListPtr = nullptr;
-    device->CreateCommandList(0, 0, static_cast<ID3D12CommandAllocator*>(alloc), nullptr, IID_ID3D12GraphicsCommandList, &cmdListPtr);
+    device->CreateCommandList(0, 0, static_cast<ID3D12CommandAllocator*>(alloc), nullptr, IID_ID3D12GraphicsCommandList,
+                              &cmdListPtr);
     auto* cmdList = static_cast<ID3D12GraphicsCommandList*>(cmdListPtr);
 
     D3D12_DISPATCH_RAYS_DESC desc = {};
@@ -175,12 +186,14 @@ static bool test_dispatch_rays_command() {
 static bool test_build_acceleration_structure() {
     D3D12DeviceImpl* device = nullptr;
     D3D12DeviceImpl::create(&device);
-    if (!device) return false;
+    if (!device)
+        return false;
 
     void* alloc = nullptr;
     device->CreateCommandAllocator(0, IID_ID3D12CommandAllocator, &alloc);
     void* cmdListPtr = nullptr;
-    device->CreateCommandList(0, 0, static_cast<ID3D12CommandAllocator*>(alloc), nullptr, IID_ID3D12GraphicsCommandList, &cmdListPtr);
+    device->CreateCommandList(0, 0, static_cast<ID3D12CommandAllocator*>(alloc), nullptr, IID_ID3D12GraphicsCommandList,
+                              &cmdListPtr);
     auto* cmdList = static_cast<ID3D12GraphicsCommandList*>(cmdListPtr);
 
     D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC desc = {};
@@ -200,12 +213,14 @@ static bool test_build_acceleration_structure() {
 static bool test_dispatch_mesh_command() {
     D3D12DeviceImpl* device = nullptr;
     D3D12DeviceImpl::create(&device);
-    if (!device) return false;
+    if (!device)
+        return false;
 
     void* alloc = nullptr;
     device->CreateCommandAllocator(0, IID_ID3D12CommandAllocator, &alloc);
     void* cmdListPtr = nullptr;
-    device->CreateCommandList(0, 0, static_cast<ID3D12CommandAllocator*>(alloc), nullptr, IID_ID3D12GraphicsCommandList, &cmdListPtr);
+    device->CreateCommandList(0, 0, static_cast<ID3D12CommandAllocator*>(alloc), nullptr, IID_ID3D12GraphicsCommandList,
+                              &cmdListPtr);
     auto* cmdList = static_cast<ID3D12GraphicsCommandList*>(cmdListPtr);
 
     HRESULT hr = cmdList->DispatchMesh(4, 1, 1);
@@ -218,7 +233,8 @@ static bool test_dispatch_mesh_command() {
 static bool test_compute_root_signature() {
     D3D12DeviceImpl* device = nullptr;
     D3D12DeviceImpl::create(&device);
-    if (!device) return false;
+    if (!device)
+        return false;
 
     void* alloc = nullptr;
     device->CreateCommandAllocator(0, IID_ID3D12CommandAllocator, &alloc);
@@ -240,7 +256,8 @@ static bool test_compute_root_signature() {
     device->CreateRootSignature(0, &blob, sizeof(blob), IID_ID3D12RootSignature, &rsPtr);
 
     void* cmdListPtr = nullptr;
-    device->CreateCommandList(0, 0, static_cast<ID3D12CommandAllocator*>(alloc), nullptr, IID_ID3D12GraphicsCommandList, &cmdListPtr);
+    device->CreateCommandList(0, 0, static_cast<ID3D12CommandAllocator*>(alloc), nullptr, IID_ID3D12GraphicsCommandList,
+                              &cmdListPtr);
     auto* cmdList = static_cast<ID3D12GraphicsCommandList*>(cmdListPtr);
 
     HRESULT hr = cmdList->SetComputeRootSignature(static_cast<ID3D12RootSignature*>(rsPtr));
@@ -263,12 +280,14 @@ static bool test_compute_root_signature() {
 static bool test_compute_dispatch_records() {
     D3D12DeviceImpl* device = nullptr;
     D3D12DeviceImpl::create(&device);
-    if (!device) return false;
+    if (!device)
+        return false;
 
     void* alloc = nullptr;
     device->CreateCommandAllocator(0, IID_ID3D12CommandAllocator, &alloc);
     void* cmdListPtr = nullptr;
-    device->CreateCommandList(0, 0, static_cast<ID3D12CommandAllocator*>(alloc), nullptr, IID_ID3D12GraphicsCommandList, &cmdListPtr);
+    device->CreateCommandList(0, 0, static_cast<ID3D12CommandAllocator*>(alloc), nullptr, IID_ID3D12GraphicsCommandList,
+                              &cmdListPtr);
     auto* cmdList = static_cast<ID3D12GraphicsCommandList*>(cmdListPtr);
 
     HRESULT hr1 = cmdList->Dispatch(8, 8, 1);
@@ -286,25 +305,13 @@ static bool test_sm66_wave_size_validation() {
 }
 
 static bool test_sm66_compute_validation() {
-    ShaderModelValidator::validateComputeShader(
-        66,
-        256, 1, 1,
-        true, true, true
-    );
-    ShaderModelValidator::validateComputeShader(
-        66,
-        8, 8, 1,
-        true, false, false
-    );
+    ShaderModelValidator::validateComputeShader(66, 256, 1, 1, true, true, true);
+    ShaderModelValidator::validateComputeShader(66, 8, 8, 1, true, false, false);
     return true;
 }
 
 static bool test_sm_pre60_no_validation() {
-    ShaderModelValidator::validateComputeShader(
-        50,
-        8, 8, 8,
-        true, true, true
-    );
+    ShaderModelValidator::validateComputeShader(50, 8, 8, 8, true, true, true);
     ShaderModelValidator::validateWaveSize(60, 64);
     return true;
 }
@@ -317,7 +324,8 @@ static bool test_irconverter_availability() {
 
 static bool test_detect_shader_model_dxil() {
     auto& bridge = IRConverterBridge::instance();
-    if (!bridge.isAvailable()) return true;
+    if (!bridge.isAvailable())
+        return true;
 
     uint8_t fakeDXBC[64] = {};
     memcpy(fakeDXBC, "DXBC", 4);
@@ -374,7 +382,8 @@ int main() {
     TEST(shader_model_50_no_capabilities);
 
     printf("\n%d/%d passed", testsPassed, testsPassed + testsFailed);
-    if (testsFailed > 0) printf(" (%d FAILED)", testsFailed);
+    if (testsFailed > 0)
+        printf(" (%d FAILED)", testsFailed);
     printf("\n");
 
     return testsFailed > 0 ? 1 : 0;

--- a/tests/test_phase2.mm
+++ b/tests/test_phase2.mm
@@ -1,17 +1,23 @@
-#include <metalsharp/D3D11Device.h>
-#include <metalsharp/D3D11DeviceContext.h>
-#include <d3d/D3D11.h>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <d3d/D3D11.h>
+#include <metalsharp/D3D11Device.h>
+#include <metalsharp/D3D11DeviceContext.h>
 
 static int g_pass = 0;
 static int g_fail = 0;
 
-#define CHECK(cond, msg) do { \
-    if (cond) { printf("  [OK] %s\n", msg); g_pass++; } \
-    else { printf("  [FAIL] %s\n", msg); g_fail++; } \
-} while(0)
+#define CHECK(cond, msg)                                                                                               \
+    do {                                                                                                               \
+        if (cond) {                                                                                                    \
+            printf("  [OK] %s\n", msg);                                                                                \
+            g_pass++;                                                                                                  \
+        } else {                                                                                                       \
+            printf("  [FAIL] %s\n", msg);                                                                              \
+            g_fail++;                                                                                                  \
+        }                                                                                                              \
+    } while (0)
 
 static const char* kMSL = R"msl(
 #include <metal_stdlib>
@@ -184,8 +190,8 @@ int main() {
 
     {
         D3D11_INPUT_ELEMENT_DESC elements[] = {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,  D3D11_INPUT_PER_VERTEX_DATA, 0 },
-            { "COLOR",    0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+            {"POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0},
+            {"COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0},
         };
         ID3D11InputLayout* layout = nullptr;
         hr = device->CreateInputLayout(elements, 2, kMSL, strlen(kMSL), &layout);
@@ -236,16 +242,16 @@ int main() {
         }
 
         FLOAT clear_color[4] = {0.1f, 0.1f, 0.1f, 1.0f};
-        if (rtv) ctx->ClearRenderTargetView(rtv, clear_color);
+        if (rtv)
+            ctx->ClearRenderTargetView(rtv, clear_color);
 
-        struct Vertex { float x,y,z; float r,g,b,a; };
+        struct Vertex {
+            float x, y, z;
+            float r, g, b, a;
+        };
         Vertex verts[6] = {
-            {-0.5f, 0.5f, 0.0f, 1,0,0,1},
-            { 0.5f, 0.5f, 0.0f, 0,1,0,1},
-            {-0.5f,-0.5f, 0.0f, 0,0,1,1},
-            { 0.5f,-0.5f, 0.0f, 1,1,0,1},
-            {-0.5f,-0.5f, 0.0f, 0,1,1,1},
-            { 0.5f,-0.5f, 0.0f, 1,0,1,1},
+            {-0.5f, 0.5f, 0.0f, 1, 0, 0, 1}, {0.5f, 0.5f, 0.0f, 0, 1, 0, 1},   {-0.5f, -0.5f, 0.0f, 0, 0, 1, 1},
+            {0.5f, -0.5f, 0.0f, 1, 1, 0, 1}, {-0.5f, -0.5f, 0.0f, 0, 1, 1, 1}, {0.5f, -0.5f, 0.0f, 1, 0, 1, 1},
         };
 
         D3D11_BUFFER_DESC vbDesc = {};
@@ -253,7 +259,7 @@ int main() {
         vbDesc.BindFlags = D3D11_BIND_VERTEX_BUFFER;
         vbDesc.Usage = D3D11_USAGE_DEFAULT;
 
-        D3D11_SUBRESOURCE_DATA initData = { verts };
+        D3D11_SUBRESOURCE_DATA initData = {verts};
         ID3D11Buffer* vb = nullptr;
         hr = device->CreateBuffer(&vbDesc, &initData, &vb);
         CHECK(SUCCEEDED(hr) && vb, "CreateBuffer (vertex buffer for draw test)");
@@ -276,16 +282,22 @@ int main() {
             hr = ctx->Draw(6, 0);
             CHECK(SUCCEEDED(hr), "Draw(6 vertices) — two triangles");
 
-            if (vs) vs->Release();
-            if (ps) ps->Release();
+            if (vs)
+                vs->Release();
+            if (ps)
+                ps->Release();
             vb->Release();
         }
     }
 
-    if (rtv) rtv->Release();
-    if (rtTexture) rtTexture->Release();
-    if (srv) srv->Release();
-    if (srTexture) srTexture->Release();
+    if (rtv)
+        rtv->Release();
+    if (rtTexture)
+        rtTexture->Release();
+    if (srv)
+        srv->Release();
+    if (srTexture)
+        srTexture->Release();
     ctx->Release();
     device->Release();
 

--- a/tests/test_phase20.cpp
+++ b/tests/test_phase20.cpp
@@ -1,17 +1,22 @@
-#include <metalsharp/AntiCheatDB.h>
-#include <cstring>
-#include <cstdio>
 #include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <metalsharp/AntiCheatDB.h>
 
 using namespace metalsharp::win32;
 
 static int testsPassed = 0;
 static int testsFailed = 0;
 
-#define TEST(name) \
-    printf("  TEST: %-55s", #name); \
-    if (test_##name()) { printf("PASS\n"); testsPassed++; } \
-    else { printf("FAIL\n"); testsFailed++; }
+#define TEST(name)                                                                                                     \
+    printf("  TEST: %-55s", #name);                                                                                    \
+    if (test_##name()) {                                                                                               \
+        printf("PASS\n");                                                                                              \
+        testsPassed++;                                                                                                 \
+    } else {                                                                                                           \
+        printf("FAIL\n");                                                                                              \
+        testsFailed++;                                                                                                 \
+    }
 
 static bool test_anticheat_db_has_entries() {
     return kAntiCheatEntryCount > 0;
@@ -52,9 +57,8 @@ static bool test_anticheat_kernel_impossible() {
     auto* eac = findAntiCheat("Easy Anti-Cheat");
     auto* be = findAntiCheat("BattlEye");
     auto* ricochet = findAntiCheat("Ricochet");
-    return eac && be && ricochet &&
-           !eac->compatible && !be->compatible && !ricochet->compatible &&
-           eac->kernelLevel && be->kernelLevel && ricochet->kernelLevel;
+    return eac && be && ricochet && !eac->compatible && !be->compatible && !ricochet->compatible && eac->kernelLevel &&
+           be->kernelLevel && ricochet->kernelLevel;
 }
 
 static bool test_anticheat_find_nonexistent() {
@@ -133,7 +137,8 @@ int main() {
     TEST(qpc_frequency_realistic);
 
     printf("\n%d/%d passed", testsPassed, testsPassed + testsFailed);
-    if (testsFailed > 0) printf(" (%d FAILED)", testsFailed);
+    if (testsFailed > 0)
+        printf(" (%d FAILED)", testsFailed);
     printf("\n");
 
     return testsFailed > 0 ? 1 : 0;

--- a/tests/test_phase21.cpp
+++ b/tests/test_phase21.cpp
@@ -1,23 +1,28 @@
-#include <metalsharp/ShaderCache.h>
-#include <metalsharp/PipelineCache.h>
+#include <cstdio>
+#include <cstring>
 #include <metalsharp/FramePacer.h>
 #include <metalsharp/GPUProfiler.h>
 #include <metalsharp/MetalFXUpscaler.h>
+#include <metalsharp/PipelineCache.h>
 #include <metalsharp/RenderThreadPool.h>
-#include <cstdio>
-#include <cstring>
-#include <vector>
+#include <metalsharp/ShaderCache.h>
 #include <thread>
+#include <vector>
 
 using namespace metalsharp;
 
 static int testsPassed = 0;
 static int testsFailed = 0;
 
-#define TEST(name) \
-    printf("  TEST: %-55s", #name); \
-    if (test_##name()) { printf("PASS\n"); testsPassed++; } \
-    else { printf("FAIL\n"); testsFailed++; }
+#define TEST(name)                                                                                                     \
+    printf("  TEST: %-55s", #name);                                                                                    \
+    if (test_##name()) {                                                                                               \
+        printf("PASS\n");                                                                                              \
+        testsPassed++;                                                                                                 \
+    } else {                                                                                                           \
+        printf("FAIL\n");                                                                                              \
+        testsFailed++;                                                                                                 \
+    }
 
 // 21.1 Shader Cache
 static bool test_shader_cache_hash_consistency() {
@@ -299,9 +304,7 @@ static bool test_gpu_profiler_callback() {
     profiler.setEnabled(true);
 
     bool callbackFired = false;
-    profiler.setStatsCallback([&callbackFired](const GPUProfiler::FrameStats& s) {
-        callbackFired = true;
-    });
+    profiler.setStatsCallback([&callbackFired](const GPUProfiler::FrameStats& s) { callbackFired = true; });
 
     profiler.beginFrame();
     profiler.endFrame();
@@ -349,7 +352,8 @@ int main() {
     TEST(gpu_profiler_callback);
 
     printf("\n%d/%d passed", testsPassed, testsPassed + testsFailed);
-    if (testsFailed > 0) printf(" (%d FAILED)", testsFailed);
+    if (testsFailed > 0)
+        printf(" (%d FAILED)", testsFailed);
     printf("\n");
 
     return testsFailed > 0 ? 1 : 0;

--- a/tests/test_phase22.cpp
+++ b/tests/test_phase22.cpp
@@ -1,10 +1,10 @@
-#include <metalsharp/CoreAudioBackend.h>
-#include <metalsharp/XAudio2Engine.h>
-#include <metalsharp/X3DAudioEngine.h>
-#include <metalsharp/DirectSoundBackend.h>
+#include <cmath>
 #include <cstdio>
 #include <cstring>
-#include <cmath>
+#include <metalsharp/CoreAudioBackend.h>
+#include <metalsharp/DirectSoundBackend.h>
+#include <metalsharp/X3DAudioEngine.h>
+#include <metalsharp/XAudio2Engine.h>
 
 using namespace metalsharp;
 
@@ -13,19 +13,27 @@ extern "C" HRESULT XAudio2Create(void** ppXAudio2, UINT Flags, UINT XAudio2Proce
 static int testsPassed = 0;
 static int testsFailed = 0;
 
-#define TEST(name) \
-    printf("  TEST: %-55s", #name); \
-    if (test_##name()) { printf("PASS\n"); testsPassed++; } \
-    else { printf("FAIL\n"); testsFailed++; }
+#define TEST(name)                                                                                                     \
+    printf("  TEST: %-55s", #name);                                                                                    \
+    if (test_##name()) {                                                                                               \
+        printf("PASS\n");                                                                                              \
+        testsPassed++;                                                                                                 \
+    } else {                                                                                                           \
+        printf("FAIL\n");                                                                                              \
+        testsFailed++;                                                                                                 \
+    }
 
 // 22.1 CoreAudio / XAudio2
 static bool test_coreaudio_lifecycle() {
     CoreAudioBackend backend;
-    if (backend.isActive()) return false;
+    if (backend.isActive())
+        return false;
 
     bool initOk = backend.init();
-    if (!initOk) return false;
-    if (!backend.isActive()) return false;
+    if (!initOk)
+        return false;
+    if (!backend.isActive())
+        return false;
 
     backend.play();
     backend.pause();
@@ -57,16 +65,20 @@ static bool test_coreaudio_volume() {
     backend.init();
 
     backend.setVolume(0.0f);
-    if (backend.volume() != 0.0f) return false;
+    if (backend.volume() != 0.0f)
+        return false;
 
     backend.setVolume(1.0f);
-    if (backend.volume() != 1.0f) return false;
+    if (backend.volume() != 1.0f)
+        return false;
 
     backend.setVolume(1.5f);
-    if (backend.volume() != 1.0f) return false;
+    if (backend.volume() != 1.0f)
+        return false;
 
     backend.setVolume(-0.5f);
-    if (backend.volume() != 0.0f) return false;
+    if (backend.volume() != 0.0f)
+        return false;
 
     backend.shutdown();
     return true;
@@ -89,10 +101,12 @@ static bool test_coreaudio_queued_buffers() {
     XAudio2WaveFormat fmt = {1, 2, 44100, 176400, 4, 16};
     uint32_t samples[64] = {};
 
-    if (backend.queuedBufferCount() != 0) return false;
+    if (backend.queuedBufferCount() != 0)
+        return false;
     backend.submitBuffer(samples, sizeof(samples), fmt);
     backend.submitBuffer(samples, sizeof(samples), fmt);
-    if (backend.queuedBufferCount() != 2) return false;
+    if (backend.queuedBufferCount() != 2)
+        return false;
 
     backend.flushBuffers();
     bool empty = backend.queuedBufferCount() == 0;
@@ -104,7 +118,8 @@ static bool test_xaudio2_create() {
     void* engine = nullptr;
     HRESULT hr = XAudio2Create(&engine, 0, 0);
     bool ok = hr == S_OK && engine != nullptr;
-    if (engine) delete static_cast<XAudio2Engine*>(engine);
+    if (engine)
+        delete static_cast<XAudio2Engine*>(engine);
     return ok;
 }
 
@@ -131,8 +146,13 @@ static bool test_xaudio2_submit_start_stop() {
     XAudio2WaveFormat fmt = {1, 2, 44100, 176400, 4, 16};
     engine.createSourceVoice(&voice, &fmt);
 
-    struct { uint32_t flags; uint32_t audioBytes; const void* pAudioData;
-            uint32_t pb, pl, lb, ll, lc; void* ctx; } buf = {};
+    struct {
+        uint32_t flags;
+        uint32_t audioBytes;
+        const void* pAudioData;
+        uint32_t pb, pl, lb, ll, lc;
+        void* ctx;
+    } buf = {};
     uint32_t samples[64] = {};
     buf.audioBytes = sizeof(samples);
     buf.pAudioData = samples;
@@ -168,9 +188,9 @@ static bool test_x3daudio_pan() {
     auto& engine = X3DAudioEngine::instance();
     engine.init(0x3);
 
-    Audio3DListener listener = {{0,0,0}, {0,0,-1}, {0,1,0}, {0,0,0}, 1, 1, 0};
-    Audio3DEmitter left = {{-5,0,-5}, {0,0,-1}, {0,1,0}, {0,0,0}, 0, 0, 1, 1, 1, 1};
-    Audio3DEmitter right = {{5,0,-5}, {0,0,-1}, {0,1,0}, {0,0,0}, 0, 0, 1, 1, 1, 1};
+    Audio3DListener listener = {{0, 0, 0}, {0, 0, -1}, {0, 1, 0}, {0, 0, 0}, 1, 1, 0};
+    Audio3DEmitter left = {{-5, 0, -5}, {0, 0, -1}, {0, 1, 0}, {0, 0, 0}, 0, 0, 1, 1, 1, 1};
+    Audio3DEmitter right = {{5, 0, -5}, {0, 0, -1}, {0, 1, 0}, {0, 0, 0}, 0, 0, 1, 1, 1, 1};
 
     float panL = engine.computePan(listener, left);
     float panR = engine.computePan(listener, right);
@@ -184,8 +204,8 @@ static bool test_x3daudio_doppler() {
     engine.init(0x3);
     engine.setDopplerFactor(1.0f);
 
-    Audio3DListener listener = {{0,0,0}, {0,0,-1}, {0,1,0}, {0,0,0}, 1, 1, 0};
-    Audio3DEmitter approaching = {{0,0,-10}, {0,0,-1}, {0,1,0}, {0,0,50}, 0, 0, 1, 1, 1, 1};
+    Audio3DListener listener = {{0, 0, 0}, {0, 0, -1}, {0, 1, 0}, {0, 0, 0}, 1, 1, 0};
+    Audio3DEmitter approaching = {{0, 0, -10}, {0, 0, -1}, {0, 1, 0}, {0, 0, 50}, 0, 0, 1, 1, 1, 1};
 
     float doppler = engine.computeDoppler(listener, approaching);
     engine.shutdown();
@@ -196,8 +216,8 @@ static bool test_x3daudio_calculate() {
     auto& engine = X3DAudioEngine::instance();
     engine.init(0x3);
 
-    Audio3DListener listener = {{0,0,0}, {0,0,-1}, {0,1,0}, {0,0,0}, 1, 1, 0};
-    Audio3DEmitter emitter = {{0,0,-10}, {0,0,-1}, {0,1,0}, {0,0,0}, 0, 0, 1, 1, 1, 1};
+    Audio3DListener listener = {{0, 0, 0}, {0, 0, -1}, {0, 1, 0}, {0, 0, 0}, 1, 1, 0};
+    Audio3DEmitter emitter = {{0, 0, -10}, {0, 0, -1}, {0, 1, 0}, {0, 0, 0}, 0, 0, 1, 1, 1, 1};
 
     Audio3DOutput output = {};
     engine.calculate(listener, emitter, 0, 2, output);
@@ -287,7 +307,8 @@ int main() {
     TEST(directsound_volume);
 
     printf("\n%d/%d passed", testsPassed, testsPassed + testsFailed);
-    if (testsFailed > 0) printf(" (%d FAILED)", testsFailed);
+    if (testsFailed > 0)
+        printf(" (%d FAILED)", testsFailed);
     printf("\n");
 
     return testsFailed > 0 ? 1 : 0;

--- a/tests/test_phase23.cpp
+++ b/tests/test_phase23.cpp
@@ -1,10 +1,10 @@
+#include <cstdio>
+#include <cstring>
 #include <metalsharp/CompatDatabase.h>
-#include <metalsharp/ImportReporter.h>
 #include <metalsharp/CrashDiagnostics.h>
 #include <metalsharp/DRMDetector.h>
 #include <metalsharp/GameValidator.h>
-#include <cstdio>
-#include <cstring>
+#include <metalsharp/ImportReporter.h>
 #include <vector>
 
 using namespace metalsharp;
@@ -12,10 +12,15 @@ using namespace metalsharp;
 static int testsPassed = 0;
 static int testsFailed = 0;
 
-#define TEST(name) \
-    printf("  TEST: %-55s", #name); \
-    if (test_##name()) { printf("PASS\n"); testsPassed++; } \
-    else { printf("FAIL\n"); testsFailed++; }
+#define TEST(name)                                                                                                     \
+    printf("  TEST: %-55s", #name);                                                                                    \
+    if (test_##name()) {                                                                                               \
+        printf("PASS\n");                                                                                              \
+        testsPassed++;                                                                                                 \
+    } else {                                                                                                           \
+        printf("FAIL\n");                                                                                              \
+        testsFailed++;                                                                                                 \
+    }
 
 // 23.1 CompatDatabase
 static bool test_compat_status_roundtrip() {
@@ -65,9 +70,12 @@ static bool test_compat_query_by_status() {
     db.init("/tmp/metalsharp_test/compat.json");
 
     GameEntry e1, e2, e3;
-    e1.gameId = "g1"; e1.status = CompatStatus::Platinum;
-    e2.gameId = "g2"; e2.status = CompatStatus::Gold;
-    e3.gameId = "g3"; e3.status = CompatStatus::Platinum;
+    e1.gameId = "g1";
+    e1.status = CompatStatus::Platinum;
+    e2.gameId = "g2";
+    e2.status = CompatStatus::Gold;
+    e3.gameId = "g3";
+    e3.status = CompatStatus::Platinum;
 
     db.addOrUpdate(e1);
     db.addOrUpdate(e2);
@@ -161,8 +169,7 @@ static bool test_compat_report_generation() {
     db.addOrUpdate(entry);
 
     std::string report = db.generateReport("report_test");
-    bool ok = report.find("Report Game") != std::string::npos &&
-              report.find("Gold") != std::string::npos;
+    bool ok = report.find("Report Game") != std::string::npos && report.find("Gold") != std::string::npos;
 
     db.shutdown();
     return ok;
@@ -178,9 +185,7 @@ static bool test_import_reporter_record() {
     reporter.recordImport("d3d11.dll", "CreateDevice", true);
     reporter.recordImport("d3d11.dll", "MissingFeature", false);
 
-    return reporter.totalCount() == 4 &&
-           reporter.resolvedCount() == 2 &&
-           reporter.missingCount() == 2;
+    return reporter.totalCount() == 4 && reporter.resolvedCount() == 2 && reporter.missingCount() == 2;
 }
 
 static bool test_import_reporter_ordinal() {
@@ -214,8 +219,7 @@ static bool test_import_reporter_summary() {
     reporter.recordImport("test.dll", "Func2", false);
 
     std::string summary = reporter.generateSummary();
-    return summary.find("Total:") != std::string::npos &&
-           summary.find("Missing:") != std::string::npos;
+    return summary.find("Total:") != std::string::npos && summary.find("Missing:") != std::string::npos;
 }
 
 // 23.3 CrashDiagnostics
@@ -255,12 +259,14 @@ static bool test_crash_diagnostics_timestamp() {
 static bool test_drm_detector_memory_denuvo() {
     auto& detector = DRMDetector::instance();
 
-    const char* fakeExe = "SomeBinary\x44\x65\x6E\x75\x76\x6F""MoreData";
+    const char* fakeExe = "SomeBinary\x44\x65\x6E\x75\x76\x6F"
+                          "MoreData";
     auto results = detector.scanMemory(reinterpret_cast<const uint8_t*>(fakeExe), strlen(fakeExe));
 
     bool foundDenuvo = false;
     for (const auto& d : results) {
-        if (d.name == "Denuvo Anti-Tamper" && d.detected) foundDenuvo = true;
+        if (d.name == "Denuvo Anti-Tamper" && d.detected)
+            foundDenuvo = true;
     }
     return foundDenuvo;
 }
@@ -273,7 +279,8 @@ static bool test_drm_detector_memory_steam() {
 
     bool foundSteam = false;
     for (const auto& d : results) {
-        if (d.name == "Steam Stub" && d.detected) foundSteam = true;
+        if (d.name == "Steam Stub" && d.detected)
+            foundSteam = true;
     }
     return foundSteam;
 }
@@ -281,8 +288,8 @@ static bool test_drm_detector_memory_steam() {
 static bool test_drm_detector_kernel_anticheat() {
     auto& detector = DRMDetector::instance();
 
-    const uint8_t fakeExe[] = {'E','a','s','y','A','n','t','i','C','h','e','a','t',
-                                0x00, 'B','i','n','a','r','y'};
+    const uint8_t fakeExe[] = {'E', 'a', 's', 'y',  'A', 'n', 't', 'i', 'C', 'h',
+                               'e', 'a', 't', 0x00, 'B', 'i', 'n', 'a', 'r', 'y'};
     auto results = detector.scanMemory(fakeExe, sizeof(fakeExe));
 
     return detector.hasKernelAntiCheat(results) && !detector.isCompatible(results);
@@ -371,7 +378,8 @@ int main() {
     TEST(game_validator_validate_clean);
 
     printf("\n%d/%d passed", testsPassed, testsPassed + testsFailed);
-    if (testsFailed > 0) printf(" (%d FAILED)", testsFailed);
+    if (testsFailed > 0)
+        printf(" (%d FAILED)", testsFailed);
     printf("\n");
 
     return testsFailed > 0 ? 1 : 0;

--- a/tests/test_phase24.cpp
+++ b/tests/test_phase24.cpp
@@ -1,12 +1,12 @@
-#include "metalsharp/GameDetector.h"
 #include "metalsharp/CrashReporter.h"
-#include "metalsharp/UpdateChecker.h"
+#include "metalsharp/GameDetector.h"
 #include "metalsharp/SettingsManager.h"
+#include "metalsharp/UpdateChecker.h"
 #include <cassert>
 #include <cstdio>
 #include <cstring>
-#include <fstream>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -16,17 +16,17 @@ namespace fs = std::filesystem;
 static int g_pass = 0;
 static int g_fail = 0;
 
-#define TEST(name)                                              \
-    do {                                                        \
-        printf("  TEST: %-50s", #name);                         \
-        fflush(stdout);                                         \
-        if (name()) {                                           \
-            printf("PASS\n");                                   \
-            g_pass++;                                           \
-        } else {                                                \
-            printf("FAIL\n");                                   \
-            g_fail++;                                           \
-        }                                                       \
+#define TEST(name)                                                                                                     \
+    do {                                                                                                               \
+        printf("  TEST: %-50s", #name);                                                                                \
+        fflush(stdout);                                                                                                \
+        if (name()) {                                                                                                  \
+            printf("PASS\n");                                                                                          \
+            g_pass++;                                                                                                  \
+        } else {                                                                                                       \
+            printf("FAIL\n");                                                                                          \
+            g_fail++;                                                                                                  \
+        }                                                                                                              \
     } while (0)
 
 static bool game_detector_platform_strings() {
@@ -61,10 +61,12 @@ static bool game_detector_detect_all() {
 
 static bool game_detector_local_scan() {
     const char* home = std::getenv("HOME");
-    if (!home) return true;
+    if (!home)
+        return true;
 
     std::string testDir = std::string(home) + "/.metalsharp/games";
-    if (!fs::exists(testDir)) return true;
+    if (!fs::exists(testDir))
+        return true;
 
     auto games = metalsharp::GameDetector::detectLocal();
     for (const auto& g : games) {
@@ -208,7 +210,8 @@ static bool update_checker_user_agent() {
 }
 
 static bool update_checker_parse_release() {
-    std::string json = R"({"tag_name":"v0.2.0","html_url":"https://github.com/test/repo/releases/tag/v0.2.0","zipball_url":"https://github.com/test/repo/zipball/v0.2.0","body":"Release notes here"})";
+    std::string json =
+        R"({"tag_name":"v0.2.0","html_url":"https://github.com/test/repo/releases/tag/v0.2.0","zipball_url":"https://github.com/test/repo/zipball/v0.2.0","body":"Release notes here"})";
 
     auto current = metalsharp::Version::parse("0.1.0");
     auto info = metalsharp::UpdateChecker::parseGitHubRelease(json, current);
@@ -225,7 +228,8 @@ static bool update_checker_parse_release() {
 }
 
 static bool update_checker_no_update() {
-    std::string json = R"({"tag_name":"v0.1.0","html_url":"https://github.com/test/repo","zipball_url":"https://github.com/test/repo/zipball","body":""})";
+    std::string json =
+        R"({"tag_name":"v0.1.0","html_url":"https://github.com/test/repo","zipball_url":"https://github.com/test/repo/zipball","body":""})";
 
     auto current = metalsharp::Version::parse("0.1.0");
     auto info = metalsharp::UpdateChecker::parseGitHubRelease(json, current);

--- a/tests/test_phase5.cpp
+++ b/tests/test_phase5.cpp
@@ -1,22 +1,28 @@
-#include <metalsharp/ShaderCache.h>
-#include <metalsharp/PipelineCache.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <metalsharp/BufferPool.h>
+#include <metalsharp/CommandBatcher.h>
 #include <metalsharp/FramePacer.h>
 #include <metalsharp/GPUProfiler.h>
-#include <metalsharp/CommandBatcher.h>
 #include <metalsharp/MetalFXUpscaler.h>
-#include <cstdio>
-#include <cstring>
-#include <cstdlib>
+#include <metalsharp/PipelineCache.h>
+#include <metalsharp/ShaderCache.h>
 #include <vector>
 
 static int passed = 0;
 static int failed = 0;
 
-#define CHECK(cond, msg) do { \
-    if (cond) { printf("  [OK] %s\n", msg); passed++; } \
-    else { printf("  [FAIL] %s\n", msg); failed++; } \
-} while(0)
+#define CHECK(cond, msg)                                                                                               \
+    do {                                                                                                               \
+        if (cond) {                                                                                                    \
+            printf("  [OK] %s\n", msg);                                                                                \
+            passed++;                                                                                                  \
+        } else {                                                                                                       \
+            printf("  [FAIL] %s\n", msg);                                                                              \
+            failed++;                                                                                                  \
+        }                                                                                                              \
+    } while (0)
 
 int main() {
     printf("=== Phase 5 Performance Tests ===\n\n");
@@ -28,17 +34,17 @@ int main() {
         cache.init(tmpDir);
 
         const char* testData = "test shader data";
-        uint64_t hash = metalsharp::ShaderCache::computeHash(
-            reinterpret_cast<const uint8_t*>(testData), strlen(testData));
+        uint64_t hash =
+            metalsharp::ShaderCache::computeHash(reinterpret_cast<const uint8_t*>(testData), strlen(testData));
         CHECK(hash != 0, "Compute hash returns non-zero");
 
-        uint64_t sameHash = metalsharp::ShaderCache::computeHash(
-            reinterpret_cast<const uint8_t*>(testData), strlen(testData));
+        uint64_t sameHash =
+            metalsharp::ShaderCache::computeHash(reinterpret_cast<const uint8_t*>(testData), strlen(testData));
         CHECK(hash == sameHash, "Same input produces same hash");
 
         const char* otherData = "different data";
-        uint64_t otherHash = metalsharp::ShaderCache::computeHash(
-            reinterpret_cast<const uint8_t*>(otherData), strlen(otherData));
+        uint64_t otherHash =
+            metalsharp::ShaderCache::computeHash(reinterpret_cast<const uint8_t*>(otherData), strlen(otherData));
         CHECK(hash != otherHash, "Different input produces different hash");
 
         metalsharp::CachedShader lookup;
@@ -177,9 +183,7 @@ int main() {
         CHECK(batcher.batchSize() == 0, "Batch size is 0 initially");
 
         int executeCount = 0;
-        batcher.setExecuteFunction([&executeCount](const metalsharp::BatchedCommand& cmd) {
-            executeCount++;
-        });
+        batcher.setExecuteFunction([&executeCount](const metalsharp::BatchedCommand& cmd) { executeCount++; });
 
         batcher.beginFrame();
 

--- a/tests/test_runtime.cpp
+++ b/tests/test_runtime.cpp
@@ -1,17 +1,23 @@
-#include <metalsharp/Logger.h>
-#include <metalsharp/PEHook.h>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
+#include <metalsharp/Logger.h>
+#include <metalsharp/PEHook.h>
 
 static int passed = 0;
 static int failed = 0;
 
-#define CHECK(cond, msg) do { \
-    if (cond) { printf("  [OK] %s\n", msg); passed++; } \
-    else { printf("  [FAIL] %s\n", msg); failed++; } \
-} while(0)
+#define CHECK(cond, msg)                                                                                               \
+    do {                                                                                                               \
+        if (cond) {                                                                                                    \
+            printf("  [OK] %s\n", msg);                                                                                \
+            passed++;                                                                                                  \
+        } else {                                                                                                       \
+            printf("  [FAIL] %s\n", msg);                                                                              \
+            failed++;                                                                                                  \
+        }                                                                                                              \
+    } while (0)
 
 int main() {
     printf("=== Runtime Tests ===\n\n");
@@ -30,8 +36,7 @@ int main() {
         metalsharp::Logger::shutdown();
 
         std::ifstream f(tmpPath);
-        std::string contents((std::istreambuf_iterator<char>(f)),
-                              std::istreambuf_iterator<char>());
+        std::string contents((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
         CHECK(contents.find("trace msg") != std::string::npos, "Trace message logged");
         CHECK(contents.find("info msg") != std::string::npos, "Info message logged");
         CHECK(contents.find("warn msg") != std::string::npos, "Warn message logged");
@@ -61,11 +66,16 @@ int main() {
         bool hasD3D11 = false, hasD3D12 = false, hasDXGI = false;
         bool hasXAudio = false, hasXInput = false;
         for (const auto& m : mappings) {
-            if (strcmp(m.windowsDll, "d3d11.dll") == 0) hasD3D11 = true;
-            if (strcmp(m.windowsDll, "d3d12.dll") == 0) hasD3D12 = true;
-            if (strcmp(m.windowsDll, "dxgi.dll") == 0) hasDXGI = true;
-            if (strcmp(m.windowsDll, "xaudio2_9.dll") == 0) hasXAudio = true;
-            if (strcmp(m.windowsDll, "xinput1_4.dll") == 0) hasXInput = true;
+            if (strcmp(m.windowsDll, "d3d11.dll") == 0)
+                hasD3D11 = true;
+            if (strcmp(m.windowsDll, "d3d12.dll") == 0)
+                hasD3D12 = true;
+            if (strcmp(m.windowsDll, "dxgi.dll") == 0)
+                hasDXGI = true;
+            if (strcmp(m.windowsDll, "xaudio2_9.dll") == 0)
+                hasXAudio = true;
+            if (strcmp(m.windowsDll, "xinput1_4.dll") == 0)
+                hasXInput = true;
         }
         CHECK(hasD3D11, "d3d11.dll mapped");
         CHECK(hasD3D12, "d3d12.dll mapped");

--- a/tests/test_tiled_resources.cpp
+++ b/tests/test_tiled_resources.cpp
@@ -1,14 +1,20 @@
-#include <d3d/D3D12.h>
 #include <cstdio>
 #include <cstring>
+#include <d3d/D3D12.h>
 
 static int passed = 0;
 static int failed = 0;
 
-#define CHECK(cond, msg) do { \
-    if (cond) { printf("  [OK] %s\n", msg); passed++; } \
-    else { printf("  [FAIL] %s\n", msg); failed++; } \
-} while(0)
+#define CHECK(cond, msg)                                                                                               \
+    do {                                                                                                               \
+        if (cond) {                                                                                                    \
+            printf("  [OK] %s\n", msg);                                                                                \
+            passed++;                                                                                                  \
+        } else {                                                                                                       \
+            printf("  [FAIL] %s\n", msg);                                                                              \
+            failed++;                                                                                                  \
+        }                                                                                                              \
+    } while (0)
 
 int main() {
     printf("=== Tiled Resources & Sampler Feedback Tests ===\n\n");
@@ -16,7 +22,10 @@ int main() {
     {
         printf("--- D3D12_TILED_RESOURCE_COORDINATE ---\n");
         D3D12_TILED_RESOURCE_COORDINATE coord{};
-        coord.X = 4; coord.Y = 2; coord.Z = 1; coord.Subresource = 3;
+        coord.X = 4;
+        coord.Y = 2;
+        coord.Z = 1;
+        coord.Subresource = 3;
         CHECK(coord.X == 4, "X coordinate set");
         CHECK(coord.Y == 2, "Y coordinate set");
         CHECK(coord.Z == 1, "Z coordinate set");
@@ -26,7 +35,11 @@ int main() {
     {
         printf("\n--- D3D12_TILE_REGION_SIZE ---\n");
         D3D12_TILE_REGION_SIZE region{};
-        region.NumTiles = 16; region.Width = 4; region.Height = 4; region.Depth = 1; region.bUseBox = TRUE;
+        region.NumTiles = 16;
+        region.Width = 4;
+        region.Height = 4;
+        region.Depth = 1;
+        region.bUseBox = TRUE;
         CHECK(region.NumTiles == 16, "NumTiles set");
         CHECK(region.Width == 4, "Width set");
         CHECK(region.Height == 4, "Height set");
@@ -38,8 +51,10 @@ int main() {
     {
         printf("\n--- D3D12_PACKED_MIP_INFO ---\n");
         D3D12_PACKED_MIP_INFO info{};
-        info.NumStandardMips = 8; info.NumPackedMips = 2;
-        info.NumTilesForPackedMips = 1; info.StartTileIndexInOverallResource = 64;
+        info.NumStandardMips = 8;
+        info.NumPackedMips = 2;
+        info.NumTilesForPackedMips = 1;
+        info.StartTileIndexInOverallResource = 64;
         CHECK(info.NumStandardMips == 8, "NumStandardMips set");
         CHECK(info.NumPackedMips == 2, "NumPackedMips set");
         CHECK(info.NumTilesForPackedMips == 1, "NumTilesForPackedMips set");
@@ -49,7 +64,9 @@ int main() {
     {
         printf("\n--- D3D12_TILE_SHAPE ---\n");
         D3D12_TILE_SHAPE shape{};
-        shape.WidthInTexels = 128; shape.HeightInTexels = 128; shape.DepthInTexels = 1;
+        shape.WidthInTexels = 128;
+        shape.HeightInTexels = 128;
+        shape.DepthInTexels = 1;
         CHECK(shape.WidthInTexels == 128, "Tile width is 128 texels");
         CHECK(shape.HeightInTexels == 128, "Tile height is 128 texels");
         CHECK(shape.DepthInTexels == 1, "Tile depth is 1");
@@ -59,8 +76,11 @@ int main() {
     {
         printf("\n--- D3D12_SUBRESOURCE_TILING ---\n");
         D3D12_SUBRESOURCE_TILING tiling{};
-        tiling.WidthInTiles = 16; tiling.HeightInTiles = 8; tiling.DepthInTiles = 1;
-        tiling.StartTileIndexInOverallResource = 0; tiling.NumTiles = 128;
+        tiling.WidthInTiles = 16;
+        tiling.HeightInTiles = 8;
+        tiling.DepthInTiles = 1;
+        tiling.StartTileIndexInOverallResource = 0;
+        tiling.NumTiles = 128;
         CHECK(tiling.WidthInTiles == 16, "WidthInTiles set");
         CHECK(tiling.HeightInTiles == 8, "HeightInTiles set");
         CHECK(tiling.DepthInTiles == 1, "DepthInTiles set");
@@ -116,8 +136,12 @@ int main() {
         UINT totalMips = 13;
         UINT totalTiles = 0;
         for (UINT mip = 0; mip < totalMips; mip++) {
-            UINT w = 4096 >> mip; if (w == 0) w = 1;
-            UINT h = 4096 >> mip; if (h == 0) h = 1;
+            UINT w = 4096 >> mip;
+            if (w == 0)
+                w = 1;
+            UINT h = 4096 >> mip;
+            if (h == 0)
+                h = 1;
             UINT tw = (w + 127) / 128;
             UINT th = (h + 127) / 128;
             totalTiles += tw * th;
@@ -132,7 +156,10 @@ int main() {
         UINT mips = 9;
         UINT packedMips = 0;
         for (UINT i = 0; i < mips; i++) {
-            if (w < 128 && h < 128) { packedMips = mips - i; break; }
+            if (w < 128 && h < 128) {
+                packedMips = mips - i;
+                break;
+            }
             w = w > 1 ? w >> 1 : 1;
             h = h > 1 ? h >> 1 : 1;
         }

--- a/tests/test_triangle.mm
+++ b/tests/test_triangle.mm
@@ -1,12 +1,12 @@
-#include <metalsharp/D3D11Device.h>
-#include <metalsharp/D3D11DeviceContext.h>
-#include <d3d/D3D11.h>
 #include <AppKit/AppKit.h>
-#include <Metal/Metal.h>
-#include <QuartzCore/QuartzCore.h>
+#include <cmath>
 #include <cstdio>
 #include <cstdlib>
-#include <cmath>
+#include <d3d/D3D11.h>
+#include <Metal/Metal.h>
+#include <metalsharp/D3D11Device.h>
+#include <metalsharp/D3D11DeviceContext.h>
+#include <QuartzCore/QuartzCore.h>
 
 static const char* kTriangleMSL = R"msl(
 #include <metal_stdlib>
@@ -76,9 +76,9 @@ int main() {
         printf("[OK] Pixel shader compiled (MSL)\n");
 
         Vertex vertices[] = {
-            {  0.0f,  0.5f, 0.0f,   1.0f, 0.0f, 0.0f, 1.0f },
-            { -0.5f, -0.5f, 0.0f,   0.0f, 1.0f, 0.0f, 1.0f },
-            {  0.5f, -0.5f, 0.0f,   0.0f, 0.0f, 1.0f, 1.0f },
+            {0.0f, 0.5f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f},
+            {-0.5f, -0.5f, 0.0f, 0.0f, 1.0f, 0.0f, 1.0f},
+            {0.5f, -0.5f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f},
         };
 
         D3D11_BUFFER_DESC vbDesc = {};
@@ -105,7 +105,7 @@ int main() {
         ctx->VSSetShader(vs, nullptr, 0);
         ctx->PSSetShader(ps, nullptr, 0);
 
-        D3D11_VIEWPORT vp = { 800, 600 };
+        D3D11_VIEWPORT vp = {800, 600};
         ctx->RSSetViewports(1, &vp);
 
         hr = ctx->Draw(3, 0);

--- a/tools/launcher/Config.cpp
+++ b/tools/launcher/Config.cpp
@@ -1,7 +1,7 @@
 #include "Config.h"
+#include <cstdlib>
 #include <fstream>
 #include <sstream>
-#include <cstdlib>
 #include <sys/stat.h>
 
 namespace metalsharp {
@@ -15,20 +15,18 @@ Config::Config() {
 
 std::string Config::defaultConfigPath() {
     const char* home = getenv("HOME");
-    if (home) return std::string(home) + "/.metalsharp/metalsharp.toml";
+    if (home)
+        return std::string(home) + "/.metalsharp/metalsharp.toml";
     return "/tmp/metalsharp/metalsharp.toml";
 }
 
 std::string Config::findSteamInstallDir() {
     const char* home = getenv("HOME");
-    if (!home) return "";
+    if (!home)
+        return "";
 
-    const char* candidates[] = {
-        "/Applications/Steam.app/Contents/MacOS",
-        ".steam/steam",
-        ".local/share/Steam",
-        "Library/Application Support/Steam"
-    };
+    const char* candidates[] = {"/Applications/Steam.app/Contents/MacOS", ".steam/steam", ".local/share/Steam",
+                                "Library/Application Support/Steam"};
 
     for (const auto* rel : candidates) {
         std::string path = std::string(home) + "/" + rel;
@@ -42,18 +40,21 @@ std::string Config::findSteamInstallDir() {
 
 bool Config::load(const std::string& path) {
     std::ifstream file(path);
-    if (!file.is_open()) return false;
+    if (!file.is_open())
+        return false;
 
     std::string line;
     std::string currentSection;
     GameProfile* currentProfile = nullptr;
 
     while (std::getline(file, line)) {
-        if (line.empty() || line[0] == '#') continue;
+        if (line.empty() || line[0] == '#')
+            continue;
 
         if (line[0] == '[') {
             auto end = line.find(']');
-            if (end == std::string::npos) continue;
+            if (end == std::string::npos)
+                continue;
             currentSection = line.substr(1, end - 1);
 
             if (currentSection != "general" && currentSection != "steam") {
@@ -67,31 +68,48 @@ bool Config::load(const std::string& path) {
         }
 
         auto eq = line.find('=');
-        if (eq == std::string::npos) continue;
+        if (eq == std::string::npos)
+            continue;
 
         std::string key = line.substr(0, eq);
         std::string val = line.substr(eq + 1);
 
-        while (!key.empty() && key.back() == ' ') key.pop_back();
-        while (!val.empty() && val.front() == ' ') val = val.substr(1);
+        while (!key.empty() && key.back() == ' ')
+            key.pop_back();
+        while (!val.empty() && val.front() == ' ')
+            val = val.substr(1);
 
         if (currentSection == "general") {
-            if (key == "width") width = (uint32_t)std::stoul(val);
-            else if (key == "height") height = (uint32_t)std::stoul(val);
-            else if (key == "fullscreen") fullscreen = (val == "true");
-            else if (key == "vsync") vsync = (val == "true");
-            else if (key == "debug_metal") debugMetal = (val == "true");
-            else if (key == "wine_prefix") winePrefix = val;
+            if (key == "width")
+                width = (uint32_t)std::stoul(val);
+            else if (key == "height")
+                height = (uint32_t)std::stoul(val);
+            else if (key == "fullscreen")
+                fullscreen = (val == "true");
+            else if (key == "vsync")
+                vsync = (val == "true");
+            else if (key == "debug_metal")
+                debugMetal = (val == "true");
+            else if (key == "wine_prefix")
+                winePrefix = val;
         } else if (currentSection == "steam") {
-            if (key == "user_id") steamUserId = val;
-            else if (key == "install_dir") steamInstallDir = val;
+            if (key == "user_id")
+                steamUserId = val;
+            else if (key == "install_dir")
+                steamInstallDir = val;
         } else if (currentProfile) {
-            if (key == "width") currentProfile->width = (uint32_t)std::stoul(val);
-            else if (key == "height") currentProfile->height = (uint32_t)std::stoul(val);
-            else if (key == "fullscreen") currentProfile->fullscreen = (val == "true");
-            else if (key == "vsync") currentProfile->vsync = (val == "true");
-            else if (key == "debug_metal") currentProfile->debugMetal = (val == "true");
-            else if (key == "dxgi_format") currentProfile->dxgiFormat = val;
+            if (key == "width")
+                currentProfile->width = (uint32_t)std::stoul(val);
+            else if (key == "height")
+                currentProfile->height = (uint32_t)std::stoul(val);
+            else if (key == "fullscreen")
+                currentProfile->fullscreen = (val == "true");
+            else if (key == "vsync")
+                currentProfile->vsync = (val == "true");
+            else if (key == "debug_metal")
+                currentProfile->debugMetal = (val == "true");
+            else if (key == "dxgi_format")
+                currentProfile->dxgiFormat = val;
         }
     }
 
@@ -100,7 +118,8 @@ bool Config::load(const std::string& path) {
 
 bool Config::save(const std::string& path) {
     std::ofstream file(path);
-    if (!file.is_open()) return false;
+    if (!file.is_open())
+        return false;
 
     file << "[general]\n";
     file << "width = " << width << "\n";
@@ -110,8 +129,10 @@ bool Config::save(const std::string& path) {
     file << "debug_metal = " << (debugMetal ? "true" : "false") << "\n";
     file << "wine_prefix = \"" << winePrefix << "\"\n";
     file << "\n[steam]\n";
-    if (!steamUserId.empty()) file << "user_id = \"" << steamUserId << "\"\n";
-    if (!steamInstallDir.empty()) file << "install_dir = \"" << steamInstallDir << "\"\n";
+    if (!steamUserId.empty())
+        file << "user_id = \"" << steamUserId << "\"\n";
+    if (!steamInstallDir.empty())
+        file << "install_dir = \"" << steamInstallDir << "\"\n";
 
     for (auto& [name, profile] : m_profiles) {
         file << "\n[" << name << "]\n";
@@ -120,7 +141,8 @@ bool Config::save(const std::string& path) {
         file << "fullscreen = " << (profile.fullscreen ? "true" : "false") << "\n";
         file << "vsync = " << (profile.vsync ? "true" : "false") << "\n";
         file << "debug_metal = " << (profile.debugMetal ? "true" : "false") << "\n";
-        if (profile.dxgiFormat != "auto") file << "dxgi_format = \"" << profile.dxgiFormat << "\"\n";
+        if (profile.dxgiFormat != "auto")
+            file << "dxgi_format = \"" << profile.dxgiFormat << "\"\n";
     }
 
     return true;
@@ -135,4 +157,4 @@ bool Config::loadGameProfile(const std::string& exeName) {
     return false;
 }
 
-}
+} // namespace metalsharp

--- a/tools/launcher/Config.h
+++ b/tools/launcher/Config.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <string>
-#include <vector>
-#include <unordered_map>
 #include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 namespace metalsharp {
 
@@ -19,7 +19,7 @@ struct GameProfile {
 };
 
 class Config {
-public:
+  public:
     Config();
 
     bool load(const std::string& path);
@@ -43,8 +43,8 @@ public:
     static std::string defaultConfigPath();
     static std::string findSteamInstallDir();
 
-private:
+  private:
     std::unordered_map<std::string, GameProfile> m_profiles;
 };
 
-}
+} // namespace metalsharp

--- a/tools/launcher/NativeLauncher.cpp
+++ b/tools/launcher/NativeLauncher.cpp
@@ -1,28 +1,28 @@
 #define _XOPEN_SOURCE
-#include <metalsharp/PELoader.h>
-#include <metalsharp/PEHeader.h>
-#include <metalsharp/Kernel32Shim.h>
-#include <metalsharp/NtdllShim.h>
-#include <metalsharp/ExtraShims.h>
-#include <metalsharp/D3DShims.h>
-#include <metalsharp/MSABITrampolines.h>
-#include <metalsharp/Logger.h>
-#include <metalsharp/VirtualFileSystem.h>
-#include <metalsharp/Registry.h>
-#include <metalsharp/WindowManager.h>
-#include <metalsharp/NetworkContext.h>
-#include <metalsharp/SecureTransport.h>
-#include <metalsharp/SyncContext.h>
-#include <metalsharp/ShaderCache.h>
-#include <metalsharp/PipelineCache.h>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <unistd.h>
-#include <signal.h>
-#include <ucontext.h>
-#include <sys/mman.h>
+#include <metalsharp/D3DShims.h>
+#include <metalsharp/ExtraShims.h>
+#include <metalsharp/Kernel32Shim.h>
+#include <metalsharp/Logger.h>
+#include <metalsharp/MSABITrampolines.h>
+#include <metalsharp/NetworkContext.h>
+#include <metalsharp/NtdllShim.h>
+#include <metalsharp/PEHeader.h>
+#include <metalsharp/PELoader.h>
+#include <metalsharp/PipelineCache.h>
+#include <metalsharp/Registry.h>
+#include <metalsharp/SecureTransport.h>
+#include <metalsharp/ShaderCache.h>
+#include <metalsharp/SyncContext.h>
+#include <metalsharp/VirtualFileSystem.h>
+#include <metalsharp/WindowManager.h>
 #include <pthread.h>
+#include <signal.h>
+#include <sys/mman.h>
+#include <ucontext.h>
+#include <unistd.h>
 
 static metalsharp::LoadedModule* g_mainModule = nullptr;
 
@@ -35,12 +35,16 @@ static int g_fmode = 0;
 static char** g_environ_data = nullptr;
 
 static void MSABI stub_noop_void() {}
-static int MSABI stub_noop_int() { return 0; }
-static void* MSABI stub_noop_ptr() { return nullptr; }
+static int MSABI stub_noop_int() {
+    return 0;
+}
+static void* MSABI stub_noop_ptr() {
+    return nullptr;
+}
 
-#define STUB_V ((void*)(void(*)())stub_noop_void)
-#define STUB_I ((void*)(int(*)())stub_noop_int)
-#define STUB_P ((void*)(void*(*)())stub_noop_ptr)
+#define STUB_V ((void*)(void (*)())stub_noop_void)
+#define STUB_I ((void*)(int (*)())stub_noop_int)
+#define STUB_P ((void*)(void* (*)())stub_noop_ptr)
 
 static void crash_handler(int sig, siginfo_t* info, void* ucontext) {
 #if defined(__x86_64__)
@@ -55,9 +59,8 @@ static void crash_handler(int sig, siginfo_t* info, void* ucontext) {
     fprintf(stderr, "\n=== CRASH (signal %d) ===\n", sig);
     fprintf(stderr, "Faulting address: 0x%llX\n", (unsigned long long)(uintptr_t)info->si_addr);
     fprintf(stderr, "RIP: 0x%llX  RSP: 0x%llX\n", (unsigned long long)rip, (unsigned long long)rsp);
-    fprintf(stderr, "RAX: 0x%llX  RBX: 0x%llX  RCX: 0x%llX  RDX: 0x%llX\n",
-            (unsigned long long)rax, (unsigned long long)rbx,
-            (unsigned long long)rcx, (unsigned long long)rdx);
+    fprintf(stderr, "RAX: 0x%llX  RBX: 0x%llX  RCX: 0x%llX  RDX: 0x%llX\n", (unsigned long long)rax,
+            (unsigned long long)rbx, (unsigned long long)rcx, (unsigned long long)rdx);
 
     if (g_mainModule) {
         uint64_t base = (uint64_t)g_mainModule->base;
@@ -72,15 +75,14 @@ static void crash_handler(int sig, siginfo_t* info, void* ucontext) {
         for (int i = 0; i < 16; i++) {
             uint64_t val = stack[i];
             if (val >= base && val < end)
-                fprintf(stderr, "  [RSP+0x%02X] = 0x%llX  (PE RVA 0x%llX)\n",
-                        i*8, (unsigned long long)val, (unsigned long long)(val - base));
+                fprintf(stderr, "  [RSP+0x%02X] = 0x%llX  (PE RVA 0x%llX)\n", i * 8, (unsigned long long)val,
+                        (unsigned long long)(val - base));
             else
-                fprintf(stderr, "  [RSP+0x%02X] = 0x%llX\n", i*8, (unsigned long long)val);
+                fprintf(stderr, "  [RSP+0x%02X] = 0x%llX\n", i * 8, (unsigned long long)val);
         }
     }
 #else
-    fprintf(stderr, "\n=== CRASH (signal %d) at 0x%llX ===\n",
-            sig, (unsigned long long)(uintptr_t)info->si_addr);
+    fprintf(stderr, "\n=== CRASH (signal %d) at 0x%llX ===\n", sig, (unsigned long long)(uintptr_t)info->si_addr);
 #endif
     _exit(139);
 }
@@ -94,12 +96,12 @@ using namespace metalsharp::win32;
 
 static void printUsage(const char* prog) {
     fprintf(stderr,
-        "Usage: %s <game.exe> [args...]\n"
-        "\n"
-        "MetalSharp %s — Native D3D→Metal translation layer\n"
-        "Loads Windows x86_64 executables and translates D3D11/D3D12 calls to Metal.\n"
-        "No Wine dependency.\n",
-        prog, METALSHARP_VERSION);
+            "Usage: %s <game.exe> [args...]\n"
+            "\n"
+            "MetalSharp %s — Native D3D→Metal translation layer\n"
+            "Loads Windows x86_64 executables and translates D3D11/D3D12 calls to Metal.\n"
+            "No Wine dependency.\n",
+            prog, METALSHARP_VERSION);
 }
 
 int main(int argc, char* argv[]) {
@@ -247,9 +249,7 @@ int main(int argc, char* argv[]) {
 
     ShimLibrary msvcrt;
     msvcrt.name = "msvcrt.dll";
-    auto fn = [](void* ptr) -> ExportedFunction {
-        return [ptr]() -> void* { return ptr; };
-    };
+    auto fn = [](void* ptr) -> ExportedFunction { return [ptr]() -> void* { return ptr; }; };
     msvcrt.functions["malloc"] = fn((void*)msabi_malloc);
     msvcrt.functions["free"] = fn((void*)msabi_free);
     msvcrt.functions["realloc"] = fn((void*)msabi_realloc);
@@ -495,7 +495,8 @@ int main(int argc, char* argv[]) {
 
     const char* envCmdline = getenv("METALSHARP_CMDLINE");
     const char* envCwd = getenv("METALSHARP_CWD");
-    if (envCwd) chdir(envCwd);
+    if (envCwd)
+        chdir(envCwd);
     if (envCmdline) {
         g_cmdline = const_cast<char*>(envCmdline);
     } else {
@@ -527,25 +528,23 @@ int main(int argc, char* argv[]) {
     uint8_t* fakeTeb = nullptr;
     if (main->isPE) {
         auto* dos = reinterpret_cast<const IMAGE_DOS_HEADER*>(main->base);
-        auto* opt = reinterpret_cast<const IMAGE_OPTIONAL_HEADER64*>(
-            main->base + dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER));
+        auto* opt = reinterpret_cast<const IMAGE_OPTIONAL_HEADER64*>(main->base + dos->e_lfanew + 4 +
+                                                                     sizeof(IMAGE_FILE_HEADER));
 
         bool isDll = false;
-        auto* fileHdr = reinterpret_cast<const IMAGE_FILE_HEADER*>(
-            main->base + dos->e_lfanew + 4);
+        auto* fileHdr = reinterpret_cast<const IMAGE_FILE_HEADER*>(main->base + dos->e_lfanew + 4);
         if (fileHdr->Characteristics & IMAGE_FILE_DLL) {
             isDll = true;
         }
 
-        fakeTeb = (uint8_t*)mmap(nullptr, 0x10000, PROT_READ | PROT_WRITE,
-            MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        fakeTeb = (uint8_t*)mmap(nullptr, 0x10000, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
         memset(fakeTeb, 0, 0x10000);
 
         fakeTeb[0x30] = 0;
         uint64_t tebAddr = (uint64_t)fakeTeb;
         memcpy(&fakeTeb[0x30], &tebAddr, 8);
-        uint64_t stackTop = (uint64_t)mmap(nullptr, 0x100000, PROT_READ | PROT_WRITE,
-            MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        uint64_t stackTop =
+            (uint64_t)mmap(nullptr, 0x100000, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
         uint64_t stackBase = stackTop + 0x100000;
         memcpy(&fakeTeb[0x08], &stackTop, 8);
         memcpy(&fakeTeb[0x10], &stackBase, 8);
@@ -561,11 +560,11 @@ int main(int argc, char* argv[]) {
         memcpy(&fakeTeb[0x1488], &tlsValueAddr, 8);
 
 #if defined(__x86_64__)
-        __asm__ volatile (
-            "mov %0, %%rax\n"
-            "mov %%rax, %%gs:0x30\n"
-            : : "r"(tebAddr) : "rax", "memory"
-        );
+        __asm__ volatile("mov %0, %%rax\n"
+                         "mov %%rax, %%gs:0x30\n"
+                         :
+                         : "r"(tebAddr)
+                         : "rax", "memory");
 #else
         fprintf(stderr, "PE execution requires x86_64 (Rosetta 2)\n");
         return 1;

--- a/tools/launcher/SteamIntegration.cpp
+++ b/tools/launcher/SteamIntegration.cpp
@@ -1,27 +1,25 @@
 #include "SteamIntegration.h"
-#include <sys/stat.h>
+#include <cstdio>
+#include <cstdlib>
 #include <fstream>
 #include <sstream>
-#include <cstdlib>
-#include <cstdio>
+#include <sys/stat.h>
 
 namespace metalsharp {
 
 std::string SteamIntegration::findSteamInstallDir() {
     const char* home = getenv("HOME");
-    if (!home) return "";
+    if (!home)
+        return "";
 
-    const char* candidates[] = {
-        "/Applications/Steam.app/Contents/MacOS",
-        ".steam/steam",
-        ".local/share/Steam",
-        "Library/Application Support/Steam"
-    };
+    const char* candidates[] = {"/Applications/Steam.app/Contents/MacOS", ".steam/steam", ".local/share/Steam",
+                                "Library/Application Support/Steam"};
 
     for (const auto* rel : candidates) {
         std::string path = std::string(home) + "/" + rel;
         struct stat st{};
-        if (stat(path.c_str(), &st) == 0 && (st.st_mode & S_IFDIR)) return path;
+        if (stat(path.c_str(), &st) == 0 && (st.st_mode & S_IFDIR))
+            return path;
     }
     return "";
 }
@@ -33,7 +31,8 @@ std::vector<SteamGame> SteamIntegration::enumerateLibrary(const std::string& ste
     for (int i = 0; i < 100000; ++i) {
         std::string manifest = manifestDir + "/appmanifest_" + std::to_string(i) + ".acf";
         std::ifstream file(manifest);
-        if (!file.is_open()) continue;
+        if (!file.is_open())
+            continue;
 
         SteamGame game;
         game.appId = i;
@@ -41,7 +40,8 @@ std::vector<SteamGame> SteamIntegration::enumerateLibrary(const std::string& ste
         std::string line;
         while (std::getline(file, line)) {
             auto quotes = line.find('"');
-            if (quotes == std::string::npos) continue;
+            if (quotes == std::string::npos)
+                continue;
 
             if (line.find("\"name\"") != std::string::npos) {
                 auto first = line.find('"', quotes + 1);
@@ -67,14 +67,16 @@ std::vector<SteamGame> SteamIntegration::enumerateLibrary(const std::string& ste
 
 std::string SteamIntegration::defaultDownloadDir() {
     const char* home = getenv("HOME");
-    if (home) return std::string(home) + "/.metalsharp/games";
+    if (home)
+        return std::string(home) + "/.metalsharp/games";
     return "/tmp/metalsharp/games";
 }
 
 std::string SteamIntegration::findGameExecutable(const std::string& gameDir) {
     std::string cmd = "find \"" + gameDir + "\" -maxdepth 2 -name \"*.exe\" -type f 2>/dev/null";
     FILE* pipe = popen(cmd.c_str(), "r");
-    if (!pipe) return "";
+    if (!pipe)
+        return "";
 
     char buffer[1024];
     std::string result;
@@ -87,4 +89,4 @@ std::string SteamIntegration::findGameExecutable(const std::string& gameDir) {
     return result;
 }
 
-}
+} // namespace metalsharp

--- a/tools/launcher/SteamIntegration.h
+++ b/tools/launcher/SteamIntegration.h
@@ -13,7 +13,7 @@ struct SteamGame {
 };
 
 class SteamIntegration {
-public:
+  public:
     static std::string findSteamInstallDir();
     static std::vector<SteamGame> enumerateLibrary(const std::string& steamDir);
     static std::string findGameExecutable(const std::string& gameDir);
@@ -21,4 +21,4 @@ public:
     static std::string defaultDownloadDir();
 };
 
-}
+} // namespace metalsharp

--- a/tools/launcher/WinePrefix.cpp
+++ b/tools/launcher/WinePrefix.cpp
@@ -1,10 +1,10 @@
 #include "WinePrefix.h"
-#include <sys/stat.h>
 #include <cstdio>
-#include <cstring>
 #include <cstdlib>
+#include <cstring>
 #include <fstream>
 #include <sstream>
+#include <sys/stat.h>
 
 namespace metalsharp {
 
@@ -13,14 +13,16 @@ WinePrefix::~WinePrefix() = default;
 
 std::string WinePrefix::defaultPrefixPath() {
     const char* home = getenv("HOME");
-    if (home) return std::string(home) + "/.metalsharp/prefix";
+    if (home)
+        return std::string(home) + "/.metalsharp/prefix";
     return "/tmp/metalsharp/prefix";
 }
 
 bool WinePrefix::init() {
     struct stat st{};
     if (stat(m_path.c_str(), &st) != 0) {
-        if (!createWinePrefix()) return false;
+        if (!createWinePrefix())
+            return false;
     }
 
     std::string dllDir = dllPath();
@@ -56,11 +58,21 @@ bool WinePrefix::createWinePrefix() {
     return true;
 }
 
-bool WinePrefix::isValid() const { return m_initialized; }
-std::string WinePrefix::dllPath() const { return m_path + "/dlls"; }
-std::string WinePrefix::winePrefixPath() const { return m_path; }
-std::string WinePrefix::userRegPath() const { return m_path + "/user.reg"; }
-std::string WinePrefix::systemRegPath() const { return m_path + "/system.reg"; }
+bool WinePrefix::isValid() const {
+    return m_initialized;
+}
+std::string WinePrefix::dllPath() const {
+    return m_path + "/dlls";
+}
+std::string WinePrefix::winePrefixPath() const {
+    return m_path;
+}
+std::string WinePrefix::userRegPath() const {
+    return m_path + "/user.reg";
+}
+std::string WinePrefix::systemRegPath() const {
+    return m_path + "/system.reg";
+}
 
 bool WinePrefix::setDllOverride(const std::string& dllName) {
     m_dllOverrides.push_back(dllName);
@@ -68,10 +80,12 @@ bool WinePrefix::setDllOverride(const std::string& dllName) {
 }
 
 bool WinePrefix::writeRegistryDllOverrides() {
-    if (m_dllOverrides.empty()) return true;
+    if (m_dllOverrides.empty())
+        return true;
 
     std::ofstream reg(userRegPath(), std::ios::app);
-    if (!reg.is_open()) return false;
+    if (!reg.is_open())
+        return false;
 
     reg << "\n[Software\\\\Wine\\\\DllOverrides]\n";
     for (const auto& dll : m_dllOverrides) {
@@ -85,8 +99,7 @@ bool WinePrefix::copyMetalSharpDlls() {
     const char* buildDir = getenv("METALSHARP_BUILD_DIR");
     std::string sourceDir = buildDir ? buildDir : "";
 
-    const char* dllNames[] = {"d3d11.dylib", "d3d12.dylib", "dxgi.dylib",
-                              "xaudio2_9.dylib", "xinput1_4.dylib"};
+    const char* dllNames[] = {"d3d11.dylib", "d3d12.dylib", "dxgi.dylib", "xaudio2_9.dylib", "xinput1_4.dylib"};
 
     std::string dest = dllPath();
     printf("  Installing MetalSharp DLLs to %s\n", dest.c_str());
@@ -108,4 +121,4 @@ bool WinePrefix::copyMetalSharpDlls() {
     return true;
 }
 
-}
+} // namespace metalsharp

--- a/tools/launcher/WinePrefix.h
+++ b/tools/launcher/WinePrefix.h
@@ -6,7 +6,7 @@
 namespace metalsharp {
 
 class WinePrefix {
-public:
+  public:
     explicit WinePrefix(const std::string& path);
     ~WinePrefix();
 
@@ -24,10 +24,10 @@ public:
 
     static std::string defaultPrefixPath();
 
-private:
+  private:
     std::string m_path;
     bool m_initialized = false;
     std::vector<std::string> m_dllOverrides;
 };
 
-}
+} // namespace metalsharp

--- a/tools/launcher/WinePrefix.mm
+++ b/tools/launcher/WinePrefix.mm
@@ -1,6 +1,4 @@
 #include "WinePrefix.h"
 #include <Foundation/Foundation.h>
 
-namespace metalsharp {
-
-}
+namespace metalsharp {}

--- a/tools/launcher/main.cpp
+++ b/tools/launcher/main.cpp
@@ -1,6 +1,6 @@
-#include "WinePrefix.h"
 #include "Config.h"
 #include "SteamIntegration.h"
+#include "WinePrefix.h"
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -13,22 +13,22 @@
 
 static void printUsage(const char* prog) {
     fprintf(stderr,
-        "Usage: %s [options] <game.exe>\n"
-        "\n"
-        "Options:\n"
-        "  --prefix, -p     Wine prefix directory (default: ~/.metalsharp/prefix)\n"
-        "  --width, -W      Window width (default: 1920)\n"
-        "  --height, -H     Window height (default: 1080)\n"
-        "  --list-games     List Steam library games\n"
-        "  --config, -c     Config file path (default: ~/.metalsharp/metalsharp.toml)\n"
-        "  --verbose, -v    Verbose output\n"
-        "  --debug-metal    Enable Metal validation\n"
-        "  --fullscreen, -f Fullscreen mode\n"
-        "  --help, -h       Show this help\n"
-        "\n"
-        "MetalSharp %s — Direct3D -> Metal translation layer\n"
-        "Runs Windows game executables through Wine + MetalSharp.\n",
-        prog, METALSHARP_VERSION);
+            "Usage: %s [options] <game.exe>\n"
+            "\n"
+            "Options:\n"
+            "  --prefix, -p     Wine prefix directory (default: ~/.metalsharp/prefix)\n"
+            "  --width, -W      Window width (default: 1920)\n"
+            "  --height, -H     Window height (default: 1080)\n"
+            "  --list-games     List Steam library games\n"
+            "  --config, -c     Config file path (default: ~/.metalsharp/metalsharp.toml)\n"
+            "  --verbose, -v    Verbose output\n"
+            "  --debug-metal    Enable Metal validation\n"
+            "  --fullscreen, -f Fullscreen mode\n"
+            "  --help, -h       Show this help\n"
+            "\n"
+            "MetalSharp %s — Direct3D -> Metal translation layer\n"
+            "Runs Windows game executables through Wine + MetalSharp.\n",
+            prog, METALSHARP_VERSION);
 }
 
 int main(int argc, char* argv[]) {
@@ -37,35 +37,50 @@ int main(int argc, char* argv[]) {
     std::string configPath;
 
     static struct option longOpts[] = {
-        {"prefix",      required_argument, nullptr, 'p'},
-        {"width",       required_argument, nullptr, 'W'},
-        {"height",      required_argument, nullptr, 'H'},
-        {"list-games",  no_argument,       nullptr, 'l'},
-        {"config",      required_argument, nullptr, 'c'},
-        {"verbose",     no_argument,       nullptr, 'v'},
-        {"debug-metal", no_argument,       nullptr, 'D'},
-        {"fullscreen",  no_argument,       nullptr, 'f'},
-        {"help",        no_argument,       nullptr, 'h'},
-        {nullptr, 0, nullptr, 0}
-    };
+        {"prefix", required_argument, nullptr, 'p'}, {"width", required_argument, nullptr, 'W'},
+        {"height", required_argument, nullptr, 'H'}, {"list-games", no_argument, nullptr, 'l'},
+        {"config", required_argument, nullptr, 'c'}, {"verbose", no_argument, nullptr, 'v'},
+        {"debug-metal", no_argument, nullptr, 'D'},  {"fullscreen", no_argument, nullptr, 'f'},
+        {"help", no_argument, nullptr, 'h'},         {nullptr, 0, nullptr, 0}};
 
     int opt;
     while ((opt = getopt_long(argc, argv, "p:W:H:lc:vDfh", longOpts, nullptr)) != -1) {
         switch (opt) {
-            case 'p': config.winePrefix = optarg; break;
-            case 'W': config.width = atoi(optarg); break;
-            case 'H': config.height = atoi(optarg); break;
-            case 'l': listGames = true; break;
-            case 'c': configPath = optarg; break;
-            case 'v': config.verbose = true; break;
-            case 'D': config.debugMetal = true; break;
-            case 'f': config.fullscreen = true; break;
-            case 'h': printUsage(argv[0]); return 0;
-            default: printUsage(argv[0]); return 1;
+        case 'p':
+            config.winePrefix = optarg;
+            break;
+        case 'W':
+            config.width = atoi(optarg);
+            break;
+        case 'H':
+            config.height = atoi(optarg);
+            break;
+        case 'l':
+            listGames = true;
+            break;
+        case 'c':
+            configPath = optarg;
+            break;
+        case 'v':
+            config.verbose = true;
+            break;
+        case 'D':
+            config.debugMetal = true;
+            break;
+        case 'f':
+            config.fullscreen = true;
+            break;
+        case 'h':
+            printUsage(argv[0]);
+            return 0;
+        default:
+            printUsage(argv[0]);
+            return 1;
         }
     }
 
-    if (configPath.empty()) configPath = metalsharp::Config::defaultConfigPath();
+    if (configPath.empty())
+        configPath = metalsharp::Config::defaultConfigPath();
     config.load(configPath);
 
     if (optind < argc) {
@@ -133,13 +148,13 @@ int main(int argc, char* argv[]) {
     }
 
     setenv("WINEPREFIX", config.winePrefix.c_str(), 1);
-    setenv("WINEDLLOVERRIDES",
-        "d3d11=native;d3d12=native;dxgi=native;xaudio2_9=native;xinput1_4=native", 1);
+    setenv("WINEDLLOVERRIDES", "d3d11=native;d3d12=native;dxgi=native;xaudio2_9=native;xinput1_4=native", 1);
 
     printf("\nLaunching %s via MetalSharp...\n", config.executable.c_str());
 
     std::string launchCmd = "wine \"" + config.executable + "\"";
-    if (config.verbose) printf("  Command: %s\n", launchCmd.c_str());
+    if (config.verbose)
+        printf("  Command: %s\n", launchCmd.c_str());
 
     return system(launchCmd.c_str());
 }


### PR DESCRIPTION
## Summary
- **Rust**: Remove nightly-only rustfmt options (`fn_single_line`, `imports_granularity`, `group_imports`) and run `cargo fmt` — passes `cargo fmt --all -- --check`
- **C/C++/ObjC**: Run `clang-format` on all 209 source files (`.cpp`, `.h`, `.mm`, `.c`) — passes `clang-format --dry-run --Werror`
- **JS/TS**: Add `biome.json` config tuned for Electron app patterns, fix lint errors (add `type="button"` to HTML buttons, fix `forEach` callback returns), disable rules not applicable to Electron code (`noImplicitAnyLet`, `noUnusedVariables`, `noNonNullAssertion`, `useNodejsImportProtocol`) — passes `biome ci`

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `clang-format --dry-run --Werror` passes on all 209 files
- [x] `biome ci src/` passes (0 errors, 2 warnings for `!important` CSS)
- [ ] All 4 CI workflows pass on this branch