### PR TITLE
ci: add CodeQL scanning for PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,40 @@ on:
 
 permissions:
   contents: read
+  security-events: write
+  actions: read
 
 jobs:
+  codeql:
+    name: CodeQL
+    runs-on: macos-14
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [c-cpp, javascript-typescript, rust, actions]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - if: matrix.language == 'c-cpp'
+        run: |
+          mkdir build && cd build
+          cmake .. -DCMAKE_BUILD_TYPE=Release
+          cmake --build . --parallel $(sysctl -n hw.ncpu)
+
+      - if: matrix.language == 'rust'
+        uses: dtolnay/rust-toolchain@stable
+
+      - if: matrix.language == 'rust'
+        run: cd app/src-rust && cargo build --release
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"
+
   check-rust:
     name: Rust
     runs-on: macos-14
@@ -174,7 +206,7 @@ jobs:
 
   build:
     name: Build DMG
-    needs: [check-rust, check-cpp, check-js]
+    needs: [check-rust, check-cpp, check-js, codeql]
     runs-on: macos-14
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Adds CodeQL security scanning as a required PR check, running alongside the existing lint/build/test jobs.

### CodeQL matrix (4 languages, parallel)
- **C/C++** — builds full MetalSharp CMake project (Metal, D3D, DXGI) so CodeQL traces the native call graph. Catches: buffer overflows, use-after-free, command injection, format string bugs.
- **JS/TS** — scans Electron main + renderer. Catches: command injection, prototype pollution, path traversal.
- **Rust** — scans backend. Catches: unsafe violations, integer overflow, logic bugs.
- **Actions** — scans all workflow files. Catches: injection via untrusted inputs, missing permissions.

### Dependency graph
```
codeql ────────┐
check-rust ────┤
check-cpp ─────┼── build (DMG) ── release (on tag)
check-js ──────┘
```

All jobs run in parallel. Build only starts after CodeQL + all checks pass.