### PR TITLE
fix(security): resolve CodeQL code scanning alerts

### DIFF
--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -1,5 +1,8 @@
 name: C++ CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -1,5 +1,8 @@
 name: JS/TS CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/ci-metal.yml
+++ b/.github/workflows/ci-metal.yml
@@ -1,5 +1,8 @@
 name: Metal CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -1,5 +1,8 @@
 name: Python CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -1,5 +1,8 @@
 name: Rust CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/app/src/main/rust-bridge.ts
+++ b/app/src/main/rust-bridge.ts
@@ -192,9 +192,10 @@ export class RustBridge {
   }
 
   private async getProcessPath(pid: number): Promise<string | null> {
+    if (!Number.isInteger(pid) || pid <= 0) return null;
     return new Promise((resolve) => {
       const { exec } = require("child_process");
-      exec(`ps -o comm= -p ${pid} 2>/dev/null`, (err: Error | null, stdout: string) => {
+      exec(`ps -o comm= -p ${Math.floor(pid)} 2>/dev/null`, (err: Error | null, stdout: string) => {
         if (err || !stdout.trim()) {
           resolve(null);
         } else {

--- a/src/win32/kernel32/Kernel32Extra.cpp
+++ b/src/win32/kernel32/Kernel32Extra.cpp
@@ -1181,8 +1181,16 @@ static BOOL MSABI shim_CopyFileExW(const wchar_t* lpExistingFileName, const wcha
     {
         size_t pos = dst.rfind('/');
         if (pos != std::string::npos) {
-            std::string cmd = "mkdir -p \"" + dst.substr(0, pos) + "\"";
-            system(cmd.c_str());
+            std::string dir = dst.substr(0, pos);
+            struct stat st;
+            if (stat(dir.c_str(), &st) != 0) {
+                size_t start = 0;
+                while ((start = dir.find('/', start + 1)) != std::string::npos) {
+                    std::string part = dir.substr(0, start);
+                    mkdir(part.c_str(), 0755);
+                }
+                mkdir(dir.c_str(), 0755);
+            }
         }
     }
     FILE* fout = fopen(dst.c_str(), "wb");

--- a/src/win32/kernel32/VirtualFileSystem.cpp
+++ b/src/win32/kernel32/VirtualFileSystem.cpp
@@ -18,6 +18,11 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <cerrno>
+#include <cstring>
+
 namespace metalsharp {
 namespace win32 {
 
@@ -27,14 +32,26 @@ static std::string toLower(std::string s) {
     return s;
 }
 
+static bool mkdirRecursive(const std::string& path) {
+    size_t pos = path.rfind('/');
+    if (pos != std::string::npos && pos > 0) {
+        std::string parent = path.substr(0, pos);
+        struct stat st;
+        if (stat(parent.c_str(), &st) != 0) {
+            mkdirRecursive(parent);
+        }
+    }
+    mkdir(path.c_str(), 0755);
+    return true;
+}
+
 static std::string ensureDir(const std::string& path) {
     size_t pos = path.rfind('/');
     if (pos != std::string::npos) {
         std::string dir = path.substr(0, pos);
         struct stat st;
         if (stat(dir.c_str(), &st) != 0) {
-            std::string cmd = "mkdir -p \"" + dir + "\"";
-            system(cmd.c_str());
+            mkdirRecursive(dir);
         }
     }
     return path;

--- a/src/win32/user32/User32Shim.cpp
+++ b/src/win32/user32/User32Shim.cpp
@@ -58,27 +58,47 @@ static int MSABI shim_wsprintfA(char* buf, const char* fmt, ...) {
             case 'd':
             case 'i': {
                 int val = (argIdx < 4) ? (int)stack[argIdx++] : 0;
-                out += snprintf(out, 2047 - (out - buf), "%d", val);
+                int remaining = 2047 - (int)(out - buf);
+                if (remaining > 0) {
+                    int n = snprintf(out, remaining, "%d", val);
+                    out += (n > 0 && n < remaining) ? n : remaining;
+                }
                 break;
             }
             case 'u': {
                 unsigned val = (argIdx < 4) ? (unsigned)stack[argIdx++] : 0;
-                out += snprintf(out, 2047 - (out - buf), "%u", val);
+                int remaining = 2047 - (int)(out - buf);
+                if (remaining > 0) {
+                    int n = snprintf(out, remaining, "%u", val);
+                    out += (n > 0 && n < remaining) ? n : remaining;
+                }
                 break;
             }
             case 'x': {
                 unsigned val = (argIdx < 4) ? (unsigned)stack[argIdx++] : 0;
-                out += snprintf(out, 2047 - (out - buf), "%x", val);
+                int remaining = 2047 - (int)(out - buf);
+                if (remaining > 0) {
+                    int n = snprintf(out, remaining, "%x", val);
+                    out += (n > 0 && n < remaining) ? n : remaining;
+                }
                 break;
             }
             case 'X': {
                 unsigned val = (argIdx < 4) ? (unsigned)stack[argIdx++] : 0;
-                out += snprintf(out, 2047 - (out - buf), "%X", val);
+                int remaining = 2047 - (int)(out - buf);
+                if (remaining > 0) {
+                    int n = snprintf(out, remaining, "%X", val);
+                    out += (n > 0 && n < remaining) ? n : remaining;
+                }
                 break;
             }
             case 'p': {
                 void* val = (argIdx < 4) ? (void*)stack[argIdx++] : nullptr;
-                out += snprintf(out, 2047 - (out - buf), "%p", val);
+                int remaining = 2047 - (int)(out - buf);
+                if (remaining > 0) {
+                    int n = snprintf(out, remaining, "%p", val);
+                    out += (n > 0 && n < remaining) ? n : remaining;
+                }
                 break;
             }
             case 'c': {


### PR DESCRIPTION
## Summary

Resolves all 16 open CodeQL code scanning alerts.

### C++ snprintf overflow (5 alerts)
`src/win32/user32/User32Shim.cpp` — `snprintf` return value can exceed remaining buffer space, causing the output pointer to advance past the buffer boundary. Fixed by clamping the advance to `min(returned, remaining)`.

### C++ command-line injection (2 alerts)
- `src/win32/kernel32/VirtualFileSystem.cpp` — `system("mkdir -p ...")` with env-derived paths. Replaced with recursive `mkdir()` syscalls.
- `src/win32/kernel32/Kernel32Extra.cpp` — same pattern. Replaced with recursive `mkdir()`.

### JS command-line injection (1 alert)
`app/src/main/rust-bridge.ts` — `exec(\`ps -o comm= -p ${pid}\`)` with IPC-derived pid. Added integer validation before interpolation.

### Missing workflow permissions (8 alerts)
Added `permissions: contents: read` to all 5 non-release workflows (ci-cpp, ci-js, ci-metal, ci-python, ci-rust).

## Checklist
- [x] TypeScript compiles clean
- [x] Biome lint passes
- [x] No functional behavior changes — same mkdir semantics, same snprintf output, same process lookup