### PR TITLE
ci: add dedicated Metal CI workflow

### DIFF
--- a/.github/workflows/ci-metal.yml
+++ b/.github/workflows/ci-metal.yml
@@ -1,0 +1,119 @@
+name: Metal CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/metal/**'
+      - 'src/d3d/**'
+      - 'src/dxgi/**'
+      - 'src/audio/**'
+      - 'src/input/**'
+      - 'src/loader/**'
+      - 'src/runtime/**'
+      - 'src/perf/**'
+      - 'include/**'
+      - 'tests/**'
+      - 'CMakeLists.txt'
+      - '.github/workflows/ci-metal.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/metal/**'
+      - 'src/d3d/**'
+      - 'src/dxgi/**'
+      - 'src/audio/**'
+      - 'src/input/**'
+      - 'src/loader/**'
+      - 'src/runtime/**'
+      - 'src/perf/**'
+      - 'include/**'
+      - 'tests/**'
+      - 'CMakeLists.txt'
+      - '.github/workflows/ci-metal.yml'
+
+jobs:
+  metal:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure
+        run: |
+          mkdir build && cd build
+          cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON
+
+      - name: Build
+        run: cmake --build build --parallel $(sysctl -n hw.ncpu)
+
+      - name: Metal adapter check
+        run: |
+          echo "::group::Metal Device Validation"
+          ./build/test_metal_device
+          echo "::endgroup::"
+
+      - name: Shader translation tests
+        run: |
+          echo "::group::DXBC Parser"
+          ./build/test_dxbc
+          echo "::endgroup::"
+          echo "::group::Format Translation"
+          ./build/test_format_translation
+          echo "::endgroup::"
+          echo "::group::Argument Buffers"
+          ./build/test_phase17
+          echo "::endgroup::"
+
+      - name: D3D11 Metal tests
+        run: |
+          echo "::group::D3D11 Device"
+          ./build/test_d3d11_device
+          echo "::endgroup::"
+          echo "::group::Deferred Context"
+          ./build/test_deferred_context
+          echo "::endgroup::"
+
+      - name: D3D12 Metal tests
+        run: |
+          echo "::group::D3D12 Device"
+          ./build/test_d3d12
+          echo "::endgroup::"
+          echo "::group::Phase 18"
+          ./build/test_phase18
+          echo "::endgroup::"
+          echo "::group::Phase 19"
+          ./build/test_phase19
+          echo "::endgroup::"
+
+      - name: Audio & Input backend tests
+        run: |
+          echo "::group::XAudio2"
+          ./build/test_audio
+          echo "::endgroup::"
+          echo "::group::XInput"
+          ./build/test_input
+          echo "::endgroup::"
+
+      - name: Runtime tests
+        run: |
+          echo "::group::Runtime"
+          ./build/test_runtime
+          echo "::endgroup::"
+          echo "::group::Phase 20"
+          ./build/test_phase20
+          echo "::endgroup::"
+          echo "::group::Phase 21"
+          ./build/test_phase21
+          echo "::endgroup::"
+          echo "::group::Phase 22"
+          ./build/test_phase22
+          echo "::endgroup::"
+          echo "::group::Phase 23"
+          ./build/test_phase23
+          echo "::endgroup::"
+          echo "::group::Phase 24"
+          ./build/test_phase24
+          echo "::endgroup::"
+
+      - name: Full ctest suite
+        run: cd build && ctest --output-on-failure


### PR DESCRIPTION
## Summary

Adds a dedicated Metal CI workflow (`ci-metal.yml`) that separates Metal/D3D compilation and adapter validation from the general C++ CI (which is mainly format + clang-tidy).

### Why

The existing `ci-cpp.yml` lumps format checking, clang-tidy, build, and tests into two jobs but doesn't give clear signal on Metal health. This workflow runs explicit grouped steps so CI failures are immediately obvious — you can see which subsystem broke without digging through ctest output.

### What it does

Runs on `macos-14` (M1) with explicit grouped steps:

1. **Metal adapter check** — `test_metal_device` verifies `MTLCreateSystemDefaultDevice()` returns a valid device with command queue
2. **Shader translation** — DXBC parser, format translation, argument buffer binding
3. **D3D11 Metal** — device creation, deferred context
4. **D3D12 Metal** — device, command list, pipeline state
5. **Audio & Input** — XAudio2, XInput backends
6. **Runtime** — all phase tests (20–24)
7. **Full ctest** — final gate, catches anything missed above

### Triggers

Only runs when these paths change:
- `src/metal/**`, `src/d3d/**`, `src/dxgi/**`, `src/audio/**`, `src/input/**`, `src/loader/**`, `src/runtime/**`, `src/perf/**`
- `include/**`, `tests/**`, `CMakeLists.txt`

## Testing

- Workflow syntax is valid YAML
- Build/test commands match existing `ci-cpp.yml` pattern
- All test binaries referenced exist in `tests/CMakeLists.txt`