### PR TITLE
fix: updater never runs install script after closing app

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metalsharp",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metalsharp",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "dependencies": {
         "electron-store": "^10.0.0"
       },

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -328,4 +328,8 @@ function registerIpc() {
   ipcMain.handle("backend:get-pid", async () => {
     return bridge.getBackendPid();
   });
+
+  ipcMain.on("app:quit", () => {
+    app.quit();
+  });
 }

--- a/app/src/main/preload.ts
+++ b/app/src/main/preload.ts
@@ -17,4 +17,5 @@ contextBridge.exposeInMainWorld("metalsharp", {
   updaterInstallStatus: () => ipcRenderer.invoke("updater:install-status"),
   updaterClearStatus: () => ipcRenderer.invoke("updater:clear-status"),
   backendGetPid: () => ipcRenderer.invoke("backend:get-pid"),
+  quitApp: () => ipcRenderer.send("app:quit"),
 });

--- a/app/src/main/updater-bridge.ts
+++ b/app/src/main/updater-bridge.ts
@@ -1,4 +1,4 @@
-import { type ChildProcess, spawn } from "child_process";
+import { spawn } from "child_process";
 import * as fs from "fs";
 import * as http from "http";
 import * as path from "path";
@@ -22,7 +22,6 @@ export class UpdaterBridge {
   private pythonPath: string | null = null;
   private scriptPath: string | null = null;
   private backendPort: number;
-  private proc: ChildProcess | null = null;
 
   constructor(port: number = 9274) {
     this.backendPort = port;
@@ -124,7 +123,7 @@ export class UpdaterBridge {
       "--python", this.pythonPath,
     ];
 
-    this.proc = spawn(this.pythonPath, args, {
+    const child = spawn(this.pythonPath, args, {
       detached: true,
       stdio: "ignore",
       env: {
@@ -140,10 +139,10 @@ export class UpdaterBridge {
       },
     });
 
-    this.proc.unref();
+    child.unref();
 
     console.log(
-      `Updater: spawned install updater (pid=${this.proc.pid}) for v${targetVersion}`,
+      `Updater: spawned install updater (pid=${child.pid}) for v${targetVersion}`,
     );
 
     return { ok: true };

--- a/app/src/renderer/api-types.ts
+++ b/app/src/renderer/api-types.ts
@@ -113,4 +113,5 @@ type MetalsharpAPI = {
   updaterInstallStatus: () => Promise<InstallStatus | null>;
   updaterClearStatus: () => Promise<void>;
   backendGetPid: () => Promise<number | null>;
+  quitApp: () => void;
 };

--- a/app/src/renderer/index.ts
+++ b/app/src/renderer/index.ts
@@ -338,9 +338,8 @@ class App {
       return;
     }
 
-    await new Promise((r) => setTimeout(r, 2000));
-    const { remote } = require("electron");
-    remote?.app?.quit();
+    await new Promise((r) => setTimeout(r, 3000));
+    getAPI().quitApp();
   }
 
   private async checkForInstallResult() {

--- a/app/updater/update.py
+++ b/app/updater/update.py
@@ -21,6 +21,11 @@ import sys
 import time
 import urllib.request
 
+try:
+    os.setsid()
+except OSError:
+    pass
+
 APP_PATH = "/Applications/MetalSharp.app"
 BACKEND_PORT = 9274
 


### PR DESCRIPTION
## Summary

The auto-updater flow was broken: clicking "Install Update" would close the MetalSharp app but never actually spawn the Python install script or prompt for an admin password, leaving the update stuck and the app process running in the background.

Three root causes:

1. **`remote?.app?.quit()` was a no-op** — `@electron/remote` is not installed or initialized, so `require("electron").remote` is `undefined`. The optional chaining silently swallowed the failure. The app never quit, leaving it in a zombie state.

2. **No proper quit IPC channel** — the renderer had no way to ask the main process to quit. Added `app:quit` IPC handler and `quitApp()` preload bridge.

3. **Python script not fully detached** — added `os.setsid()` at script startup to create a new session group, ensuring the child survives parent termination.

## Changes

- `app/src/main/index.ts` — add `ipcMain.on("app:quit")` handler
- `app/src/main/preload.ts` — expose `quitApp()` via `ipcRenderer.send`
- `app/src/renderer/index.ts` — replace broken `remote?.app?.quit()` with `getAPI().quitApp()`, increase pre-quit delay to 3s
- `app/src/renderer/api-types.ts` — add `quitApp` to `MetalsharpAPI` type
- `app/src/main/updater-bridge.ts` — remove unused `proc` field and `ChildProcess` import
- `app/updater/update.py` — add `os.setsid()` for process group isolation

## Testing

- TypeScript compiles clean (`tsc --noEmit` passes)
- Manual test: triggered update flow, verified Python script spawns and survives app quit

## Checklist

- [x] Code compiles without errors
- [x] No new dependencies introduced
- [x] Follows existing code conventions