### PR TITLE
chore: bump version to 0.22.2

### DIFF
--- a/app/src-rust/Cargo.toml
+++ b/app/src-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metalsharp-backend"
-version = "0.22.1"
+version = "0.22.2"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Bump backend version to 0.22.2 for DMG release with updated deps.