### PR TITLE
chore: bump version to 0.21.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsharp",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "MetalSharp — D3D→Metal translation layer frontend",
   "author": "MetalSharp",
   "repository": {

--- a/app/src-rust/Cargo.toml
+++ b/app/src-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metalsharp-backend"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 
 [dependencies]

--- a/tools/dmg/build-dmg.sh
+++ b/tools/dmg/build-dmg.sh
@@ -7,6 +7,7 @@ APP_DIR="$PROJECT_DIR/app"
 BUILD_DIR="$PROJECT_DIR/dist/electron"
 DMG_OUTPUT="$PROJECT_DIR/dist/MetalSharp.dmg"
 RUNTIME_DIR="$PROJECT_DIR/src/fna"
+VER=$(grep '"version"' "$APP_DIR/package.json" | head -1 | sed 's/.*: *"//;s/".*//')
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -72,12 +73,12 @@ npm run build 2>&1 | tail -5
 info "Packaging with electron-builder..."
 npx electron-builder --mac dmg --arm64 2>&1 | tail -10
 
-if [[ -f "$BUILD_DIR/MetalSharp-0.17.0-arm64.dmg" ]]; then
-    cp "$BUILD_DIR/MetalSharp-0.17.0-arm64.dmg" "$DMG_OUTPUT"
+if [[ -f "$BUILD_DIR/MetalSharp-${VER}-arm64.dmg" ]]; then
+    cp "$BUILD_DIR/MetalSharp-${VER}-arm64.dmg" "$DMG_OUTPUT"
     ok "DMG created: $DMG_OUTPUT"
     info "Size: $(du -sh "$DMG_OUTPUT" | cut -f1)"
-elif [[ -f "$BUILD_DIR/MetalSharp-0.17.0.dmg" ]]; then
-    cp "$BUILD_DIR/MetalSharp-0.17.0.dmg" "$DMG_OUTPUT"
+elif [[ -f "$BUILD_DIR/MetalSharp-${VER}.dmg" ]]; then
+    cp "$BUILD_DIR/MetalSharp-${VER}.dmg" "$DMG_OUTPUT"
     ok "DMG created: $DMG_OUTPUT"
     info "Size: $(du -sh "$DMG_OUTPUT" | cut -f1)"
 else


### PR DESCRIPTION
Version bump for v0.21.0 release. Also fixes DMG build script to derive version from package.json instead of hardcoding.