### PR TITLE
fix(security): resolve high severity Dependabot alerts

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "metalsharp",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metalsharp",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "dependencies": {
         "electron-store": "^10.0.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
-        "electron": "^35.0.0",
+        "electron": "^39.8.10",
         "electron-builder": "^26.0.0",
         "typescript": "^5.7.0"
       }
@@ -1899,9 +1899,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "35.7.5",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-35.7.5.tgz",
-      "integrity": "sha512-dnL+JvLraKZl7iusXTVTGYs10TKfzUi30uEDTqsmTm0guN9V2tbOjTzyIZbh9n3ygUjgEYyo+igAwMRXIi3IPw==",
+      "version": "39.8.10",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-39.8.10.tgz",
+      "integrity": "sha512-zbYtGPYUI7PzqLAzkk21Rk6j67WN0hxn0Mq/njErZo1d0HSf33is4f8ICI5fMLy5vYe0JtCtM5sYunNOaochSQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2271,9 +2271,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",

--- a/app/package.json
+++ b/app/package.json
@@ -24,10 +24,10 @@
     "electron-store": "^10.0.0"
   },
   "devDependencies": {
-    "electron": "^35.0.0",
+    "@types/node": "^22.0.0",
+    "electron": "^39.8.10",
     "electron-builder": "^26.0.0",
-    "typescript": "^5.7.0",
-    "@types/node": "^22.0.0"
+    "typescript": "^5.7.0"
   },
   "build": {
     "appId": "com.metalsharp.app",


### PR DESCRIPTION
## Summary

Resolves all 6 high severity Dependabot alerts.

### Electron 35.7.5 → 39.8.10

Fixes 4 CVEs:
- **CVE-2026-34769** — Renderer command-line switch injection via undocumented `commandLineSwitches` webPreference
- **CVE-2026-34770** — Use-after-free in PowerMonitor on macOS
- **CVE-2026-34771** — Use-after-free in WebContents fullscreen, pointer-lock, and keyboard-lock permission callbacks
- **CVE-2026-34774** — Use-after-free in offscreen child window paint callback

### fast-uri 3.1.0 → 3.1.2

Fixes 2 CVEs (transitive dependency via `ajv` → `electron-store`):
- **CVE-2026-6321** — Path traversal via percent-encoded dot segments
- **CVE-2026-6322** — Host confusion via percent-encoded authority delimiters

### Compatibility

- TypeScript compiles clean with Electron 39
- Biome lint passes
- All Electron APIs used by MetalSharp (`BrowserWindow`, `ipcMain`, `ipcRenderer`, `app`, `contextBridge`, `shell`, `dialog`) are stable across 35→39
- No deprecated APIs used (`nodeIntegration: false`, no `@electron/remote`, no `webPreferences` changes needed)

## Checklist

- [x] Code compiles without errors
- [x] No new vulnerabilities introduced (`npm audit` reports 0 high)
- [x] Follows existing code conventions