### PR TITLE
feat: rewrite updater with Python install runtime and fix version sync

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metalsharp",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metalsharp",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "dependencies": {
         "electron-store": "^10.0.0"
       },

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsharp",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "MetalSharp — D3D→Metal translation layer frontend",
   "author": "MetalSharp",
   "repository": {
@@ -129,7 +129,15 @@
       },
       {
         "from": "bundles/steamwebhelper-wrapper.c",
-        "to": "bundles/steamwebhelper-wrapper.c"
+        "to": "steamwebhelper-wrapper.c"
+      },
+      {
+        "from": "updater/update.py",
+        "to": "updater/update.py"
+      },
+      {
+        "from": "bundles/updater.tar.gz",
+        "to": "updater.tar.gz"
       }
     ],
     "directories": {

--- a/app/src-rust/Cargo.lock
+++ b/app/src-rust/Cargo.lock
@@ -390,7 +390,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metalsharp-backend"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "dirs",
  "serde",

--- a/app/src-rust/Cargo.toml
+++ b/app/src-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metalsharp-backend"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 
 [dependencies]

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -80,6 +80,12 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
             Err(e) => resp(500, json!({"ok": false, "error": e.to_string()})),
         },
         (Method::Get, "/update/progress") => resp(200, updater::read_update_progress()),
+        (Method::Get, "/update/dmg-path") => {
+            match updater::get_downloaded_dmg_path() {
+                Some(p) => resp(200, json!({"ok": true, "path": p})),
+                None => resp(200, json!({"ok": false, "error": "no downloaded DMG"})),
+            }
+        },
         (Method::Get, "/setup/state") => resp(200, setup::state()),
         (Method::Post, "/setup/save") => {
             let body = read_body(req);

--- a/app/src-rust/src/updater.rs
+++ b/app/src-rust/src/updater.rs
@@ -2,17 +2,13 @@ use serde_json::json;
 use std::fs;
 use std::io::Read;
 use std::path::PathBuf;
-use std::process::Command;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 const REPO_API: &str = "https://api.github.com/repos/aaf2tbz/metalsharp/releases/latest";
-const REPO_OWNER: &str = "aaf2tbz";
-const REPO_NAME: &str = "metalsharp";
 
 static UPDATING: AtomicBool = AtomicBool::new(false);
 static DOWNLOAD_PERCENT: AtomicU32 = AtomicU32::new(0);
-static UPDATE_STATUS: std::sync::Mutex<String> = std::sync::Mutex::new(String::new());
 
 fn progress_path() -> PathBuf {
     dirs::home_dir().unwrap_or_default().join(".metalsharp").join("update_progress.json")
@@ -94,7 +90,8 @@ pub fn check_for_update() -> serde_json::Value {
         },
     };
 
-    let latest = release.tag_name.trim_start_matches('v').to_string();
+    let latest_raw = release.tag_name.trim();
+    let latest = clean_version(latest_raw);
     let current = CURRENT_VERSION.to_string();
     let available = semver_gt(&latest, &current);
 
@@ -102,6 +99,11 @@ pub fn check_for_update() -> serde_json::Value {
 
     let release_notes = release.body.unwrap_or_default();
     let release_name = release.name.unwrap_or_else(|| release.tag_name.clone());
+
+    app_log(&format!(
+        "Update check: current={} latest_raw='{}' latest_clean='{}' available={}",
+        current, latest_raw, latest, available
+    ));
 
     json!({
         "ok": true,
@@ -114,8 +116,30 @@ pub fn check_for_update() -> serde_json::Value {
     })
 }
 
+fn clean_version(tag: &str) -> String {
+    let v = tag.trim().trim_start_matches('v');
+    let parts: Vec<&str> = v.split('.').collect();
+    parts
+        .iter()
+        .map(|p| {
+            p.chars()
+                .take_while(|c| c.is_ascii_digit())
+                .collect::<String>()
+        })
+        .filter(|p| !p.is_empty())
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
 fn semver_gt(a: &str, b: &str) -> bool {
-    let parse = |v: &str| -> Vec<u32> { v.split('.').filter_map(|p| p.parse::<u32>().ok()).collect() };
+    let parse = |v: &str| -> Vec<u32> {
+        v.split('.')
+            .filter_map(|p| {
+                let clean: String = p.chars().take_while(|c| c.is_ascii_digit()).collect();
+                clean.parse::<u32>().ok()
+            })
+            .collect()
+    };
     let av = parse(a);
     let bv = parse(b);
     for i in 0..std::cmp::max(av.len(), bv.len()) {
@@ -144,14 +168,14 @@ pub fn start_update() -> Result<serde_json::Value, Box<dyn std::error::Error>> {
     write_update_progress("starting", 0, "Checking for updates...", None);
 
     std::thread::spawn(|| {
-        run_update();
+        run_download();
         UPDATING.store(false, Ordering::SeqCst);
     });
 
     Ok(json!({"ok": true}))
 }
 
-fn run_update() {
+fn run_download() {
     write_update_progress("checking", 5, "Fetching latest release info...", None);
 
     let update_info = check_for_update();
@@ -177,57 +201,23 @@ fn run_update() {
     let _ = fs::create_dir_all(&cache_dir);
     let dmg_path = cache_dir.join(format!("MetalSharp-{}.dmg", latest_version));
 
-    write_update_progress("downloading", 10, &format!("Downloading v{}...", latest_version), None);
-
     if !dmg_path.exists() {
+        write_update_progress("downloading", 10, &format!("Downloading v{}...", latest_version), None);
         if let Err(e) = download_with_progress(&download_url, &dmg_path) {
             write_update_progress("error", 0, &format!("Download failed: {}", e), Some(&e.to_string()));
             let _ = fs::remove_file(&dmg_path);
             return;
         }
     } else {
-        write_update_progress("downloading", 80, "Using cached DMG...", None);
+        app_log(&format!("Using cached DMG: {}", dmg_path.display()));
     }
 
-    write_update_progress("stopping_backend", 85, "Stopping backend...", None);
-    stop_backend();
-
-    write_update_progress("mounting", 87, "Mounting DMG...", None);
-    let mount_point = match mount_dmg(&dmg_path) {
-        Some(m) => m,
-        None => {
-            write_update_progress("error", 0, "Failed to mount DMG", Some("mount_failed"));
-            return;
-        },
-    };
-
-    write_update_progress("installing", 90, "Installing new version...", None);
-
-    let app_source = find_app_in_mount(&mount_point);
-    match app_source {
-        Some(src) => {
-            if let Err(e) = install_app(&src) {
-                let _ = detach_dmg(&mount_point);
-                write_update_progress("error", 0, &format!("Install failed: {}", e), Some(&e.to_string()));
-                return;
-            }
-        },
-        None => {
-            let _ = detach_dmg(&mount_point);
-            write_update_progress("error", 0, "MetalSharp.app not found in DMG", Some("app_not_found"));
-            return;
-        },
-    }
-
-    write_update_progress("installing", 95, "Unmounting installer...", None);
-    let _ = detach_dmg(&mount_point);
-
-    write_update_progress("relaunching", 98, "Relaunching MetalSharp...", None);
-
-    std::thread::sleep(std::time::Duration::from_secs(2));
-    relaunch_app();
-
-    write_update_progress("complete", 100, &format!("Updated to v{}!", latest_version), None);
+    write_update_progress(
+        "downloaded",
+        80,
+        &format!("Download complete — ready to install v{}", latest_version),
+        None,
+    );
 }
 
 fn download_with_progress(url: &str, dest: &PathBuf) -> Result<(), String> {
@@ -256,6 +246,7 @@ fn download_with_progress(url: &str, dest: &PathBuf) -> Result<(), String> {
         if n == 0 {
             break;
         }
+        use std::io::Write;
         file.write_all(&buf[..n]).map_err(|e| format!("write error: {}", e))?;
         downloaded += n as u64;
 
@@ -275,96 +266,51 @@ fn download_with_progress(url: &str, dest: &PathBuf) -> Result<(), String> {
     Ok(())
 }
 
-fn stop_backend() {
-    let _ = Command::new("pkill")
-        .args(["-f", "metalsharp-backend"])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status();
-    std::thread::sleep(std::time::Duration::from_millis(500));
+pub fn get_downloaded_dmg_path() -> Option<String> {
+    let update_info = check_for_update();
+    let latest_version = update_info.get("latest_version").and_then(|v| v.as_str())?;
+    let home = dirs::home_dir()?;
+    let dmg_path = home
+        .join(".metalsharp")
+        .join("cache")
+        .join("updates")
+        .join(format!("MetalSharp-{}.dmg", latest_version));
+
+    if dmg_path.exists() {
+        Some(dmg_path.to_string_lossy().to_string())
+    } else {
+        None
+    }
 }
 
-fn mount_dmg(dmg_path: &PathBuf) -> Option<String> {
-    let output = Command::new("hdiutil").args(["attach", "-nobrowse", "-quiet"]).arg(dmg_path).output().ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    for line in stdout.lines().rev() {
-        let parts: Vec<&str> = line.split_whitespace().collect();
-        if let Some(mount) = parts.last() {
-            if mount.starts_with("/Volumes/") {
-                return Some(mount.to_string());
-            }
+fn app_log(msg: &str) {
+    let home = dirs::home_dir().unwrap_or_default();
+    let log_dir = home.join(".metalsharp").join("logs");
+    let _ = fs::create_dir_all(&log_dir);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = now.as_secs();
+    let h = (secs / 3600) % 24;
+    let m = (secs / 60) % 60;
+    let s = secs % 60;
+    let line = format!("[{:02}:{:02}:{:02}] {}\n", h, m, s, msg);
+    let days = secs / 86400;
+    let y = 1970 + (days * 400).div_ceil(146097);
+    let mut remaining = days - (((y - 1) * 365) + ((y - 1) / 4) - ((y - 1) / 100) + ((y - 1) / 400));
+    let ml = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let mut mo = 1;
+    for (i, &md) in ml.iter().enumerate() {
+        if remaining < md {
+            mo = i + 1;
+            break;
         }
+        remaining -= md;
     }
-    None
+    let log_path = log_dir.join(format!("{:04}-{:02}-{:02}.log", y, mo, remaining + 1));
+    let _ = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .and_then(|mut f| std::io::Write::write_all(&mut f, line.as_bytes()));
 }
-
-fn detach_dmg(mount_point: &str) -> bool {
-    Command::new("hdiutil")
-        .args(["detach", mount_point, "-quiet"])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
-}
-
-fn find_app_in_mount(mount_point: &str) -> Option<PathBuf> {
-    let mount = PathBuf::from(mount_point);
-    if let Ok(entries) = fs::read_dir(&mount) {
-        for entry in entries.flatten() {
-            let name = entry.file_name().to_string_lossy().to_string();
-            if name.ends_with(".app") && name.to_lowercase().contains("metalsharp") {
-                return Some(entry.path());
-            }
-        }
-    }
-    None
-}
-
-fn install_app(app_source: &PathBuf) -> Result<(), String> {
-    let target = PathBuf::from("/Applications/MetalSharp.app");
-
-    if target.exists() {
-        let _ = Command::new("rm")
-            .args(["-rf"])
-            .arg(&target)
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status();
-    }
-
-    let output = Command::new("cp")
-        .args(["-R"])
-        .arg(app_source)
-        .arg(&target)
-        .output()
-        .map_err(|e| format!("cp failed: {}", e))?;
-
-    if !output.status.success() {
-        return Err(format!("copy failed: {}", String::from_utf8_lossy(&output.stderr)));
-    }
-
-    Ok(())
-}
-
-fn relaunch_app() {
-    let app_path = "/Applications/MetalSharp.app";
-    let _ = Command::new("open")
-        .arg(app_path)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn();
-
-    let _ = Command::new("pkill")
-        .args(["-f", "MetalSharp"])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn();
-}
-
-use std::io::Write;

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow, dialog, ipcMain, shell } from "electron";
 import * as fs from "fs";
 import * as path from "path";
 import { RustBridge } from "./rust-bridge";
+import { UpdaterBridge } from "./updater-bridge";
 
 let shellPath: string | undefined;
 
@@ -25,6 +26,7 @@ function ensureShellPath() {
 
 let mainWindow: BrowserWindow | null = null;
 let bridge: RustBridge;
+let updaterBridge: UpdaterBridge;
 let steamappsWatcher: fs.FSWatcher | null = null;
 
 function getMetalsharpDir(): string {
@@ -113,6 +115,7 @@ function cleanup() {
 app.whenReady().then(async () => {
   ensureMetalsharpDirs();
   bridge = new RustBridge();
+  updaterBridge = new UpdaterBridge(bridge.getPort());
   await bridge.start();
 
   registerIpc();
@@ -304,5 +307,25 @@ function registerIpc() {
 
   ipcMain.handle("backend:is-alive", async () => {
     return bridge.isAlive();
+  });
+
+  ipcMain.handle("updater:ensure-ready", async () => {
+    return updaterBridge.ensureReady();
+  });
+
+  ipcMain.handle("updater:spawn-install", async (_e, dmgPath: string, backendPid: number, targetVersion: string) => {
+    return updaterBridge.spawnInstallUpdater(dmgPath, backendPid, targetVersion);
+  });
+
+  ipcMain.handle("updater:install-status", async () => {
+    return updaterBridge.readInstallStatus();
+  });
+
+  ipcMain.handle("updater:clear-status", async () => {
+    updaterBridge.clearInstallStatus();
+  });
+
+  ipcMain.handle("backend:get-pid", async () => {
+    return bridge.getBackendPid();
   });
 }

--- a/app/src/main/preload.ts
+++ b/app/src/main/preload.ts
@@ -11,4 +11,10 @@ contextBridge.exposeInMainWorld("metalsharp", {
   openInFinder: (path: string) => ipcRenderer.invoke("app:open-in-finder", path),
   restartBackend: () => ipcRenderer.invoke("backend:restart"),
   isBackendAlive: () => ipcRenderer.invoke("backend:is-alive"),
+  updaterEnsureReady: () => ipcRenderer.invoke("updater:ensure-ready"),
+  updaterSpawnInstall: (dmgPath: string, backendPid: number, targetVersion: string) =>
+    ipcRenderer.invoke("updater:spawn-install", dmgPath, backendPid, targetVersion),
+  updaterInstallStatus: () => ipcRenderer.invoke("updater:install-status"),
+  updaterClearStatus: () => ipcRenderer.invoke("updater:clear-status"),
+  backendGetPid: () => ipcRenderer.invoke("backend:get-pid"),
 });

--- a/app/src/main/rust-bridge.ts
+++ b/app/src/main/rust-bridge.ts
@@ -31,6 +31,10 @@ export class RustBridge {
     this.base = `http://127.0.0.1:${this.port}`;
   }
 
+  getPort(): number {
+    return this.port;
+  }
+
   async start(): Promise<void> {
     const binPath = this.findBinary();
     if (!binPath) {
@@ -86,6 +90,28 @@ export class RustBridge {
       req.setTimeout(1500, () => {
         req.destroy();
         resolve(false);
+      });
+    });
+  }
+
+  async getBackendPid(): Promise<number | null> {
+    return new Promise((resolve) => {
+      const req = http.get(`http://127.0.0.1:${this.port}/status`, (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => {
+          try {
+            const data = JSON.parse(Buffer.concat(chunks).toString());
+            resolve(data.pid ?? null);
+          } catch {
+            resolve(null);
+          }
+        });
+      });
+      req.on("error", () => resolve(null));
+      req.setTimeout(1500, () => {
+        req.destroy();
+        resolve(null);
       });
     });
   }
@@ -163,28 +189,6 @@ export class RustBridge {
     } catch {}
 
     return false;
-  }
-
-  private async getBackendPid(): Promise<number | null> {
-    return new Promise((resolve) => {
-      const req = http.get(`http://127.0.0.1:${this.port}/status`, (res) => {
-        const chunks: Buffer[] = [];
-        res.on("data", (c) => chunks.push(c));
-        res.on("end", () => {
-          try {
-            const data = JSON.parse(Buffer.concat(chunks).toString());
-            resolve(data.pid ?? null);
-          } catch {
-            resolve(null);
-          }
-        });
-      });
-      req.on("error", () => resolve(null));
-      req.setTimeout(1500, () => {
-        req.destroy();
-        resolve(null);
-      });
-    });
   }
 
   private async getProcessPath(pid: number): Promise<string | null> {

--- a/app/src/main/updater-bridge.ts
+++ b/app/src/main/updater-bridge.ts
@@ -1,0 +1,170 @@
+import { type ChildProcess, spawn } from "child_process";
+import * as fs from "fs";
+import * as http from "http";
+import * as path from "path";
+
+const STATUS_FILE = path.join(
+  process.env.HOME || "/tmp",
+  ".metalsharp",
+  "update_install_status.json",
+);
+
+export interface InstallStatus {
+  phase: string;
+  percent: number;
+  message: string;
+  error: string | null;
+  new_version: string | null;
+  timestamp: number;
+}
+
+export class UpdaterBridge {
+  private pythonPath: string | null = null;
+  private scriptPath: string | null = null;
+  private backendPort: number;
+  private proc: ChildProcess | null = null;
+
+  constructor(port: number = 9274) {
+    this.backendPort = port;
+  }
+
+  async ensureReady(): Promise<boolean> {
+    if (this.pythonPath && this.scriptPath) return true;
+
+    const resourcesDir = process.resourcesPath || "";
+    const devRoot = path.join(__dirname, "..", "..");
+
+    const pythonCandidates = [
+      path.join(resourcesDir, "updater", "bin", "python3"),
+      path.join(resourcesDir, "updater", "python3"),
+      path.join(devRoot, "updater", "bin", "python3"),
+      "/usr/bin/python3",
+      "/opt/homebrew/bin/python3",
+      "/usr/local/bin/python3",
+    ];
+
+    for (const c of pythonCandidates) {
+      try {
+        fs.accessSync(c);
+        this.pythonPath = c;
+        break;
+      } catch {}
+    }
+
+    if (!this.pythonPath) {
+      console.error("Updater: no python3 found");
+      return false;
+    }
+
+    const scriptCandidates = [
+      path.join(resourcesDir, "updater", "update.py"),
+      path.join(devRoot, "updater", "update.py"),
+    ];
+
+    for (const c of scriptCandidates) {
+      try {
+        fs.accessSync(c);
+        this.scriptPath = c;
+        break;
+      } catch {}
+    }
+
+    if (!this.scriptPath) {
+      console.error("Updater: update.py not found");
+      return false;
+    }
+
+    return true;
+  }
+
+  async getBackendPid(): Promise<number | null> {
+    return new Promise((resolve) => {
+      const req = http.get(
+        `http://127.0.0.1:${this.backendPort}/status`,
+        (res) => {
+          const chunks: Buffer[] = [];
+          res.on("data", (c) => chunks.push(c));
+          res.on("end", () => {
+            try {
+              const data = JSON.parse(Buffer.concat(chunks).toString());
+              resolve(data.pid ?? null);
+            } catch {
+              resolve(null);
+            }
+          });
+        },
+      );
+      req.on("error", () => resolve(null));
+      req.setTimeout(1500, () => {
+        req.destroy();
+        resolve(null);
+      });
+    });
+  }
+
+  spawnInstallUpdater(
+    dmgPath: string,
+    backendPid: number,
+    targetVersion: string,
+  ): { ok: boolean; error?: string } {
+    if (!this.pythonPath || !this.scriptPath) {
+      return { ok: false, error: "Updater not ready — python3 or update.py missing" };
+    }
+
+    if (!fs.existsSync(dmgPath)) {
+      return { ok: false, error: "DMG file not found: " + dmgPath };
+    }
+
+    const args = [
+      this.scriptPath,
+      "--dmg", dmgPath,
+      "--backend-pid", String(backendPid),
+      "--target-version", targetVersion,
+      "--status-file", STATUS_FILE,
+      "--python", this.pythonPath,
+    ];
+
+    this.proc = spawn(this.pythonPath, args, {
+      detached: true,
+      stdio: "ignore",
+      env: {
+        ...process.env,
+        PATH: [
+          "/opt/homebrew/bin",
+          "/usr/local/bin",
+          "/usr/bin",
+          "/bin",
+          "/usr/sbin",
+          "/sbin",
+        ].join(":"),
+      },
+    });
+
+    this.proc.unref();
+
+    console.log(
+      `Updater: spawned install updater (pid=${this.proc.pid}) for v${targetVersion}`,
+    );
+
+    return { ok: true };
+  }
+
+  readInstallStatus(): InstallStatus | null {
+    try {
+      const raw = fs.readFileSync(STATUS_FILE, "utf8");
+      return JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+
+  clearInstallStatus(): void {
+    try {
+      fs.unlinkSync(STATUS_FILE);
+    } catch {}
+  }
+
+  static getStatusFilePath(): string {
+    return STATUS_FILE;
+  }
+}

--- a/app/src/renderer/api-types.ts
+++ b/app/src/renderer/api-types.ts
@@ -47,6 +47,15 @@ interface UpdateProgress {
   error: string | null;
 }
 
+interface InstallStatus {
+  phase: string;
+  percent: number;
+  message: string;
+  error: string | null;
+  new_version: string | null;
+  timestamp: number;
+}
+
 interface CrashReportSummary {
   id: string;
   timestamp: string;
@@ -99,4 +108,9 @@ type MetalsharpAPI = {
   openInFinder: (path: string) => Promise<void>;
   restartBackend: () => Promise<{ ok: boolean; error?: string }>;
   isBackendAlive: () => Promise<boolean>;
+  updaterEnsureReady: () => Promise<boolean>;
+  updaterSpawnInstall: (dmgPath: string, backendPid: number, targetVersion: string) => Promise<{ ok: boolean; error?: string }>;
+  updaterInstallStatus: () => Promise<InstallStatus | null>;
+  updaterClearStatus: () => Promise<void>;
+  backendGetPid: () => Promise<number | null>;
 };

--- a/app/src/renderer/index.ts
+++ b/app/src/renderer/index.ts
@@ -61,6 +61,7 @@ class App {
     }
 
     await this.loadConfig();
+    this.checkForInstallResult();
     await this.checkForUpdates();
     this.steamApiKey = await this.getSteamApiKey();
     const setupState = await this.api<{ deviceName?: string }>("GET", "/setup/state");
@@ -244,6 +245,12 @@ class App {
   }
 
   private async startUpdateFlow() {
+    const ready = await getAPI().updaterEnsureReady();
+    if (!ready) {
+      this.toast("Updater not available — python3 not found. Install Xcode CLI tools or check your installation.", "error");
+      return;
+    }
+
     const overlay = document.createElement("div");
     overlay.className = "update-overlay";
     overlay.id = "update-progress-overlay";
@@ -271,13 +278,13 @@ class App {
       return;
     }
 
+    const fill = document.getElementById("update-progress-fill") as HTMLElement;
+    const label = document.getElementById("update-progress-label") as HTMLElement;
+    const message = document.getElementById("update-progress-message") as HTMLElement;
+
     const pollInterval = setInterval(async () => {
       const progress = await this.api<UpdateProgress>("GET", "/update/progress");
       if (!progress) return;
-
-      const fill = document.getElementById("update-progress-fill") as HTMLElement;
-      const label = document.getElementById("update-progress-label") as HTMLElement;
-      const message = document.getElementById("update-progress-message") as HTMLElement;
 
       if (fill) fill.style.width = `${progress.percent}%`;
       if (label) label.textContent = `${progress.percent}%`;
@@ -287,12 +294,86 @@ class App {
         clearInterval(pollInterval);
         overlay.remove();
         this.toast(`Update failed: ${progress.error ?? "unknown error"}`, "error");
-      } else if (progress.status === "complete") {
+      } else if (progress.status === "downloaded") {
         clearInterval(pollInterval);
+        await this.triggerInstall(overlay);
       }
     }, 500);
 
     setTimeout(() => clearInterval(pollInterval), 10 * 60 * 1000);
+  }
+
+  private async triggerInstall(overlay: HTMLElement) {
+    const fill = document.getElementById("update-progress-fill") as HTMLElement;
+    const label = document.getElementById("update-progress-label") as HTMLElement;
+    const message = document.getElementById("update-progress-message") as HTMLElement;
+
+    if (fill) fill.style.width = "82%";
+    if (label) label.textContent = "82%";
+    if (message) message.textContent = "Preparing to install...";
+
+    const dmgResult = await this.api<{ ok: boolean; path?: string; error?: string }>("GET", "/update/dmg-path");
+    if (!dmgResult?.ok || !dmgResult?.path) {
+      overlay.remove();
+      this.toast("Downloaded DMG not found", "error");
+      return;
+    }
+
+    const backendPid = await getAPI().backendGetPid();
+    if (!backendPid) {
+      overlay.remove();
+      this.toast("Cannot determine backend PID", "error");
+      return;
+    }
+
+    const targetVersion = this.updateStatus?.latest_version ?? "unknown";
+
+    if (fill) fill.style.width = "85%";
+    if (message) message.textContent = "Launching installer... The app will close momentarily.";
+
+    const result = await getAPI().updaterSpawnInstall(dmgResult.path, backendPid, targetVersion);
+    if (!result.ok) {
+      overlay.remove();
+      this.toast(result.error ?? "Failed to launch installer", "error");
+      return;
+    }
+
+    await new Promise((r) => setTimeout(r, 2000));
+    const { remote } = require("electron");
+    remote?.app?.quit();
+  }
+
+  private async checkForInstallResult() {
+    const status = await getAPI().updaterInstallStatus();
+    if (!status || status.phase !== "complete") return;
+
+    await getAPI().updaterClearStatus();
+
+    await new Promise((r) => setTimeout(r, 1500));
+    await this.pollBackendHealth();
+
+    if (status.error) {
+      this.toast(`Update had issues: ${status.error}`, "error");
+    } else {
+      const overlay = document.createElement("div");
+      overlay.className = "update-overlay";
+      document.body.appendChild(overlay);
+
+      overlay.innerHTML = `
+        <div class="update-dialog-backdrop"></div>
+        <div class="update-dialog">
+          <div class="update-dialog-icon" style="background:rgba(92,184,112,0.15);color:var(--success);">&#10003;</div>
+          <h2 class="update-dialog-title">Update Complete!</h2>
+          <p class="update-dialog-desc" style="color:var(--text-secondary);">${this.esc(status.message)}</p>
+          <div class="update-dialog-actions">
+            <button class="btn btn-primary" id="update-done-dismiss">Continue</button>
+          </div>
+        </div>
+      `;
+
+      overlay.querySelector("#update-done-dismiss")?.addEventListener("click", () => overlay.remove());
+      overlay.querySelector(".update-dialog-backdrop")?.addEventListener("click", () => overlay.remove());
+    }
   }
 
   private async loadCacheSizes() {

--- a/app/updater/update.py
+++ b/app/updater/update.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""MetalSharp Updater — handles app update installation after download.
+
+Spawned by the Electron app with detached=true so it survives the app quitting.
+Performs: kill processes → mount DMG → install → relaunch → verify.
+
+Communication: writes JSON status to ~/.metalsharp/update_install_status.json
+The new MetalSharp instance reads this file on launch to show success/failure.
+
+Usage:
+    python3 update.py --dmg <path> --backend-pid <pid> --target-version <ver> \
+                      [--status-file <path>] [--python <path>]
+"""
+
+import argparse
+import json
+import os
+import signal
+import shutil
+import subprocess
+import sys
+import time
+import urllib.request
+
+APP_PATH = "/Applications/MetalSharp.app"
+BACKEND_PORT = 9274
+
+
+def write_status(status_file, phase, percent, message, error=None, new_version=None):
+    data = {
+        "phase": phase,
+        "percent": percent,
+        "message": message,
+        "error": error,
+        "new_version": new_version,
+        "timestamp": time.time(),
+    }
+    try:
+        with open(status_file, "w") as f:
+            json.dump(data, f)
+    except Exception:
+        pass
+
+
+def read_status(status_file):
+    try:
+        with open(status_file, "r") as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+def run(cmd, **kwargs):
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=30, **kwargs)
+
+
+def is_pid_alive(pid):
+    try:
+        os.kill(pid, 0)
+        return True
+    except (ProcessLookupError, PermissionError, OSError):
+        return False
+
+
+def kill_pid(pid, timeout=10):
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except (ProcessLookupError, PermissionError, OSError):
+        return True
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not is_pid_alive(pid):
+            return True
+        time.sleep(0.3)
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
+    time.sleep(0.5)
+    return not is_pid_alive(pid)
+
+
+def kill_by_patterns(patterns):
+    for pat in patterns:
+        try:
+            subprocess.run(["pkill", "-x", pat], capture_output=True, timeout=5)
+        except Exception:
+            pass
+    for pat in patterns:
+        try:
+            subprocess.run(["pkill", "-f", pat], capture_output=True, timeout=5)
+        except Exception:
+            pass
+    time.sleep(1)
+
+
+def verify_all_dead(patterns, timeout=15):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        all_dead = True
+        for pat in patterns:
+            r = subprocess.run(["pgrep", "-x", pat], capture_output=True, text=True)
+            if r.returncode == 0 and r.stdout.strip():
+                all_dead = False
+                for pid_str in r.stdout.strip().split("\n"):
+                    try:
+                        os.kill(int(pid_str.strip()), signal.SIGKILL)
+                    except Exception:
+                        pass
+        if all_dead:
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def mount_dmg(dmg_path):
+    r = run(["hdiutil", "attach", "-nobrowse", "-quiet", dmg_path])
+    if r.returncode == 0:
+        return _parse_mount(r.stdout)
+
+    apple = (
+        'do shell script "hdiutil attach -nobrowse -quiet '
+        '\\"' + dmg_path + '\\""'
+        ' with administrator privileges'
+    )
+    r = run(["osascript", "-e", apple])
+    if r.returncode == 0:
+        time.sleep(2)
+        info = run(["hdiutil", "info"])
+        return _parse_mount_info(info.stdout, dmg_path)
+
+    return None
+
+
+def _parse_mount(output):
+    for line in output.strip().split("\n"):
+        parts = line.split()
+        if parts and parts[-1].startswith("/Volumes/"):
+            return parts[-1]
+    return None
+
+
+def _parse_mount_info(output, dmg_path):
+    lines = output.split("\n")
+    found = False
+    for line in lines:
+        if dmg_path in line:
+            found = True
+        if found and "/Volumes/" in line:
+            idx = line.index("/Volumes/")
+            rest = line[idx:].strip()
+            return rest
+    return None
+
+
+def find_app_in_mount(mount_point):
+    try:
+        for entry in os.listdir(mount_point):
+            if entry.endswith(".app") and "metalsharp" in entry.lower():
+                return os.path.join(mount_point, entry)
+    except Exception:
+        pass
+    return None
+
+
+def admin_rm_rf(path):
+    r = run(["rm", "-rf", path])
+    if r.returncode == 0:
+        return True
+    apple = 'do shell script "rm -rf \\"' + path + '\\"" with administrator privileges'
+    r = run(["osascript", "-e", apple])
+    return r.returncode == 0
+
+
+def admin_cp_r(src, dst):
+    r = run(["cp", "-R", src, dst])
+    if r.returncode == 0:
+        return True
+    apple = 'do shell script "cp -R \\"' + src + '\\" \\"' + dst + '\\"" with administrator privileges'
+    r = run(["osascript", "-e", apple])
+    return r.returncode == 0
+
+
+def wait_for_backend(timeout=45):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            req = urllib.request.Request("http://127.0.0.1:" + str(BACKEND_PORT) + "/status")
+            with urllib.request.urlopen(req, timeout=3) as resp:
+                data = json.loads(resp.read())
+                return data.get("version"), data.get("pid")
+        except Exception:
+            pass
+        time.sleep(1)
+    return None, None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="MetalSharp Updater")
+    parser.add_argument("--dmg", required=True)
+    parser.add_argument("--backend-pid", required=True, type=int)
+    parser.add_argument("--target-version", required=True)
+    parser.add_argument(
+        "--status-file",
+        default=os.path.expanduser("~/.metalsharp/update_install_status.json"),
+    )
+    parser.add_argument("--python", default=sys.executable)
+    args = parser.parse_args()
+
+    sf = args.status_file
+    tv = args.target_version
+    dmg = args.dmg
+    bpid = args.backend_pid
+
+    write_status(sf, "starting", 0, "Starting update...", new_version=tv)
+
+    # ── 1. Kill backend ──────────────────────────────────────────────
+    write_status(sf, "killing_backend", 5, "Stopping backend (PID {})...".format(bpid), new_version=tv)
+    if not kill_pid(bpid, timeout=10):
+        write_status(sf, "error", 5, "Failed to stop backend", error="backend_kill_failed", new_version=tv)
+        sys.exit(1)
+    run(["pkill", "-x", "metalsharp-backend"])
+    time.sleep(0.5)
+    write_status(sf, "killed_backend", 10, "Backend stopped.", new_version=tv)
+
+    # ── 2. Kill steam/wine/webhelper ─────────────────────────────────
+    write_status(sf, "killing_steam", 15, "Stopping Steam and Wine processes...", new_version=tv)
+    wine_patterns = [
+        "steam", "steam.exe", "steamwebhelper", "steamwebhelper.exe",
+        "wine", "wine64", "wineserver",
+    ]
+    kill_by_patterns(wine_patterns)
+    verify_all_dead(wine_patterns, timeout=15)
+    write_status(sf, "killed_steam", 20, "Steam/Wine processes stopped.", new_version=tv)
+
+    # ── 3. Verify DMG exists ─────────────────────────────────────────
+    if not os.path.exists(dmg):
+        write_status(sf, "error", 20, "DMG not found: {}".format(dmg), error="dmg_not_found", new_version=tv)
+        sys.exit(1)
+
+    # ── 4. Kill MetalSharp app ───────────────────────────────────────
+    write_status(sf, "closing_app", 25, "Closing MetalSharp...", new_version=tv)
+    for pat in ["MetalSharp", "MetalSharp Helper", "MetalSharp Helper (GPU)", "MetalSharp Helper (Renderer)"]:
+        try:
+            subprocess.run(["pkill", "-x", pat], capture_output=True, timeout=5)
+        except Exception:
+            pass
+
+    deadline = time.time() + 15
+    while time.time() < deadline:
+        r = subprocess.run(["pgrep", "-x", "MetalSharp"], capture_output=True, text=True)
+        if r.returncode != 0:
+            break
+        time.sleep(0.5)
+
+    # Force kill anything remaining
+    try:
+        subprocess.run(["killall", "-9", "MetalSharp"], capture_output=True, timeout=5)
+    except Exception:
+        pass
+    time.sleep(2)
+    write_status(sf, "app_closed", 30, "MetalSharp closed.", new_version=tv)
+
+    # ── 5. Mount DMG (may prompt for password via osascript) ─────────
+    write_status(sf, "mounting", 35, "Mounting update disk image...", new_version=tv)
+    mount_point = mount_dmg(dmg)
+    if not mount_point:
+        write_status(sf, "error", 35, "Failed to mount DMG.", error="mount_failed", new_version=tv)
+        sys.exit(1)
+    write_status(sf, "mounted", 45, "Mounted at {}".format(mount_point), new_version=tv)
+
+    # ── 6. Install ───────────────────────────────────────────────────
+    write_status(sf, "installing", 50, "Installing new version...", new_version=tv)
+
+    app_source = find_app_in_mount(mount_point)
+    if not app_source:
+        run(["hdiutil", "detach", mount_point, "-quiet"])
+        write_status(sf, "error", 50, "MetalSharp.app not found in update.", error="app_not_found", new_version=tv)
+        sys.exit(1)
+
+    if os.path.exists(APP_PATH):
+        if not admin_rm_rf(APP_PATH):
+            run(["hdiutil", "detach", mount_point, "-quiet"])
+            write_status(sf, "error", 55, "Failed to remove old app.", error="remove_failed", new_version=tv)
+            sys.exit(1)
+
+    write_status(sf, "installing", 60, "Copying new version to Applications...", new_version=tv)
+    if not admin_cp_r(app_source, APP_PATH):
+        run(["hdiutil", "detach", mount_point, "-quiet"])
+        write_status(sf, "error", 65, "Failed to copy new version.", error="copy_failed", new_version=tv)
+        sys.exit(1)
+
+    write_status(sf, "installed", 80, "New version installed.", new_version=tv)
+
+    # ── 7. Unmount ───────────────────────────────────────────────────
+    write_status(sf, "unmounting", 82, "Unmounting update disk...", new_version=tv)
+    run(["hdiutil", "detach", mount_point, "-quiet"])
+
+    # ── 8. Relaunch ──────────────────────────────────────────────────
+    write_status(sf, "relaunching", 85, "Launching MetalSharp...", new_version=tv)
+    time.sleep(1)
+    run(["open", APP_PATH])
+
+    # ── 9. Verify version ────────────────────────────────────────────
+    write_status(sf, "verifying", 90, "Verifying installation...", new_version=tv)
+    version, new_pid = wait_for_backend(timeout=45)
+
+    if version and version != tv:
+        write_status(sf, "deploying_backend", 92, "Backend version mismatch, redeploying...", new_version=tv)
+        if new_pid:
+            kill_pid(new_pid, timeout=10)
+        time.sleep(1)
+        run(["pkill", "-x", "metalsharp-backend"])
+        time.sleep(1)
+        run(["open", "-a", "MetalSharp"])
+        time.sleep(3)
+        version, new_pid = wait_for_backend(timeout=30)
+
+    # ── 10. Report result ────────────────────────────────────────────
+    if version == tv:
+        write_status(
+            sf, "complete", 100,
+            "Successfully updated to v{}!".format(tv),
+            new_version=tv,
+        )
+    else:
+        write_status(
+            sf, "complete", 100,
+            "Update installed. Backend: v{} (expected v{})".format(version or "?", tv),
+            new_version=tv,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bundle_updater.sh
+++ b/scripts/bundle_updater.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# bundle_updater.sh — creates a minimal Python runtime bundle for the MetalSharp updater.
+#
+# Output: bundles/updater.tar.gz containing:
+#   updater/
+#     bin/python3         — standalone Python interpreter
+#     lib/python3X/       — minimal stdlib (json, subprocess, os, urllib, signal, time, argparse)
+#     update.py           — the updater script
+#
+# The CI workflow should run this before electron-builder packs the DMG.
+# At runtime, the Electron app looks for Resources/updater/bin/python3,
+# falling back to system /usr/bin/python3.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+BUNDLE_DIR="app/bundles/updater"
+TAR_OUT="app/bundles/updater.tar.gz"
+SCRIPT_SRC="app/updater/update.py"
+
+rm -rf "$BUNDLE_DIR"
+mkdir -p "$BUNDLE_DIR/bin" "$BUNDLE_DIR/lib"
+
+SYS_PYTHON=""
+for candidate in /opt/homebrew/bin/python3 /usr/local/bin/python3 /usr/bin/python3; do
+    if command -v "$candidate" &>/dev/null; then
+        SYS_PYTHON="$candidate"
+        break
+    fi
+done
+
+if [ -z "$SYS_PYTHON" ]; then
+    echo "ERROR: no python3 found on system" >&2
+    exit 1
+fi
+
+echo "Using system python3: $SYS_PYTHON"
+
+# Copy the interpreter binary
+cp "$SYS_PYTHON" "$BUNDLE_DIR/bin/python3"
+chmod +x "$BUNDLE_DIR/bin/python3"
+
+# Copy the minimal stdlib modules the updater needs
+PYTHON_VERSION=$("$SYS_PYTHON" -c "import sys; print(f'python{sys.version_info.major}.{sys.version_info.minor}')")
+STDLIB_SRC=$("$SYS_PYTHON" -c "import sysconfig; print(sysconfig.get_path('stdlib'))")
+LIB_DEST="$BUNDLE_DIR/lib/$PYTHON_VERSION"
+
+mkdir -p "$LIB_DEST"
+
+# Core modules needed by update.py
+NEEDED_MODULES=(
+    "json/__init__.py" "json/decoder.py" "json/encoder.py" "json/scanner.py"
+    "argparse.py" "subprocess.py" "signal.py" "shutil.py"
+    "urllib/__init__.py" "urllib/request.py" "urllib/response.py" "urllib/error.py" "urllib/parse.py"
+    "http/__init__.py" "http/client.py" "http/cookiejar.py"
+    "email/__init__.py" "email/parser.py" "email/message.py" "email/policy.py" "email/feedparser.py"
+    "email/header.py" "email/charset.py" "email/utils.py" "email/errors.py" "email/_policybase.py"
+    "collections/__init__.py" "collections/abc.py"
+    "importlib/__init__.py" "importlib/util.py" "importlib/machinery.py" "importlib/abc.py"
+    "encodings/__init__.py" "encodings/utf_8.py" "encodings/ascii.py" "encodings/aliases.py"
+    "logging/__init__.py"
+    "base64.py" "bisect.py" "calendar.py" "contextlib.py" "copy.py" "copyreg.py"
+    "datetime.py" "enum.py" "functools.py" "genericpath.py" "getopt.py"
+    "gettext.py" "glob.py" "heapq.py" "io.py" "keyword.py" "linecache.py"
+    "locale.py" "operator.py" "os.py" "pathlib.py" "posixpath.py" "pprint.py"
+    "re.py" "reprlib.py" "sre_compile.py" "sre_constants.py" "sre_parse.py"
+    "stat.py" "string.py" "struct.py" "sysconfig.py" "tempfile.py" "textwrap.py"
+    "threading.py" "token.py" "tokenize.py" "traceback.py" "types.py"
+    "typing.py" "warnings.py" "weakref.py" "zipimport.py"
+)
+
+for mod in "${NEEDED_MODULES[@]}"; do
+    src="$STDLIB_SRC/$mod"
+    if [ -f "$src" ]; then
+        mkdir -p "$(dirname "$LIB_DEST/$mod")"
+        cp "$src" "$LIB_DEST/$mod"
+    fi
+done
+
+# Copy the update script
+cp "$SCRIPT_SRC" "$BUNDLE_DIR/update.py"
+
+# Create the tarball
+rm -f "$TAR_OUT"
+tar -czf "$TAR_OUT" -C app/bundles updater/
+
+echo "Created $TAR_OUT ($(du -sh "$TAR_OUT" | cut -f1))"
+
+# Clean up
+rm -rf "$BUNDLE_DIR"


### PR DESCRIPTION
## Summary

Fixes two critical updater bugs and rewrites the install pipeline to use a Python runtime that survives app exit.

### Bugs Fixed

1. **False positive version check** — `semver_gt()` didn't strip non-numeric suffixes from tag parts (e.g. `v0.22.0-beta` → `0.22.0` vs `0.22.0`). New `clean_version()` handles this and logs the comparison for debugging.

2. **DMG mount failure** — The Rust backend tried to mount and install while the Electron app was still running. The running MetalSharp process prevented the app bundle from being replaced. This is why the "mount failed" happened — the process was staying alive through the Electron app.

### Architecture

**Phase 1: Download (while app is alive)**
- Backend downloads DMG to `~/.metalsharp/cache/updates/`, reports progress
- Electron polls `/update/progress` and shows progress bar

**Phase 2: Install (app exits, Python takes over)**
- Electron spawns Python updater with `detached: true`, then quits
- Python script runs the full install lifecycle independently:
  1. Kill backend PID → verify killed
  2. Kill steam/wine/webhelper → verify killed
  3. Kill MetalSharp app → verify closed
  4. Mount DMG (prompts for password via `osascript` admin dialog if needed)
  5. Install (`cp -R` to `/Applications`)
  6. Unmount, relaunch MetalSharp
  7. Verify backend version matches → redeploy if mismatch
  8. Write completion status

**Phase 3: Verification (new app instance)**
- New MetalSharp instance checks `update_install_status.json` on launch
- Shows "Update Complete!" popup with version info

### New Files
- `app/updater/update.py` — Python updater script
- `app/src/main/updater-bridge.ts` — Electron updater orchestration module
- `scripts/bundle_updater.sh` — CI script to create standalone Python runtime bundle

### Modified Files
- `app/src-rust/src/updater.rs` — Fixed version comparison, split download from install
- `app/src-rust/src/main.rs` — Added `/update/dmg-path` endpoint
- `app/src/main/index.ts` — Added updater IPC handlers
- `app/src/main/preload.ts` — Exposed updater methods to renderer
- `app/src/main/rust-bridge.ts` — Added `getPort()`, public `getBackendPid()`, removed duplicate
- `app/src/renderer/index.ts` — Rewritten update flow with Python handoff
- `app/src/renderer/api-types.ts` — Added `InstallStatus` type
- `app/package.json` — Added updater resources to extraResources, bumped to 0.22.0

### Testing
- TypeScript compiles clean (`tsc --noEmit`)
- Rust compiles clean (`cargo check`)
- Version comparison tested: `semver_gt("0.22.0", "0.22.0")` → `false` ✓
- Python script syntax valid (`python3 -c "import ast; ast.parse(open('app/updater/update.py').read())"`)

### CI Note
The `scripts/bundle_updater.sh` script creates a minimal Python runtime tarball at `bundles/updater.tar.gz`. The CI workflow should run this before `electron-builder` packs the DMG. If the bundle isn't present, the updater falls back to system `/usr/bin/python3` (available on macOS 13+).