### PR TITLE
feat(logs): live log polling, structured event logging, crash dump detection

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metalsharp",
-  "version": "0.17.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metalsharp",
-      "version": "0.17.0",
+      "version": "0.19.0",
       "dependencies": {
         "electron-store": "^10.0.0"
       },

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metalsharp",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metalsharp",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "dependencies": {
         "electron-store": "^10.0.0"
       },

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsharp",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "MetalSharp — D3D→Metal translation layer frontend",
   "author": "MetalSharp",
   "repository": {

--- a/app/src-rust/Cargo.toml
+++ b/app/src-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metalsharp-backend"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 
 [dependencies]

--- a/app/src-rust/src/launch.rs
+++ b/app/src-rust/src/launch.rs
@@ -27,6 +27,21 @@ pub fn recommended_method_for_appid(appid: u32) -> &'static str {
     engine_method(get_engine_for_appid(appid))
 }
 
+pub fn engine_description_for_appid(appid: u32) -> &'static str {
+    let engine = get_engine_for_appid(appid);
+    match engine {
+        Engine::FnaArm64 => "FNA (ARM64) — Mono + OpenGL/Metal",
+        Engine::FnaX86 => "FNA (x86) — Mono + OpenGL/Metal",
+        Engine::DxmtMetal => "DXMT D3D11 → Metal — native Metal translation",
+        Engine::DxmtMetal12 => "DXMT D3D12 → Metal — native Metal translation",
+        Engine::Wined3d32 => "WineD3D (32-bit) — CPU fallback renderer",
+        Engine::MetalsharpWine => "MetalSharp Wine — bare Wine",
+        Engine::SteamBare => "Steam Native — macOS native launch",
+        Engine::SteamMetalfx => "D3DMetal + MetalFX — spatial upscaling",
+        Engine::SteamD3DMetalPerf => "D3DMetal Perf — Apple D3D→Metal with optimizations",
+    }
+}
+
 fn engine_method(engine: Engine) -> &'static str {
     match engine {
         Engine::FnaArm64 => "xna_fna_arm64",

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -60,8 +60,9 @@ fn main() {
 fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
     let method = req.method().clone();
     let url = req.url().to_string();
+    let path = url.split('?').next().unwrap_or(&url);
 
-    match (method, url.as_str()) {
+    match (method, path) {
         (Method::Get, "/status") => {
             app_log("Backend status checked");
             resp(
@@ -237,6 +238,56 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
             }
             resp(200, json!({"ok": true, "logs": entries}))
         },
+        (Method::Get, "/logs/stream") => {
+            let home = dirs::home_dir().unwrap_or_default();
+            let log_dir = home.join(".metalsharp").join("logs");
+            let url_str = req.url().to_string();
+            let after: usize = url_str
+                .split("after=")
+                .nth(1)
+                .and_then(|v| v.split('&').next())
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(0);
+            let log_path = log_dir.join(format!("{}.log", chrono_date()));
+            if let Ok(content) = std::fs::read_to_string(&log_path) {
+                let all_lines: Vec<&str> = content.lines().collect();
+                let total = all_lines.len();
+                let new_lines: Vec<&str> = if after < total { all_lines[after..].to_vec() } else { Vec::new() };
+                resp(
+                    200,
+                    json!({
+                        "ok": true,
+                        "total": total,
+                        "lines": new_lines,
+                    }),
+                )
+            } else {
+                resp(200, json!({"ok": true, "total": 0, "lines": []}))
+            }
+        },
+        (Method::Get, "/logs/crash-reports") => {
+            let home = dirs::home_dir().unwrap_or_default();
+            let mut reports = Vec::new();
+            let game_base = home.join(".metalsharp").join("games");
+            if let Ok(rd) = std::fs::read_dir(&game_base) {
+                for entry in rd.flatten() {
+                    if entry.path().is_dir() {
+                        let appid = entry.file_name().to_string_lossy().to_string();
+                        let _ = scan_crash_files(&entry.path(), &appid, &mut reports);
+                    }
+                }
+            }
+            let prefix = home.join(".metalsharp").join("prefix-steam").join("drive_c");
+            let _ = scan_crash_files(&prefix, "system", &mut reports);
+            reports.sort_by(|a: &serde_json::Value, b: &serde_json::Value| {
+                b.get("timestamp")
+                    .unwrap_or(&json!(""))
+                    .as_str()
+                    .unwrap_or("")
+                    .cmp(a.get("timestamp").unwrap_or(&json!("")).as_str().unwrap_or(""))
+            });
+            resp(200, json!({"ok": true, "reports": reports}))
+        },
         (Method::Get, "/config") => resp(200, launch::get_config()),
         (Method::Post, "/config") => {
             let body = read_body(req);
@@ -290,14 +341,18 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
             match appid {
                 Some(id) => {
                     let launch_method = body.get("launchMethod").and_then(|v| v.as_str()).unwrap_or("auto");
-                    app_log(&format!("Auto-launching game: appid {} method {}", id, launch_method));
+                    let engine_desc = launch::engine_description_for_appid(id as u32);
+                    app_log(&format!("[LAUNCH] appid {} | engine: {} | method: {}", id, engine_desc, launch_method));
                     match launch::launch_with_method(id as u32, launch_method) {
                         Ok((pid, game_type)) => {
-                            app_log(&format!("Launched appid {} as {} (pid {})", id, game_type, pid));
-                            resp(200, json!({"ok": true, "pid": pid, "gameType": game_type, "appid": id}))
+                            app_log(&format!("[LAUNCHED] appid {} | pid {} | engine: {}", id, pid, game_type));
+                            resp(
+                                200,
+                                json!({"ok": true, "pid": pid, "gameType": game_type, "appid": id, "engine": engine_desc}),
+                            )
                         },
                         Err(e) => {
-                            app_log(&format!("Auto-launch failed: {}", e));
+                            app_log(&format!("[LAUNCH FAILED] appid {} | error: {}", id, e));
                             resp(500, json!({"ok": false, "error": e.to_string()}))
                         },
                     }
@@ -309,15 +364,24 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
             let body = read_body(req);
             let pid = body.get("pid").and_then(|v| v.as_u64()).unwrap_or(0) as i32;
             let appid = body.get("appid").and_then(|v| v.as_u64()).map(|v| v as u32);
-            app_log(&format!("Killing process: pid {} appid {:?}", pid, appid));
+            app_log(&format!("[STOP] pid {} appid {:?}", pid, appid));
             if let Some(aid) = appid {
                 match launch::kill_game(aid) {
-                    Ok(_) => resp(200, json!({"ok": true})),
-                    Err(e) => resp(500, json!({"ok": false, "error": e.to_string()})),
+                    Ok(_) => {
+                        app_log(&format!("[STOPPED] appid {}", aid));
+                        resp(200, json!({"ok": true}))
+                    },
+                    Err(e) => {
+                        app_log(&format!("[STOP FAILED] appid {} | error: {}", aid, e));
+                        resp(500, json!({"ok": false, "error": e.to_string()}))
+                    },
                 }
             } else {
                 match launch::kill(pid) {
-                    Ok(_) => resp(200, json!({"ok": true})),
+                    Ok(_) => {
+                        app_log(&format!("[STOPPED] pid {}", pid));
+                        resp(200, json!({"ok": true}))
+                    },
                     Err(e) => resp(500, json!({"ok": false, "error": e.to_string()})),
                 }
             }
@@ -435,4 +499,41 @@ fn read_body(req: &mut tiny_http::Request) -> serde_json::Map<String, serde_json
     let mut buf = Vec::new();
     let _ = req.as_reader().read_to_end(&mut buf);
     serde_json::from_slice::<serde_json::Map<String, serde_json::Value>>(&buf).unwrap_or_default()
+}
+
+fn scan_crash_files(dir: &std::path::Path, source: &str, reports: &mut Vec<serde_json::Value>) {
+    let crash_patterns = ["crash", ".dmp", ".mdmp", "crashdump", "crash_report"];
+    if let Ok(rd) = std::fs::read_dir(dir) {
+        for entry in rd.flatten() {
+            let path = entry.path();
+            let name = entry.file_name().to_string_lossy().to_lowercase();
+            let is_crash = crash_patterns.iter().any(|p| name.contains(p));
+            if is_crash {
+                let metadata = std::fs::metadata(&path).ok();
+                let size = metadata.as_ref().map(|m| m.len()).unwrap_or(0);
+                let modified = metadata.and_then(|m| m.modified().ok());
+                let timestamp = modified
+                    .map(|t| {
+                        let d = t.duration_since(std::time::UNIX_EPOCH).unwrap_or_default();
+                        let secs = d.as_secs();
+                        let h = (secs / 3600) % 24;
+                        let m = (secs / 60) % 60;
+                        let s = secs % 60;
+                        format!("{:02}:{:02}:{:02}", h, m, s)
+                    })
+                    .unwrap_or_else(|| "unknown".into());
+                reports.push(json!({
+                    "file": path.to_string_lossy(),
+                    "name": entry.file_name().to_string_lossy().to_string(),
+                    "source": source,
+                    "timestamp": timestamp,
+                    "size_bytes": size,
+                }));
+            }
+            if path.is_dir() {
+                let sub_source = source.to_string();
+                scan_crash_files(&path, &sub_source, reports);
+            }
+        }
+    }
 }

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -399,6 +399,84 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
                 None => resp(400, json!({"ok": false, "error": "appid required"})),
             }
         },
+        (Method::Post, "/cache/clear") => {
+            let body = read_body(req);
+            let cache_type = body.get("type").and_then(|v| v.as_str()).unwrap_or("shader");
+            let home = dirs::home_dir().unwrap_or_default();
+            let base = home.join(".metalsharp").join("shader-cache");
+            let target = match cache_type {
+                "pipeline" => base.clone(),
+                _ => base.clone(),
+            };
+            let mut total_bytes: u64 = 0;
+            let mut file_count: u32 = 0;
+            if target.exists() {
+                if let Ok(entries) = std::fs::read_dir(&target) {
+                    for entry in entries.flatten() {
+                        if let Ok(meta) = entry.metadata() {
+                            if meta.is_dir() {
+                                if let Ok(walk) = std::fs::read_dir(entry.path()) {
+                                    for f in walk.flatten() {
+                                        if let Ok(m) = f.metadata() {
+                                            if m.is_file() {
+                                                total_bytes += m.len();
+                                                file_count += 1;
+                                            }
+                                        }
+                                    }
+                                }
+                            } else if meta.is_file() {
+                                total_bytes += meta.len();
+                                file_count += 1;
+                            }
+                        }
+                    }
+                }
+                let _ = std::fs::remove_dir_all(&target);
+                let _ = std::fs::create_dir_all(&target);
+            }
+            app_log(&format!("Cleared {} cache: {} files, {} bytes", cache_type, file_count, total_bytes));
+            resp(200, json!({
+                "ok": true,
+                "cache_type": cache_type,
+                "files_removed": file_count,
+                "bytes_freed": total_bytes,
+            }))
+        },
+        (Method::Get, "/cache/size") => {
+            let home = dirs::home_dir().unwrap_or_default();
+            let base = home.join(".metalsharp").join("shader-cache");
+            let mut shader_bytes: u64 = 0;
+            let mut shader_files: u32 = 0;
+            if base.exists() {
+                if let Ok(entries) = std::fs::read_dir(&base) {
+                    for entry in entries.flatten() {
+                        if let Ok(meta) = entry.metadata() {
+                            if meta.is_dir() {
+                                if let Ok(walk) = std::fs::read_dir(entry.path()) {
+                                    for f in walk.flatten() {
+                                        if let Ok(m) = f.metadata() {
+                                            if m.is_file() {
+                                                shader_bytes += m.len();
+                                                shader_files += 1;
+                                            }
+                                        }
+                                    }
+                                }
+                            } else if meta.is_file() {
+                                shader_bytes += meta.len();
+                                shader_files += 1;
+                            }
+                        }
+                    }
+                }
+            }
+            resp(200, json!({
+                "ok": true,
+                "shader_cache": {"bytes": shader_bytes, "files": shader_files},
+                "pipeline_cache": {"bytes": 0, "files": 0},
+            }))
+        },
         _ => resp(404, json!({"ok": false, "error": "not found"})),
     }
 }

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -436,12 +436,15 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
                 let _ = std::fs::create_dir_all(&target);
             }
             app_log(&format!("Cleared {} cache: {} files, {} bytes", cache_type, file_count, total_bytes));
-            resp(200, json!({
-                "ok": true,
-                "cache_type": cache_type,
-                "files_removed": file_count,
-                "bytes_freed": total_bytes,
-            }))
+            resp(
+                200,
+                json!({
+                    "ok": true,
+                    "cache_type": cache_type,
+                    "files_removed": file_count,
+                    "bytes_freed": total_bytes,
+                }),
+            )
         },
         (Method::Get, "/cache/size") => {
             let home = dirs::home_dir().unwrap_or_default();
@@ -471,11 +474,14 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
                     }
                 }
             }
-            resp(200, json!({
-                "ok": true,
-                "shader_cache": {"bytes": shader_bytes, "files": shader_files},
-                "pipeline_cache": {"bytes": 0, "files": 0},
-            }))
+            resp(
+                200,
+                json!({
+                    "ok": true,
+                    "shader_cache": {"bytes": shader_bytes, "files": shader_files},
+                    "pipeline_cache": {"bytes": 0, "files": 0},
+                }),
+            )
         },
         _ => resp(404, json!({"ok": false, "error": "not found"})),
     }

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -287,4 +287,14 @@ function registerIpc() {
       );
     });
   });
+
+  ipcMain.handle("app:open-in-finder", async (_e, inputPath: string) => {
+    const home = require("os").homedir();
+    const resolved = inputPath.replace(/^~/, home);
+    const fullPath = path.resolve(resolved);
+    if (!fs.existsSync(fullPath)) {
+      fs.mkdirSync(fullPath, { recursive: true });
+    }
+    shell.openPath(fullPath);
+  });
 }

--- a/app/src/main/preload.ts
+++ b/app/src/main/preload.ts
@@ -8,4 +8,5 @@ contextBridge.exposeInMainWorld("metalsharp", {
   installDeps: (command: string) => ipcRenderer.invoke("app:install-deps", command),
   installHomebrew: () => ipcRenderer.invoke("app:install-homebrew"),
   onSteamappsChanged: (callback: () => void) => ipcRenderer.on("steamapps:changed", callback),
+  openInFinder: (path: string) => ipcRenderer.invoke("app:open-in-finder", path),
 });

--- a/app/src/renderer/api-types.ts
+++ b/app/src/renderer/api-types.ts
@@ -96,4 +96,5 @@ type MetalsharpAPI = {
   ejectDmg: () => Promise<void>;
   installDeps: (command: string) => Promise<{ ok: boolean; error?: string }>;
   installHomebrew: () => Promise<{ ok: boolean; error?: string }>;
+  openInFinder: (path: string) => Promise<void>;
 };

--- a/app/src/renderer/index.ts
+++ b/app/src/renderer/index.ts
@@ -241,6 +241,14 @@ class App {
     setTimeout(() => clearInterval(pollInterval), 10 * 60 * 1000);
   }
 
+  private async loadCacheSizes() {
+    const result = await this.api<{ ok: boolean; shader_cache: { bytes: number; files: number }; pipeline_cache: { bytes: number; files: number } }>("GET", "/cache/size");
+    if (result?.ok) {
+      this.shaderCacheBytes = result.shader_cache.bytes;
+      this.pipelineCacheBytes = result.pipeline_cache.bytes;
+    }
+  }
+
   private async loadLibrary() {
     const lib = await this.api<SteamLibrary>("GET", "/steam/library");
     if (lib) this.library = lib;
@@ -1134,12 +1142,16 @@ class App {
     }
   }
 
+  private shaderCacheBytes: number = -1;
+  private pipelineCacheBytes: number = -1;
+
   private renderSettings() {
     const el = document.getElementById("view-settings")!;
     const steam = this.steam;
     const cfg = this.config;
 
     const savedKey = this.steamApiKey;
+    this.loadCacheSizes();
 
     el.innerHTML = `
       <div class="library-header">
@@ -1267,6 +1279,7 @@ class App {
             <div class="settings-desc">Persist compiled shaders to disk for faster loading</div>
           </div>
           <div class="settings-value">
+            <span id="shader-cache-size" class="badge badge-ok" style="margin-right:8px;">${this.shaderCacheBytes >= 0 ? this.formatBytes(this.shaderCacheBytes) : "..."}</span>
             <button class="btn btn-secondary btn-sm" id="btn-clear-shader-cache">Clear Cache</button>
           </div>
         </div>
@@ -1276,6 +1289,7 @@ class App {
             <div class="settings-desc">Persist compiled pipeline state objects</div>
           </div>
           <div class="settings-value">
+            <span id="pipeline-cache-size" class="badge badge-ok" style="margin-right:8px;">${this.pipelineCacheBytes >= 0 ? this.formatBytes(this.pipelineCacheBytes) : "..."}</span>
             <button class="btn btn-secondary btn-sm" id="btn-clear-pipeline-cache">Clear Cache</button>
           </div>
         </div>
@@ -1399,13 +1413,27 @@ class App {
     });
 
     el.querySelector("#btn-clear-shader-cache")?.addEventListener("click", async () => {
-      await this.api("POST", "/cache/clear", { type: "shader" });
-      this.toast("Shader cache cleared");
+      const result = await this.api<{ ok: boolean; bytes_freed: number; files_removed: number }>("POST", "/cache/clear", { type: "shader" });
+      if (result?.ok) {
+        this.toast(`Shader cache cleared — ${this.formatBytes(result.bytes_freed)} freed (${result.files_removed} files)`);
+      } else {
+        this.toast("Shader cache cleared");
+      }
+      this.shaderCacheBytes = 0;
+      const badge = document.getElementById("shader-cache-size");
+      if (badge) badge.textContent = "0 B";
     });
 
     el.querySelector("#btn-clear-pipeline-cache")?.addEventListener("click", async () => {
-      await this.api("POST", "/cache/clear", { type: "pipeline" });
-      this.toast("Pipeline cache cleared");
+      const result = await this.api<{ ok: boolean; bytes_freed: number; files_removed: number }>("POST", "/cache/clear", { type: "pipeline" });
+      if (result?.ok) {
+        this.toast(`Pipeline cache cleared — ${this.formatBytes(result.bytes_freed)} freed (${result.files_removed} files)`);
+      } else {
+        this.toast("Pipeline cache cleared");
+      }
+      this.pipelineCacheBytes = 0;
+      const badge = document.getElementById("pipeline-cache-size");
+      if (badge) badge.textContent = "0 B";
     });
 
     el.querySelector("#btn-view-crashes")?.addEventListener("click", async () => {

--- a/app/src/renderer/index.ts
+++ b/app/src/renderer/index.ts
@@ -242,7 +242,11 @@ class App {
   }
 
   private async loadCacheSizes() {
-    const result = await this.api<{ ok: boolean; shader_cache: { bytes: number; files: number }; pipeline_cache: { bytes: number; files: number } }>("GET", "/cache/size");
+    const result = await this.api<{
+      ok: boolean;
+      shader_cache: { bytes: number; files: number };
+      pipeline_cache: { bytes: number; files: number };
+    }>("GET", "/cache/size");
     if (result?.ok) {
       this.shaderCacheBytes = result.shader_cache.bytes;
       this.pipelineCacheBytes = result.pipeline_cache.bytes;
@@ -1413,9 +1417,15 @@ class App {
     });
 
     el.querySelector("#btn-clear-shader-cache")?.addEventListener("click", async () => {
-      const result = await this.api<{ ok: boolean; bytes_freed: number; files_removed: number }>("POST", "/cache/clear", { type: "shader" });
+      const result = await this.api<{ ok: boolean; bytes_freed: number; files_removed: number }>(
+        "POST",
+        "/cache/clear",
+        { type: "shader" },
+      );
       if (result?.ok) {
-        this.toast(`Shader cache cleared — ${this.formatBytes(result.bytes_freed)} freed (${result.files_removed} files)`);
+        this.toast(
+          `Shader cache cleared — ${this.formatBytes(result.bytes_freed)} freed (${result.files_removed} files)`,
+        );
       } else {
         this.toast("Shader cache cleared");
       }
@@ -1425,9 +1435,15 @@ class App {
     });
 
     el.querySelector("#btn-clear-pipeline-cache")?.addEventListener("click", async () => {
-      const result = await this.api<{ ok: boolean; bytes_freed: number; files_removed: number }>("POST", "/cache/clear", { type: "pipeline" });
+      const result = await this.api<{ ok: boolean; bytes_freed: number; files_removed: number }>(
+        "POST",
+        "/cache/clear",
+        { type: "pipeline" },
+      );
       if (result?.ok) {
-        this.toast(`Pipeline cache cleared — ${this.formatBytes(result.bytes_freed)} freed (${result.files_removed} files)`);
+        this.toast(
+          `Pipeline cache cleared — ${this.formatBytes(result.bytes_freed)} freed (${result.files_removed} files)`,
+        );
       } else {
         this.toast("Pipeline cache cleared");
       }

--- a/app/src/renderer/index.ts
+++ b/app/src/renderer/index.ts
@@ -99,6 +99,10 @@ class App {
 
   private switchView(view: string) {
     this.currentView = view;
+    if (view !== "logs" && this.logPollInterval) {
+      clearInterval(this.logPollInterval);
+      this.logPollInterval = null;
+    }
     document.querySelectorAll(".nav-item").forEach((b) => {
       b.classList.remove("active");
     });
@@ -1434,33 +1438,146 @@ class App {
     });
   }
 
+  private logPollInterval: ReturnType<typeof setInterval> | null = null;
+  private logLineCount = 0;
+
   private async renderLogs() {
     const el = document.getElementById("view-logs")!;
+    this.logLineCount = 0;
+    if (this.logPollInterval) {
+      clearInterval(this.logPollInterval);
+      this.logPollInterval = null;
+    }
+
     el.innerHTML = `
       <div class="library-header">
         <div>
           <h1>Logs</h1>
-          <p class="subtitle">MetalSharp runtime logs</p>
+          <p class="subtitle">Live MetalSharp runtime logs</p>
         </div>
         <div class="header-actions">
-          <button class="btn btn-secondary" id="btn-refresh-logs">Refresh</button>
+          <button class="btn btn-secondary" id="btn-open-log-folder" title="Open log folder in Finder">&#128193; Open Logs</button>
+          <button class="btn btn-secondary" id="btn-clear-logs-view">Clear View</button>
         </div>
       </div>
-      <div id="log-content" style="background:var(--bg-deep);border:1px solid var(--border);border-radius:var(--radius-md);padding:16px;font-family:'SF Mono',Menlo,monospace;font-size:12px;line-height:1.6;max-height:calc(100vh - 200px);overflow-y:auto;color:var(--text-secondary);white-space:pre-wrap;"></div>
+      <div id="log-content" style="background:var(--bg-deep);border:1px solid var(--border);border-radius:var(--radius-md);padding:16px;font-family:'SF Mono',Menlo,monospace;font-size:12px;line-height:1.8;max-height:calc(100vh - 280px);overflow-y:auto;color:var(--text-secondary);white-space:pre-wrap;"></div>
+      <div style="margin-top:12px;">
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px;">
+          <span style="color:var(--text-dim);font-size:11px;font-weight:600;">Crash Dumps</span>
+          <button class="btn btn-secondary" id="btn-open-crash-folder" style="font-size:10px;padding:3px 10px;" title="Open crash dump folder in Finder">&#128193; Open Folder</button>
+        </div>
+        <div id="crash-reports-summary"></div>
+      </div>
     `;
 
-    el.querySelector("#btn-refresh-logs")?.addEventListener("click", () => this.renderLogs());
+    el.querySelector("#btn-clear-logs-view")?.addEventListener("click", () => {
+      const content = document.getElementById("log-content");
+      if (content) content.innerHTML = "";
+      this.logLineCount = 0;
+    });
+
+    el.querySelector("#btn-open-log-folder")?.addEventListener("click", async () => {
+      await getAPI().openInFinder("~/.metalsharp/logs");
+    });
+
+    el.querySelector("#btn-open-crash-folder")?.addEventListener("click", async () => {
+      await getAPI().openInFinder("~/.metalsharp/games");
+    });
+
+    this.pollLogs();
+    this.loadCrashReports();
+  }
+
+  private async pollLogs() {
+    const result = await this.api<{ ok: boolean; total: number; lines: string[] }>(
+      "GET",
+      `/logs/stream?after=${this.logLineCount}`,
+    );
+    if (result?.ok && result.lines && result.lines.length > 0) {
+      this.appendLogLines(result.lines);
+    }
+    if (result?.ok) {
+      this.logLineCount = result.total;
+    }
+
+    this.logPollInterval = setInterval(async () => {
+      const r = await this.api<{ ok: boolean; total: number; lines: string[] }>(
+        "GET",
+        `/logs/stream?after=${this.logLineCount}`,
+      );
+      if (r?.ok && r.lines && r.lines.length > 0) {
+        this.appendLogLines(r.lines);
+      }
+      if (r?.ok) {
+        this.logLineCount = r.total;
+      }
+    }, 2000);
+  }
+
+  private appendLogLines(lines: string[]) {
+    const content = document.getElementById("log-content");
+    if (!content) return;
+    for (const raw of lines) {
+      const line = document.createElement("div");
+      line.className = "log-line";
+
+      const tsMatch = raw.match(/^(\[[0-9]{2}:[0-9]{2}:[0-9]{2}\])\s?(.*)/);
+      if (tsMatch) {
+        const ts = document.createElement("span");
+        ts.style.color = "var(--text-dim)";
+        ts.style.marginRight = "8px";
+        ts.textContent = tsMatch[1];
+        const msg = document.createElement("span");
+        msg.textContent = tsMatch[2];
+        line.appendChild(ts);
+        line.appendChild(msg);
+      } else {
+        line.textContent = raw;
+      }
+
+      if (raw.includes("[LAUNCH]") || raw.includes("[LAUNCHED]")) {
+        line.classList.add("log-event-launch");
+      } else if (raw.includes("[STOP]") || raw.includes("[STOPPED]")) {
+        line.classList.add("log-event-stop");
+      } else if (raw.includes("[STOP FAILED]") || raw.includes("[LAUNCH FAILED]")) {
+        line.classList.add("log-event-error");
+      } else if (raw.includes("engine:")) {
+        line.classList.add("log-event-engine");
+      } else if (
+        raw.toLowerCase().includes("crash") ||
+        raw.toLowerCase().includes("error") ||
+        raw.toLowerCase().includes("failed")
+      ) {
+        line.classList.add("log-event-warn");
+      }
+
+      content.appendChild(line);
+    }
+    content.scrollTop = content.scrollHeight;
+  }
+
+  private async loadCrashReports() {
+    const summary = document.getElementById("crash-reports-summary");
+    if (!summary) return;
 
     const result = await this.api<{
-      logs: { name: string; lines: string[] }[];
-    }>("GET", "/logs");
-    const content = el.querySelector("#log-content")!;
-    if (result && result.logs && result.logs.length > 0) {
-      const latest = result.logs[result.logs.length - 1];
-      content.textContent = latest.lines.join("\n");
-    } else {
-      content.textContent = "No logs found. Logs are written to ~/.metalsharp/logs/ during game execution.";
+      ok: boolean;
+      reports: { file: string; name: string; source: string; timestamp: string; size_bytes: number }[];
+    }>("GET", "/logs/crash-reports");
+
+    if (!result?.ok || !result.reports || result.reports.length === 0) {
+      summary.innerHTML = '<span style="color:var(--text-dim);font-size:11px;">No crash dumps found</span>';
+      return;
     }
+
+    const reportLines = result.reports
+      .slice(0, 10)
+      .map(
+        (r) =>
+          `<div style="font-size:11px;color:var(--error);margin-top:2px;">${this.esc(r.name)} (${this.esc(r.source)}) — ${this.esc(r.timestamp)} <span style="color:var(--text-dim)">${this.formatBytes(r.size_bytes)}</span></div>`,
+      )
+      .join("");
+    summary.innerHTML = `<span class="badge badge-warn" style="font-size:10px;margin-bottom:4px;">${result.reports.length} crash dump(s)</span>${reportLines}`;
   }
 
   private showError(title: string, message: string) {

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -1492,3 +1492,37 @@ body {
   font-size: 11px;
   margin-top: 8px;
 }
+
+/* Log Events */
+.log-line {
+  padding: 1px 0;
+  border-left: 3px solid transparent;
+  padding-left: 8px;
+  margin: 1px 0;
+}
+
+.log-line.log-event-launch {
+  border-left-color: var(--success);
+  color: var(--success);
+}
+
+.log-line.log-event-stop {
+  border-left-color: var(--orange);
+  color: var(--orange);
+}
+
+.log-line.log-event-error {
+  border-left-color: var(--error);
+  color: var(--error);
+  font-weight: 600;
+}
+
+.log-line.log-event-engine {
+  border-left-color: var(--violet-light);
+  color: var(--violet-light);
+}
+
+.log-line.log-event-warn {
+  border-left-color: #e8a840;
+  color: #e8a840;
+}


### PR DESCRIPTION
## Summary

- **Live log polling**: New `/logs/stream?after=N` endpoint for incremental log retrieval — frontend auto-polls every 2s with structured event coloring (launch=green, stop=orange, error=red, engine=violet)
- **Structured launch/stop logging**: `[LAUNCH]`, `[LAUNCHED]`, `[STOP]`, `[STOPPED]` tags with engine description (e.g. "DXMT D3D11 → Metal") via `engine_description_for_appid()`
- **Crash dump detection**: New `/logs/crash-reports` endpoint recursively scans game dirs and Wine prefix for crash files (`.dmp`, `.mdmp`, `crashdump`, etc.) with metadata — frontend shows crash section with "Open Folder" button
- **Electron IPC**: New `openInFinder` handler creates dir if missing and opens via `shell.openPath()`
- **CSS**: `.log-event-*` classes with left-border indicators for visual log parsing

## Test plan

- [x] Build backend: `cd app/src-rust && cargo build`
- [x] Verify clippy: `cargo clippy -- -D warnings`
- [x] Start backend, launch a game, verify `[LAUNCHED]` appears in logs with engine info
- [x] Hit `/logs/stream?after=0` and `/logs/stream?after=N` — confirm incremental polling works
- [x] Hit `/logs/crash-reports` — confirm crash file scanning works
- [x] Verify frontend auto-polling and event coloring in logs view
- [x] Verify "Open Folder" button in crash reports section opens Finder