### PR TITLE
chore: bump backend version to 0.22.1

### DIFF
--- a/app/src-rust/Cargo.lock
+++ b/app/src-rust/Cargo.lock
@@ -28,9 +28,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -390,7 +390,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metalsharp-backend"
-version = "0.21.0"
+version = "0.22.1"
 dependencies = [
  "dirs",
  "serde",

--- a/app/src-rust/Cargo.toml
+++ b/app/src-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metalsharp-backend"
-version = "0.22.0"
+version = "0.22.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Bump `Cargo.toml` version from `0.22.0` → `0.22.1` to match the `v0.22.1` release tag
- Regenerate `Cargo.lock` — previous lock was stale at `0.21.0`, meaning the DMG never shipped a rebuilt backend binary