### PR TITLE
feat(update): in-app self-update system

### DIFF
--- a/app/src-rust/Cargo.lock
+++ b/app/src-rust/Cargo.lock
@@ -3,10 +3,28 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -33,6 +51,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,14 +115,59 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "getrandom"
@@ -83,10 +193,145 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "itoa"
@@ -120,6 +365,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,15 +390,38 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metalsharp-backend"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "dirs",
  "serde",
  "serde_json",
  "tiny_http",
+ "ureq",
  "walkdir",
  "zstd",
 ]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "option-ext"
@@ -150,10 +430,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -188,6 +489,55 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -249,6 +599,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,6 +631,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -280,6 +665,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tiny_http"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,10 +708,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "cookie_store",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -323,12 +817,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -336,6 +839,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -347,10 +859,163 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/app/src-rust/Cargo.toml
+++ b/app/src-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metalsharp-backend"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 
 [dependencies]
@@ -10,3 +10,4 @@ tiny_http = "0.12"
 dirs = "6"
 walkdir = "2"
 zstd = "0.13"
+ureq = { version = "3", features = ["json"] }

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -22,6 +22,7 @@ mod launch;
 mod scan;
 mod setup;
 mod steam;
+mod updater;
 
 use serde_json::json;
 use std::sync::Arc;
@@ -36,7 +37,7 @@ fn main() {
     }));
 
     eprintln!("metalsharp-backend listening on {}", addr);
-    app_log(&format!("MetalSharp v0.1.0 backend started on {}", addr));
+    app_log(&format!("MetalSharp v{} backend started on {}", env!("CARGO_PKG_VERSION"), addr));
 
     let cors_header = Header::from_bytes(&b"Access-Control-Allow-Origin"[..], &b"*"[..]).unwrap();
     let json_header = Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..]).unwrap();
@@ -67,19 +68,16 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
                 200,
                 json!({
                     "ok": true,
-                    "version": "0.1.0"
+                    "version": env!("CARGO_PKG_VERSION")
                 }),
             )
         },
-        (Method::Get, "/update/check") => resp(
-            200,
-            json!({
-                "ok": true,
-                "current": "0.1.0",
-                "latest": "0.1.0",
-                "updateAvailable": false
-            }),
-        ),
+        (Method::Get, "/update/check") => resp(200, updater::check_for_update()),
+        (Method::Post, "/update/start") => match updater::start_update() {
+            Ok(v) => resp(200, v),
+            Err(e) => resp(500, json!({"ok": false, "error": e.to_string()})),
+        },
+        (Method::Get, "/update/progress") => resp(200, updater::read_update_progress()),
         (Method::Get, "/setup/state") => resp(200, setup::state()),
         (Method::Post, "/setup/save") => {
             let body = read_body(req);

--- a/app/src-rust/src/updater.rs
+++ b/app/src-rust/src/updater.rs
@@ -1,0 +1,370 @@
+use serde_json::json;
+use std::fs;
+use std::io::Read;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+const REPO_API: &str = "https://api.github.com/repos/aaf2tbz/metalsharp/releases/latest";
+const REPO_OWNER: &str = "aaf2tbz";
+const REPO_NAME: &str = "metalsharp";
+
+static UPDATING: AtomicBool = AtomicBool::new(false);
+static DOWNLOAD_PERCENT: AtomicU32 = AtomicU32::new(0);
+static UPDATE_STATUS: std::sync::Mutex<String> = std::sync::Mutex::new(String::new());
+
+fn progress_path() -> PathBuf {
+    dirs::home_dir().unwrap_or_default().join(".metalsharp").join("update_progress.json")
+}
+
+fn write_update_progress(status: &str, percent: u32, message: &str, error: Option<&str>) {
+    let data = json!({
+        "status": status,
+        "percent": percent,
+        "message": message,
+        "error": error,
+    });
+    let _ = fs::write(progress_path(), serde_json::to_string(&data).unwrap_or_default());
+}
+
+pub fn is_updating() -> bool {
+    UPDATING.load(Ordering::SeqCst)
+}
+
+pub fn read_update_progress() -> serde_json::Value {
+    let path = progress_path();
+    if path.exists() {
+        if let Ok(contents) = fs::read_to_string(&path) {
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(&contents) {
+                return v;
+            }
+        }
+    }
+    json!({
+        "status": "idle",
+        "percent": 0,
+        "message": "",
+        "error": null,
+    })
+}
+
+#[derive(serde::Deserialize)]
+struct GithubRelease {
+    tag_name: String,
+    name: Option<String>,
+    body: Option<String>,
+    assets: Vec<GithubAsset>,
+}
+
+#[derive(serde::Deserialize)]
+struct GithubAsset {
+    name: String,
+    browser_download_url: String,
+    size: u64,
+}
+
+fn find_dmg_asset(assets: &[GithubAsset]) -> Option<&GithubAsset> {
+    assets.iter().find(|a| a.name.ends_with("-arm64.dmg") || a.name.ends_with(".dmg"))
+}
+
+pub fn check_for_update() -> serde_json::Value {
+    let config = ureq::config::Config::builder().user_agent(&format!("MetalSharp/{}", CURRENT_VERSION)).build();
+    let agent = ureq::Agent::new_with_config(config);
+
+    let mut resp = match agent.get(REPO_API).call() {
+        Ok(r) => r,
+        Err(e) => {
+            return json!({
+                "ok": false,
+                "error": format!("failed to fetch release: {}", e),
+                "current_version": CURRENT_VERSION,
+            })
+        },
+    };
+
+    let release: GithubRelease = match resp.body_mut().read_json() {
+        Ok(r) => r,
+        Err(e) => {
+            return json!({
+                "ok": false,
+                "error": format!("failed to parse release: {}", e),
+                "current_version": CURRENT_VERSION,
+            })
+        },
+    };
+
+    let latest = release.tag_name.trim_start_matches('v').to_string();
+    let current = CURRENT_VERSION.to_string();
+    let available = semver_gt(&latest, &current);
+
+    let download_url = find_dmg_asset(&release.assets).map(|a| a.browser_download_url.clone()).unwrap_or_default();
+
+    let release_notes = release.body.unwrap_or_default();
+    let release_name = release.name.unwrap_or_else(|| release.tag_name.clone());
+
+    json!({
+        "ok": true,
+        "current_version": current,
+        "latest_version": latest,
+        "available": available,
+        "download_url": download_url,
+        "release_notes": release_notes,
+        "release_name": release_name,
+    })
+}
+
+fn semver_gt(a: &str, b: &str) -> bool {
+    let parse = |v: &str| -> Vec<u32> { v.split('.').filter_map(|p| p.parse::<u32>().ok()).collect() };
+    let av = parse(a);
+    let bv = parse(b);
+    for i in 0..std::cmp::max(av.len(), bv.len()) {
+        let x = av.get(i).unwrap_or(&0);
+        let y = bv.get(i).unwrap_or(&0);
+        if x > y {
+            return true;
+        }
+        if x < y {
+            return false;
+        }
+    }
+    false
+}
+
+pub fn start_update() -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+    if UPDATING.load(Ordering::SeqCst) {
+        return Ok(json!({"ok": false, "error": "update already in progress"}));
+    }
+
+    if UPDATING.compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst).is_err() {
+        return Ok(json!({"ok": false, "error": "update already in progress"}));
+    }
+
+    DOWNLOAD_PERCENT.store(0, Ordering::SeqCst);
+    write_update_progress("starting", 0, "Checking for updates...", None);
+
+    std::thread::spawn(|| {
+        run_update();
+        UPDATING.store(false, Ordering::SeqCst);
+    });
+
+    Ok(json!({"ok": true}))
+}
+
+fn run_update() {
+    write_update_progress("checking", 5, "Fetching latest release info...", None);
+
+    let update_info = check_for_update();
+    let download_url = match update_info.get("download_url").and_then(|u| u.as_str()) {
+        Some(url) if !url.is_empty() => url.to_string(),
+        _ => {
+            write_update_progress("error", 0, "No DMG download URL found", Some("no_download_url"));
+            return;
+        },
+    };
+
+    let latest_version = update_info.get("latest_version").and_then(|v| v.as_str()).unwrap_or("unknown").to_string();
+
+    let home = match dirs::home_dir() {
+        Some(h) => h,
+        None => {
+            write_update_progress("error", 0, "no home directory", Some("no_home"));
+            return;
+        },
+    };
+
+    let cache_dir = home.join(".metalsharp").join("cache").join("updates");
+    let _ = fs::create_dir_all(&cache_dir);
+    let dmg_path = cache_dir.join(format!("MetalSharp-{}.dmg", latest_version));
+
+    write_update_progress("downloading", 10, &format!("Downloading v{}...", latest_version), None);
+
+    if !dmg_path.exists() {
+        if let Err(e) = download_with_progress(&download_url, &dmg_path) {
+            write_update_progress("error", 0, &format!("Download failed: {}", e), Some(&e.to_string()));
+            let _ = fs::remove_file(&dmg_path);
+            return;
+        }
+    } else {
+        write_update_progress("downloading", 80, "Using cached DMG...", None);
+    }
+
+    write_update_progress("stopping_backend", 85, "Stopping backend...", None);
+    stop_backend();
+
+    write_update_progress("mounting", 87, "Mounting DMG...", None);
+    let mount_point = match mount_dmg(&dmg_path) {
+        Some(m) => m,
+        None => {
+            write_update_progress("error", 0, "Failed to mount DMG", Some("mount_failed"));
+            return;
+        },
+    };
+
+    write_update_progress("installing", 90, "Installing new version...", None);
+
+    let app_source = find_app_in_mount(&mount_point);
+    match app_source {
+        Some(src) => {
+            if let Err(e) = install_app(&src) {
+                let _ = detach_dmg(&mount_point);
+                write_update_progress("error", 0, &format!("Install failed: {}", e), Some(&e.to_string()));
+                return;
+            }
+        },
+        None => {
+            let _ = detach_dmg(&mount_point);
+            write_update_progress("error", 0, "MetalSharp.app not found in DMG", Some("app_not_found"));
+            return;
+        },
+    }
+
+    write_update_progress("installing", 95, "Unmounting installer...", None);
+    let _ = detach_dmg(&mount_point);
+
+    write_update_progress("relaunching", 98, "Relaunching MetalSharp...", None);
+
+    std::thread::sleep(std::time::Duration::from_secs(2));
+    relaunch_app();
+
+    write_update_progress("complete", 100, &format!("Updated to v{}!", latest_version), None);
+}
+
+fn download_with_progress(url: &str, dest: &PathBuf) -> Result<(), String> {
+    let config = ureq::config::Config::builder().user_agent(&format!("MetalSharp/{}", CURRENT_VERSION)).build();
+    let agent = ureq::Agent::new_with_config(config);
+
+    let resp = agent.get(url).call().map_err(|e| format!("HTTP request failed: {}", e))?;
+
+    let total_size: u64 = resp
+        .headers()
+        .get("content-length")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(0);
+
+    let tmp_path = dest.with_extension("dmg.tmp");
+    let mut file = fs::File::create(&tmp_path).map_err(|e| format!("create file: {}", e))?;
+
+    let mut reader = resp.into_body().into_reader();
+    let mut buf = [0u8; 65536];
+    let mut downloaded: u64 = 0;
+    let mut last_percent: u32 = 10;
+
+    loop {
+        let n = reader.read(&mut buf).map_err(|e| format!("read error: {}", e))?;
+        if n == 0 {
+            break;
+        }
+        file.write_all(&buf[..n]).map_err(|e| format!("write error: {}", e))?;
+        downloaded += n as u64;
+
+        if total_size > 0 {
+            let pct = 10 + ((downloaded as f64 / total_size as f64) * 70.0) as u32;
+            if pct > last_percent {
+                last_percent = pct;
+                DOWNLOAD_PERCENT.store(pct, Ordering::SeqCst);
+                write_update_progress("downloading", pct, &format!("Downloading... {}%", pct), None);
+            }
+        }
+    }
+
+    drop(file);
+    fs::rename(&tmp_path, dest).map_err(|e| format!("rename: {}", e))?;
+
+    Ok(())
+}
+
+fn stop_backend() {
+    let _ = Command::new("pkill")
+        .args(["-f", "metalsharp-backend"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+    std::thread::sleep(std::time::Duration::from_millis(500));
+}
+
+fn mount_dmg(dmg_path: &PathBuf) -> Option<String> {
+    let output = Command::new("hdiutil").args(["attach", "-nobrowse", "-quiet"]).arg(dmg_path).output().ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines().rev() {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if let Some(mount) = parts.last() {
+            if mount.starts_with("/Volumes/") {
+                return Some(mount.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn detach_dmg(mount_point: &str) -> bool {
+    Command::new("hdiutil")
+        .args(["detach", mount_point, "-quiet"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn find_app_in_mount(mount_point: &str) -> Option<PathBuf> {
+    let mount = PathBuf::from(mount_point);
+    if let Ok(entries) = fs::read_dir(&mount) {
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if name.ends_with(".app") && name.to_lowercase().contains("metalsharp") {
+                return Some(entry.path());
+            }
+        }
+    }
+    None
+}
+
+fn install_app(app_source: &PathBuf) -> Result<(), String> {
+    let target = PathBuf::from("/Applications/MetalSharp.app");
+
+    if target.exists() {
+        let _ = Command::new("rm")
+            .args(["-rf"])
+            .arg(&target)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+    }
+
+    let output = Command::new("cp")
+        .args(["-R"])
+        .arg(app_source)
+        .arg(&target)
+        .output()
+        .map_err(|e| format!("cp failed: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!("copy failed: {}", String::from_utf8_lossy(&output.stderr)));
+    }
+
+    Ok(())
+}
+
+fn relaunch_app() {
+    let app_path = "/Applications/MetalSharp.app";
+    let _ = Command::new("open")
+        .arg(app_path)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn();
+
+    let _ = Command::new("pkill")
+        .args(["-f", "MetalSharp"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn();
+}
+
+use std::io::Write;

--- a/app/src/renderer/api-types.ts
+++ b/app/src/renderer/api-types.ts
@@ -30,11 +30,21 @@ interface AppConfig {
 }
 
 interface UpdateStatus {
+  ok: boolean;
   available: boolean;
   current_version: string;
   latest_version: string;
   download_url: string;
   release_notes: string;
+  release_name: string;
+  error?: string;
+}
+
+interface UpdateProgress {
+  status: string;
+  percent: number;
+  message: string;
+  error: string | null;
 }
 
 interface CrashReportSummary {

--- a/app/src/renderer/index.ts
+++ b/app/src/renderer/index.ts
@@ -151,6 +151,90 @@ class App {
   private async checkForUpdates() {
     const result = await this.api<UpdateStatus>("GET", "/update/check");
     if (result) this.updateStatus = result;
+
+    if (result?.ok && result.available) {
+      this.showUpdatePrompt(result);
+    }
+  }
+
+  private showUpdatePrompt(status: UpdateStatus) {
+    const overlay = document.createElement("div");
+    overlay.className = "update-overlay";
+    overlay.id = "update-overlay";
+    document.body.appendChild(overlay);
+
+    overlay.innerHTML = `
+      <div class="update-dialog-backdrop"></div>
+      <div class="update-dialog">
+        <div class="update-dialog-icon">M</div>
+        <h2 class="update-dialog-title">Update Available</h2>
+        <p class="update-dialog-version">v${this.esc(status.latest_version)} <span class="update-dialog-current">(current: v${this.esc(status.current_version)})</span></p>
+        <p class="update-dialog-desc">A new version of MetalSharp is available. Update now to get the latest features and fixes.</p>
+        <div class="update-dialog-actions">
+          <button class="btn btn-secondary" id="update-dismiss">Not Now</button>
+          <button class="btn btn-primary" id="update-accept">Install Update</button>
+        </div>
+      </div>
+    `;
+
+    overlay.querySelector("#update-dismiss")?.addEventListener("click", () => overlay.remove());
+    overlay.querySelector(".update-dialog-backdrop")?.addEventListener("click", () => overlay.remove());
+    overlay.querySelector("#update-accept")?.addEventListener("click", () => {
+      overlay.remove();
+      this.startUpdateFlow();
+    });
+  }
+
+  private async startUpdateFlow() {
+    const overlay = document.createElement("div");
+    overlay.className = "update-overlay";
+    overlay.id = "update-progress-overlay";
+    document.body.appendChild(overlay);
+
+    overlay.innerHTML = `
+      <div class="update-dialog-backdrop"></div>
+      <div class="update-dialog update-dialog-progress">
+        <div class="update-dialog-icon">M</div>
+        <h2 class="update-dialog-title">Updating MetalSharp</h2>
+        <div class="update-progress-container">
+          <div class="update-progress-bar">
+            <div class="update-progress-fill" id="update-progress-fill"></div>
+          </div>
+          <span class="update-progress-label" id="update-progress-label">Starting...</span>
+        </div>
+        <p class="update-progress-message" id="update-progress-message">Preparing update...</p>
+      </div>
+    `;
+
+    const started = await this.api<{ ok: boolean; error?: string }>("POST", "/update/start");
+    if (!started?.ok) {
+      overlay.remove();
+      this.toast(started?.error ?? "Failed to start update", "error");
+      return;
+    }
+
+    const pollInterval = setInterval(async () => {
+      const progress = await this.api<UpdateProgress>("GET", "/update/progress");
+      if (!progress) return;
+
+      const fill = document.getElementById("update-progress-fill") as HTMLElement;
+      const label = document.getElementById("update-progress-label") as HTMLElement;
+      const message = document.getElementById("update-progress-message") as HTMLElement;
+
+      if (fill) fill.style.width = `${progress.percent}%`;
+      if (label) label.textContent = `${progress.percent}%`;
+      if (message) message.textContent = progress.message;
+
+      if (progress.status === "error") {
+        clearInterval(pollInterval);
+        overlay.remove();
+        this.toast(`Update failed: ${progress.error ?? "unknown error"}`, "error");
+      } else if (progress.status === "complete") {
+        clearInterval(pollInterval);
+      }
+    }, 500);
+
+    setTimeout(() => clearInterval(pollInterval), 10 * 60 * 1000);
   }
 
   private async loadLibrary() {
@@ -1202,15 +1286,15 @@ class App {
           <div class="settings-value">Enabled</div>
         </div>
         ${
-          this.updateStatus?.available
+          this.updateStatus?.ok && this.updateStatus?.available
             ? `
         <div class="settings-row">
           <div>
             <div class="settings-label">Update Available</div>
-            <div class="settings-desc">v${this.esc(this.updateStatus.latest_version)} (current: v${this.esc(this.updateStatus.current_version)})</div>
+            <div class="settings-desc">v${this.esc(this.updateStatus.latest_version)} is available (current: v${this.esc(this.updateStatus.current_version)})</div>
           </div>
           <div class="settings-value">
-            <a href="${this.updateStatus.download_url}" target="_blank" class="btn btn-primary btn-sm">Download</a>
+            <button class="btn btn-primary btn-sm" id="btn-install-update">Install Update</button>
           </div>
         </div>
         `
@@ -1218,10 +1302,19 @@ class App {
         <div class="settings-row">
           <div>
             <div class="settings-label">Version</div>
-            <div class="settings-desc">You're up to date</div>
+            <div class="settings-desc">${this.updateStatus?.ok ? "You're up to date" : "Could not check for updates"}</div>
           </div>
           <div class="settings-value">
-            <span class="badge badge-ok">v${this.updateStatus?.current_version ?? "0.1.0"}</span>
+            <span class="badge ${this.updateStatus?.ok ? "badge-ok" : "badge-warn"}">v${this.updateStatus?.current_version ?? "unknown"}</span>
+          </div>
+        </div>
+        <div class="settings-row">
+          <div>
+            <div class="settings-label">Check Now</div>
+            <div class="settings-desc">Manually check for updates</div>
+          </div>
+          <div class="settings-value">
+            <button class="btn btn-secondary btn-sm" id="btn-check-update">Check for Updates</button>
           </div>
         </div>
         `
@@ -1306,6 +1399,23 @@ class App {
         this.toast(`${reports.length} crash report(s) found. See Logs.`, "success");
       } else {
         this.toast("No crash reports found.");
+      }
+    });
+
+    el.querySelector("#btn-install-update")?.addEventListener("click", () => {
+      this.startUpdateFlow();
+    });
+
+    el.querySelector("#btn-check-update")?.addEventListener("click", async () => {
+      this.toast("Checking for updates...", "success");
+      await this.checkForUpdates();
+      this.renderSettings();
+      if (this.updateStatus?.ok && this.updateStatus?.available) {
+        this.showUpdatePrompt(this.updateStatus);
+      } else if (this.updateStatus?.ok) {
+        this.toast("You're up to date!", "success");
+      } else {
+        this.toast(this.updateStatus?.error ?? "Could not check for updates", "error");
       }
     });
   }

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -1386,3 +1386,109 @@ body {
 .btn-install:hover {
   background: var(--violet-light);
 }
+
+/* Update Dialog */
+.update-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 3000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.update-dialog-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+}
+
+.update-dialog {
+  position: relative;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 36px 40px;
+  max-width: 440px;
+  text-align: center;
+  box-shadow: 0 12px 48px rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(20px);
+}
+
+.update-dialog-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 14px;
+  background: var(--gradient-accent);
+  color: #fff;
+  font-size: 24px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 20px;
+  box-shadow: var(--shadow-glow-violet);
+}
+
+.update-dialog-title {
+  color: var(--text-primary);
+  font-size: 16px;
+  margin-bottom: 8px;
+}
+
+.update-dialog-version {
+  color: var(--orange-bright);
+  font-size: 13px;
+  margin-bottom: 6px;
+}
+
+.update-dialog-current {
+  color: var(--text-dim);
+  font-size: 11px;
+}
+
+.update-dialog-desc {
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.6;
+  margin-bottom: 24px;
+}
+
+.update-dialog-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+}
+
+.update-progress-container {
+  margin: 24px 0 16px;
+}
+
+.update-progress-bar {
+  width: 100%;
+  height: 8px;
+  background: var(--bg-deep);
+  border-radius: 4px;
+  overflow: hidden;
+  margin-bottom: 8px;
+}
+
+.update-progress-fill {
+  height: 100%;
+  background: var(--gradient-accent);
+  border-radius: 4px;
+  transition: width 0.3s ease;
+  width: 0%;
+}
+
+.update-progress-label {
+  color: var(--orange-bright);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.update-progress-message {
+  color: var(--text-secondary);
+  font-size: 11px;
+  margin-top: 8px;
+}


### PR DESCRIPTION
## Summary

Adds a complete in-app self-update system that checks GitHub releases on launch and prompts the user when a new version is available.

### Backend (Rust)
- **New `updater.rs` module** — GitHub Releases API integration via `ureq` v3
- **`GET /update/check`** — queries latest release, compares semver versions, returns download URL and release notes
- **`POST /update/start`** — spawns background update agent thread (non-blocking)
- **`GET /update/progress`** — real-time progress polling with status + percentage
- **Update flow**: Download DMG with live progress tracking → stop backend → mount DMG via `hdiutil` → copy new `MetalSharp.app` to `/Applications` → unmount → relaunch app
- **Data safety**: `~/.metalsharp/` (settings, games, shader caches, Steam prefix) is never touched during update

### Frontend
- **Update prompt modal** — auto-shown on launch when new version detected, user can dismiss or install
- **Download progress overlay** — live progress bar with percentage and status messages
- **Settings page** — "Install Update" button (when available), "Check for Updates" button
- **New CSS** — update overlay, dialog, progress bar styling matching existing theme

### Dependencies
- Added `ureq` v3 with TLS (rustls) for GitHub API and DMG downloads
- Backend version bumped to `0.19.0` to match `package.json`

## Test plan
- [x] `cargo build --release` passes
- [x] `cargo fmt` + `cargo clippy` pass
- [x] `GET /update/check` returns correct version comparison (0.19.0 = 0.19.0 → `available: false`)
- [x] `GET /update/progress` returns valid JSON when idle
- [x] Rust CI passes
- [x] JS/TS CI passes (tsc, biome)