### PR TITLE
ci: merge jobs to eliminate duplicate runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,13 @@ jobs:
       - name: Test
         run: cargo test
 
+      - name: Audit
+        run: |
+          cargo install cargo-audit
+          cargo audit
+
   check-cpp:
-    name: C++
+    name: C++ / Metal
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
@@ -51,67 +56,6 @@ jobs:
 
       - name: Format check
         run: find src include tests tools -name '*.cpp' -o -name '*.mm' -o -name '*.h' -o -name '*.c' | xargs clang-format --dry-run --Werror
-
-      - name: Configure
-        run: mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON
-
-      - name: Build
-        run: cmake --build build --parallel $(sysctl -n hw.ncpu)
-
-      - name: Test
-        run: cd build && ctest --output-on-failure
-
-  check-js:
-    name: JS/TS
-    runs-on: macos-14
-    defaults:
-      run:
-        working-directory: app
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: TypeScript
-        run: npx tsc --noEmit
-
-      - name: Biome
-        run: npx @biomejs/biome ci src/
-
-      - name: Prettier
-        run: npx prettier --check 'src/**/*.{ts,js,html,css,json}'
-
-  check-python:
-    name: Python
-    runs-on: macos-14
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Syntax check
-        run: python3 -m py_compile app/updater/update.py
-
-      - name: Lint
-        run: |
-          pip install ruff
-          ruff check app/updater/update.py
-
-      - name: Format check
-        run: ruff format --check app/updater/update.py
-
-  check-metal:
-    name: Metal
-    runs-on: macos-14
-    steps:
-      - uses: actions/checkout@v4
 
       - name: Configure
         run: mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON
@@ -191,26 +135,46 @@ jobs:
       - name: Full ctest suite
         run: cd build && ctest --output-on-failure
 
-  audit:
-    name: Audit
+  check-js:
+    name: JS / Python
     runs-on: macos-14
-    defaults:
-      run:
-        working-directory: app/src-rust
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
 
-      - name: Install cargo-audit
-        run: cargo install cargo-audit
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
 
-      - name: Audit dependencies
-        run: cargo audit
+      - name: Install JS dependencies
+        run: cd app && npm install
+
+      - name: TypeScript
+        run: cd app && npx tsc --noEmit
+
+      - name: Biome
+        run: cd app && npx @biomejs/biome ci src/
+
+      - name: Prettier
+        run: cd app && npx prettier --check 'src/**/*.{ts,js,html,css,json}'
+
+      - name: Python syntax check
+        run: python3 -m py_compile app/updater/update.py
+
+      - name: Python lint
+        run: |
+          pip install ruff
+          ruff check app/updater/update.py
+
+      - name: Python format check
+        run: ruff format --check app/updater/update.py
 
   build:
     name: Build DMG
-    needs: [check-rust, check-cpp, check-js, check-metal]
+    needs: [check-rust, check-cpp, check-js]
     runs-on: macos-14
     permissions:
       contents: read


### PR DESCRIPTION
8 jobs → 5. check-cpp+check-metal merged (single cmake build), check-js+check-python merged (both lightweight lint), check-rust+audit merged. Same coverage, 3 fewer runners per push.