### PR TITLE
fix(ui): harden install wizard — cleaner text and accurate progress

### DIFF
--- a/app/src-rust/src/installer.rs
+++ b/app/src-rust/src/installer.rs
@@ -75,16 +75,15 @@ fn run_install_all() {
 
     let steps: Vec<(&str, Box<dyn Fn(&PathBuf) -> Result<bool, String>>)> = vec![
         ("Rosetta 2", Box::new(|_| install_rosetta())),
-        ("Xcode CLI Tools", Box::new(|_| install_xcode_cli())),
-        ("MetalSharp Bundle", Box::new(install_metalsharp_bundle)),
-        ("Game Porting Toolkit", Box::new(install_gptk)),
-        ("Mono (arm64)", Box::new(|_| install_mono_arm64())),
+        ("System Tools", Box::new(|_| install_xcode_cli())),
+        ("Runtime Assets", Box::new(install_metalsharp_bundle)),
+        ("Compatibility Layer", Box::new(install_gptk)),
+        ("Runtime Support", Box::new(|_| install_mono_arm64())),
     ];
 
     let total = steps.len();
 
     write_progress(0, total, "Starting...", "starting", "Verifying prerequisites...", None);
-
     if !check_command("tar") {
         write_progress(
             0,
@@ -115,10 +114,10 @@ fn run_install_all() {
 
         match installer(&home) {
             Ok(false) => {
-                write_progress(step_num, total, name, "done", &format!("{} already installed — skipping", name), None);
+                write_progress(step_num, total, name, "done", &format!("{} ready", name), None);
             },
             Ok(true) => {
-                write_progress(step_num, total, name, "done", &format!("{} installed!", name), None);
+                write_progress(step_num, total, name, "done", &format!("{} installed", name), None);
             },
             Err(e) => {
                 let is_required = i < 7;
@@ -134,7 +133,7 @@ fn run_install_all() {
         std::thread::sleep(Duration::from_millis(200));
     }
 
-    write_progress(total, total, "Complete", "complete", "All dependencies installed!", None);
+    write_progress(total, total, "Complete", "complete", "All assets installed!", None);
 }
 
 fn install_rosetta() -> Result<bool, String> {

--- a/app/src/renderer/index.ts
+++ b/app/src/renderer/index.ts
@@ -303,7 +303,7 @@ class App {
   }
 
   private renderSetupStepIndicator(container: HTMLElement, current: number) {
-    const steps = ["Welcome", "Install", "Steam", "Done"];
+    const steps = ["Welcome", "Install Assets", "Steam", "Done"];
     const indicator = document.createElement("div");
     indicator.className = "setup-steps";
 
@@ -387,8 +387,8 @@ class App {
 
     body.innerHTML = `
       <div class="setup-section-header">
-        <h1>Install Dependencies</h1>
-        <p>MetalSharp needs a few system tools and runtimes. Install Homebrew first, then hit the button below.</p>
+        <h1>Install Assets</h1>
+        <p>MetalSharp needs game runtimes and translation layers. Install Homebrew first, then hit the button below.</p>
       </div>
       <div id="install-buttons" class="setup-install-buttons"></div>
       <div id="install-log-container" class="setup-install-log-container" style="display:none;">
@@ -428,7 +428,7 @@ class App {
       const depBtn = document.createElement("button");
       depBtn.className = "btn btn-secondary btn-lg setup-install-btn";
       depBtn.id = "btn-install-deps";
-      depBtn.innerHTML = `<span class="setup-install-btn-label">Install Dependencies</span><span class="setup-install-btn-desc">MetalSharp Wine, GPTK, Mono, DXVK, Wine, and more</span>`;
+      depBtn.innerHTML = `<span class="setup-install-btn-label">Install Assets</span><span class="setup-install-btn-desc">Game runtimes and translation layers</span>`;
       depBtn.style.opacity = "0.5";
       depBtn.style.pointerEvents = "none";
       buttonsDiv.appendChild(depBtn);
@@ -459,7 +459,7 @@ class App {
       const depBtn = document.createElement("button");
       depBtn.className = "btn btn-primary btn-lg setup-install-btn";
       depBtn.id = "btn-install-deps";
-      depBtn.innerHTML = `<span class="setup-install-btn-label">Install Dependencies</span><span class="setup-install-btn-desc">MetalSharp Wine, GPTK, Mono, DXVK, Wine, and more</span>`;
+      depBtn.innerHTML = `<span class="setup-install-btn-label">Install Assets</span><span class="setup-install-btn-desc">Game runtimes and translation layers</span>`;
       buttonsDiv.appendChild(depBtn);
 
       depBtn.addEventListener("click", () =>
@@ -508,6 +508,9 @@ class App {
 
     addLog("Starting installation...", "info");
 
+    let lastStep = -1;
+    let lastStatus = "";
+
     const pollInterval = setInterval(async () => {
       const progress = await this.api<{
         step: number;
@@ -523,11 +526,16 @@ class App {
       progressBar.style.width = `${pct}%`;
       progressLabel.textContent = `${pct}%`;
 
+      const stepChanged = progress.step !== lastStep;
+      const statusChanged = progress.status !== lastStatus;
+
       if (progress.status === "done" || progress.status === "skipped") {
-        if (progress.status === "done") {
-          addLog(`${progress.log}`, "success");
-        } else {
-          addLog(`${progress.log}`, "warn");
+        if (stepChanged || statusChanged) {
+          if (progress.status === "done") {
+            addLog(`${progress.log}`, "success");
+          } else {
+            addLog(`${progress.log}`, "warn");
+          }
         }
       } else if (progress.status === "error") {
         if (!logDiv.querySelector(`[data-error-step="${progress.step}"]`)) {
@@ -548,8 +556,7 @@ class App {
         }
         return;
       } else if (progress.status === "installing") {
-        const existing = logDiv.querySelector(`[data-step="${progress.step}"]`);
-        if (!existing) {
+        if (stepChanged) {
           const line = document.createElement("div");
           line.className = "setup-log-line active";
           line.dataset.step = String(progress.step);
@@ -558,16 +565,23 @@ class App {
           logDiv.scrollTop = logDiv.scrollHeight;
         }
       } else if (progress.status === "complete") {
-        addLog("All dependencies installed!", "success");
-        clearInterval(pollInterval);
-        progressBar.style.width = "100%";
-        progressLabel.textContent = "100%";
-        nextBtn.style.display = "inline-flex";
-        this.toast("All dependencies installed!", "success");
-        return;
+        if (statusChanged) {
+          addLog("All assets installed!", "success");
+          clearInterval(pollInterval);
+          progressBar.style.width = "100%";
+          progressLabel.textContent = "100%";
+          nextBtn.style.display = "inline-flex";
+          this.toast("All assets installed!", "success");
+          return;
+        }
       } else if (progress.status === "starting") {
-        addLog(progress.log, "info");
+        if (statusChanged) {
+          addLog(progress.log, "info");
+        }
       }
+
+      lastStep = progress.step;
+      lastStatus = progress.status;
     }, 500);
 
     setTimeout(() => clearInterval(pollInterval), 30 * 60 * 1000);


### PR DESCRIPTION
## Summary

Cleans up the Phase 2 install wizard step with simpler copy and fixes the live progress reporting.

### UI text changes
- "Install Dependencies" → **"Install Assets"** (step indicator, header, buttons)
- Button description: ~~"MetalSharp Wine, GPTK, Mono, DXVK, Wine, and more"~~ → **"Game runtimes and translation layers"**
- Completion message: ~~"All dependencies installed!"~~ → **"All assets installed!"**

### Backend step names
| Before | After |
|--------|-------|
| Rosetta 2 | Rosetta 2 |
| Xcode CLI Tools | **System Tools** |
| MetalSharp Bundle | **Runtime Assets** |
| Game Porting Toolkit | **Compatibility Layer** |
| Mono (arm64) | **Runtime Support** |

Step completion messages also simplified: ~~"Rosetta 2 already installed — skipping"~~ → **"Rosetta 2 ready"**

### Progress polling fix
The frontend was re-adding identical log lines on every 500ms poll because it only checked `data-step` existence for the `installing` status but not for `done`/`skipped`/`starting`/`complete`. Now tracks `lastStep` and `lastStatus` and only emits a log entry when the step or status actually changes.

## Test plan
- [x] `cargo build --release` passes
- [x] `cargo fmt` + `cargo clippy` pass
- [x] Rust CI passes
- [x] JS/TS CI passes