### PR TITLE
feat(launch): separate shader cache by engine and game appid

### DIFF
--- a/app/src-rust/src/launch.rs
+++ b/app/src-rust/src/launch.rs
@@ -175,13 +175,13 @@ pub fn launch_auto(appid: u32) -> Result<(u32, &'static str), Box<dyn std::error
         Engine::DxmtMetal => {
             let dir = game_dir.as_ref().unwrap_or(&local_dir);
             let exe = resolve_game_exe_fallback(dir);
-            let pid = launch_dxmt_metal(&exe, dir)?;
+            let pid = launch_dxmt_metal(appid, &exe, dir)?;
             Ok((pid, "dxmt_metal"))
         },
         Engine::DxmtMetal12 => {
             let dir = game_dir.as_ref().unwrap_or(&local_dir);
             let exe = resolve_game_exe_fallback(dir);
-            let pid = launch_dxmt_metal12(&exe, dir)?;
+            let pid = launch_dxmt_metal12(appid, &exe, dir)?;
             Ok((pid, "dxmt_metal12"))
         },
         Engine::Wined3d32 => {
@@ -418,7 +418,7 @@ fn launch_fna_arm64(exe_path: &str, game_dir: &PathBuf) -> Result<u32, Box<dyn s
     Ok(child.id())
 }
 
-fn launch_dxmt_metal(exe_path: &str, game_dir: &PathBuf) -> Result<u32, Box<dyn std::error::Error>> {
+fn launch_dxmt_metal(appid: u32, exe_path: &str, game_dir: &PathBuf) -> Result<u32, Box<dyn std::error::Error>> {
     let home = dirs::home_dir().ok_or("no home dir")?;
     let ms_root = home.join(".metalsharp").join("runtime").join("wine");
     let wine = ms_root.join("bin").join("metalsharp-wine");
@@ -442,10 +442,9 @@ fn launch_dxmt_metal(exe_path: &str, game_dir: &PathBuf) -> Result<u32, Box<dyn 
     let _ = std::fs::copy(dxmt_x64.join("d3d10core.dll"), game.join("d3d10core.dll"));
     let _ = std::fs::copy(dxmt_x64.join("winemetal.dll"), game.join("winemetal.dll"));
 
-    let shader_cache_base = home.join(".metalsharp").join("shader-cache");
-    let game_cache_dir = shader_cache_base.join(&exe_name);
-    let _ = std::fs::create_dir_all(&game_cache_dir);
-    let shader_cache_path = game_cache_dir.to_string_lossy().to_string();
+    let shader_cache_base = home.join(".metalsharp").join("shader-cache").join("dxmt-metal").join(appid.to_string());
+    let _ = std::fs::create_dir_all(&shader_cache_base);
+    let shader_cache_path = shader_cache_base.to_string_lossy().to_string();
     let dxmt_config_file = ms_root.join("etc").join("dxmt.conf").to_string_lossy().to_string();
 
     let child = Command::new(&wine)
@@ -463,7 +462,7 @@ fn launch_dxmt_metal(exe_path: &str, game_dir: &PathBuf) -> Result<u32, Box<dyn 
     Ok(child.id())
 }
 
-fn launch_dxmt_metal12(exe_path: &str, game_dir: &PathBuf) -> Result<u32, Box<dyn std::error::Error>> {
+fn launch_dxmt_metal12(appid: u32, exe_path: &str, game_dir: &PathBuf) -> Result<u32, Box<dyn std::error::Error>> {
     let home = dirs::home_dir().ok_or("no home dir")?;
     let ms_root = home.join(".metalsharp").join("runtime").join("wine");
     let wine = ms_root.join("bin").join("metalsharp-wine");
@@ -488,10 +487,9 @@ fn launch_dxmt_metal12(exe_path: &str, game_dir: &PathBuf) -> Result<u32, Box<dy
     let _ = std::fs::copy(dxmt_x64.join("d3d10core.dll"), game.join("d3d10core.dll"));
     let _ = std::fs::copy(dxmt_x64.join("winemetal.dll"), game.join("winemetal.dll"));
 
-    let shader_cache_base = home.join(".metalsharp").join("shader-cache");
-    let game_cache_dir = shader_cache_base.join(&exe_name);
-    let _ = std::fs::create_dir_all(&game_cache_dir);
-    let shader_cache_path = game_cache_dir.to_string_lossy().to_string();
+    let shader_cache_base = home.join(".metalsharp").join("shader-cache").join("dxmt-metal12").join(appid.to_string());
+    let _ = std::fs::create_dir_all(&shader_cache_base);
+    let shader_cache_path = shader_cache_base.to_string_lossy().to_string();
     let dxmt_config_file = ms_root.join("etc").join("dxmt.conf").to_string_lossy().to_string();
 
     let child = Command::new(&wine)


### PR DESCRIPTION
## Summary

DXMT shader caches are now organized under `~/.metalsharp/shader-cache/{engine}/{appid}/` instead of the flat `~/.metalsharp/shader-cache/{exe_name}/` structure.

**Before:**
```
~/.metalsharp/shader-cache/
  ├── RainWorld.exe/          (could collide if run under different engines)
  ├── Schedule I.exe/
  └── SubnauticaZero.exe/
```

**After:**
```
~/.metalsharp/shader-cache/
  ├── dxmt-metal/312520/      (Rain World — DXMT D3D11→Metal)
  ├── dxmt-metal/848450/      (Subnautica: Below Zero)
  ├── dxmt-metal/3164500/     (Schedule I)
  └── dxmt-metal12/2050650/   (DXMT D3D12→Metal)
```

**Why:**
- Prevents cache collisions when the same game could run under different engines (DXMT D3D11 vs D3D12)
- Uses stable appid identifiers instead of exe names that can change between game updates
- Makes it easy to clear cache per-engine or per-game

**Changes:**
- `launch_dxmt_metal(appid, ...)` — cache at `shader-cache/dxmt-metal/{appid}/`
- `launch_dxmt_metal12(appid, ...)` — cache at `shader-cache/dxmt-metal12/{appid}/`
- Threaded appid through from `launch_auto()` to the launch functions

## Live verification

Tested with Rain World (appid 312520):
1. First launch → `dxmt-metal/312520/shaders_320.db` created (4096 bytes db, 309032 bytes wal)
2. Second launch → same files, identical sizes — DXMT read and reused the cached shaders

## Test plan
- [x] `cargo build --release` passes
- [x] `cargo fmt` + `cargo clippy` pass
- [x] Rain World (312520) writes shaders to `dxmt-metal/312520/` on first launch
- [x] Rain World reuses shaders from `dxmt-metal/312520/` on second launch (no new writes)
- [ ] Rust CI passes