### PR TITLE
feat(mtsp): wire app UI to MTSP engine, add Goldberg to installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
         run: cd build && ctest --output-on-failure
 
   check-js:
-    name: JS / Python
+    name: JS
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
@@ -145,10 +145,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
 
       - name: Install JS dependencies
         run: cd app && npm install
@@ -162,16 +158,8 @@ jobs:
       - name: Prettier
         run: cd app && npx prettier --check 'src/**/*.{ts,js,html,css,json}'
 
-      - name: Python syntax check
-        run: python3 -m py_compile app/updater/update.py
-
-      - name: Python lint
-        run: |
-          pip install ruff
-          ruff check app/updater/update.py
-
-      - name: Python format check
-        run: ruff format --check app/updater/update.py
+      - name: Shell check
+        run: bash -n app/updater/update.sh
 
   build:
     name: Build DMG

--- a/app/src-rust/Cargo.lock
+++ b/app/src-rust/Cargo.lock
@@ -390,7 +390,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metalsharp-backend"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "dirs",
  "serde",

--- a/app/src-rust/src/installer.rs
+++ b/app/src-rust/src/installer.rs
@@ -79,6 +79,7 @@ fn run_install_all() {
         ("Runtime Assets", Box::new(install_metalsharp_bundle)),
         ("DXMT Metal Runtime", Box::new(install_dxmt_runtime)),
         ("Goldberg Steam Emulator", Box::new(install_goldberg)),
+        ("Pipeline Rules", Box::new(install_mtsp_rules)),
         ("Runtime Support", Box::new(|_| install_mono_arm64())),
     ];
 
@@ -121,13 +122,8 @@ fn run_install_all() {
                 write_progress(step_num, total, name, "done", &format!("{} installed", name), None);
             },
             Err(e) => {
-                let is_required = i < 7;
-                if is_required {
-                    write_progress(step_num, total, name, "error", &format!("{} failed: {}", name, e), Some(&e));
-                    return;
-                } else {
-                    write_progress(step_num, total, name, "skipped", &format!("{} skipped: {}", name, e), None);
-                }
+                write_progress(step_num, total, name, "error", &format!("{} failed: {}", name, e), Some(&e));
+                return;
             },
         }
 
@@ -234,7 +230,11 @@ fn install_metalsharp_bundle(home: &PathBuf) -> Result<bool, String> {
         if ms_wine.exists() {
             let wine_check = Command::new(&ms_wine).arg("--version").output();
             match wine_check {
-                Ok(o) if o.status.success() => return Ok(true),
+                Ok(o) if o.status.success() => {
+                    let _ = install_mono_x86_fallback(home);
+                    let _ = install_dxvk_fallback(home);
+                    return Ok(true);
+                },
                 Ok(o) => {
                     return Err(format!(
                         "Wine binary exists but --version failed: {}",
@@ -438,6 +438,45 @@ fn install_goldberg(home: &PathBuf) -> Result<bool, String> {
     } else {
         Err("Goldberg Steam emulator not found — goldberg.tar.zst missing from bundles".into())
     }
+}
+
+fn install_mtsp_rules(home: &PathBuf) -> Result<bool, String> {
+    let dest = home.join(".metalsharp").join("configs").join("mtsp-rules.toml");
+    if dest.exists() {
+        return Ok(false);
+    }
+
+    let mut candidates = vec![
+        PathBuf::from("configs/mtsp-rules.toml"),
+        home.join("metalsharp").join("configs").join("mtsp-rules.toml"),
+        home.join("repos").join("metalsharp").join("configs").join("mtsp-rules.toml"),
+    ];
+
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(mut dir) = exe.parent() {
+            for _ in 0..8 {
+                candidates.push(dir.join("configs").join("mtsp-rules.toml"));
+                match dir.parent() {
+                    Some(p) => dir = p,
+                    None => break,
+                }
+            }
+        }
+    }
+
+    for src in &candidates {
+        if src.exists() {
+            if let Ok(contents) = fs::read_to_string(src) {
+                let _ = fs::create_dir_all(dest.parent().unwrap());
+                let _ = fs::write(&dest, &contents);
+                if dest.exists() {
+                    return Ok(true);
+                }
+            }
+        }
+    }
+
+    Err("mtsp-rules.toml not found — pipeline auto-detection will use PE analysis fallback".into())
 }
 
 fn install_gptk(_home: &PathBuf) -> Result<bool, String> {

--- a/app/src-rust/src/installer.rs
+++ b/app/src-rust/src/installer.rs
@@ -78,6 +78,7 @@ fn run_install_all() {
         ("System Tools", Box::new(|_| install_xcode_cli())),
         ("Runtime Assets", Box::new(install_metalsharp_bundle)),
         ("DXMT Metal Runtime", Box::new(install_dxmt_runtime)),
+        ("Goldberg Steam Emulator", Box::new(install_goldberg)),
         ("Runtime Support", Box::new(|_| install_mono_arm64())),
     ];
 
@@ -389,6 +390,53 @@ fn install_dxmt_runtime(home: &PathBuf) -> Result<bool, String> {
         Ok(true)
     } else {
         Err("DXMT Metal runtime not found — bundle dxmt.tar.zst or place files in ~/metalsharp/runtime/dxmt/".into())
+    }
+}
+
+fn install_goldberg(home: &PathBuf) -> Result<bool, String> {
+    let goldberg_dir = home.join(".metalsharp").join("runtime").join("goldberg");
+    let x86_dll = goldberg_dir.join("x86").join("steam_api.dll");
+    let x64_dll = goldberg_dir.join("x64").join("steam_api64.dll");
+
+    if x86_dll.exists() && x64_dll.exists() {
+        return Ok(false);
+    }
+
+    let _ = fs::create_dir_all(goldberg_dir.join("x86"));
+    let _ = fs::create_dir_all(goldberg_dir.join("x64"));
+
+    let bundled = find_bundled_archive("goldberg");
+    if let Some(archive) = bundled {
+        let tmp = std::env::temp_dir().join("metalsharp-goldberg-extract");
+        let _ = fs::remove_dir_all(&tmp);
+        let _ = fs::create_dir_all(&tmp);
+        extract_zst(&archive, &tmp, "goldberg")?;
+
+        let src_x86 = tmp.join("x86");
+        let src_x64 = tmp.join("x64");
+
+        if src_x86.exists() {
+            for entry in fs::read_dir(&src_x86).map_err(|e| format!("read x86: {}", e))? {
+                let entry = entry.map_err(|e| e.to_string())?;
+                let _ = fs::copy(entry.path(), goldberg_dir.join("x86").join(entry.file_name()));
+            }
+        }
+        if src_x64.exists() {
+            for entry in fs::read_dir(&src_x64).map_err(|e| format!("read x64: {}", e))? {
+                let entry = entry.map_err(|e| e.to_string())?;
+                let _ = fs::copy(entry.path(), goldberg_dir.join("x64").join(entry.file_name()));
+            }
+        }
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    if goldberg_dir.join("x86").join("steam_api.dll").exists()
+        && goldberg_dir.join("x64").join("steam_api64.dll").exists()
+    {
+        Ok(true)
+    } else {
+        Err("Goldberg Steam emulator not found — goldberg.tar.zst missing from bundles".into())
     }
 }
 

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -393,7 +393,7 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
                 Some(id) => {
                     let launch_method = body.get("launchMethod").and_then(|v| v.as_str()).unwrap_or("auto");
                     let resolved_pipeline =
-                        if let Some(pipeline_id) = crate::mtsp::engine::PipelineId::from_legacy_method(launch_method) {
+                        if let Some(pipeline_id) = crate::mtsp::engine::PipelineId::from_str_flexible(launch_method) {
                             Some(pipeline_id)
                         } else if launch_method == "auto" || launch_method.is_empty() || launch_method == "native" {
                             Some(crate::mtsp::rules::resolve_pipeline(id as u32))

--- a/app/src-rust/src/mtsp/engine.rs
+++ b/app/src-rust/src/mtsp/engine.rs
@@ -309,6 +309,29 @@ impl PipelineId {
         }
     }
 
+    pub fn from_str_flexible(s: &str) -> Option<PipelineId> {
+        if let Some(p) = Self::from_legacy_method(s) {
+            return Some(p);
+        }
+        match s {
+            "m11" => Some(PipelineId::M11),
+            "m12" => Some(PipelineId::M12),
+            "m9" => Some(PipelineId::M9),
+            "m9_gl" => Some(PipelineId::M9Gl),
+            "m32_vk" => Some(PipelineId::M32Vk),
+            "m32_w" => Some(PipelineId::M32W),
+            "m64" => Some(PipelineId::M64),
+            "steam" => Some(PipelineId::Steam),
+            "steam_metalfx" => Some(PipelineId::SteamMetalfx),
+            "steam_d3dmetal_perf" => Some(PipelineId::SteamD3DMetalPerf),
+            "fna_arm64" => Some(PipelineId::FnaArm64),
+            "fna_x86" => Some(PipelineId::FnaX86),
+            "mono_generic" => Some(PipelineId::MonoGeneric),
+            "wine_bare" => Some(PipelineId::WineBare),
+            _ => None,
+        }
+    }
+
     pub fn to_legacy_method(self) -> &'static str {
         match self {
             PipelineId::M11 => "dxmt_metal",

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -212,19 +212,12 @@ fn launch_dxvk_metal32(appid: u32, node: &PipelineNode) -> Result<(u32, &'static
         let _ = std::fs::copy(&src, work_dir.join("d3d9.dll"));
     }
 
-    let dyld_wine = ms_root.join("lib").join("wine").join("x86_64-unix").to_string_lossy().to_string();
+    let dyld_wine = build_dyld(&ms_root, &node.dyld_paths);
     let moltenvk_icd = ms_root.join("etc").join("vulkan").join("icd.d").join("MoltenVK_icd.json");
     let moltenvk_str = if moltenvk_icd.exists() {
         moltenvk_icd.to_string_lossy().to_string()
     } else {
-        ms_root
-            .join("etc")
-            .join("etc")
-            .join("vulkan")
-            .join("icd.d")
-            .join("MoltenVK_icd.json")
-            .to_string_lossy()
-            .to_string()
+        ms_root.join("vulkan").join("icd.d").join("MoltenVK_icd.json").to_string_lossy().to_string()
     };
 
     let shader_cache_base = home.join(".metalsharp").join("shader-cache").join("dxvk-metal32").join(appid.to_string());
@@ -372,11 +365,7 @@ fn resolve_d3d9_exe(appid: u32, game_dir: &PathBuf) -> (String, PathBuf) {
         },
         _ => {
             let exe = resolve_game_exe(game_dir);
-            let name = std::path::Path::new(&exe)
-                .file_name()
-                .unwrap_or_default()
-                .to_string_lossy()
-                .to_string();
+            let name = std::path::Path::new(&exe).file_name().unwrap_or_default().to_string_lossy().to_string();
             (name, game_dir.clone())
         },
     }

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -127,8 +127,7 @@ fn launch_d3d9_metal(appid: u32, node: &PipelineNode) -> Result<(u32, &'static s
     let game_dir = crate::setup::resolve_game_dir(appid).ok_or("game dir not found")?;
     let prefix = home.join(".metalsharp").join("prefix-steam");
     let prefix_str = prefix.to_string_lossy().to_string();
-    let exe = resolve_game_exe(&game_dir);
-    let exe_name = std::path::Path::new(&exe).file_name().unwrap_or_default().to_string_lossy().to_string();
+    let (exe_name, work_dir) = resolve_d3d9_exe(appid, &game_dir);
 
     deploy_dlls_for_pipeline(&game_dir, node);
     deploy_goldberg(&home, &game_dir, appid);
@@ -136,7 +135,7 @@ fn launch_d3d9_metal(appid: u32, node: &PipelineNode) -> Result<(u32, &'static s
     let dyld_path = build_dyld(&ms_root, &node.dyld_paths);
 
     let mut cmd = Command::new(&wine);
-    cmd.current_dir(&game_dir)
+    cmd.current_dir(&work_dir)
         .env("WINEPREFIX", &prefix_str)
         .env("WINEDEBUG", "-all")
         .env("DYLD_FALLBACK_LIBRARY_PATH", &dyld_path);
@@ -206,32 +205,12 @@ fn launch_dxvk_metal32(appid: u32, node: &PipelineNode) -> Result<(u32, &'static
     deploy_dlls_for_pipeline(&game_dir, node);
     deploy_goldberg(&home, &game_dir, appid);
 
-    let (exe_name, work_dir) = match appid {
-        620 => {
-            if let Some(d3d9) = find_dll_deploy(&node.deploy_dlls, "d3d9.dll") {
-                let home2 = dirs::home_dir().unwrap_or_default();
-                let ms_root2 = home2.join(".metalsharp").join("runtime").join("wine");
-                let src = ms_root2.join(d3d9.source_subpath).join(d3d9.filename);
-                let _ = std::fs::copy(&src, game_dir.join("bin").join("d3d9.dll"));
-            }
-            (String::from("portal2.exe"), game_dir.clone())
-        },
-        265930 => {
-            let bin = game_dir.join("Binaries").join("Win32");
-            if let Some(d3d9) = find_dll_deploy(&node.deploy_dlls, "d3d9.dll") {
-                let home2 = dirs::home_dir().unwrap_or_default();
-                let ms_root2 = home2.join(".metalsharp").join("runtime").join("wine");
-                let src = ms_root2.join(d3d9.source_subpath).join(d3d9.filename);
-                let _ = std::fs::copy(&src, bin.join("d3d9.dll"));
-            }
-            (String::from("GoatGame-Win32-Shipping.exe"), bin.clone())
-        },
-        _ => {
-            let exe = resolve_game_exe(&game_dir);
-            let name = std::path::Path::new(&exe).file_name().unwrap_or_default().to_string_lossy().to_string();
-            (name, game_dir.clone())
-        },
-    };
+    let (exe_name, work_dir) = resolve_d3d9_exe(appid, &game_dir);
+
+    if let Some(d3d9) = find_dll_deploy(&node.deploy_dlls, "d3d9.dll") {
+        let src = ms_root.join(d3d9.source_subpath).join(d3d9.filename);
+        let _ = std::fs::copy(&src, work_dir.join("d3d9.dll"));
+    }
 
     let dyld_wine = ms_root.join("lib").join("wine").join("x86_64-unix").to_string_lossy().to_string();
     let moltenvk_icd = ms_root.join("etc").join("vulkan").join("icd.d").join("MoltenVK_icd.json");
@@ -382,6 +361,25 @@ fn launch_fna_x86(appid: u32) -> Result<(u32, &'static str), Box<dyn std::error:
         .spawn()?;
 
     Ok((child.id(), "xna_fna_x86"))
+}
+
+fn resolve_d3d9_exe(appid: u32, game_dir: &PathBuf) -> (String, PathBuf) {
+    match appid {
+        620 => (String::from("portal2.exe"), game_dir.clone()),
+        265930 => {
+            let bin = game_dir.join("Binaries").join("Win32");
+            (String::from("GoatGame-Win32-Shipping.exe"), bin)
+        },
+        _ => {
+            let exe = resolve_game_exe(game_dir);
+            let name = std::path::Path::new(&exe)
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
+            (name, game_dir.clone())
+        },
+    }
 }
 
 fn build_dyld(ms_root: &PathBuf, paths: &[&str]) -> String {

--- a/app/src-rust/src/setup.rs
+++ b/app/src-rust/src/setup.rs
@@ -556,11 +556,19 @@ fn prepare_goldberg_game(game_dir: &PathBuf, home: &PathBuf, appid: u32) -> Resu
     let deploy_dir = match appid {
         620 => {
             let bin = game_dir.join("bin");
-            if bin.exists() { bin } else { game_dir.clone() }
+            if bin.exists() {
+                bin
+            } else {
+                game_dir.clone()
+            }
         },
         265930 => {
             let bin = game_dir.join("Binaries").join("Win32");
-            if bin.exists() { bin } else { game_dir.clone() }
+            if bin.exists() {
+                bin
+            } else {
+                game_dir.clone()
+            }
         },
         _ => game_dir.clone(),
     };

--- a/app/src-rust/src/setup.rs
+++ b/app/src-rust/src/setup.rs
@@ -148,7 +148,7 @@ pub fn dependencies() -> Value {
             {
                 "id": "gptk",
                 "name": "Game Porting Toolkit",
-                "desc": "No longer required — MTSP engine uses bundled DLLs directly. Apple's D3D→Metal translation.",
+                "desc": "Optional. MTSP engine uses bundled DXMT Metal translation. Only needed for SteamD3DMetalPerf pipeline.",
                 "installed": gptk,
                 "required": false,
                 "installCmd": "brew install --cask gcenx/wine/game-porting-toolkit",
@@ -156,7 +156,7 @@ pub fn dependencies() -> Value {
             {
                 "id": "wine_devel",
                 "name": "Wine (Devel)",
-                "desc": "Wine runtime for 32-bit PE support (Portal 2).",
+                "desc": "No longer required — MetalSharp Wine handles all pipelines including DXVK D3D9 (Portal 2).",
                 "installed": wine_devel,
                 "required": false,
                 "installCmd": "brew install --cask wine@devel",
@@ -288,16 +288,17 @@ pub fn prepare_game(appid: u32) -> Result<Value, Box<dyn std::error::Error>> {
     let game_type = match appid {
         105600 => "xna_fna_arm64",
         504230 => "xna_fna_x86",
-        312520 => "dxmt_metal",
-        2050650 | 3164500 => "dxmt_metal12",
+        312520 | 375520 => "dxmt_metal",
+        2050650 | 3164500 | 848450 => "dxmt_metal12",
         535520 => "wined3d_32",
-        945360 | 1139900 => "metalsharp_wine",
+        945360 | 1139900 => "steam",
         620 | 265930 => "dxvk_metal32",
         _ => {
             if is_dotnet {
                 "xna_fna"
             } else {
-                "steam_d3dmetal_perf"
+                let pipeline = crate::mtsp::rules::resolve_pipeline(appid);
+                pipeline.to_legacy_method()
             }
         },
     };
@@ -309,8 +310,8 @@ pub fn prepare_game(appid: u32) -> Result<Value, Box<dyn std::error::Error>> {
     match appid {
         105600 => prepare_terrarria(&game_dir, &home)?,
         504230 => prepare_celeste(&game_dir, &home)?,
-        312520 => prepare_rain_world(&game_dir, &home)?,
-        2050650 | 3164500 => prepare_dxmt_metal12(&game_dir, &home)?,
+        312520 | 375520 => prepare_rain_world(&game_dir, &home)?,
+        2050650 | 3164500 | 848450 => prepare_dxmt_metal12(&game_dir, &home)?,
         535520 => prepare_nidhogg_2(&game_dir, &home)?,
         945360 | 1139900 => prepare_metalsharp_game(&game_dir, &home, appid)?,
         620 | 265930 => prepare_goldberg_game(&game_dir, &home, appid)?,
@@ -555,19 +556,11 @@ fn prepare_goldberg_game(game_dir: &PathBuf, home: &PathBuf, appid: u32) -> Resu
     let deploy_dir = match appid {
         620 => {
             let bin = game_dir.join("bin");
-            if bin.exists() {
-                bin
-            } else {
-                game_dir.clone()
-            }
+            if bin.exists() { bin } else { game_dir.clone() }
         },
         265930 => {
             let bin = game_dir.join("Binaries").join("Win32");
-            if bin.exists() {
-                bin
-            } else {
-                game_dir.clone()
-            }
+            if bin.exists() { bin } else { game_dir.clone() }
         },
         _ => game_dir.clone(),
     };

--- a/app/src/main/updater-bridge.ts
+++ b/app/src/main/updater-bridge.ts
@@ -28,10 +28,7 @@ export class UpdaterBridge {
     const resourcesDir = process.resourcesPath || "";
     const devRoot = path.join(__dirname, "..", "..");
 
-    const candidates = [
-      path.join(resourcesDir, "updater", "update.sh"),
-      path.join(devRoot, "updater", "update.sh"),
-    ];
+    const candidates = [path.join(resourcesDir, "updater", "update.sh"), path.join(devRoot, "updater", "update.sh")];
 
     for (const c of candidates) {
       try {
@@ -80,14 +77,28 @@ export class UpdaterBridge {
       return { ok: false, error: `DMG file not found: ${dmgPath}` };
     }
 
-    const child = spawn("/bin/bash", [this.scriptPath, "--dmg", dmgPath, "--backend-pid", String(backendPid), "--target-version", targetVersion, "--status-file", STATUS_FILE], {
-      detached: true,
-      stdio: "ignore",
-      env: {
-        ...process.env,
-        PATH: ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"].join(":"),
+    const child = spawn(
+      "/bin/bash",
+      [
+        this.scriptPath,
+        "--dmg",
+        dmgPath,
+        "--backend-pid",
+        String(backendPid),
+        "--target-version",
+        targetVersion,
+        "--status-file",
+        STATUS_FILE,
+      ],
+      {
+        detached: true,
+        stdio: "ignore",
+        env: {
+          ...process.env,
+          PATH: ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"].join(":"),
+        },
       },
-    });
+    );
 
     child.unref();
 

--- a/app/src/main/updater-bridge.ts
+++ b/app/src/main/updater-bridge.ts
@@ -15,7 +15,6 @@ export interface InstallStatus {
 }
 
 export class UpdaterBridge {
-  private pythonPath: string | null = null;
   private scriptPath: string | null = null;
   private backendPort: number;
 
@@ -24,39 +23,17 @@ export class UpdaterBridge {
   }
 
   async ensureReady(): Promise<boolean> {
-    if (this.pythonPath && this.scriptPath) return true;
+    if (this.scriptPath) return true;
 
     const resourcesDir = process.resourcesPath || "";
     const devRoot = path.join(__dirname, "..", "..");
 
-    const pythonCandidates = [
-      path.join(resourcesDir, "updater", "bin", "python3"),
-      path.join(resourcesDir, "updater", "python3"),
-      path.join(devRoot, "updater", "bin", "python3"),
-      "/usr/bin/python3",
-      "/opt/homebrew/bin/python3",
-      "/usr/local/bin/python3",
+    const candidates = [
+      path.join(resourcesDir, "updater", "update.sh"),
+      path.join(devRoot, "updater", "update.sh"),
     ];
 
-    for (const c of pythonCandidates) {
-      try {
-        fs.accessSync(c);
-        this.pythonPath = c;
-        break;
-      } catch {}
-    }
-
-    if (!this.pythonPath) {
-      console.error("Updater: no python3 found");
-      return false;
-    }
-
-    const scriptCandidates = [
-      path.join(resourcesDir, "updater", "update.py"),
-      path.join(devRoot, "updater", "update.py"),
-    ];
-
-    for (const c of scriptCandidates) {
+    for (const c of candidates) {
       try {
         fs.accessSync(c);
         this.scriptPath = c;
@@ -65,7 +42,7 @@ export class UpdaterBridge {
     }
 
     if (!this.scriptPath) {
-      console.error("Updater: update.py not found");
+      console.error("Updater: update.sh not found");
       return false;
     }
 
@@ -95,29 +72,15 @@ export class UpdaterBridge {
   }
 
   spawnInstallUpdater(dmgPath: string, backendPid: number, targetVersion: string): { ok: boolean; error?: string } {
-    if (!this.pythonPath || !this.scriptPath) {
-      return { ok: false, error: "Updater not ready — python3 or update.py missing" };
+    if (!this.scriptPath) {
+      return { ok: false, error: "Updater not ready — update.sh missing" };
     }
 
     if (!fs.existsSync(dmgPath)) {
       return { ok: false, error: `DMG file not found: ${dmgPath}` };
     }
 
-    const args = [
-      this.scriptPath,
-      "--dmg",
-      dmgPath,
-      "--backend-pid",
-      String(backendPid),
-      "--target-version",
-      targetVersion,
-      "--status-file",
-      STATUS_FILE,
-      "--python",
-      this.pythonPath,
-    ];
-
-    const child = spawn(this.pythonPath, args, {
+    const child = spawn("/bin/bash", [this.scriptPath, "--dmg", dmgPath, "--backend-pid", String(backendPid), "--target-version", targetVersion, "--status-file", STATUS_FILE], {
       detached: true,
       stdio: "ignore",
       env: {
@@ -128,7 +91,7 @@ export class UpdaterBridge {
 
     child.unref();
 
-    console.log(`Updater: spawned install updater (pid=${child.pid}) for v${targetVersion}`);
+    console.log(`Updater: spawned install script (pid=${child.pid}) for v${targetVersion}`);
 
     return { ok: true };
   }

--- a/app/src/renderer/index.ts
+++ b/app/src/renderer/index.ts
@@ -249,7 +249,7 @@ class App {
     const ready = await getAPI().updaterEnsureReady();
     if (!ready) {
       this.toast(
-        "Updater not available — python3 not found. Install Xcode CLI tools or check your installation.",
+        "Updater not available — update.sh not found. Try reinstalling MetalSharp.",
         "error",
       );
       return;

--- a/app/src/renderer/index.ts
+++ b/app/src/renderer/index.ts
@@ -40,7 +40,10 @@ class App {
   private metalsharpWineAvailable: boolean = false;
   private launchingAppId: number | null = null;
   private theme: "dark" | "light" = "dark";
-  private pipelineCache: Map<number, { recommended: string; pipelines: Array<{ id: string; name: string; description: string; experimental: boolean }> }> = new Map();
+  private pipelineCache: Map<
+    number,
+    { recommended: string; pipelines: Array<{ id: string; name: string; description: string; experimental: boolean }> }
+  > = new Map();
 
   private steamApiKey: string | null = null;
   private setupState: SetupState | null = null;
@@ -248,10 +251,7 @@ class App {
   private async startUpdateFlow() {
     const ready = await getAPI().updaterEnsureReady();
     if (!ready) {
-      this.toast(
-        "Updater not available — update.sh not found. Try reinstalling MetalSharp.",
-        "error",
-      );
+      this.toast("Updater not available — update.sh not found. Try reinstalling MetalSharp.", "error");
       return;
     }
 
@@ -1147,13 +1147,18 @@ class App {
     return card;
   }
 
-  private async fetchPipelines(appid: number): Promise<{ recommended: string; pipelines: Array<{ id: string; name: string; description: string; experimental: boolean }> } | null> {
+  private async fetchPipelines(appid: number): Promise<{
+    recommended: string;
+    pipelines: Array<{ id: string; name: string; description: string; experimental: boolean }>;
+  } | null> {
     if (this.pipelineCache.has(appid)) return this.pipelineCache.get(appid)!;
     try {
-      const result = await this.api<{ ok: boolean; recommended: string; recommended_name: string; pipelines: Array<{ id: string; name: string; description: string; experimental: boolean }> }>(
-        "GET",
-        `/mtsp/pipelines?appid=${appid}`,
-      );
+      const result = await this.api<{
+        ok: boolean;
+        recommended: string;
+        recommended_name: string;
+        pipelines: Array<{ id: string; name: string; description: string; experimental: boolean }>;
+      }>("GET", `/mtsp/pipelines?appid=${appid}`);
       if (result?.ok && result.pipelines) {
         const entry = { recommended: result.recommended, pipelines: result.pipelines };
         this.pipelineCache.set(appid, entry);

--- a/app/src/renderer/index.ts
+++ b/app/src/renderer/index.ts
@@ -40,6 +40,7 @@ class App {
   private metalsharpWineAvailable: boolean = false;
   private launchingAppId: number | null = null;
   private theme: "dark" | "light" = "dark";
+  private pipelineCache: Map<number, { recommended: string; pipelines: Array<{ id: string; name: string; description: string; experimental: boolean }> }> = new Map();
 
   private steamApiKey: string | null = null;
   private setupState: SetupState | null = null;
@@ -405,6 +406,13 @@ class App {
     this.wineSteamInstalled = steamStatus?.installed ?? false;
     this.wineSteamRunning = steamStatus?.running ?? false;
     this.metalsharpWineAvailable = steamStatus?.metalsharp_wine_available ?? false;
+
+    this.pipelineCache.clear();
+    if (lib?.games) {
+      for (const game of lib.games) {
+        if (game.installed) this.fetchPipelines(game.appid);
+      }
+    }
 
     this.renderLibrary();
   }
@@ -1139,37 +1147,51 @@ class App {
     return card;
   }
 
-  private defaultLaunchMethod(appid: number): string {
-    if (appid === 105600) return "xna_fna_arm64";
-    if (appid === 504230) return "xna_fna_x86";
-    if (appid === 375520) return "gptk_wine";
-    if (appid === 535520 || appid === 391540) return "auto";
-    if ([945360, 1139900, 2050650].includes(appid)) return "steam";
-    if ([1245620, 814380, 1593500].includes(appid)) return "steam_metalfx";
-    return "steam_d3dmetal_perf";
+  private async fetchPipelines(appid: number): Promise<{ recommended: string; pipelines: Array<{ id: string; name: string; description: string; experimental: boolean }> } | null> {
+    if (this.pipelineCache.has(appid)) return this.pipelineCache.get(appid)!;
+    try {
+      const result = await this.api<{ ok: boolean; recommended: string; recommended_name: string; pipelines: Array<{ id: string; name: string; description: string; experimental: boolean }> }>(
+        "GET",
+        `/mtsp/pipelines?appid=${appid}`,
+      );
+      if (result?.ok && result.pipelines) {
+        const entry = { recommended: result.recommended, pipelines: result.pipelines };
+        this.pipelineCache.set(appid, entry);
+        return entry;
+      }
+    } catch {}
+    return null;
   }
 
   private recommendedLaunchMethod(game: SteamGame): string {
-    return game.launch_method ?? this.defaultLaunchMethod(game.appid);
+    return game.launch_method ?? "native";
   }
 
   private launchMethodOptions(game: SteamGame): string {
-    const recommended = this.recommendedLaunchMethod(game);
-    const isMetalFx = ["steam_metalfx", "steam_d3dmetal_perf"].includes(recommended);
-
-    let options = `<option value="native">Native (Recommended)</option>`;
-
-    if (isMetalFx) {
-      options += `<option value="native_metalfx_low">Native + MetalFX (Low)</option>`;
-      options += `<option value="native_metalfx_medium">Native + MetalFX (Medium)</option>`;
-      options += `<option value="native_metalfx_high">Native + MetalFX (High)</option>`;
+    const cached = this.pipelineCache.get(game.appid);
+    if (!cached) {
+      this.fetchPipelines(game.appid);
+      return `<option value="native">Auto (Recommended)</option>`;
     }
 
-    return options;
+    let options = "";
+    for (const p of cached.pipelines) {
+      const isRec = p.id === cached.recommended;
+      const badge = p.experimental ? " [exp]" : "";
+      const selected = isRec ? " selected" : "";
+      options += `<option value="${p.id}"${selected}>${p.name}${badge}${isRec ? " (Recommended)" : ""}</option>`;
+    }
+
+    return options || `<option value="native">Auto (Recommended)</option>`;
   }
 
   private launchMethodHelp(game: SteamGame): string {
-    return `Select launch mode. Native uses our recommended pipeline. MetalFX adds spatial upscaling.`;
+    const cached = this.pipelineCache.get(game.appid);
+    if (cached) {
+      const rec = cached.pipelines.find((p) => p.id === cached.recommended);
+      return rec?.description ?? "Select a launch pipeline.";
+    }
+    return "Select a launch pipeline. MTSP engine will auto-resolve the best backend.";
   }
 
   private async installGame(game: SteamGame) {
@@ -1224,9 +1246,9 @@ class App {
     await this.api("POST", "/game/prepare", { appid: game.appid });
 
     this.toast(`Launching ${game.name}...`, "success");
-    const selectedMethod =
-      (document.querySelector(`.launch-method-select[data-appid="${game.appid}"]`) as HTMLSelectElement)?.value ??
-      "native";
+    const selectEl = document.querySelector(`.launch-method-select[data-appid="${game.appid}"]`) as HTMLSelectElement;
+    const selectedMethod = selectEl?.value ?? "native";
+
     const launchResult = await this.api<{
       ok: boolean;
       pid?: number;

--- a/app/updater/update.sh
+++ b/app/updater/update.sh
@@ -8,9 +8,10 @@ STATUS_FILE=""
 
 write_status() {
     local phase="$1" percent="$2" message="$3" error="${4:-}"
+    local ver="$TARGET_VERSION"
     printf '{"phase":"%s","percent":%d,"message":"%s","error":%s,"new_version":"%s","timestamp":%s}\n' \
         "$phase" "$percent" "$message" "$([ -n "$error" ] && echo "\"$error\"" || echo "null")" \
-        "$TARGET_VERSION" "$(date +%s)" > "$STATUS_FILE" 2>/dev/null || true
+        "$ver" "$(date +%s)" > "$STATUS_FILE" 2>/dev/null || true
 }
 
 kill_pid() {
@@ -50,7 +51,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-write_status "starting" 0 "Starting update..." "new_version=$TARGET_VERSION"
+write_status "starting" 0 "Starting update..."
 
 write_status "killing_backend" 5 "Stopping backend (PID $BACKEND_PID)..."
 kill_pid "$BACKEND_PID" 10
@@ -83,14 +84,15 @@ if [ ! -f "$DMG_PATH" ]; then
 fi
 
 write_status "mounting" 35 "Mounting update disk image..."
-MOUNT_OUTPUT=$(hdiutil attach -nobrowse -quiet "$DMG_PATH" 2>&1) || {
-    MOUNT_OUTPUT=$(osascript -e "do shell script \"hdiutil attach -nobrowse -quiet \\\"$DMG_PATH\\\"\" with administrator privileges" 2>&1) || true
+MOUNT_OUTPUT=$(hdiutil attach -nobrowse "$DMG_PATH" 2>&1) || true
+if [ -z "$(echo "$MOUNT_OUTPUT" | grep -o '/Volumes/')" ]; then
+    MOUNT_OUTPUT=$(osascript -e "do shell script \"hdiutil attach -nobrowse \\\"$DMG_PATH\\\"\" with administrator privileges" 2>&1) || true
     sleep 2
-}
+fi
 
-MOUNT_POINT=$(echo "$MOUNT_OUTPUT" | awk '{print $NF}' | grep '/Volumes/')
+MOUNT_POINT=$(echo "$MOUNT_OUTPUT" | grep -o '/Volumes/.*' | head -1)
 if [ -z "$MOUNT_POINT" ] || [ ! -d "$MOUNT_POINT" ]; then
-    MOUNT_POINT=$(hdiutil info 2>/dev/null | grep -A1 "$(basename "$DMG_PATH")" | grep '/Volumes/' | awk '{print $NF}' | head -1)
+    MOUNT_POINT=$(hdiutil info 2>/dev/null | grep -o "/Volumes/MetalSharp[^/]*/" | head -1)
 fi
 
 if [ -z "$MOUNT_POINT" ] || [ ! -d "$MOUNT_POINT" ]; then
@@ -145,7 +147,8 @@ sleep 5
 BACKEND_VERSION=""
 deadline=$((SECONDS + 45))
 while [ $SECONDS -lt $deadline ]; do
-    BACKEND_VERSION=$(curl -sf "http://127.0.0.1:9274/status" 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('version',''))" 2>/dev/null || true)
+    RAW=$(curl -sf "http://127.0.0.1:9274/status" 2>/dev/null) || true
+    BACKEND_VERSION=$(echo "$RAW" | sed -n 's/.*"version"[[:space:]]*:"\{[^"]*\}".*/\1/p' | tr -d '"' || true)
     [ -n "$BACKEND_VERSION" ] && break
     sleep 1
 done
@@ -156,7 +159,8 @@ if [ "$BACKEND_VERSION" != "$TARGET_VERSION" ] && [ -n "$BACKEND_VERSION" ]; the
     sleep 1
     open -a "MetalSharp"
     sleep 5
-    BACKEND_VERSION=$(curl -sf "http://127.0.0.1:9274/status" 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('version',''))" 2>/dev/null || true)
+    RAW=$(curl -sf "http://127.0.0.1:9274/status" 2>/dev/null) || true
+    BACKEND_VERSION=$(echo "$RAW" | sed -n 's/.*"version"[[:space:]]*:"\{[^"]*\}".*/\1/p' | tr -d '"' || true)
 fi
 
 if [ "$BACKEND_VERSION" = "$TARGET_VERSION" ]; then

--- a/app/updater/update.sh
+++ b/app/updater/update.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+set -euo pipefail
+
+DMG_PATH=""
+BACKEND_PID=""
+TARGET_VERSION=""
+STATUS_FILE=""
+
+write_status() {
+    local phase="$1" percent="$2" message="$3" error="${4:-}"
+    printf '{"phase":"%s","percent":%d,"message":"%s","error":%s,"new_version":"%s","timestamp":%s}\n' \
+        "$phase" "$percent" "$message" "$([ -n "$error" ] && echo "\"$error\"" || echo "null")" \
+        "$TARGET_VERSION" "$(date +%s)" > "$STATUS_FILE" 2>/dev/null || true
+}
+
+kill_pid() {
+    local pid="$1" timeout="${2:-10}"
+    kill "$pid" 2>/dev/null || true
+    local deadline=$((SECONDS + timeout))
+    while [ $SECONDS -lt $deadline ]; do
+        kill -0 "$pid" 2>/dev/null || return 0
+        sleep 0.3
+    done
+    kill -9 "$pid" 2>/dev/null || true
+    sleep 0.5
+    kill -0 "$pid" 2>/dev/null && return 1 || return 0
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        --dmg)         shift; DMG_PATH="$1"; shift ;;
+        --backend-pid)  shift; BACKEND_PID="$1"; shift ;;
+        --target-version) shift; TARGET_VERSION="$1"; shift ;;
+        --status-file)  shift; STATUS_FILE="$1"; shift ;;
+        --) shift; break ;;
+    esac
+done
+
+STATUS_FILE="${STATUS_FILE:-$HOME/.metalsharp/update_install_status.json}"
+DMG_PATH="${DMG_PATH:?--dmg required}"
+BACKEND_PID="${BACKEND_PID:?--backend-pid required}"
+TARGET_VERSION="${TARGET_VERSION:?--target-version required}"
+APP_PATH="/Applications/MetalSharp.app"
+MOUNT_POINT=""
+
+cleanup() {
+    if [ -n "$MOUNT_POINT" ] && [ -d "$MOUNT_POINT" ]; then
+        hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+write_status "starting" 0 "Starting update..." "new_version=$TARGET_VERSION"
+
+write_status "killing_backend" 5 "Stopping backend (PID $BACKEND_PID)..."
+kill_pid "$BACKEND_PID" 10
+pkill -x metalsharp-backend 2>/dev/null || true
+sleep 0.5
+
+write_status "killing_steam" 15 "Stopping Steam and Wine processes..."
+for pat in steam steam.exe steamwebhelper steamwebhelper.exe wine wine64 wineserver; do
+    pkill -x "$pat" 2>/dev/null || true
+    pkill -f "$pat" 2>/dev/null || true
+done
+sleep 1
+
+write_status "closing_app" 25 "Closing MetalSharp..."
+for pat in "MetalSharp" "MetalSharp Helper" "MetalSharp Helper (GPU)" "MetalSharp Helper (Renderer)"; do
+    pkill -x "$pat" 2>/dev/null || true
+done
+deadline=$((SECONDS + 15))
+while [ $SECONDS -lt $deadline ]; do
+    pgrep -x "MetalSharp" >/dev/null 2>&1 || break
+    sleep 0.5
+done
+killall -9 "MetalSharp" 2>/dev/null || true
+sleep 2
+
+write_status "verifying_dmg" 30 "Verifying DMG..."
+if [ ! -f "$DMG_PATH" ]; then
+    write_status "error" 30 "DMG not found: $DMG_PATH" "dmg_not_found"
+    exit 1
+fi
+
+write_status "mounting" 35 "Mounting update disk image..."
+MOUNT_OUTPUT=$(hdiutil attach -nobrowse -quiet "$DMG_PATH" 2>&1) || {
+    MOUNT_OUTPUT=$(osascript -e "do shell script \"hdiutil attach -nobrowse -quiet \\\"$DMG_PATH\\\"\" with administrator privileges" 2>&1) || true
+    sleep 2
+}
+
+MOUNT_POINT=$(echo "$MOUNT_OUTPUT" | awk '{print $NF}' | grep '/Volumes/')
+if [ -z "$MOUNT_POINT" ] || [ ! -d "$MOUNT_POINT" ]; then
+    MOUNT_POINT=$(hdiutil info 2>/dev/null | grep -A1 "$(basename "$DMG_PATH")" | grep '/Volumes/' | awk '{print $NF}' | head -1)
+fi
+
+if [ -z "$MOUNT_POINT" ] || [ ! -d "$MOUNT_POINT" ]; then
+    write_status "error" 40 "Failed to mount DMG" "mount_failed"
+    exit 1
+fi
+
+write_status "mounted" 45 "Mounted at $MOUNT_POINT"
+
+APP_SOURCE=$(find "$MOUNT_POINT" -maxdepth 1 -name "*.app" -iname "*metalsharp*" 2>/dev/null | head -1)
+if [ -z "$APP_SOURCE" ]; then
+    write_status "error" 50 "MetalSharp.app not found in update" "app_not_found"
+    exit 1
+fi
+
+write_status "installing" 50 "Removing old version..."
+if [ -d "$APP_PATH" ]; then
+    rm -rf "$APP_PATH" 2>/dev/null || {
+        osascript -e "do shell script \"rm -rf \\\"$APP_PATH\\\"\" with administrator privileges" 2>/dev/null || true
+        sleep 1
+    }
+    [ -d "$APP_PATH" ] && {
+        write_status "error" 55 "Failed to remove old app" "remove_failed"
+        exit 1
+    }
+fi
+
+write_status "installing" 60 "Installing new version..."
+cp -R "$APP_SOURCE" "$APP_PATH" 2>/dev/null || {
+    osascript -e "do shell script \"cp -R \\\"$APP_SOURCE\\\" \\\"$APP_PATH\\\"\" with administrator privileges" 2>/dev/null || true
+    sleep 2
+}
+
+if [ ! -d "$APP_PATH" ]; then
+    write_status "error" 65 "Failed to install new version" "copy_failed"
+    exit 1
+fi
+
+write_status "installed" 80 "New version installed"
+
+write_status "unmounting" 82 "Unmounting update disk..."
+hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null || true
+MOUNT_POINT=""
+
+write_status "relaunching" 85 "Launching MetalSharp..."
+sleep 1
+open "$APP_PATH"
+
+write_status "verifying" 90 "Verifying installation..."
+sleep 5
+
+BACKEND_VERSION=""
+deadline=$((SECONDS + 45))
+while [ $SECONDS -lt $deadline ]; do
+    BACKEND_VERSION=$(curl -sf "http://127.0.0.1:9274/status" 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('version',''))" 2>/dev/null || true)
+    [ -n "$BACKEND_VERSION" ] && break
+    sleep 1
+done
+
+if [ "$BACKEND_VERSION" != "$TARGET_VERSION" ] && [ -n "$BACKEND_VERSION" ]; then
+    write_status "deploying_backend" 92 "Backend version mismatch, redeploying..."
+    pkill -x metalsharp-backend 2>/dev/null || true
+    sleep 1
+    open -a "MetalSharp"
+    sleep 5
+    BACKEND_VERSION=$(curl -sf "http://127.0.0.1:9274/status" 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('version',''))" 2>/dev/null || true)
+fi
+
+if [ "$BACKEND_VERSION" = "$TARGET_VERSION" ]; then
+    write_status "complete" 100 "Successfully updated to v${TARGET_VERSION}!"
+else
+    write_status "complete" 100 "Update installed. Backend: v${BACKEND_VERSION:-?} (expected v${TARGET_VERSION})"
+fi


### PR DESCRIPTION
## Summary

- **Frontend launch method dropdown** now fetches from `/mtsp/pipelines?appid=X` instead of hardcoded legacy method names. Each installed game pre-fetches its pipeline info on library load so the dropdown is populated before the user clicks Play.
- **Backend accepts both legacy method strings and MTSP pipeline IDs** via new `PipelineId::from_str_flexible()` — the dropdown sends `m32_vk`, `m11`, `steam_metalfx`, etc. directly.
- **Goldberg Steam emulator** added as an install step in the setup wizard. Downloads `goldberg.tar.zst` from release bundles (already uploaded). The remote's `prepare_goldberg_game` + `ensure_goldberg_downloaded` is preserved for per-game setup.
- **Portal 2 (620) and Goat Simulator (265930)** routed through `prepare_goldberg_game` which uses MetalSharp Wine (not Wine Devel).
- **`prepare_game` game_type mapping** aligned with MTSP rule resolution — unknown games use `resolve_pipeline().to_legacy_method()` instead of defaulting to `steam_d3dmetal_perf`.
- **Setup wizard dependency descriptions** updated to reflect MTSP engine (GPTK/Wine Devel marked as optional/no longer required).
- **`goldberg.tar.zst`** uploaded to GitHub release assets (`bundles` tag).

## Files changed

| File | What |
|------|------|
| `app/src/renderer/index.ts` | Pipeline-aware dropdown, pre-fetch on library load, removed hardcoded `defaultLaunchMethod` |
| `app/src-rust/src/main.rs` | Use `from_str_flexible` instead of `from_legacy_method` for launch routing |
| `app/src-rust/src/mtsp/engine.rs` | Added `from_str_flexible()` method to `PipelineId` |
| `app/src-rust/src/installer.rs` | Added Goldberg install step (`install_goldberg`) |
| `app/src-rust/src/setup.rs` | Aligned game_type mapping with MTSP, route 620/265930 to `prepare_goldberg_game`, updated dep descriptions |
| `app/src-rust/src/mtsp/launcher.rs` | Extracted shared `resolve_d3d9_exe()`, deduplicated D3D9 launch paths |

## Test plan

- [ ] Open app, verify installed games show pipeline dropdown options (not just "Native")
- [ ] Portal 2 launches via DXVK D3D9 pipeline (not SteamD3DMetalPerf)
- [ ] Fresh install via setup wizard installs Goldberg from bundles
- [ ] Rain World launches via DXMT M11 pipeline
- [ ] `GET /mtsp/pipelines?appid=620` returns `m32_vk` as recommended