### PR TITLE
fix(ci): remove rust-cache from Build & Release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,6 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Verify Rust toolchain
-        run: rustup show && cargo --version
-
-      - name: Install Rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: app/src-rust
-
       - name: Build Rust backend
         run: cd app/src-rust && cargo build --release
 


### PR DESCRIPTION
## Summary
`Swatinem/rust-cache@v2` restores a stale cached `~/.cargo/bin/cargo` that resolves to `rustup-init`, breaking all subsequent `cargo` commands. The verify step confirms cargo works before cache restore, then fails after.

Removing the cache from this workflow — it's not critical for release builds. `ci-rust.yml` retains the cache for faster PR CI.

## Test plan
- [ ] Build & Release workflow passes (3 consecutive failures from this issue)