### PR TITLE
ci: add Python CI for updater and fix JS/TS CI paths

### DIFF
--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -6,14 +6,18 @@ on:
     paths:
       - 'app/src/**'
       - 'app/package.json'
+      - 'app/package-lock.json'
       - 'app/tsconfig.json'
+      - 'app/biome.json'
       - '.github/workflows/ci-js.yml'
   pull_request:
     branches: [main]
     paths:
       - 'app/src/**'
       - 'app/package.json'
+      - 'app/package-lock.json'
       - 'app/tsconfig.json'
+      - 'app/biome.json'
       - '.github/workflows/ci-js.yml'
 
 jobs:

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -1,0 +1,56 @@
+name: Python CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'app/updater/**'
+      - 'scripts/bundle_updater.sh'
+      - '.github/workflows/ci-python.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'app/updater/**'
+      - 'scripts/bundle_updater.sh'
+      - '.github/workflows/ci-python.yml'
+
+jobs:
+  check:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Syntax check
+        run: python3 -m py_compile app/updater/update.py
+
+      - name: Lint with ruff
+        run: |
+          pip install ruff
+          ruff check app/updater/update.py
+
+      - name: Format check
+        run: ruff format --check app/updater/update.py
+
+  bundle:
+    runs-on: macos-14
+    needs: check
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Bundle updater Python runtime
+        run: bash scripts/bundle_updater.sh
+
+      - name: Verify bundle
+        run: |
+          ls -lh app/bundles/updater.tar.gz
+          tar -tzf app/bundles/updater.tar.gz | head -10
+
+      - name: Test bundled script runs
+        run: |
+          TMPDIR=$(mktemp -d)
+          tar -xzf app/bundles/updater.tar.gz -C "$TMPDIR"
+          "$TMPDIR/updater/bin/python3" "$TMPDIR/updater/update.py" --help


### PR DESCRIPTION
## Summary

- **New `ci-python.yml`**: Syntax check, ruff lint/format, bundle build verification, and end-to-end test of the bundled Python runtime running `update.py --help`
- **Fix `ci-js.yml` path triggers**: Added `package-lock.json` and `biome.json` so JS CI triggers on all relevant file changes