### PR TITLE
fix: Undertale crashes on launch — route through Steam instead of direct exe

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metalsharp",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metalsharp",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "dependencies": {
         "electron-store": "^10.0.0"
       },

--- a/app/src-rust/Cargo.lock
+++ b/app/src-rust/Cargo.lock
@@ -390,7 +390,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metalsharp-backend"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "dirs",
  "serde",

--- a/app/src-rust/src/launch.rs
+++ b/app/src-rust/src/launch.rs
@@ -330,9 +330,16 @@ pub fn launch_with_method(appid: u32, method: &str) -> Result<(u32, &'static str
         },
         _ => {
             let known = [
-                "dxmt_metal", "dxmt_metal12", "wined3d_32", "dxvk_metal32",
-                "metalsharp_wine", "steam", "steam_metalfx", "steam_d3dmetal_perf",
-                "xna_fna_arm64", "xna_fna_x86",
+                "dxmt_metal",
+                "dxmt_metal12",
+                "wined3d_32",
+                "dxvk_metal32",
+                "metalsharp_wine",
+                "steam",
+                "steam_metalfx",
+                "steam_d3dmetal_perf",
+                "xna_fna_arm64",
+                "xna_fna_x86",
             ];
             if known.contains(&method) {
                 return launch_auto(appid);
@@ -561,7 +568,10 @@ fn launch_wined3d_32(exe_path: &str, game_dir: &PathBuf) -> Result<u32, Box<dyn 
         .env("WINEDEBUG", "-all")
         .env("WINEDLLOVERRIDES", "dxgi,d3d11=b;gameoverlayrenderer,gameoverlayrenderer64=d;steamclient64,steamclient=d")
         .env("SteamOverlayDisabled", "1")
-        .env("DYLD_FALLBACK_LIBRARY_PATH", ms_root.join("lib").join("wine").join("x86_64-unix").to_string_lossy().to_string())
+        .env(
+            "DYLD_FALLBACK_LIBRARY_PATH",
+            ms_root.join("lib").join("wine").join("x86_64-unix").to_string_lossy().to_string(),
+        )
         .arg(&exe_name)
         .spawn()?;
 

--- a/app/src-rust/src/launch.rs
+++ b/app/src-rust/src/launch.rs
@@ -65,7 +65,8 @@ fn get_engine_for_appid(appid: u32) -> Engine {
         504230 => Engine::SteamD3DMetalPerf,
         265930 | 620 => Engine::DxvkMetal32,
         312520 | 375520 | 848450 => Engine::DxmtMetal,
-        535520 | 391540 => Engine::Wined3d32,
+        535520 => Engine::Wined3d32,
+        391540 => Engine::SteamBare,
 
         2050650 | 1583230 => Engine::SteamD3DMetalPerf,
         3164500 => Engine::DxmtMetal,
@@ -327,7 +328,17 @@ pub fn launch_with_method(appid: u32, method: &str) -> Result<(u32, &'static str
             )?;
             Ok((pid, "native_metalfx_high"))
         },
-        _ => Err(format!("Unknown launch method: {}", method).into()),
+        _ => {
+            let known = [
+                "dxmt_metal", "dxmt_metal12", "wined3d_32", "dxvk_metal32",
+                "metalsharp_wine", "steam", "steam_metalfx", "steam_d3dmetal_perf",
+                "xna_fna_arm64", "xna_fna_x86",
+            ];
+            if known.contains(&method) {
+                return launch_auto(appid);
+            }
+            Err(format!("Unknown launch method: {}", method).into())
+        },
     }
 }
 
@@ -548,11 +559,9 @@ fn launch_wined3d_32(exe_path: &str, game_dir: &PathBuf) -> Result<u32, Box<dyn 
         .current_dir(game_dir)
         .env("WINEPREFIX", &prefix_str)
         .env("WINEDEBUG", "-all")
-        .env("WINEDLLOVERRIDES", "dxgi,d3d11=b;gameoverlayrenderer,gameoverlayrenderer64=d")
-        .env(
-            "DYLD_FALLBACK_LIBRARY_PATH",
-            ms_root.join("lib").join("wine").join("x86_64-unix").to_string_lossy().to_string(),
-        )
+        .env("WINEDLLOVERRIDES", "dxgi,d3d11=b;gameoverlayrenderer,gameoverlayrenderer64=d;steamclient64,steamclient=d")
+        .env("SteamOverlayDisabled", "1")
+        .env("DYLD_FALLBACK_LIBRARY_PATH", ms_root.join("lib").join("wine").join("x86_64-unix").to_string_lossy().to_string())
         .arg(&exe_name)
         .spawn()?;
 

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -69,7 +69,8 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
                 200,
                 json!({
                     "ok": true,
-                    "version": env!("CARGO_PKG_VERSION")
+                    "version": env!("CARGO_PKG_VERSION"),
+                    "pid": std::process::id(),
                 }),
             )
         },

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -297,4 +297,12 @@ function registerIpc() {
     }
     shell.openPath(fullPath);
   });
+
+  ipcMain.handle("backend:restart", async () => {
+    return bridge.restart();
+  });
+
+  ipcMain.handle("backend:is-alive", async () => {
+    return bridge.isAlive();
+  });
 }

--- a/app/src/main/preload.ts
+++ b/app/src/main/preload.ts
@@ -9,4 +9,6 @@ contextBridge.exposeInMainWorld("metalsharp", {
   installHomebrew: () => ipcRenderer.invoke("app:install-homebrew"),
   onSteamappsChanged: (callback: () => void) => ipcRenderer.on("steamapps:changed", callback),
   openInFinder: (path: string) => ipcRenderer.invoke("app:open-in-finder", path),
+  restartBackend: () => ipcRenderer.invoke("backend:restart"),
+  isBackendAlive: () => ipcRenderer.invoke("backend:is-alive"),
 });

--- a/app/src/main/rust-bridge.ts
+++ b/app/src/main/rust-bridge.ts
@@ -1,7 +1,7 @@
 import { type ChildProcess, spawn } from "child_process";
+import * as fs from "fs";
 import * as http from "http";
 import * as path from "path";
-import * as fs from "fs";
 
 function getShellPath(): string {
   const home = process.env.HOME || "";

--- a/app/src/main/rust-bridge.ts
+++ b/app/src/main/rust-bridge.ts
@@ -1,6 +1,7 @@
 import { type ChildProcess, spawn } from "child_process";
 import * as http from "http";
 import * as path from "path";
+import * as fs from "fs";
 
 function getShellPath(): string {
   const home = process.env.HOME || "";
@@ -37,28 +38,56 @@ export class RustBridge {
       return;
     }
 
-    this.proc = spawn(binPath, [], {
-      env: {
-        ...process.env,
-        PATH: shellPath,
-        METALSHARP_PORT: String(this.port),
-      },
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    const needsRestart = await this.shouldRestart(binPath);
+    if (needsRestart) {
+      console.log("Backend version mismatch or not running — restarting...");
+      this.killExisting();
+      await new Promise((r) => setTimeout(r, 500));
+    } else if (await this.isAlive()) {
+      console.log("Backend already running and up to date");
+      return;
+    }
 
-    this.proc.stdout?.on("data", (d: Buffer) => process.stdout.write(d));
-    this.proc.stderr?.on("data", (d: Buffer) => process.stderr.write(d));
-
-    this.proc.on("exit", (code) => {
-      console.log(`metalsharp-backend exited with code ${code}`);
-    });
-
+    this.spawnBackend(binPath);
     await this.waitForReady();
+  }
+
+  async restart(): Promise<{ ok: boolean; error?: string }> {
+    const binPath = this.findBinary();
+    if (!binPath) {
+      return { ok: false, error: "Backend binary not found" };
+    }
+
+    this.stop();
+    this.killExisting();
+    await new Promise((r) => setTimeout(r, 500));
+
+    try {
+      this.spawnBackend(binPath);
+      await this.waitForReady(10000);
+      return { ok: true };
+    } catch (e) {
+      return { ok: false, error: (e as Error).message };
+    }
   }
 
   stop() {
     this.proc?.kill();
     this.proc = null;
+  }
+
+  async isAlive(): Promise<boolean> {
+    return new Promise((resolve) => {
+      const req = http.get(`http://127.0.0.1:${this.port}/status`, (res) => {
+        res.resume();
+        resolve(true);
+      });
+      req.on("error", () => resolve(false));
+      req.setTimeout(1500, () => {
+        req.destroy();
+        resolve(false);
+      });
+    });
   }
 
   async request(method: string, url: string, body?: Record<string, unknown>, timeoutMs?: number): Promise<unknown> {
@@ -99,6 +128,85 @@ export class RustBridge {
     });
   }
 
+  private spawnBackend(binPath: string) {
+    this.proc = spawn(binPath, [], {
+      env: {
+        ...process.env,
+        PATH: shellPath,
+        METALSHARP_PORT: String(this.port),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    this.proc.stdout?.on("data", (d: Buffer) => process.stdout.write(d));
+    this.proc.stderr?.on("data", (d: Buffer) => process.stderr.write(d));
+
+    this.proc.on("exit", (code) => {
+      console.log(`metalsharp-backend exited with code ${code}`);
+      this.proc = null;
+    });
+  }
+
+  private async shouldRestart(binPath: string): Promise<boolean> {
+    if (!(await this.isAlive())) return true;
+
+    try {
+      const binStat = fs.statSync(binPath);
+      const runningPid = await this.getBackendPid();
+      if (!runningPid) return false;
+
+      const runningPath = await this.getProcessPath(runningPid);
+      if (runningPath && runningPath !== binPath) return true;
+
+      const runningMtime = runningPath ? fs.statSync(runningPath).mtimeMs : 0;
+      if (binStat.mtimeMs > runningMtime + 1000) return true;
+    } catch {}
+
+    return false;
+  }
+
+  private async getBackendPid(): Promise<number | null> {
+    return new Promise((resolve) => {
+      const req = http.get(`http://127.0.0.1:${this.port}/status`, (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => {
+          try {
+            const data = JSON.parse(Buffer.concat(chunks).toString());
+            resolve(data.pid ?? null);
+          } catch {
+            resolve(null);
+          }
+        });
+      });
+      req.on("error", () => resolve(null));
+      req.setTimeout(1500, () => {
+        req.destroy();
+        resolve(null);
+      });
+    });
+  }
+
+  private async getProcessPath(pid: number): Promise<string | null> {
+    return new Promise((resolve) => {
+      const { exec } = require("child_process");
+      exec(`ps -o comm= -p ${pid} 2>/dev/null`, (err: Error | null, stdout: string) => {
+        if (err || !stdout.trim()) {
+          resolve(null);
+        } else {
+          resolve(stdout.trim());
+        }
+      });
+    });
+  }
+
+  private killExisting() {
+    const { execSync } = require("child_process");
+    try {
+      execSync("pkill -x metalsharp-backend 2>/dev/null", { stdio: "ignore" });
+    } catch {}
+  }
+
   private findBinary(): string | null {
     const candidates = [
       path.join(process.resourcesPath || "", "metalsharp-backend"),
@@ -109,7 +217,7 @@ export class RustBridge {
 
     for (const c of candidates) {
       try {
-        require("fs").accessSync(c);
+        fs.accessSync(c);
         return c;
       } catch {}
     }

--- a/app/src/renderer/api-types.ts
+++ b/app/src/renderer/api-types.ts
@@ -97,4 +97,6 @@ type MetalsharpAPI = {
   installDeps: (command: string) => Promise<{ ok: boolean; error?: string }>;
   installHomebrew: () => Promise<{ ok: boolean; error?: string }>;
   openInFinder: (path: string) => Promise<void>;
+  restartBackend: () => Promise<{ ok: boolean; error?: string }>;
+  isBackendAlive: () => Promise<boolean>;
 };

--- a/app/src/renderer/index.ts
+++ b/app/src/renderer/index.ts
@@ -1006,8 +1006,7 @@ class App {
     if (appid === 105600) return "xna_fna_arm64";
     if (appid === 504230) return "xna_fna_x86";
     if (appid === 375520) return "gptk_wine";
-    if (appid === 535520) return "metalsharp_wine";
-    if (appid === 391540) return "metalsharp_wine";
+    if (appid === 535520 || appid === 391540) return "auto";
     if ([945360, 1139900, 2050650].includes(appid)) return "steam";
     if ([1245620, 814380, 1593500].includes(appid)) return "steam_metalfx";
     return "steam_d3dmetal_perf";

--- a/app/src/renderer/index.ts
+++ b/app/src/renderer/index.ts
@@ -45,6 +45,9 @@ class App {
   private setupState: SetupState | null = null;
   private setupStep = 0;
   private setupDeviceName = "";
+  private backendConnected: boolean = false;
+  private backendVersion: string | null = null;
+  private healthPollInterval: ReturnType<typeof setInterval> | null = null;
 
   async init() {
     this.initTheme();
@@ -63,6 +66,7 @@ class App {
     const setupState = await this.api<{ deviceName?: string }>("GET", "/setup/state");
     if (setupState?.deviceName) this.setupDeviceName = setupState.deviceName;
     await this.loadLibrary();
+    this.startHealthPolling();
   }
 
   private bindNav() {
@@ -89,12 +93,62 @@ class App {
     this.updateThemeToggle();
   }
 
-  private updateThemeToggle() {
+  private async updateThemeToggle() {
     const btn = document.getElementById("btn-theme");
     if (!btn) return;
     const next = this.theme === "dark" ? "light" : "dark";
     btn.textContent = this.theme === "dark" ? "Light Mode" : "Dark Mode";
     btn.setAttribute("title", `Toggle ${next} mode`);
+  }
+
+  private startHealthPolling() {
+    if (this.healthPollInterval) clearInterval(this.healthPollInterval);
+    this.pollBackendHealth();
+    this.healthPollInterval = setInterval(() => this.pollBackendHealth(), 120000);
+  }
+
+  private async pollBackendHealth() {
+    const prev = this.backendConnected;
+    const alive = await getAPI().isBackendAlive();
+    this.backendConnected = alive;
+
+    if (alive) {
+      try {
+        const status = await this.api<{ ok?: boolean; version?: string }>("GET", "/status");
+        if (status?.version) this.backendVersion = status.version;
+      } catch {}
+    } else {
+      this.backendVersion = null;
+    }
+
+    this.renderBackendStatusDot();
+
+    if (prev && !alive) {
+      this.toast("Backend connection lost", "error");
+    } else if (!prev && alive) {
+      this.toast("Backend connected", "success");
+    }
+  }
+
+  private renderBackendStatusDot() {
+    const dot = document.getElementById("backend-status");
+    const text = document.getElementById("backend-status-text");
+    if (dot) {
+      dot.classList.remove("connected", "error");
+      dot.classList.add(this.backendConnected ? "connected" : "error");
+    }
+    if (text) {
+      text.textContent = this.backendConnected
+        ? `Connected${this.backendVersion ? ` — v${this.backendVersion}` : ""}`
+        : "Offline";
+    }
+
+    const headerDot = document.getElementById("backend-status-header");
+    if (headerDot) {
+      headerDot.classList.remove("connected", "error");
+      headerDot.classList.add(this.backendConnected ? "connected" : "error");
+      headerDot.textContent = this.backendConnected ? "Backend" : "Backend Offline";
+    }
   }
 
   private switchView(view: string) {
@@ -853,7 +907,7 @@ class App {
       <div class="library-header">
         <div>
           <h1>Library</h1>
-          <p class="subtitle">${lib.total} games &middot; ${installedGames.length} installed ${steamStatusBadge}</p>
+          <p class="subtitle">${lib.total} games &middot; ${installedGames.length} installed ${steamStatusBadge} <span class="backend-status-badge ${this.backendConnected ? "connected" : "error"}" id="backend-status-header">${this.backendConnected ? "Backend" : "Backend Offline"}</span></p>
         </div>
         <div class="header-actions">
           <button class="btn btn-secondary" id="btn-steam-launch" title="${this.wineSteamRunning ? "Stop Wine Steam" : "Start Wine Steam"}">${this.wineSteamRunning ? "Stop Steam" : "Start Steam"}</button>
@@ -1222,6 +1276,31 @@ class App {
       </div>
 
       <div class="settings-section">
+        <h2>Backend</h2>
+        <div class="settings-row">
+          <div>
+            <div class="settings-label">Game Runtime Backend</div>
+            <div class="settings-desc">The Rust backend handles game launches, Steam integration, and shader management</div>
+          </div>
+          <div class="settings-value">
+            <div style="display:flex;gap:8px;align-items:center;">
+              <span class="badge ${this.backendConnected ? "badge-ok" : "badge-warn"}">${this.backendConnected ? "Connected" : "Offline"}</span>
+              ${this.backendVersion ? `<span style="color:var(--text-dim);font-size:12px;">v${this.esc(this.backendVersion)}</span>` : ""}
+            </div>
+          </div>
+        </div>
+        <div class="settings-row">
+          <div>
+            <div class="settings-label">Restart Backend</div>
+            <div class="settings-desc">Kill and restart the backend process. Use this if games fail to launch or the status shows Offline.</div>
+          </div>
+          <div class="settings-value">
+            <button class="btn btn-secondary btn-sm" id="btn-restart-backend">Restart Backend</button>
+          </div>
+        </div>
+      </div>
+
+      <div class="settings-section">
         <h2>Graphics</h2>
         <div class="settings-row">
           <div>
@@ -1478,6 +1557,23 @@ class App {
       } else {
         this.toast(this.updateStatus?.error ?? "Could not check for updates", "error");
       }
+    });
+
+    el.querySelector("#btn-restart-backend")?.addEventListener("click", async () => {
+      const btn = el.querySelector("#btn-restart-backend") as HTMLButtonElement;
+      if (btn) {
+        btn.disabled = true;
+        btn.textContent = "Restarting...";
+      }
+      this.toast("Restarting backend...", "success");
+      const result = await getAPI().restartBackend();
+      if (result.ok) {
+        await this.pollBackendHealth();
+        this.toast("Backend restarted", "success");
+      } else {
+        this.toast(result.error ?? "Failed to restart backend", "error");
+      }
+      this.renderSettings();
     });
   }
 

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -218,6 +218,30 @@ body {
   color: var(--text-dim);
 }
 
+.backend-status-badge {
+  display: inline-block;
+  font-size: 10px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 10px;
+  margin-left: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  transition: all var(--transition);
+}
+
+.backend-status-badge.connected {
+  background: rgba(52, 199, 89, 0.15);
+  color: var(--success);
+  border: 1px solid rgba(52, 199, 89, 0.3);
+}
+
+.backend-status-badge.error {
+  background: rgba(255, 59, 48, 0.15);
+  color: var(--error);
+  border: 1px solid rgba(255, 59, 48, 0.3);
+}
+
 /* Main content */
 .content {
   flex: 1;


### PR DESCRIPTION
## Summary

Undertale (appid 391540) crashed with a Wine page fault when launched from the MetalSharp app or Steam. The game calls `SteamAPI_RestartAppIfNecessary()`, which detects it's not running through the Steam client and either demands a restart or crashes on a null pointer.

- Route Undertale through `steam://run/` (`Engine::SteamBare`) instead of direct exe (`Engine::Wined3d32`)
- Fix frontend sending `launchMethod: "metalsharp_wine"` for Undertale and Nidhogg 2 — now sends `"auto"`
- Add fallback in `launch_with_method()` to delegate known engine method strings to `launch_auto()` instead of erroring
- Harden `launch_wined3d_32()` with `steamclient` DLL disable and `SteamOverlayDisabled=1` for future games that use this path

## Testing

- Confirmed Undertale launches and renders correctly via `steam://run/391540` with Steam running
- Verified Steam prefix remains intact after game exit
- Backend compiles clean with `cargo check` and `cargo build --release`