### PR TITLE
docs: update all docs to match v0.22.0 code reality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## v0.22.0 — 2026-05-14
+
+Native engine build, DXVK MoltenVK for 32-bit D3D9, engine routing overhaul.
+
+### Added
+
+- **Native C++ engine** — full D3D11, D3D12, DXGI, XAudio2, and XInput implementations built via CMake (`metalsharp_core`, `metalsharp_d3d11`, `metalsharp_d3d12`, `metalsharp_dxgi`, `metalsharp_audio`, `metalsharp_input` libraries). Loads PE binaries directly via native loader without Wine
+- **`DxvkMetal32` engine** — DXVK d3d9.dll injected into game directory, routed through MoltenVK Vulkan→Metal. Per-game binary path handling (Portal 2: `bin/portal2.exe`, Goat Simulator: `Binaries/Win32/GoatGame-Win32-Shipping.exe`)
+- **`MetalsharpWine` engine** — bare Wine launch with no DLL overrides. Used for legacy D3D9 games detected by `d3dx9_43.dll` marker
+- **Native launcher** — `metalsharp_launcher` and `metalsharp_native` executables in `tools/launcher/` for running games without the Electron app
+- **Bundled MoltenVK ICD** — Vulkan ICD manifest at `etc/vulkan/icd.d/MoltenVK_icd.json` in wine runtime, DxvkMetal32 uses this instead of Homebrew path
+- **DXVK state cache** — `DXVK_STATE_CACHE_PATH` set per-appid under `~/.metalsharp/shader-cache/dxvk-metal32/<appid>/`
+- **Shader cache per-appid** — DXMT shader cache path changed from `~/.metalsharp/shader-cache/<exename>/` to `~/.metalsharp/shader-cache/dxmt-metal/<appid>/`
+- **HTTP backend uses tiny_http** — replaced Actix with tiny_http for lighter dependency footprint
+- **Updater module** — `updater.rs` for self-update DMG download and install
+- **Test suite expanded** — 20+ test files covering D3D11, D3D12, DXBC parsing, Metal device, audio, input, tiled resources, and phases 2–24
+
+### Changed
+
+- **Celeste (appid 504230) → SteamD3DMetalPerf** — was FnaX86. Steam Celeste uses Steam DRM, launches via GPTK D3DMetal
+- **Portal 2 (appid 620) → DxvkMetal32** — was SteamD3DMetalPerf. Now uses DXVK d3d9→MoltenVK→Metal, no GPTK needed
+- **Goat Simulator (appid 265930) → DxvkMetal32** — was SteamD3DMetalPerf. 32-bit UE3 D3D9 via DXVK
+- **Undertale (appid 375520) → DxmtMetal** — mapped alongside Rain World and Subnautica BZ
+- **Among Us (appid 945360), Valheim (appid 892970) → SteamBare** — Steam DRM, no extra env vars
+- **Wined3d32** now sets `steamclient64,steamclient=d` in WINEDLLOVERRIDES and `SteamOverlayDisabled=1`
+- **DxmtMetal WINEDLLOVERRIDES** includes `gameoverlayrenderer,gameoverlayrenderer64=d`
+- **Steam launch wait** — increased to 60s with 2s polling interval for `launch_via_steam_with_env()`
+- **DXVK i386-windows path** — DXVK 32-bit DLLs located at `lib/dxvk/i386-windows/` in wine runtime (not `lib/wine/i386-windows/`)
+
+### Removed
+
+- **`Engine::FnaX86` active routing** — Celeste no longer uses FnaX86 path (FnaX86 enum variant still exists but no game maps to it)
+- **Actix dependency** — replaced by tiny_http
+
 ## v0.18.0 — 2026-05-12
 
 Performance optimizations, GPTK D3DMetal integration for Steam DRM games, 7 games confirmed working.

--- a/README.md
+++ b/README.md
@@ -2,19 +2,21 @@
 
 Play Windows Steam games on macOS. One app, one click.
 
-MetalSharp bundles a custom Wine 11.5 runtime with DXMT (D3D→Metal translation), Apple GPTK D3DMetal, DXVK, and FNA into a single Electron app with a setup wizard and one-click launch. It picks the right backend for each game automatically.
+MetalSharp bundles a custom Wine 11.5 runtime with DXMT (D3D→Metal translation), DXVK + MoltenVK, and FNA into a single Electron app with a setup wizard and one-click launch. It picks the right backend for each game automatically.
 
 ## How games run
 
 | Backend | How it works | Used for |
 |---------|-------------|----------|
 | **DXMT Metal** | D3D11 calls translated directly to Metal command buffers via DXMT + winemetal.so. Per-game shader cache + MetalFX spatial upscaling. | Rain World, Schedule I, Subnautica BZ |
-| **GPTK D3DMetal** | Steam DRM games launched via `steam://run/` with GPTK's D3DMetal framework loaded (WINEDLLPATH pointing to GPTK's d3d11.dll). | Portal 2, Goat Simulator, Celeste, 50+ other Steam games |
-| **WineD3D OpenGL** | Wine's builtin wined3d with OpenGL backend. Only option for 32-bit games (no 32-bit Metal API on macOS). | Nidhogg 2 |
-| **DXVK + MoltenVK** | D3D→Vulkan→Metal fallback (2 hops). DXVK 1.10.3 limited to Vulkan 1.1 by MoltenVK. | Future D3D9 games |
-| **FNA + SDL3** | Native Mono + FNA + SDL3 Metal rendering — no Wine. | Terraria (arm64), future FNA games |
+| **DXVK + MoltenVK (32-bit)** | D3D9→Vulkan→Metal for 32-bit games. DXVK 1.10.3 d3d9.dll injected into game dir, MoltenVK translates Vulkan to Metal. | Portal 2, Goat Simulator |
+| **WineD3D OpenGL** | Wine's builtin wined3d with OpenGL backend. For 32-bit games that don't work through DXVK. | Nidhogg 2 |
+| **SteamD3DMetalPerf** | Steam DRM games launched via `steam://run/` with GPTK's D3DMetal framework loaded (WINEDLLPATH pointing to GPTK's d3d11.dll). | Celeste, High on Life, RE4, 50+ other Steam games |
+| **SteamMetalfx** | Steam DRM games with D3DMetal MetalFX env vars. | Elden Ring, Sekiro |
+| **SteamBare** | Steam DRM games with no extra env vars. | Among Us, Valheim |
+| **FNA + SDL3** | Native Mono + FNA + SDL3 rendering — no Wine. | Terraria (arm64) |
 
-Games are auto-detected by scanning their install directory for engine markers (Unity, Unreal, FromSoftware, RE Engine, .NET/FNA). Unknown games default to GPTK D3DMetal Steam launch.
+Games are auto-detected by scanning their install directory for engine markers (Unity, Unreal, FromSoftware, RE Engine, .NET/FNA, D3D9 DLLs). Unknown games default to SteamD3DMetalPerf.
 
 ## Supported games
 
@@ -25,23 +27,23 @@ See [docs/GAMES-SUPPORTED.md](docs/GAMES-SUPPORTED.md) for full details includin
 | Rain World | DXMT Metal (D3D11→Metal) | Working |
 | Schedule I | DXMT Metal (D3D11→Metal) | Working |
 | Subnautica: Below Zero | DXMT Metal (D3D11→Metal) | Working |
-| Nidhogg 2 | WineD3D OpenGL (32-bit) | Working |
-| Portal 2 | GPTK D3DMetal (Steam DRM) | Working |
-| Goat Simulator | GPTK D3DMetal (Steam DRM) | Working |
+| Portal 2 | DXVK MoltenVK (D3D9→Vulkan→Metal) | Working |
+| Goat Simulator | DXVK MoltenVK (D3D9→Vulkan→Metal) | Working |
+| Nidhogg 2 | WineD3D OpenGL | Working |
 | Celeste | GPTK D3DMetal (Steam DRM) | Working |
 | High on Life | GPTK D3DMetal (Steam DRM) | Crashes after loading screen |
 | Resident Evil 4 | GPTK D3DMetal (Steam DRM) | Crashes |
 
 Tested on Apple M4, macOS 26.
 
-## What's new in v0.18.0
+## What's new in v0.22.0
 
-- **GPTK D3DMetal for Steam DRM games** — `SteamD3DMetalPerf` now loads GPTK's d3d11.dll via WINEDLLPATH, enabling Apple's D3DMetal for Steam-launched games
-- **DXMT shader cache** — per-game persistent shader cache under `~/.metalsharp/shader-cache/<exename>/`, eliminates recompilation stutter on subsequent launches
-- **MetalFX 2x spatial upscaling** — DXMT games render at half resolution, MetalFX upscales to native. Configurable via `dxmt.conf`
-- **7 games confirmed working** — Rain World, Schedule I, Subnautica BZ, Nidhogg 2, Portal 2, Goat Simulator, Celeste
-- **Bundle 2** — pre-built shims (SDL3, FNA3D, FMOD stubs, CSteamworks) and DXMT config in `metalsharp_bundle2.tar.zst`
-- **Library merge fix** — wine-steam installed games now appear in library even if Steam API doesn't report them
+- **DXVK MoltenVK for 32-bit D3D9 games** — new `DxvkMetal32` engine: injects DXVK d3d9.dll into game dir, routes through MoltenVK Vulkan→Metal. Portal 2 and Goat Simulator now use this path instead of GPTK
+- **MetalsharpWine engine** — bare Wine launch for games that need minimal interference (D3D9 games with `d3dx9_43.dll` marker)
+- **Celeste moved to SteamD3DMetalPerf** — Steam DRM + GPTK D3DMetal, no longer FnaX86
+- **Native engine** — C++ D3D11/D3D12/DXGI/XAudio2/XInput implementations built via CMake, loads PE binaries directly without Wine (for native launcher)
+- **Shader cache per-appid** — DXMT and DXVK shader caches organized by appid under `~/.metalsharp/shader-cache/<engine>/<appid>/`
+- **MoltenVK ICD bundled** — Vulkan ICD manifest shipped in wine runtime at `etc/vulkan/icd.d/`
 
 ## Install
 
@@ -93,12 +95,11 @@ cd app && npm run build:all && npx electron-builder --mac dmg --arm64
 | Layer | Technology |
 |-------|-----------|
 | Desktop app | Electron + TypeScript |
-| Backend | Rust HTTP server (Actix) |
+| Backend | Rust HTTP server (tiny_http) |
 | Wine runtime | MetalSharp Wine 11.5 (from-source, gnutls TLS, DXMT builtins, 7 custom patches) |
 | D3D→Metal | DXMT v0.80+10 (LLVM 15 + Metal toolchain) |
 | D3D→Metal (Steam) | Apple GPTK D3DMetal via WINEDLLPATH |
-| D3D→Vulkan | DXVK 1.10.3 |
-| Vulkan→Metal | MoltenVK (via Homebrew) |
+| D3D9→Vulkan→Metal | DXVK 1.10.3 + MoltenVK |
 | XNA/FNA | FNA + SDL3 + Mono |
 | Bundles | Two zstd-compressed archives (runtime + shims/config) |
 
@@ -124,16 +125,21 @@ app/
 │   └── renderer/       Electron renderer — UI, library browser, setup wizard
 └── bundles/            Pre-packaged deps
 
+src/                    C++ native engine (D3D11/D3D12/DXGI/XAudio2/XInput Metal implementations)
+include/                C++ headers
 scripts/                Per-game setup and launch scripts
 configs/                Mono DLL maps for FNA games
 docs/                   Architecture and game compatibility docs
+tools/
+├── dmg/                DMG packaging scripts
+└── launcher/           Native launcher (C++ MetalSharp binary, Wine prefix management)
 ```
 
 ## Bundled dependencies
 
 | Bundle | Contents |
 |--------|----------|
-| `metalsharp_bundle.tar.zst` | MetalSharp Wine 11.5 with DXMT Metal D3D11/D3D12 builtins, gnutls, wined3d, DXVK 1.10.3, Mono x86 + arm64 |
+| `metalsharp_bundle.tar.zst` | MetalSharp Wine 11.5 with DXMT Metal D3D11/D3D12 builtins, DXVK 1.10.3, Mono x86 + arm64, MoltenVK ICD |
 | `metalsharp_bundle2.tar.zst` | Pre-built shims (SDL3, FNA3D, FMOD stubs, CSteamworks, steam_api), DXMT config (MetalFX, framerate) |
 | `SteamSetup.exe` | Windows Steam installer |
 

--- a/docs/GAMES-SUPPORTED.md
+++ b/docs/GAMES-SUPPORTED.md
@@ -1,16 +1,18 @@
-# Games Supported — MetalSharp v0.17.0
+# Games Supported — MetalSharp v0.22.0
 
 ## Rendering Engines
 
 | Engine | Method | How It Works |
 |---|---|---|
 | **DxmtMetal** | Direct exe via Wine | DXMT D3D11/DXGI Metal-native. DLLs injected into game dir. Per-game shader cache + MetalFX upscaling. No GPTK needed. |
-| **Wined3d32** | Direct exe via Wine | WineD3D OpenGL for 32-bit games. No Metal on macOS for 32-bit. |
-| **SteamD3DMetalPerf** | `steam://run/` via Wine Steam | Steam DRM games. Launches through Wine Steam client with D3DM perf env vars. Uses our Wine runtime (MoltenVK, freetype, gnutls). |
+| **DxmtMetal12** | Direct exe via Wine | DXMT D3D12/D3D11/DXGI Metal-native. Same as DxmtMetal with additional d3d12.dll injection. |
+| **DxvkMetal32** | Direct exe via Wine | DXVK d3d9→MoltenVK→Metal for 32-bit D3D9 games. d3d9.dll injected into game's binary dir. Per-game state cache. |
+| **Wined3d32** | Direct exe via Wine | WineD3D OpenGL for 32-bit games. No Metal on macOS for 32-bit D3D11. |
+| **MetalsharpWine** | Direct exe via Wine | Bare Wine launch. No DLL overrides. For legacy D3D9 games. |
+| **SteamD3DMetalPerf** | `steam://run/` via Wine Steam | Steam DRM games. Launches through Wine Steam with GPTK's D3DMetal loaded via WINEDLLPATH. D3DM perf env vars. |
 | **SteamMetalfx** | `steam://run/` via Wine Steam | Steam DRM games with D3DMetal MetalFX env vars. |
 | **SteamBare** | `steam://run/` via Wine Steam | Steam DRM games. No extra env vars. |
 | **FnaArm64** | Direct exe via .NET ARM64 | FNA/XNA games. Native ARM64 .NET runtime. |
-| **FnaX86** | Direct exe via .NET x86 | FNA/XNA games. x86 .NET via Wine. |
 
 ---
 
@@ -21,32 +23,56 @@ These games have been tested and confirmed running on MetalSharp.
 ### Rain World
 - **AppID:** 312520
 - **Engine:** DxmtMetal (D3D11 → Metal via DXMT)
-- **Launch:** Direct exe. DXMT injects `d3d11.dll`, `dxgi.dll`, `d3d10core.dll`, `winemetal.dll` into game dir. Per-game shader cache at `~/.metalsharp/shader-cache/`. MetalFX 2x spatial upscaling enabled.
+- **Launch:** Direct exe. DXMT injects `d3d11.dll`, `dxgi.dll`, `d3d10core.dll`, `winemetal.dll` into game dir. Per-appid shader cache at `~/.metalsharp/shader-cache/dxmt-metal/312520/`. MetalFX 2x spatial upscaling enabled.
 - **Recommended Settings:** Default preset / Medium settings, V-Sync ON
 
 ### Schedule I
 - **AppID:** 3164500
 - **Engine:** DxmtMetal (D3D11 → Metal via DXMT)
-- **Launch:** Direct exe. Same DXMT injection as Rain World. Per-game shader cache + MetalFX upscaling.
+- **Launch:** Direct exe. Same DXMT injection as Rain World. Per-appid shader cache + MetalFX upscaling.
 - **Recommended Settings:** Low preset, SSAO enabled, V-Sync ON, God Rays OFF
 
 ### Subnautica: Below Zero
 - **AppID:** 848450
 - **Engine:** DxmtMetal (D3D11 → Metal via DXMT)
-- **Launch:** Direct exe. Same DXMT injection. Per-game shader cache + MetalFX upscaling.
+- **Launch:** Direct exe. Same DXMT injection. Per-appid shader cache + MetalFX upscaling.
 - **Recommended Settings:** Low preset, V-Sync ON, FXAA
+
+### Undertale
+- **AppID:** 375520
+- **Engine:** DxmtMetal (D3D11 → Metal via DXMT)
+- **Launch:** Direct exe. Same DXMT injection. Per-appid shader cache + MetalFX upscaling.
+- **Recommended Settings:** Default
+
+### Portal 2
+- **AppID:** 620
+- **Engine:** DxvkMetal32 (D3D9 → Vulkan → Metal via DXVK + MoltenVK)
+- **Launch:** Direct exe via Wine. DXVK `d3d9.dll` injected into `bin/` dir. MoltenVK bundled in wine runtime. VK_ICD_FILENAMES set to bundled ICD. Per-appid state cache at `~/.metalsharp/shader-cache/dxvk-metal32/620/`.
+- **Recommended Settings:** Low/Medium settings, V-Sync ON
+
+### Goat Simulator
+- **AppID:** 265930
+- **Engine:** DxvkMetal32 (D3D9 → Vulkan → Metal via DXVK + MoltenVK)
+- **Launch:** Direct exe via Wine. DXVK `d3d9.dll` injected into `Binaries/Win32/`. Working dir set to `Binaries/Win32/`. Same MoltenVK setup as Portal 2.
+- **Recommended Settings:** Low settings, V-Sync ON
 
 ### Nidhogg 2
 - **AppID:** 535520
 - **Engine:** Wined3d32 (D3D11 → OpenGL via WineD3D)
-- **Launch:** Direct exe via Wine. No DLL injection — uses Wine's builtin WineD3D. 32-bit game, no Metal API available on macOS.
+- **Launch:** Direct exe via Wine. No DLL injection — uses Wine's builtin WineD3D. 32-bit game, no Metal API available on macOS. Steam overlay disabled.
 - **Recommended Settings:** High settings, V-Sync ON
 
-### Portal 2
-- **AppID:** 620
-- **Engine:** SteamD3DMetalPerf (via Wine Steam)
-- **Launch:** `steam://run/620` through Wine Steam client. Uses our Wine runtime with DYLD paths for MoltenVK/freetype/gnutls. D3DM async commit + multithreaded interface enabled.
-- **Recommended Settings:** Low/Medium settings, V-Sync ON
+### Celeste
+- **AppID:** 504230
+- **Engine:** SteamD3DMetalPerf (via Wine Steam + GPTK D3DMetal)
+- **Launch:** `steam://run/504230` through Wine Steam client. WINEDLLPATH prepended with GPTK's d3d11.dll path. D3DM async commit + multithreaded interface enabled. Previously used FnaX86 — now uses Steam DRM + GPTK D3DMetal.
+- **Recommended Settings:** Default
+
+### Terraria
+- **AppID:** 105600
+- **Engine:** FnaArm64 (Native .NET ARM64 + FNA + SDL3)
+- **Launch:** Native Mono ARM64. No Wine. FNA + SDL3 + Metal rendering. macOS Steam libraries (libsteam_api.dylib, SDL3, FAudio, FNA3D) copied from macOS Terraria install. Custom launcher (`TerrariaLauncher.exe`) built from source.
+- **Recommended Settings:** Default
 
 ---
 
@@ -55,7 +81,12 @@ These games have been tested and confirmed running on MetalSharp.
 ### Resident Evil 4 (2023)
 - **AppID:** 2050650
 - **Engine:** SteamD3DMetalPerf (mapped)
-- **Status:** Blocked by Steam DRM. Game requires `steam://run/` launch. Direct exe fails (missing `steam_api64.dll`). DXMT injection through Steam launch path not yet implemented. Game's own D3D12 mode forced to D3D11 via `local_config.ini` (chmod 444 to prevent overwrite).
+- **Status:** Crashes with GPTK D3DMetal. Launches via `steam://run/` with D3DM perf env vars. UE4 compatibility limitation under investigation.
+
+### High on Life
+- **AppID:** 1583230
+- **Engine:** SteamD3DMetalPerf (mapped)
+- **Status:** Crashes after loading screen with GPTK D3DMetal. Squanch Games UE4 compatibility issue.
 
 ---
 
@@ -65,6 +96,7 @@ Games not explicitly mapped are auto-detected by scanning the game directory:
 
 | Detection | Engine |
 |---|---|
+| `.NET managed DLLs` (`*_Data/Managed/` dir, no native PE DLLs) | FnaArm64 |
 | `UnityPlayer.dll` or `GameAssembly.dll` present | SteamD3DMetalPerf |
 | `engine/` + `binaries/` dirs (Unreal Engine) | SteamMetalfx |
 | `.pak` files (Source/Unreal) | SteamD3DMetalPerf |
@@ -72,6 +104,7 @@ Games not explicitly mapped are auto-detected by scanning the game directory:
 | `.bdt` / `.bhd` files (Dark Souls / FromSoft) | SteamMetalfx |
 | `re_chunk_` or RE config files | SteamD3DMetalPerf |
 | `d3dx9_43.dll` (legacy D3D9) | MetalsharpWine |
+| `steam_api64.dll` or `steam_api.dll` | SteamD3DMetalPerf |
 | Default fallback | SteamD3DMetalPerf |
 
 ---
@@ -87,15 +120,24 @@ d3d11.maxFeatureLevel = 12_1
 ```
 
 Environment variables set for DxmtMetal games:
-- `DXMT_SHADER_CACHE_PATH` — per-game cache dir under `~/.metalsharp/shader-cache/<exename>/`
+- `DXMT_SHADER_CACHE_PATH` — per-appid cache dir under `~/.metalsharp/shader-cache/dxmt-metal/<appid>/`
 - `DXMT_CONFIG_FILE` — points to `dxmt.conf`
 - `DXMT_METALFX_SPATIAL_SWAPCHAIN=1` — enables MetalFX spatial upscaling
+
+## DXVK Configuration
+
+Environment variables set for DxvkMetal32 games:
+- `VK_ICD_FILENAMES` — points to bundled MoltenVK ICD at `~/.metalsharp/runtime/wine/etc/vulkan/icd.d/MoltenVK_icd.json`
+- `DXVK_STATE_CACHE_PATH` — per-appid cache dir under `~/.metalsharp/shader-cache/dxvk-metal32/<appid>/`
+- `WINEDLLOVERRIDES=d3d9=n,b` — loads DXVK d3d9 from game dir
 
 ---
 
 ## Notes
 
 - First launch of any DxmtMetal game will stutter while the shader cache builds. Subsequent launches are smoother.
-- All games use the shared Wine prefix at `~/.metalsharp/prefix-steam/`.
+- All games use the shared Wine prefix at `~/.metalsharp/prefix-steam/` unless game-specific setup creates a separate one.
 - Steam library on external SSD should be mapped as F: drive in Wine prefix.
-- Shader caches are per-game and persist across launches. Safe to delete `~/.metalsharp/shader-cache/` to force rebuild.
+- Shader caches are per-appid and persist across launches. Safe to delete `~/.metalsharp/shader-cache/` to force rebuild.
+- Portal 2 and Goat Simulator require DXVK + MoltenVK — no GPTK needed for these.
+- Celeste no longer uses the FNA path — it launches through Steam DRM + GPTK D3DMetal.

--- a/docs/dxmt-vulkan-architecture.md
+++ b/docs/dxmt-vulkan-architecture.md
@@ -1,6 +1,6 @@
 # DXMT & Vulkan Architecture
 
-MetalSharp uses two D3D translation pipelines: **DXMT** (D3D→Metal, direct) and **DXVK + MoltenVK** (D3D→Vulkan→Metal, indirect). DXMT is the primary path.
+MetalSharp uses two D3D translation pipelines: **DXMT** (D3D→Metal, direct) and **DXVK + MoltenVK** (D3D→Vulkan→Metal, indirect). DXMT is the primary path for 64-bit D3D11 games. DXVK is used for 32-bit D3D9 games.
 
 ## Pipeline Overview
 
@@ -78,10 +78,10 @@ DXMT has two cache systems:
 
 **Shader cache** (`DXMT_SHADER_CACHE_PATH`):
 - Stores compiled Metal shaders in `.db` files (SQLite-based via WMT::CacheWriter/CacheReader)
-- Per-game under `~/.metalsharp/shader-cache/<exename>/`
+- Per-appid under `~/.metalsharp/shader-cache/dxmt-metal/<appid>/`
 - File format: `shaders_<metal_version>.db` (e.g., `shaders_320.db`)
 - `DXMT_SHADER_CACHE=0` disables
-- Path must start with `/` — if set, DXMT uses it directly (no exe name subdirectory appended)
+- Path is set with trailing `/` by the Rust backend
 
 **Metal PSO cache** (automatic):
 - Set in `dxgi.cpp` `InitializeMetalCachePath()` → `dxmt/<exename>/com.apple.metal`
@@ -101,11 +101,11 @@ All config options documented in DXMT source: `dxmt-src/docs/CUSTOMIZATION.md`
 
 ## DXVK + MoltenVK — Vulkan Pipeline
 
-Fallback path. D3D → Vulkan → Metal. Extra translation hop but wider compatibility.
+Used for 32-bit D3D9 games (Portal 2, Goat Simulator). D3D9 → Vulkan → Metal. Two translation hops but enables D3D9 games that don't work through WineD3D OpenGL.
 
 ```
-Game D3D11 calls
-  → DXVK d3d11.dll (D3D → Vulkan)
+Game D3D9 calls
+  → DXVK d3d9.dll (D3D9 → Vulkan)
     → MoltenVK (Vulkan → Metal)
       → Metal framework
 ```
@@ -117,23 +117,25 @@ DXVK 2.x requires Vulkan 1.3. MoltenVK supports Vulkan 1.1 (some 1.2). DXVK 1.10
 ### DXVK Layout
 
 ```
+~/.metalsharp/runtime/wine/lib/dxvk/
+└── i386-windows/    32-bit DXVK DLLs (d3d9.dll, d3d11.dll, d3d10core.dll, dxgi.dll)
+
 ~/.metalsharp/runtime/dxvk-1.10.3/
 ├── x32/   (32-bit: d3d11, d3d10core, d3d9, dxgi)
 └── x64/   (64-bit: d3d11, d3d10core, d3d9, dxgi)
 ```
 
-Not placed in Wine's builtin dirs. Copied into game directories when needed.
+DXVK i386 DLLs live at `lib/dxvk/i386-windows/` inside the wine tree (not `lib/wine/i386-windows/`). The Rust backend copies `d3d9.dll` from here into the game's binary directory on every launch.
 
 ### MoltenVK
 
-Installed via Homebrew (`brew install moltenvk`). Not bundled.
+Bundled in the wine runtime. ICD manifest at `etc/vulkan/icd.d/MoltenVK_icd.json`.
 
 Env for DXVK pipeline:
 ```
-VK_ICD_FILENAMES=/opt/homebrew/share/vulkan/icd.d/MoltenVK_icd.json
-MVK_PRESENT_MODE=1
-DXVK_FRAME_RATE=60
-DXVK_ASYNC=1
+VK_ICD_FILENAMES=~/.metalsharp/runtime/wine/etc/vulkan/icd.d/MoltenVK_icd.json
+DXVK_STATE_CACHE_PATH=~/.metalsharp/shader-cache/dxvk-metal32/<appid>/
+WINEDLLOVERRIDES=d3d9=n,b;gameoverlayrenderer,gameoverlayrenderer64=d
 ```
 
 ## Comparison
@@ -144,8 +146,9 @@ DXVK_ASYNC=1
 | Latency | Lower | Higher |
 | Shader path | DXBC/DXIL → MSL direct | DXBC → SPIR-V → MSL |
 | Metal features | Direct access (Metal 3+) | Limited to MoltenVK surface |
-| 32-bit support | Via WoW64 thunks | Via WINEDLLOVERRIDES |
+| 32-bit support | Via WoW64 thunks (D3D11) | Via DXVK d3d9.dll (D3D9) |
 | Vulkan needed | No | Yes |
+| Games using it | Rain World, Schedule I, Subnautica BZ, Undertale | Portal 2, Goat Simulator |
 
 ## Current Usage
 
@@ -154,6 +157,10 @@ DXVK_ASYNC=1
 | Rain World | DXMT Metal | 64-bit D3D11, primary path |
 | Schedule I | DXMT Metal | 64-bit D3D11, Unity |
 | Subnautica BZ | DXMT Metal | 64-bit D3D11 |
+| Undertale | DXMT Metal | 64-bit D3D11 |
+| Portal 2 | DXVK MoltenVK | 32-bit Source engine D3D9, DXVK handles it better than WineD3D |
+| Goat Simulator | DXVK MoltenVK | 32-bit UE3 D3D9 |
 | Nidhogg 2 | WineD3D OpenGL | 32-bit, no 32-bit Metal API |
-| Portal 2 | Wine D3DMetal | Steam DRM, Wine builtins |
-| RE4 | Wine D3DMetal | Steam DRM, blocked on DXMT injection |
+| Celeste | GPTK D3DMetal | Steam DRM, uses SteamD3DMetalPerf |
+| RE4 | GPTK D3DMetal | Steam DRM, SteamD3DMetalPerf (crashes) |
+| Elden Ring | GPTK D3DMetal + MetalFX | Steam DRM, SteamMetalfx |

--- a/docs/launch-architecture.md
+++ b/docs/launch-architecture.md
@@ -7,7 +7,7 @@ MetalSharp's game launch system: the Rust backend (`launch.rs`) determines *what
 ```
 User clicks "Play"
   → Electron renderer → IPC → Rust backend
-    → launch_auto(appid)
+    → launch_auto(appid) or launch_with_method(appid, method)
       → resolve engine: appid map → fallback to directory scan
       → dispatch to launch function
         → spawn process with env vars
@@ -18,18 +18,20 @@ User clicks "Play"
 
 ## Engine Types
 
-`launch.rs` defines 8 engine types:
+`launch.rs` defines 10 engine types:
 
 | Engine | When used | Launch method |
 |--------|-----------|---------------|
-| `DxmtMetal` | Rain World, Schedule I, Subnautica BZ (64-bit D3D11) | Direct exe. DXMT DLLs injected into game dir. Shader cache + MetalFX. |
-| `DxmtMetal12` | Future D3D12 games | Direct exe. Also injects d3d12.dll. Currently unused. |
-| `Wined3d32` | Nidhogg 2 (32-bit games) | Direct exe via Wine. No DLL injection — Wine builtin WineD3D. |
-| `SteamD3DMetalPerf` | Portal 2, RE4, ~50 other Steam DRM games | `steam://run/` via Wine Steam with D3DM perf env vars. |
+| `DxmtMetal` | Rain World, Schedule I, Subnautica BZ, Undertale (64-bit D3D11) | Direct exe. DXMT DLLs injected into game dir. Shader cache + MetalFX. |
+| `DxmtMetal12` | Future D3D12 games (RE4, Schedule I during setup) | Direct exe. Also injects d3d12.dll. |
+| `Wined3d32` | Nidhogg 2 (32-bit games needing OpenGL) | Direct exe via Wine. No DLL injection — Wine builtin WineD3D. |
+| `DxvkMetal32` | Portal 2, Goat Simulator (32-bit D3D9 games) | Direct exe via Wine. DXVK d3d9.dll injected into game dir. MoltenVK Vulkan→Metal. |
+| `MetalsharpWine` | Legacy D3D9 games (`d3dx9_43.dll` marker) | Direct exe via bare Wine. No DLL overrides. |
+| `SteamD3DMetalPerf` | Celeste, RE4, High on Life, ~70 Steam DRM games | `steam://run/` via Wine Steam with GPTK D3DMetal (WINEDLLPATH + DYLD pointing to GPTK). |
 | `SteamMetalfx` | Elden Ring, Sekiro (Steam DRM + D3DMetal MetalFX) | `steam://run/` via Wine Steam with MetalFX env vars. |
-| `SteamBare` | Among Us, SteamVR (Steam DRM, no extras) | `steam://run/` via Wine Steam. No extra env vars. |
+| `SteamBare` | Among Us, Valheim (Steam DRM, no extras) | `steam://run/` via Wine Steam. No extra env vars. |
 | `FnaArm64` | Terraria (native ARM64 .NET + FNA) | Native Mono ARM64. No Wine. |
-| `FnaX86` | Celeste (x86 .NET + FNA + FMOD) | Rosetta Mono x86. No Wine. |
+| `FnaX86` | (reserved, not currently mapped) | Rosetta Mono x86. No Wine. |
 
 ## Engine Resolution
 
@@ -39,14 +41,16 @@ User clicks "Play"
 
 ```rust
 match appid {
-    105600 => FnaArm64,           // Terraria
-    504230 => FnaX86,             // Celeste
-    312520 | 848450 => DxmtMetal, // Rain World, Subnautica BZ
-    3164500 => DxmtMetal,         // Schedule I
-    535520 | 391540 => Wined3d32, // Nidhogg 2
-    620 => SteamD3DMetalPerf,     // Portal 2
-    2050650 => SteamD3DMetalPerf, // RE4
-    1245620 => SteamMetalfx,      // Elden Ring
+    105600 => FnaArm64,            // Terraria
+    504230 => SteamD3DMetalPerf,   // Celeste (was FnaX86)
+    312520 | 375520 | 848450 => DxmtMetal, // Rain World, Undertale, Subnautica BZ
+    3164500 => DxmtMetal,          // Schedule I
+    535520 => Wined3d32,           // Nidhogg 2
+    620 | 265930 => DxvkMetal32,   // Portal 2, Goat Simulator
+    2050650 | 1583230 => SteamD3DMetalPerf, // RE4, High on Life
+    391540 => SteamBare,           // (Steam DRM, no extras)
+    945360 | 1139900 => SteamBare, // Among Us, etc.
+    1245620 => SteamMetalfx,       // Elden Ring
     ...
 }
 ```
@@ -57,6 +61,7 @@ Unknown games get auto-detected by `detect_engine_from_dir()`:
 
 | Marker | Detected as |
 |--------|-------------|
+| `.NET managed DLLs` (`*_Data/Managed/` dir, no native PE DLLs) | `FnaArm64` |
 | `UnityPlayer.dll`, `GameAssembly.dll` | Unity → `SteamD3DMetalPerf` |
 | `engine/` + `binaries/` dirs | Unreal Engine → `SteamMetalfx` |
 | `.pak` files | Source/Unreal → `SteamD3DMetalPerf` |
@@ -64,24 +69,51 @@ Unknown games get auto-detected by `detect_engine_from_dir()`:
 | `.bdt` / `.bhd` files | FromSoftware → `SteamMetalfx` |
 | `re_chunk_*` or RE config files | RE Engine → `SteamD3DMetalPerf` |
 | `d3dx9_43.dll` | DirectX 9 → `MetalsharpWine` |
+| `steam_api64.dll` or `steam_api.dll` | `SteamD3DMetalPerf` |
 | Default fallback | `SteamD3DMetalPerf` |
 
 ## Launch Paths in Detail
 
-### DxmtMetal (Rain World, Schedule I, Subnautica BZ)
+### DxmtMetal (Rain World, Schedule I, Subnautica BZ, Undertale)
 
 Direct exe launch. Copies DXMT PE DLLs into game directory, sets up shader cache and MetalFX:
 
 ```
 metalsharp-wine "Schedule I.exe"
-  → DYLD_FALLBACK_LIBRARY_PATH includes dxmt/x86_64-unix
-  → WINEDLLOVERRIDES="dxgi,d3d11,d3d10core,winemetal=n,b"
-  → DXMT_SHADER_CACHE_PATH=~/.metalsharp/shader-cache/Schedule I.exe/
+  → DYLD_FALLBACK_LIBRARY_PATH includes lib/wine/x86_64-unix + lib/dxmt/x86_64-unix
+  → WINEDLLOVERRIDES="dxgi,d3d11,d3d10core,winemetal=n,b;gameoverlayrenderer,gameoverlayrenderer64=d"
+  → DXMT_SHADER_CACHE_PATH=~/.metalsharp/shader-cache/dxmt-metal/<appid>/
   → DXMT_CONFIG_FILE=~/.metalsharp/runtime/wine/etc/dxmt.conf
   → DXMT_METALFX_SPATIAL_SWAPCHAIN=1
   → DLLs copied: d3d11.dll, dxgi.dll, d3d10core.dll, winemetal.dll
   → Wine loads DXMT d3d11.dll → Metal rendering
 ```
+
+### DxvkMetal32 (Portal 2, Goat Simulator)
+
+Direct exe via Wine with DXVK d3d9.dll injected into game's binary directory. Routes through MoltenVK:
+
+```
+# Portal 2
+metalsharp-wine portal2.exe
+  → working dir: game root
+  → d3d9.dll copied to game bin/ dir from lib/dxvk/i386-windows/
+  → WINEDLLOVERRIDES="d3d9=n,b;gameoverlayrenderer,gameoverlayrenderer64=d"
+  → VK_ICD_FILENAMES=<ms_root>/etc/vulkan/icd.d/MoltenVK_icd.json
+  → DXVK_STATE_CACHE_PATH=~/.metalsharp/shader-cache/dxvk-metal32/<appid>/
+  → DYLD_FALLBACK_LIBRARY_PATH=<ms_root>/lib/wine/x86_64-unix
+
+# Goat Simulator
+metalsharp-wine GoatGame-Win32-Shipping.exe
+  → working dir: Binaries/Win32/
+  → d3d9.dll copied to Binaries/Win32/
+  → same env vars
+```
+
+Per-appid binary path handling in `launch_dxvk_metal32()`:
+- appid 620 (Portal 2): exe=`portal2.exe`, d3d9.dll → `bin/d3d9.dll`
+- appid 265930 (Goat Simulator): exe=`GoatGame-Win32-Shipping.exe`, d3d9.dll → `Binaries/Win32/d3d9.dll`
+- Other: d3d9.dll → game root
 
 ### Wined3d32 (Nidhogg 2)
 
@@ -89,67 +121,105 @@ Direct exe via Wine with minimal overrides. No Metal — uses OpenGL:
 
 ```
 metalsharp-wine "Nidhogg 2.exe"
-  → WINEDLLOVERRIDES="dxgi,d3d11=b;gameoverlayrenderer,gameoverlayrenderer64=d"
+  → WINEDLLOVERRIDES="dxgi,d3d11=b;gameoverlayrenderer,gameoverlayrenderer64=d;steamclient64,steamclient=d"
+  → SteamOverlayDisabled=1
   → No DXMT DLLs copied
   → Wine builtin WineD3D handles D3D11 → OpenGL
 ```
 
-### SteamD3DMetalPerf (Portal 2, RE4, etc.)
+### MetalsharpWine (Legacy D3D9)
 
-Launches through Wine Steam client with performance env vars:
+Bare Wine launch with no DLL overrides. Used for games with `d3dx9_43.dll` marker:
 
 ```
-1. Check if Wine Steam running → start if needed (up to 60s wait)
+metalsharp-wine "game.exe"
+  → DYLD_FALLBACK_LIBRARY_PATH=<ms_root>/lib/wine/x86_64-unix
+  → No WINEDLLOVERRIDES
+```
+
+### SteamD3DMetalPerf (Celeste, RE4, High on Life, etc.)
+
+Launches through Wine Steam client with GPTK D3DMetal loaded via WINEDLLPATH:
+
+```
+1. Check if Wine Steam running → start if needed (up to 60s wait with 2s polling)
 2. metalsharp-wine steam://run/{appid}
-  → D3DM_ENABLE_ASYNC_COMMIT=1
-  → D3DM_MULTITHREADED_INTERFACE_ENABLE=1
-  → D3DM_IGNORE_D3D11_RENDER_BARRIERS=1
-  → D3DM_SAMPLE_NAN_TO_ZERO=1
-  → D3DM_FLUSH_POS_INF_TO_NAN=1
-  → MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE=1
-  → MVK_ALLOW_METAL_FENCES=1
+   → WINEDLLPATH includes GPTK x86_64-windows + MS wine x86_64-windows
+   → DYLD_FALLBACK_LIBRARY_PATH includes GPTK x86_64-unix + MS wine x86_64-unix
+   → D3DM_ENABLE_ASYNC_COMMIT=1
+   → D3DM_MULTITHREADED_INTERFACE_ENABLE=1
+   → D3DM_IGNORE_D3D11_RENDER_BARRIERS=1
+   → D3DM_SAMPLE_NAN_TO_ZERO=1
+   → D3DM_FLUSH_POS_INF_TO_NAN=1
 ```
 
-### FNA (Terraria, Celeste)
+### SteamMetalfx (Elden Ring, Sekiro)
+
+Same as SteamD3DMetalPerf but with additional MetalFX env vars:
+
+```
+metalsharp-wine steam://run/{appid}
+   → D3DM_ENABLE_METALFX=1
+   → D3DM_ENABLE_ASYNC_COMMIT=1
+   → D3DM_MULTITHREADED_INTERFACE_ENABLE=1
+   → D3DM_IGNORE_D3D11_RENDER_BARRIERS=1
+   → D3DM_SAMPLE_NAN_TO_ZERO=1
+   → D3DM_FLUSH_POS_INF_TO_NAN=1
+   → MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE=1
+   → MVK_ALLOW_METAL_FENCES=1
+```
+
+### FNA (Terraria)
 
 No Wine. Native .NET runtime:
 
 ```
 # Terraria (ARM64 native)
 mono TerrariaLauncher.exe → FNA + SDL3 + Metal + FAudio
-
-# Celeste (x86 via Rosetta)
-arch -x86_64 mono Celeste.exe → FNA + SDL3 + FMOD stubs
 ```
 
 ## Process Lifecycle
 
 ### Killing a game
 
-`kill_game(appid)` does multi-pass cleanup:
+`kill_game(appid)` searches for processes matching the game directory path:
+1. `pgrep -a -f <game_dir>` — find processes in game dir
+2. `kill -9 <pid>` — direct kill each match
+3. `pkill -9 -f UnityCrashHandler` — cleanup stragglers
+
+`kill(pid)` does simpler cleanup:
 1. `kill -9 {pid}` — direct kill
 2. `pkill -9 -P {pid}` — child processes
-3. `pkill -9 -f "metalsharp.*{appid}"` — stragglers
-4. Optional: `pkill -9 -f "{exe_name}"` — name-based
+3. `pkill -9 -f UnityCrashHandler` — cleanup
 
 ### Stopping Steam
 
 `stop_wine_steam()` in `steam.rs`:
-1. `killall Steam.exe steam.exe`
-2. `wineserver -k`
-3. `killall wineloader wineserver`
-4. Retry loop
+1. `pkill -9 -f Steam.exe/steam.exe/steamservice.exe/steamwebhelper.exe/winedevice.exe`
+2. Wait 2s
+3. `pkill -9 -f wineserver`
+4. `pkill -9 -f wineloader`
+5. Wait 2s
+6. If still running: `killall -9` for each target
 
 ## Game Directory Resolution
 
-1. `~/.metalsharp/games/{appid}/` — MetalSharp's local copy (FNA games)
-2. Steam `common/` — `{prefix}/drive_c/Program Files (x86)/Steam/steamapps/common/{install_dir}/`
-3. Appmanifest parsing — `appmanifest_{appid}.acf` contains `InstallDir`
+`resolve_game_dir(appid)` in `setup.rs`:
+1. `~/.metalsharp/games/{appid}/` — MetalSharp's local copy (if `.metalsharp_prepared` marker exists)
+2. Steam `common/` — parse `appmanifest_{appid}.acf` for `installdir`, look in `steamapps/common/{install_dir}/`
+3. Search both macOS native Steam paths and Wine Steam prefix paths
+4. Fallback: return `~/.metalsharp/games/{appid}/` if it exists
 
 ## Shader Cache
 
-DXMT shader cache is per-game under `~/.metalsharp/shader-cache/<exename>/`:
-- Each game gets its own `shaders_320.db` (Metal 3.2.0 shaders)
+Shader caches are organized by engine type and appid:
+
+| Engine | Path | Format |
+|--------|------|--------|
+| DxmtMetal / DxmtMetal12 | `~/.metalsharp/shader-cache/dxmt-metal/<appid>/` | DXMT shader `.db` files |
+| DxvkMetal32 | `~/.metalsharp/shader-cache/dxvk-metal32/<appid>/` | DXVK state cache |
+
+- Each DXMT game gets its own shader `.db` files (Metal version-specific)
 - First launch builds cold cache (stutters expected)
 - Subsequent launches reuse cached shaders
 - Safe to delete entire `shader-cache/` to force rebuild

--- a/docs/wine-architecture.md
+++ b/docs/wine-architecture.md
@@ -19,17 +19,34 @@ MetalSharp Wine is a custom Wine 11.5 runtime that runs Windows applications on 
 │   │   └── i386-windows/   32-bit PE DLLs
 │   │                           DXMT builtins for d3d11/dxgi/d3d10core/winemetal
 │   │                           Originals backed up as .bak
-│   └── dxmt/
-│       ├── x86_64-unix/    winemetal.so (47MB, Mach-O x86_64)
-│       │                       Metal command buffer bridge
-│       │                       Exports __wine_unix_call_wow64_funcs for 32-bit
-│       └── x86_64-windows/ 64-bit DXMT PE DLLs
-│           d3d11.dll (72MB), dxgi.dll (20MB), d3d10core.dll (14MB)
-│           d3d12.dll (36MB), winemetal.dll (269KB)
+│   ├── dxmt/
+│   │   ├── x86_64-unix/    winemetal.so (47MB, Mach-O x86_64)
+│   │   │                       Metal command buffer bridge
+│   │   │                       Exports __wine_unix_call_wow64_funcs for 32-bit
+│   │   └── x86_64-windows/ 64-bit DXMT PE DLLs
+│   │       d3d11.dll (72MB), dxgi.dll (20MB), d3d10core.dll (14MB)
+│   │       d3d12.dll (36MB), winemetal.dll (269KB)
+│   └── dxvk/
+│       └── i386-windows/    DXVK 1.10.3 32-bit DLLs
+│           d3d9.dll, d3d11.dll, d3d10core.dll, dxgi.dll
 ├── etc/
-│   └── dxmt.conf           DXMT config (MetalFX upscaling, framerate cap)
+│   ├── dxmt.conf           DXMT config (MetalFX upscaling, framerate cap)
+│   └── vulkan/
+│       └── icd.d/
+│           └── MoltenVK_icd.json  MoltenVK ICD manifest
 └── share/
     └── wine/               Wine data files (fonts, inf, nls)
+```
+
+Also present outside the wine tree:
+
+```
+~/.metalsharp/runtime/
+├── wine/                   (see above)
+├── dxvk-1.10.3/            DXVK archive (x32/ and x64/ dirs, used by installer)
+├── mono-x86/               x86 Mono runtime for legacy FNA games
+├── mono-arm64/             ARM64 Mono runtime (or Homebrew mono)
+└── shims/                  Pre-built shims (SDL3, FNA3D, FMOD stubs, CSteamworks)
 ```
 
 ## How It Works
@@ -62,6 +79,17 @@ std::fs::copy(dxmt_x64.join("winemetal.dll"), game.join("winemetal.dll"));
 
 With `WINEDLLOVERRIDES="dxgi,d3d11,d3d10core,winemetal=n,b"`, Wine loads these from the game dir instead of its builtins. The `winebuild --builtin` post-processing ensures they're loaded as proper Wine builtins, not native overrides.
 
+### DXVK d3d9.dll Injection for 32-bit Games
+
+For DxvkMetal32 games (Portal 2, Goat Simulator), the Rust backend copies DXVK's i386 d3d9.dll into the game's binary directory:
+
+```rust
+let dxvk_i386 = ms_root.join("lib").join("dxvk").join("i386-windows");
+std::fs::copy(dxvk_i386.join("d3d9.dll"), game.join("bin").join("d3d9.dll"));
+```
+
+With `WINEDLLOVERRIDES="d3d9=n,b"` and `VK_ICD_FILENAMES` pointing to the bundled MoltenVK ICD, D3D9 calls go through DXVK → MoltenVK → Metal.
+
 ### Why mscompatdb Is Dead
 
 The old `mscompatdb.so` hooked ntdll syscalls for per-game overrides. Fragile — broke when Wine's syscall patterns changed. Now disabled (`.so.disabled`).
@@ -82,7 +110,7 @@ The `metalsharp-wine` wrapper sets:
 | `WINESERVER` | `bin/wineserver` | Wine server |
 | `DYLD_FALLBACK_LIBRARY_PATH` | Includes `lib/wine/x86_64-unix/`, `lib/dxmt/x86_64-unix/` | Unix .so resolution |
 
-## DYLD_FALLBACK_LIBRARY_PATH
+### DYLD_FALLBACK_LIBRARY_PATH
 
 Critical for DXMT — `winemetal.so` lives outside Wine's standard search paths. Without it:
 
@@ -92,12 +120,26 @@ DYLD_FALLBACK_LIBRARY_PATH="$MS_LIB/wine/x86_64-unix:$MS_LIB/dxmt/x86_64-unix:..
 
 The PE→unix bridge can't locate `winemetal.so` and D3D11 device creation fails.
 
+For SteamD3DMetalPerf games, DYLD is also augmented with GPTK paths so the Steam child process loads Apple's d3d11.dll.
+
+### Vulkan / MoltenVK
+
+For DxvkMetal32 games, the MoltenVK ICD is bundled in the wine runtime:
+
+```
+VK_ICD_FILENAMES=~/.metalsharp/runtime/wine/etc/vulkan/icd.d/MoltenVK_icd.json
+```
+
+This replaces the previous Homebrew-only path (`/opt/homebrew/share/vulkan/icd.d/MoltenVK_icd.json`).
+
 ## Wine Prefix
 
 Single shared prefix at `~/.metalsharp/prefix-steam/`:
 - Steam installed inside it (`drive_c/Program Files (x86)/Steam/`)
 - External SSD Steam library mapped as F: drive
 - `steamwebhelper.exe` wrapper deployed for CEF rendering (re-deploy after Steam auto-updates)
+
+Some games get their own prefix (appid-specific) via `prepare_metalsharp_game()` in `setup.rs` — e.g., `~/.metalsharp/prefix-{appid}/`.
 
 ## Building Wine 11.5
 
@@ -108,12 +150,10 @@ From upstream source with 7 custom patches (A-G). Key build details:
 - Bison 3.8+ required (Homebrew, not macOS system bison 2.3)
 - freetype 2.13.3, gnutls, MoltenVK linked
 
-## What Came From CrossOver
+## GPTK (Game Porting Toolkit)
 
-MetalSharp Wine is built from Wine 11.5 upstream source with 7 custom patches. Contributions include:
-- gnutls TLS support (Steam login)
-- freetype font rendering
-- macOS-specific fixes (macdrv, DIEM, CEF compatibility)
-- WoW64 implementation for 32-bit game support
+GPTK is used for `SteamD3DMetalPerf` games only. It's installed at `/Applications/Game Porting Toolkit.app/` and provides:
+- `x86_64-windows/d3d11.dll` — Apple's D3DMetal implementation
+- `x86_64-unix/` unix support libs
 
-No CrossOver proprietary code. `cxcompatdb.so` and CrossOver's bottle system are not used.
+The Rust backend prepends GPTK's paths to `WINEDLLPATH` and `DYLD_FALLBACK_LIBRARY_PATH` so Steam child processes load Apple's D3DMetal. GPTK is **not** needed for DxmtMetal (64-bit D3D11) or DxvkMetal32 (32-bit D3D9) games.


### PR DESCRIPTION
## Summary

- All 6 doc files were stale (referencing v0.17.0/v0.18.0). Verified every claim against the actual Rust and C++ source code and corrected.
- **README.md**: Engine table updated (8→10 engines), game pipelines corrected (Portal 2/Goat Sim now DxvkMetal32, Celeste now SteamD3DMetalPerf), tech stack fixed (Actix→tiny_http), architecture tree updated with native C++ engine and tools/launcher.
- **CHANGELOG.md**: Added v0.22.0 entry covering DxvkMetal32 engine, MetalsharpWine engine, all game routing changes, native C++ engine, shader cache per-appid, bundled MoltenVK ICD.
- **docs/launch-architecture.md**: All 10 engines documented with correct launch paths. AppID mappings verified against `get_engine_for_appid()`. Shader cache paths corrected from `<exename>` to `<engine>/<appid>` format. Added DxvkMetal32 and MetalsharpWine sections.
- **docs/wine-architecture.md**: DXVK i386 path fixed (`lib/dxvk/i386-windows` not `lib/wine/i386-windows`). MoltenVK ICD added to runtime tree. GPTK scope clarified (SteamD3DMetalPerf only). Game-specific prefixes documented.
- **docs/dxmt-vulkan-architecture.md**: Game usage table corrected. DXVK path references fixed. Added Undertale, Elden Ring, Goat Simulator.
- **docs/GAMES-SUPPORTED.md**: Updated to v0.22.0. All engine types listed. Game entries corrected. Added DXVK configuration section. Shader cache paths updated.

## Test plan

- [x] Every engine type, appid mapping, env var, file path, and launch command verified against the actual source code in `app/src-rust/src/launch.rs`, `steam.rs`, `setup.rs`, `installer.rs`, and `CMakeLists.txt`
- [ ] Visual review of rendered markdown