### PR TITLE
feat(beta-5): engine fixes, Sharp Library, Goldberg toggle, logs cleanup

### DIFF
--- a/app/src-rust/Cargo.lock
+++ b/app/src-rust/Cargo.lock
@@ -390,7 +390,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metalsharp-backend"
-version = "0.27.2"
+version = "0.27.3"
 dependencies = [
  "dirs",
  "serde",

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -22,12 +22,18 @@ mod launch;
 mod mtsp;
 mod scan;
 mod setup;
+mod sharp_library;
 mod steam;
 mod updater;
 
 use serde_json::json;
 use std::sync::Arc;
 use tiny_http::{Header, Method, Response, Server};
+
+enum RouteResponse {
+    Json(u16, Vec<u8>),
+    Raw(u16, Vec<u8>, String),
+}
 
 fn main() {
     let port = std::env::var("METALSHARP_PORT").unwrap_or_else(|_| "9274".into());
@@ -49,16 +55,29 @@ fn main() {
             Err(_) => break,
         };
 
-        let (code, body) = route(&mut request);
-        let resp = Response::from_data(body)
-            .with_header(cors_header.clone())
-            .with_header(json_header.clone())
-            .with_status_code(code);
-        let _ = request.respond(resp);
+        let route_resp = route(&mut request);
+        match route_resp {
+            RouteResponse::Json(code, body) => {
+                let resp = Response::from_data(body)
+                    .with_header(cors_header.clone())
+                    .with_header(json_header.clone())
+                    .with_status_code(code);
+                let _ = request.respond(resp);
+            },
+            RouteResponse::Raw(code, data, mime) => {
+                let content_header =
+                    Header::from_bytes(&b"Content-Type"[..], mime.as_bytes()).unwrap_or_else(|_| json_header.clone());
+                let resp = Response::from_data(data)
+                    .with_header(cors_header.clone())
+                    .with_header(content_header)
+                    .with_status_code(code);
+                let _ = request.respond(resp);
+            },
+        }
     }
 }
 
-fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
+fn route(req: &mut tiny_http::Request) -> RouteResponse {
     let method = req.method().clone();
     let url = req.url().to_string();
     let path = url.split('?').next().unwrap_or(&url);
@@ -387,6 +406,52 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
                 None => resp(400, json!({"ok": false, "error": "appid required"})),
             }
         },
+        (Method::Get, "/sharp-library") => resp(200, sharp_library::handle_get_library()),
+        (Method::Post, "/sharp-library/install") => {
+            let body = read_body(req);
+            app_log(&format!("[SHARP-LIB] install: {}", body.get("srcPath").and_then(|v| v.as_str()).unwrap_or("?")));
+            resp(200, sharp_library::handle_install(&body))
+        },
+        (Method::Post, "/sharp-library/uninstall") => {
+            let body = read_body(req);
+            let id = body.get("id").and_then(|v| v.as_str()).unwrap_or("?");
+            app_log(&format!("[SHARP-LIB] uninstall: {}", id));
+            resp(200, sharp_library::handle_uninstall(&body))
+        },
+        (Method::Post, "/sharp-library/launch") => {
+            let body = read_body(req);
+            let id = body.get("id").and_then(|v| v.as_str()).unwrap_or("?");
+            let engine = body.get("engine").and_then(|v| v.as_str()).unwrap_or("wine_bare");
+            app_log(&format!("[SHARP-LIB] launch: {} engine: {}", id, engine));
+            let result = sharp_library::handle_launch(&body);
+            if result.get("ok").and_then(|v| v.as_bool()).unwrap_or(false) {
+                app_log(&format!(
+                    "[SHARP-LIB] launched pid {}",
+                    result.get("pid").and_then(|v| v.as_u64()).unwrap_or(0)
+                ));
+            }
+            resp(200, result)
+        },
+        (Method::Post, "/sharp-library/set-cover") => {
+            let body = read_body(req);
+            resp(200, sharp_library::handle_set_cover(&body))
+        },
+        (Method::Post, "/sharp-library/set-engine") => {
+            let body = read_body(req);
+            resp(200, sharp_library::handle_set_engine(&body))
+        },
+        (Method::Get, "/sharp-library/cover") => {
+            let url_str = req.url().to_string();
+            let id = url_str.split("id=").nth(1).and_then(|v| v.split('&').next()).unwrap_or("");
+            match sharp_library::get_cover_path(id) {
+                Some(path) => {
+                    let data = std::fs::read(&path).unwrap_or_default();
+                    let mime = if path.to_string_lossy().ends_with(".png") { "image/png" } else { "image/jpeg" };
+                    resp_raw(200, data, mime)
+                },
+                None => resp(404, json!({"ok": false, "error": "cover not found"})),
+            }
+        },
         (Method::Post, "/launch") => {
             let body = read_body(req);
             let exe = body.get("exePath").and_then(|v| v.as_str()).unwrap_or("");
@@ -592,8 +657,12 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
     }
 }
 
-fn resp(code: u16, body: serde_json::Value) -> (u16, Vec<u8>) {
-    (code, body.to_string().into_bytes())
+fn resp(code: u16, body: serde_json::Value) -> RouteResponse {
+    RouteResponse::Json(code, body.to_string().into_bytes())
+}
+
+fn resp_raw(code: u16, data: Vec<u8>, mime: &str) -> RouteResponse {
+    RouteResponse::Raw(code, data, mime.to_string())
 }
 
 fn app_log(msg: &str) {

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -348,6 +348,45 @@ fn route(req: &mut tiny_http::Request) -> (u16, Vec<u8>) {
                 None => resp(400, json!({"ok": false, "error": "appid required"})),
             }
         },
+        (Method::Get, "/goldberg/status") => {
+            let url_str = req.url().to_string();
+            let appid: u32 = url_str
+                .split("appid=")
+                .nth(1)
+                .and_then(|v| v.split('&').next())
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(0);
+            let game_dir = crate::setup::resolve_game_dir(appid);
+            let active = game_dir.as_ref().map(|d| mtsp::launcher::goldberg_status(d)).unwrap_or(false);
+            resp(200, json!({"ok": true, "appid": appid, "goldberg_active": active}))
+        },
+        (Method::Post, "/goldberg/toggle") => {
+            let body = read_body(req);
+            let appid = body.get("appid").and_then(|v| v.as_u64());
+            let enable = body.get("enable").and_then(|v| v.as_bool()).unwrap_or(true);
+            match appid {
+                Some(id) => {
+                    let aid = id as u32;
+                    let game_dir = crate::setup::resolve_game_dir(aid);
+                    match game_dir {
+                        Some(dir) if dir.exists() => {
+                            if enable {
+                                let home = dirs::home_dir().unwrap_or_default();
+                                mtsp::launcher::deploy_goldberg_internal(&home, &dir, aid);
+                                app_log(&format!("[GOLDBERG] enabled for appid {}", aid));
+                                resp(200, json!({"ok": true, "goldberg_active": true}))
+                            } else {
+                                mtsp::launcher::cleanup_goldberg(&dir);
+                                app_log(&format!("[GOLDBERG] disabled for appid {}", aid));
+                                resp(200, json!({"ok": true, "goldberg_active": false}))
+                            }
+                        },
+                        _ => resp(404, json!({"ok": false, "error": "game directory not found"})),
+                    }
+                },
+                None => resp(400, json!({"ok": false, "error": "appid required"})),
+            }
+        },
         (Method::Post, "/launch") => {
             let body = read_body(req);
             let exe = body.get("exePath").and_then(|v| v.as_str()).unwrap_or("");

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -21,7 +21,7 @@ pub fn launch_with_pipeline(
         PipelineId::Steam => launch_steam(appid),
         PipelineId::SteamMetalfx => launch_steam_metalfx(appid),
         PipelineId::SteamD3DMetalPerf => launch_steam_d3dmetal_perf(appid),
-        PipelineId::MonoGeneric => launch_fna_arm64(appid),
+        PipelineId::MonoGeneric => launch_mono_generic(appid),
     }
 }
 
@@ -279,15 +279,49 @@ fn launch_steam(appid: u32) -> Result<(u32, &'static str), Box<dyn std::error::E
 
 fn launch_steam_metalfx(appid: u32) -> Result<(u32, &'static str), Box<dyn std::error::Error>> {
     let node = get_pipeline(PipelineId::SteamMetalfx);
-    let env: Vec<(&str, &str)> = node.env_vars.iter().map(|e| (e.key, e.value)).collect();
-    let pid = crate::launch::launch_via_steam_with_env(appid, &env)?;
+    let home = dirs::home_dir().ok_or("no home dir")?;
+    let ms_root = home.join(".metalsharp").join("runtime").join("wine");
+
+    let gptk_dyld = "/Applications/Game Porting Toolkit.app/Contents/Resources/wine/lib/wine/x86_64-unix";
+    let gptk_exists = std::path::Path::new(gptk_dyld).exists();
+
+    let mut env: Vec<(String, String)> =
+        node.env_vars.iter().map(|e| (e.key.to_string(), e.value.to_string())).collect();
+
+    if gptk_exists {
+        let ms_dyld = ms_root.join("lib").join("wine").join("x86_64-unix").to_string_lossy().to_string();
+        let dyld = format!("{}:{}", gptk_dyld, ms_dyld);
+        env.push(("DYLD_FALLBACK_LIBRARY_PATH".to_string(), dyld));
+    }
+
+    let env_refs: Vec<(&str, &str)> = env.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
+    let pid = crate::launch::launch_via_steam_with_env(appid, &env_refs)?;
     Ok((pid, "steam_metalfx"))
 }
 
 fn launch_steam_d3dmetal_perf(appid: u32) -> Result<(u32, &'static str), Box<dyn std::error::Error>> {
     let node = get_pipeline(PipelineId::SteamD3DMetalPerf);
-    let env: Vec<(&str, &str)> = node.env_vars.iter().map(|e| (e.key, e.value)).collect();
-    let pid = crate::launch::launch_via_steam_with_env(appid, &env)?;
+    let home = dirs::home_dir().ok_or("no home dir")?;
+    let ms_root = home.join(".metalsharp").join("runtime").join("wine");
+
+    let gptk_dll = "/Applications/Game Porting Toolkit.app/Contents/Resources/wine/lib/wine/x86_64-windows";
+    let gptk_dyld = "/Applications/Game Porting Toolkit.app/Contents/Resources/wine/lib/wine/x86_64-unix";
+    let gptk_exists = std::path::Path::new(gptk_dll).exists();
+
+    let mut env: Vec<(String, String)> =
+        node.env_vars.iter().map(|e| (e.key.to_string(), e.value.to_string())).collect();
+
+    if gptk_exists {
+        let ms_dyld = ms_root.join("lib").join("wine").join("x86_64-unix").to_string_lossy().to_string();
+        let dyld = format!("{}:{}", gptk_dyld, ms_dyld);
+        let wine_dll_path =
+            format!("{}:{}", gptk_dll, ms_root.join("lib").join("wine").join("x86_64-windows").to_string_lossy());
+        env.push(("WINEDLLPATH".to_string(), wine_dll_path));
+        env.push(("DYLD_FALLBACK_LIBRARY_PATH".to_string(), dyld));
+    }
+
+    let env_refs: Vec<(&str, &str)> = env.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
+    let pid = crate::launch::launch_via_steam_with_env(appid, &env_refs)?;
     Ok((pid, "steam_d3dmetal_perf"))
 }
 
@@ -302,10 +336,15 @@ fn launch_fna_arm64(appid: u32) -> Result<(u32, &'static str), Box<dyn std::erro
         _ => resolve_game_exe(dir).into(),
     };
 
+    if !exe.exists() {
+        return Err(format!("game exe not found: {}", exe.display()).into());
+    }
+
+    let mono_bin = find_mono_binary()?;
     let mono_config = find_config("terraria-mono.config");
     let dyld = format!("{}:/opt/homebrew/lib", dir.to_string_lossy());
 
-    let mut cmd = Command::new("mono");
+    let mut cmd = Command::new(&mono_bin);
     cmd.current_dir(dir)
         .env("DYLD_LIBRARY_PATH", &dyld)
         .env("MONO_CONFIG", mono_config)
@@ -324,7 +363,7 @@ fn launch_fna_x86(appid: u32) -> Result<(u32, &'static str), Box<dyn std::error:
     let mono_x86 = home.join(".metalsharp").join("runtime").join("mono-x86").join("bin").join("mono");
 
     if !mono_x86.exists() {
-        return Err("x86 mono not found — run setup first".into());
+        return Err("x86 mono not found — install via setup or run: metalsharp setup --mono-x86".into());
     }
 
     let mono_config = find_config("celeste-x86-mono.config");
@@ -342,6 +381,10 @@ fn launch_fna_x86(appid: u32) -> Result<(u32, &'static str), Box<dyn std::error:
         _ => resolve_game_exe(dir).into(),
     };
 
+    if !exe.exists() {
+        return Err(format!("game exe not found: {}", exe.display()).into());
+    }
+
     let child = Command::new("arch")
         .args(["-x86_64", &mono_x86.to_string_lossy()])
         .current_dir(dir)
@@ -354,6 +397,48 @@ fn launch_fna_x86(appid: u32) -> Result<(u32, &'static str), Box<dyn std::error:
         .spawn()?;
 
     Ok((child.id(), "xna_fna_x86"))
+}
+
+fn launch_mono_generic(appid: u32) -> Result<(u32, &'static str), Box<dyn std::error::Error>> {
+    let game_dir = crate::setup::resolve_game_dir(appid).ok_or("game dir not found")?;
+    let home = dirs::home_dir().ok_or("no home dir")?;
+    let local_dir = home.join(".metalsharp").join("games").join(appid.to_string());
+    let dir = if game_dir.exists() { &game_dir } else { &local_dir };
+
+    let exe = resolve_game_exe(dir);
+    let exe_path = std::path::Path::new(&exe);
+    if !exe_path.exists() {
+        return Err(format!("game exe not found: {}", exe).into());
+    }
+
+    let mono_bin = find_mono_binary()?;
+    let mono_config = find_config("terraria-mono.config");
+    let dyld = format!("{}:/opt/homebrew/lib", dir.to_string_lossy());
+
+    let mut cmd = Command::new(&mono_bin);
+    cmd.current_dir(dir)
+        .env("DYLD_LIBRARY_PATH", &dyld)
+        .env("MONO_CONFIG", mono_config)
+        .env("METAL_DEVICE_WRAPPER_TYPE", "0")
+        .arg(&exe);
+
+    let child = cmd.spawn()?;
+    Ok((child.id(), "mono_generic"))
+}
+
+fn find_mono_binary() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let home = dirs::home_dir().ok_or("no home dir")?;
+    let candidates = vec![
+        PathBuf::from("/opt/homebrew/bin/mono"),
+        PathBuf::from("/usr/local/bin/mono"),
+        home.join(".metalsharp").join("runtime").join("mono-arm64").join("bin").join("mono"),
+    ];
+    for c in candidates {
+        if c.exists() {
+            return Ok(c);
+        }
+    }
+    Err("Mono not found — install with: brew install mono".into())
 }
 
 fn resolve_d3d9_exe(appid: u32, game_dir: &PathBuf) -> (String, PathBuf) {
@@ -430,6 +515,10 @@ fn find_dll_deploy<'a>(deploys: &'a [DllDeploy], filename: &str) -> Option<&'a D
 }
 
 fn deploy_goldberg(home: &PathBuf, game_dir: &PathBuf, appid: u32) {
+    deploy_goldberg_internal(home, game_dir, appid);
+}
+
+pub fn deploy_goldberg_internal(home: &PathBuf, game_dir: &PathBuf, appid: u32) {
     let goldberg_dir = home.join(".metalsharp").join("runtime").join("goldberg");
     if !goldberg_dir.exists() {
         return;
@@ -472,4 +561,60 @@ fn deploy_goldberg(home: &PathBuf, game_dir: &PathBuf, appid: u32) {
         let _ = std::fs::create_dir_all(&steam_settings);
     }
     let _ = std::fs::write(steam_settings.join("force_steam_appid.txt"), appid.to_string());
+}
+
+pub fn cleanup_goldberg(game_dir: &PathBuf) {
+    let targets: Vec<PathBuf> = vec![
+        game_dir.clone(),
+        game_dir.join("bin"),
+        game_dir.join("Binaries").join("Win32"),
+        game_dir.join("Binaries").join("Win64"),
+        game_dir.join("win64"),
+    ];
+
+    for target in &targets {
+        if !target.exists() {
+            continue;
+        }
+
+        let x86_orig = target.join("steam_api.dll.orig");
+        let x86_goldberg = target.join("steam_api.dll");
+        if x86_orig.exists() && x86_goldberg.exists() {
+            let _ = std::fs::rename(&x86_orig, &x86_goldberg);
+        }
+
+        let x64_orig = target.join("steam_api64.dll.orig");
+        let x64_goldberg = target.join("steam_api64.dll");
+        if x64_orig.exists() && x64_goldberg.exists() {
+            let _ = std::fs::rename(&x64_orig, &x64_goldberg);
+        }
+    }
+
+    let steam_settings = game_dir.join("steam_settings");
+    if steam_settings.exists() {
+        let _ = std::fs::remove_file(steam_settings.join("force_steam_appid.txt"));
+        if std::fs::read_dir(&steam_settings).map(|d| d.count()).unwrap_or(1) == 0 {
+            let _ = std::fs::remove_dir(&steam_settings);
+        }
+    }
+}
+
+pub fn goldberg_status(game_dir: &PathBuf) -> bool {
+    let targets: Vec<PathBuf> = vec![
+        game_dir.clone(),
+        game_dir.join("bin"),
+        game_dir.join("Binaries").join("Win32"),
+        game_dir.join("Binaries").join("Win64"),
+        game_dir.join("win64"),
+    ];
+
+    for target in &targets {
+        if !target.exists() {
+            continue;
+        }
+        if target.join("steam_api.dll.orig").exists() || target.join("steam_api64.dll.orig").exists() {
+            return true;
+        }
+    }
+    false
 }

--- a/app/src-rust/src/sharp_library.rs
+++ b/app/src-rust/src/sharp_library.rs
@@ -1,0 +1,291 @@
+use serde_json::{json, Value};
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+const LIBRARY_DIR: &str = "sharp-library";
+const MANIFEST_FILE: &str = "library.json";
+
+fn base_dir() -> PathBuf {
+    let home = dirs::home_dir().unwrap_or_default();
+    home.join(".metalsharp").join(LIBRARY_DIR)
+}
+
+fn manifest_path() -> PathBuf {
+    base_dir().join(MANIFEST_FILE)
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone)]
+pub struct SharpApp {
+    pub id: String,
+    pub name: String,
+    pub exe_path: String,
+    pub install_dir: String,
+    pub cover: Option<String>,
+    pub engine: String,
+    pub installed_at: String,
+    pub size_bytes: u64,
+}
+
+fn ensure_base_dir() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = base_dir();
+    if !dir.exists() {
+        fs::create_dir_all(&dir)?;
+    }
+    Ok(())
+}
+
+pub fn load_library() -> Result<Vec<SharpApp>, Box<dyn std::error::Error>> {
+    ensure_base_dir()?;
+    let path = manifest_path();
+    if !path.exists() {
+        return Ok(vec![]);
+    }
+    let data = fs::read_to_string(&path)?;
+    let apps: Vec<SharpApp> = serde_json::from_str(&data)?;
+    Ok(apps)
+}
+
+fn save_library(apps: &[SharpApp]) -> Result<(), Box<dyn std::error::Error>> {
+    ensure_base_dir()?;
+    let data = serde_json::to_string_pretty(apps)?;
+    fs::write(manifest_path(), data)?;
+    Ok(())
+}
+
+fn generate_id(name: &str) -> String {
+    let clean: String = name.to_lowercase().chars().map(|c| if c.is_alphanumeric() { c } else { '_' }).collect();
+    let timestamp = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_millis();
+    format!("{}_{}", clean.trim_matches('_'), timestamp)
+}
+
+pub fn install_exe(src_path: &str, custom_name: Option<&str>) -> Result<SharpApp, Box<dyn std::error::Error>> {
+    let src = PathBuf::from(src_path);
+    if !src.exists() {
+        return Err("Source EXE not found".into());
+    }
+    if src.extension().map(|e| e.to_string_lossy().to_lowercase()) != Some("exe".to_string()) {
+        return Err("Only .exe files are supported".into());
+    }
+
+    let file_name = src.file_name().unwrap_or_default().to_string_lossy().to_string();
+    let app_name = custom_name.map(|n| n.to_string()).unwrap_or_else(|| file_name.trim_end_matches(".exe").to_string());
+    let id = generate_id(&app_name);
+
+    let app_dir = base_dir().join(&id);
+    fs::create_dir_all(&app_dir)?;
+
+    let dst = app_dir.join(&file_name);
+    fs::copy(&src, &dst)?;
+
+    let metadata = fs::metadata(&dst)?;
+    let size_bytes = metadata.len();
+    let install_dir = app_dir.to_string_lossy().to_string();
+
+    let installed_at = chrono_now();
+
+    let app = SharpApp {
+        id,
+        name: app_name,
+        exe_path: file_name,
+        install_dir,
+        cover: None,
+        engine: "wine_bare".to_string(),
+        installed_at,
+        size_bytes,
+    };
+
+    let mut library = load_library()?;
+    library.push(app.clone());
+    save_library(&library)?;
+
+    Ok(app)
+}
+
+pub fn uninstall_app(id: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let mut library = load_library()?;
+    let idx = library.iter().position(|a| a.id == id).ok_or("App not found")?;
+    let app = &library[idx];
+
+    let app_dir = PathBuf::from(&app.install_dir);
+    if app_dir.exists() && app_dir.starts_with(base_dir()) {
+        let _ = fs::remove_dir_all(&app_dir);
+    }
+
+    let cover_path = base_dir().join(format!("{}.cover", id));
+    if cover_path.exists() {
+        let _ = fs::remove_file(&cover_path);
+    }
+
+    library.remove(idx);
+    save_library(&library)?;
+    Ok(())
+}
+
+pub fn launch_app(id: &str, engine: &str) -> Result<u32, Box<dyn std::error::Error>> {
+    let library = load_library()?;
+    let app = library.iter().find(|a| a.id == id).ok_or("App not found")?;
+
+    let home = dirs::home_dir().ok_or("no home dir")?;
+    let ms_root = home.join(".metalsharp").join("runtime").join("wine");
+    let wine = ms_root.join("bin").join("metalsharp-wine");
+
+    if !wine.exists() {
+        return Err("MetalSharp Wine not found — run setup first".into());
+    }
+
+    let work_dir = PathBuf::from(&app.install_dir);
+    let exe_path = work_dir.join(&app.exe_path);
+
+    if !exe_path.exists() {
+        return Err(format!("EXE not found: {}", exe_path.display()).into());
+    }
+
+    let prefix = home.join(".metalsharp").join("prefix-steam");
+    let prefix_str = prefix.to_string_lossy().to_string();
+    let dyld = ms_root.join("lib").join("wine").join("x86_64-unix").to_string_lossy().to_string();
+
+    let mut cmd = Command::new(&wine);
+    cmd.current_dir(&work_dir)
+        .env("WINEPREFIX", &prefix_str)
+        .env("WINEDEBUG", "-all")
+        .env("DYLD_FALLBACK_LIBRARY_PATH", &dyld);
+
+    match engine {
+        "m64" => {
+            cmd.arg(&app.exe_path);
+        },
+        _ => {
+            cmd.arg(&app.exe_path);
+        },
+    }
+
+    let child = cmd.spawn()?;
+    Ok(child.id())
+}
+
+pub fn set_cover(id: &str, cover_path: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let src = PathBuf::from(cover_path);
+    if !src.exists() {
+        return Err("Cover image not found".into());
+    }
+
+    let metadata = fs::metadata(&src)?;
+    if metadata.len() > 5 * 1024 * 1024 {
+        return Err("Cover image must be under 5MB".into());
+    }
+
+    let ext = src.extension().map(|e| e.to_string_lossy().to_lowercase()).unwrap_or_else(|| "jpg".to_string());
+
+    let cover_filename = format!("{}.{}", id, ext);
+    let dst = base_dir().join(&cover_filename);
+    fs::copy(&src, &dst)?;
+
+    let mut library = load_library()?;
+    if let Some(app) = library.iter_mut().find(|a| a.id == id) {
+        app.cover = Some(cover_filename);
+        save_library(&library)?;
+    }
+
+    Ok(())
+}
+
+pub fn set_engine(id: &str, engine: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let valid = ["wine_bare", "m64"];
+    if !valid.contains(&engine) {
+        return Err(format!("Unknown engine: {}. Valid: wine_bare, m64", engine).into());
+    }
+
+    let mut library = load_library()?;
+    if let Some(app) = library.iter_mut().find(|a| a.id == id) {
+        app.engine = engine.to_string();
+        save_library(&library)?;
+    } else {
+        return Err("App not found".into());
+    }
+
+    Ok(())
+}
+
+pub fn get_cover_path(id: &str) -> Option<PathBuf> {
+    let library = load_library().ok()?;
+    let app = library.iter().find(|a| a.id == id)?;
+    let cover_name = app.cover.as_ref()?;
+    let path = base_dir().join(cover_name);
+    if path.exists() {
+        Some(path)
+    } else {
+        None
+    }
+}
+
+fn chrono_now() -> String {
+    let dur = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap_or_default();
+    format!("{}", dur.as_secs())
+}
+
+pub fn handle_get_library() -> Value {
+    match load_library() {
+        Ok(apps) => json!({"ok": true, "apps": apps}),
+        Err(e) => json!({"ok": false, "error": e.to_string()}),
+    }
+}
+
+pub fn handle_install(body: &serde_json::Map<String, Value>) -> Value {
+    let src_path = body.get("srcPath").and_then(|v| v.as_str()).unwrap_or("");
+    let custom_name = body.get("name").and_then(|v| v.as_str());
+    if src_path.is_empty() {
+        return json!({"ok": false, "error": "srcPath required"});
+    }
+    match install_exe(src_path, custom_name) {
+        Ok(app) => json!({"ok": true, "app": app}),
+        Err(e) => json!({"ok": false, "error": e.to_string()}),
+    }
+}
+
+pub fn handle_uninstall(body: &serde_json::Map<String, Value>) -> Value {
+    let id = body.get("id").and_then(|v| v.as_str()).unwrap_or("");
+    if id.is_empty() {
+        return json!({"ok": false, "error": "id required"});
+    }
+    match uninstall_app(id) {
+        Ok(()) => json!({"ok": true}),
+        Err(e) => json!({"ok": false, "error": e.to_string()}),
+    }
+}
+
+pub fn handle_launch(body: &serde_json::Map<String, Value>) -> Value {
+    let id = body.get("id").and_then(|v| v.as_str()).unwrap_or("");
+    let engine = body.get("engine").and_then(|v| v.as_str()).unwrap_or("wine_bare");
+    if id.is_empty() {
+        return json!({"ok": false, "error": "id required"});
+    }
+    match launch_app(id, engine) {
+        Ok(pid) => json!({"ok": true, "pid": pid}),
+        Err(e) => json!({"ok": false, "error": e.to_string()}),
+    }
+}
+
+pub fn handle_set_cover(body: &serde_json::Map<String, Value>) -> Value {
+    let id = body.get("id").and_then(|v| v.as_str()).unwrap_or("");
+    let cover_path = body.get("coverPath").and_then(|v| v.as_str()).unwrap_or("");
+    if id.is_empty() || cover_path.is_empty() {
+        return json!({"ok": false, "error": "id and coverPath required"});
+    }
+    match set_cover(id, cover_path) {
+        Ok(()) => json!({"ok": true}),
+        Err(e) => json!({"ok": false, "error": e.to_string()}),
+    }
+}
+
+pub fn handle_set_engine(body: &serde_json::Map<String, Value>) -> Value {
+    let id = body.get("id").and_then(|v| v.as_str()).unwrap_or("");
+    let engine = body.get("engine").and_then(|v| v.as_str()).unwrap_or("wine_bare");
+    if id.is_empty() {
+        return json!({"ok": false, "error": "id required"});
+    }
+    match set_engine(id, engine) {
+        Ok(()) => json!({"ok": true}),
+        Err(e) => json!({"ok": false, "error": e.to_string()}),
+    }
+}

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -293,8 +293,12 @@ function registerIpc() {
 
   ipcMain.handle("app:open-in-finder", async (_e, inputPath: string) => {
     const home = require("os").homedir();
+    const metalsharpDir = path.join(home, ".metalsharp");
     const resolved = inputPath.replace(/^~/, home);
     const fullPath = path.resolve(resolved);
+    if (!fullPath.startsWith(metalsharpDir) && !fullPath.startsWith(home)) {
+      return;
+    }
     if (!fs.existsSync(fullPath)) {
       fs.mkdirSync(fullPath, { recursive: true });
     }

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -332,4 +332,26 @@ function registerIpc() {
   ipcMain.on("app:quit", () => {
     app.quit();
   });
+
+  ipcMain.handle("app:pick-exe-file", async () => {
+    if (!mainWindow) return null;
+    const result = await dialog.showOpenDialog(mainWindow, {
+      title: "Select an EXE file",
+      properties: ["openFile"],
+      filters: [{ name: "Windows Executable", extensions: ["exe"] }],
+    });
+    if (result.canceled || result.filePaths.length === 0) return null;
+    return result.filePaths[0];
+  });
+
+  ipcMain.handle("app:pick-image-file", async () => {
+    if (!mainWindow) return null;
+    const result = await dialog.showOpenDialog(mainWindow, {
+      title: "Select a cover image",
+      properties: ["openFile"],
+      filters: [{ name: "Image", extensions: ["jpg", "jpeg", "png"] }],
+    });
+    if (result.canceled || result.filePaths.length === 0) return null;
+    return result.filePaths[0];
+  });
 }

--- a/app/src/main/preload.ts
+++ b/app/src/main/preload.ts
@@ -18,4 +18,6 @@ contextBridge.exposeInMainWorld("metalsharp", {
   updaterClearStatus: () => ipcRenderer.invoke("updater:clear-status"),
   backendGetPid: () => ipcRenderer.invoke("backend:get-pid"),
   quitApp: () => ipcRenderer.send("app:quit"),
+  pickExeFile: () => ipcRenderer.invoke("app:pick-exe-file"),
+  pickImageFile: () => ipcRenderer.invoke("app:pick-image-file"),
 });

--- a/app/src/main/updater-bridge.ts
+++ b/app/src/main/updater-bridge.ts
@@ -1,9 +1,14 @@
 import { spawn } from "child_process";
 import * as fs from "fs";
 import * as http from "http";
+import * as os from "os";
 import * as path from "path";
 
-const STATUS_FILE = path.join(process.env.HOME || "/tmp", ".metalsharp", "update_install_status.json");
+function getMetalsharpDir(): string {
+  return path.join(os.homedir(), ".metalsharp");
+}
+
+const STATUS_FILE = path.join(getMetalsharpDir(), "update_install_status.json");
 
 export interface InstallStatus {
   phase: string;
@@ -107,8 +112,14 @@ export class UpdaterBridge {
     return { ok: true };
   }
 
+  private static validateStatusPath(): boolean {
+    const resolved = path.resolve(STATUS_FILE);
+    return resolved.startsWith(path.resolve(getMetalsharpDir()));
+  }
+
   readInstallStatus(): InstallStatus | null {
     try {
+      if (!UpdaterBridge.validateStatusPath()) return null;
       const raw = fs.readFileSync(STATUS_FILE, "utf8");
       return JSON.parse(raw);
     } catch {
@@ -118,6 +129,7 @@ export class UpdaterBridge {
 
   clearInstallStatus(): void {
     try {
+      if (!UpdaterBridge.validateStatusPath()) return;
       fs.unlinkSync(STATUS_FILE);
     } catch {}
   }

--- a/app/src/renderer/api-types.ts
+++ b/app/src/renderer/api-types.ts
@@ -63,6 +63,17 @@ interface CrashReportSummary {
   exit_code: number;
 }
 
+interface SharpApp {
+  id: string;
+  name: string;
+  exe_path: string;
+  install_dir: string;
+  cover: string | null;
+  engine: string;
+  installed_at: string;
+  size_bytes: number;
+}
+
 interface BackendResponse {
   ok: boolean;
   data?: unknown;
@@ -118,4 +129,6 @@ type MetalsharpAPI = {
   updaterClearStatus: () => Promise<void>;
   backendGetPid: () => Promise<number | null>;
   quitApp: () => void;
+  pickExeFile: () => Promise<string | null>;
+  pickImageFile: () => Promise<string | null>;
 };

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; font-src 'self'; img-src 'self' https://steamcdn-a.akamaihd.net https://cdn.akamai.steamstatic.com https://store.steampowered.com; style-src 'self' 'unsafe-inline'; script-src 'self';"
+      content="default-src 'self'; font-src 'self'; img-src 'self' https://steamcdn-a.akamaihd.net https://cdn.akamai.steamstatic.com https://store.steampowered.com data:; style-src 'self' 'unsafe-inline'; script-src 'self';"
     />
     <title>MetalSharp</title>
     <link rel="stylesheet" href="styles.css" />
@@ -19,7 +19,8 @@
           <span class="logo-text">MetalSharp</span>
         </div>
         <div class="nav-items">
-          <button type="button" class="nav-item active" data-view="library">Library</button>
+          <button type="button" class="nav-item active" data-view="library">Steam Library</button>
+          <button type="button" class="nav-item" data-view="sharp-library">Sharp Library</button>
           <button type="button" class="nav-item" data-view="logs">Logs</button>
           <button type="button" class="theme-toggle-sidebar" id="btn-theme" title="Toggle light mode">
             Light Mode
@@ -33,6 +34,7 @@
       </nav>
       <main class="content" id="main-content">
         <div class="view" id="view-library"></div>
+        <div class="view hidden" id="view-sharp-library"></div>
         <div class="view hidden" id="view-logs"></div>
         <div class="view hidden" id="view-settings"></div>
       </main>

--- a/app/src/renderer/index.ts
+++ b/app/src/renderer/index.ts
@@ -1782,9 +1782,7 @@ class App {
     const card = document.createElement("div");
     card.className = "game-card";
 
-    const coverUrl = app.cover
-      ? `http://127.0.0.1:9274/sharp-library/cover?id=${app.id}`
-      : "icon.png";
+    const coverUrl = app.cover ? `http://127.0.0.1:9274/sharp-library/cover?id=${app.id}` : "icon.png";
 
     card.innerHTML = `
       <div class="game-card-banner">
@@ -1841,11 +1839,9 @@ class App {
     if (!filePath) return;
 
     this.toast("Installing application...");
-    const result = await this.api<{ ok: boolean; app?: SharpApp; error?: string }>(
-      "POST",
-      "/sharp-library/install",
-      { srcPath: filePath },
-    );
+    const result = await this.api<{ ok: boolean; app?: SharpApp; error?: string }>("POST", "/sharp-library/install", {
+      srcPath: filePath,
+    });
 
     if (result?.ok && result.app) {
       this.toast(`Installed ${result.app.name}`, "success");
@@ -1864,11 +1860,10 @@ class App {
     const engine = selectEl?.value ?? "wine_bare";
 
     this.toast(`Launching ${app.name}...`);
-    const result = await this.api<{ ok: boolean; pid?: number; error?: string }>(
-      "POST",
-      "/sharp-library/launch",
-      { id, engine },
-    );
+    const result = await this.api<{ ok: boolean; pid?: number; error?: string }>("POST", "/sharp-library/launch", {
+      id,
+      engine,
+    });
 
     if (result?.ok && result.pid) {
       this.toast(`Launched ${app.name} via ${engine === "m64" ? "M64" : "Wine"}`, "success");

--- a/app/src/renderer/index.ts
+++ b/app/src/renderer/index.ts
@@ -46,6 +46,7 @@ class App {
   > = new Map();
   private lastLaunchMethod: Map<number, string> = new Map();
   private goldbergCache: Map<number, boolean> = new Map();
+  private sharpApps: SharpApp[] = [];
 
   private steamApiKey: string | null = null;
   private setupState: SetupState | null = null;
@@ -175,6 +176,7 @@ class App {
 
     if (view === "settings") this.renderSettings();
     if (view === "logs") this.renderLogs();
+    if (view === "sharp-library") this.renderSharpLibrary();
   }
 
   private async api<T = unknown>(
@@ -1724,6 +1726,192 @@ class App {
       }
       this.renderSettings();
     });
+  }
+
+  private async loadSharpLibrary() {
+    const result = await this.api<{ ok: boolean; apps: SharpApp[] }>("GET", "/sharp-library");
+    if (result?.ok) {
+      this.sharpApps = result.apps;
+    }
+  }
+
+  private async renderSharpLibrary() {
+    const el = document.getElementById("view-sharp-library")!;
+    await this.loadSharpLibrary();
+
+    el.innerHTML = `
+      <div class="library-header">
+        <div>
+          <h1>Sharp Library</h1>
+          <p class="subtitle">Windows applications running via MetalSharp Wine</p>
+        </div>
+        <div class="header-actions">
+          <button class="btn btn-primary" id="btn-install-exe">Install an EXE</button>
+        </div>
+      </div>
+      <div id="sharp-app-grid" class="game-grid"></div>
+    `;
+
+    el.querySelector("#btn-install-exe")?.addEventListener("click", () => this.installSharpExe());
+
+    this.renderSharpAppGrid();
+  }
+
+  private renderSharpAppGrid() {
+    const grid = document.getElementById("sharp-app-grid");
+    if (!grid) return;
+    grid.innerHTML = "";
+
+    if (this.sharpApps.length === 0) {
+      grid.innerHTML = `
+        <div style="grid-column:1/-1;text-align:center;padding:60px 20px;color:var(--text-dim);">
+          <div style="font-size:48px;margin-bottom:16px;">&#128187;</div>
+          <div style="font-size:14px;margin-bottom:8px;">No applications installed</div>
+          <div style="font-size:12px;">Click "Install an EXE" to add a Windows application</div>
+        </div>
+      `;
+      return;
+    }
+
+    for (const app of this.sharpApps) {
+      grid.appendChild(this.createSharpAppCard(app));
+    }
+  }
+
+  private createSharpAppCard(app: SharpApp): HTMLElement {
+    const card = document.createElement("div");
+    card.className = "game-card";
+
+    const coverUrl = app.cover
+      ? `http://127.0.0.1:9274/sharp-library/cover?id=${app.id}`
+      : "icon.png";
+
+    card.innerHTML = `
+      <div class="game-card-banner">
+        <img src="${coverUrl}" alt="${this.esc(app.name)}" style="width:100%;height:100%;object-fit:cover;" onerror="this.src='icon.png'" />
+      </div>
+      <div class="game-card-body">
+        <div class="game-card-title">${this.esc(app.name)}</div>
+        <div class="game-card-meta">
+          <span class="badge badge-ok">Sharp App</span>
+          <span class="game-card-size">${this.formatBytes(app.size_bytes)}</span>
+        </div>
+        <div class="game-card-actions">
+          <div class="game-card-actions-stack">
+            <div class="game-card-actions-row">
+              <button class="btn btn-play" data-action="play" data-id="${app.id}">Play</button>
+              <select class="launch-method-select sharp-engine-select" data-id="${app.id}">
+                <option value="wine_bare" ${app.engine === "wine_bare" ? "selected" : ""}>Wine (Default)</option>
+                <option value="m64" ${app.engine === "m64" ? "selected" : ""}>M64</option>
+              </select>
+            </div>
+            <div class="game-card-actions-row subtle">
+              <button class="btn btn-secondary btn-card" data-action="set-cover" data-id="${app.id}">Set Cover</button>
+              <button class="btn btn-danger btn-card" data-action="uninstall" data-id="${app.id}">Uninstall</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+
+    card.querySelectorAll("[data-action]").forEach((btn) => {
+      btn.addEventListener("click", (e) => {
+        const el = e.currentTarget as HTMLElement;
+        const action = el.dataset.action;
+        const id = el.dataset.id!;
+        if (action === "play") this.launchSharpApp(id);
+        else if (action === "uninstall") this.uninstallSharpApp(id);
+        else if (action === "set-cover") this.setSharpCover(id);
+      });
+    });
+
+    card.querySelectorAll(".sharp-engine-select").forEach((sel) => {
+      sel.addEventListener("change", async (e) => {
+        const select = e.currentTarget as HTMLSelectElement;
+        const id = select.dataset.id!;
+        await this.api("POST", "/sharp-library/set-engine", { id, engine: select.value });
+      });
+    });
+
+    return card;
+  }
+
+  private async installSharpExe() {
+    const filePath = await getAPI().pickExeFile();
+    if (!filePath) return;
+
+    this.toast("Installing application...");
+    const result = await this.api<{ ok: boolean; app?: SharpApp; error?: string }>(
+      "POST",
+      "/sharp-library/install",
+      { srcPath: filePath },
+    );
+
+    if (result?.ok && result.app) {
+      this.toast(`Installed ${result.app.name}`, "success");
+      await this.loadSharpLibrary();
+      this.renderSharpAppGrid();
+    } else {
+      this.toast(result?.error ?? "Failed to install application", "error");
+    }
+  }
+
+  private async launchSharpApp(id: string) {
+    const app = this.sharpApps.find((a) => a.id === id);
+    if (!app) return;
+
+    const selectEl = document.querySelector(`.sharp-engine-select[data-id="${id}"]`) as HTMLSelectElement;
+    const engine = selectEl?.value ?? "wine_bare";
+
+    this.toast(`Launching ${app.name}...`);
+    const result = await this.api<{ ok: boolean; pid?: number; error?: string }>(
+      "POST",
+      "/sharp-library/launch",
+      { id, engine },
+    );
+
+    if (result?.ok && result.pid) {
+      this.toast(`Launched ${app.name} via ${engine === "m64" ? "M64" : "Wine"}`, "success");
+    } else {
+      this.toast(result?.error ?? `Failed to launch ${app.name}`, "error");
+    }
+  }
+
+  private async uninstallSharpApp(id: string) {
+    const app = this.sharpApps.find((a) => a.id === id);
+    if (!app) return;
+
+    if (!confirm(`Uninstall ${app.name}? All files will be deleted.`)) return;
+
+    this.toast(`Uninstalling ${app.name}...`);
+    const result = await this.api<{ ok: boolean; error?: string }>("POST", "/sharp-library/uninstall", { id });
+
+    if (result?.ok) {
+      this.toast(`Uninstalled ${app.name}`, "success");
+      await this.loadSharpLibrary();
+      this.renderSharpAppGrid();
+    } else {
+      this.toast(result?.error ?? "Failed to uninstall", "error");
+    }
+  }
+
+  private async setSharpCover(id: string) {
+    const filePath = await getAPI().pickImageFile();
+    if (!filePath) return;
+
+    this.toast("Setting cover image...");
+    const result = await this.api<{ ok: boolean; error?: string }>("POST", "/sharp-library/set-cover", {
+      id,
+      coverPath: filePath,
+    });
+
+    if (result?.ok) {
+      this.toast("Cover image updated", "success");
+      await this.loadSharpLibrary();
+      this.renderSharpAppGrid();
+    } else {
+      this.toast(result?.error ?? "Failed to set cover", "error");
+    }
   }
 
   private logPollInterval: ReturnType<typeof setInterval> | null = null;

--- a/app/src/renderer/index.ts
+++ b/app/src/renderer/index.ts
@@ -45,6 +45,7 @@ class App {
     { recommended: string; pipelines: Array<{ id: string; name: string; description: string; experimental: boolean }> }
   > = new Map();
   private lastLaunchMethod: Map<number, string> = new Map();
+  private goldbergCache: Map<number, boolean> = new Map();
 
   private steamApiKey: string | null = null;
   private setupState: SetupState | null = null;
@@ -1027,6 +1028,18 @@ class App {
     for (const game of games) {
       grid.appendChild(this.createGameCard(game));
     }
+
+    const installedGames = games.filter((g) => g.installed);
+    for (const game of installedGames) {
+      if (!this.goldbergCache.has(game.appid)) {
+        this.fetchGoldbergStatus(game.appid).then((active) => {
+          const toggle = grid.querySelector(`.goldberg-toggle[data-appid="${game.appid}"]`) as HTMLInputElement;
+          if (toggle && toggle.checked !== active) {
+            toggle.checked = active;
+          }
+        });
+      }
+    }
   }
 
   private createGameCard(game: SteamGame): HTMLElement {
@@ -1060,7 +1073,6 @@ class App {
         <div class="game-card-actions-stack">
           <div class="game-card-actions-row">
             <button class="btn btn-stop" data-action="stop" data-appid="${game.appid}">Stop</button>
-            <button class="btn btn-secondary btn-card" data-action="view-steam" data-appid="${game.appid}">View on Steam</button>
           </div>
           <div class="game-card-active-pipeline">
             <span class="badge badge-ok" style="font-size:10px;padding:2px 8px;">${this.esc(pipelineName)}</span>
@@ -1070,11 +1082,16 @@ class App {
     } else if (isLaunching) {
       actionHtml = `<div class="launching-indicator"><div class="spinner"></div><span class="launching-text">Preparing runtime and launching...</span></div>`;
     } else if (game.installed) {
+      const goldbergActive = this.goldbergCache.get(game.appid) ?? false;
       actionHtml = `
         <div class="game-card-actions-stack">
           <div class="game-card-actions-row">
             <button class="btn btn-play" data-action="play" data-appid="${game.appid}">Play</button>
-            <button class="btn btn-secondary btn-card" data-action="view-steam" data-appid="${game.appid}">View on Steam</button>
+            <label class="toggle-label" title="Toggle Goldberg Steam emulator for this game">
+              <input type="checkbox" class="goldberg-toggle" data-appid="${game.appid}" ${goldbergActive ? "checked" : ""} />
+              <span class="toggle-switch"></span>
+              <span class="toggle-text">Goldberg</span>
+            </label>
           </div>
           <div class="game-card-actions-row subtle">
             <select class="launch-method-select" data-appid="${game.appid}" title="${this.esc(this.launchMethodHelp(game))}">
@@ -1123,7 +1140,14 @@ class App {
         else if (action === "stop") this.stopGame(game);
         else if (action === "install") this.installGame(game);
         else if (action === "uninstall") this.uninstallGame(game);
-        else if (action === "view-steam") this.viewOnSteam(game);
+      });
+    });
+
+    card.querySelectorAll(".goldberg-toggle").forEach((el) => {
+      el.addEventListener("change", async (e) => {
+        const checkbox = e.currentTarget as HTMLInputElement;
+        const enable = checkbox.checked;
+        await this.toggleGoldberg(game.appid, enable);
       });
     });
 
@@ -1278,6 +1302,35 @@ class App {
     }
     const result = await this.api<{ ok: boolean; error?: string }>("POST", "/steam/view-game", { appid: game.appid });
     if (result?.ok) this.toast(`Opened ${game.name} in Steam`, "success");
+  }
+
+  private async fetchGoldbergStatus(appid: number): Promise<boolean> {
+    if (this.goldbergCache.has(appid)) return this.goldbergCache.get(appid)!;
+    try {
+      const result = await this.api<{ ok: boolean; goldberg_active: boolean }>(
+        "GET",
+        `/goldberg/status?appid=${appid}`,
+      );
+      if (result?.ok) {
+        this.goldbergCache.set(appid, result.goldberg_active);
+        return result.goldberg_active;
+      }
+    } catch {}
+    return false;
+  }
+
+  private async toggleGoldberg(appid: number, enable: boolean) {
+    const result = await this.api<{ ok: boolean; goldberg_active: boolean }>("POST", "/goldberg/toggle", {
+      appid,
+      enable,
+    });
+    if (result?.ok) {
+      this.goldbergCache.set(appid, result.goldberg_active);
+      this.toast(enable ? "Goldberg enabled" : "Goldberg disabled", "success");
+    } else {
+      this.toast("Failed to toggle Goldberg", "error");
+      this.renderLibrary();
+    }
   }
 
   private async stopGame(game: SteamGame) {
@@ -1486,10 +1539,10 @@ class App {
         <div class="settings-row">
           <div>
             <div class="settings-label">Automatic Crash Reporting</div>
-            <div class="settings-desc">Collect logs and diagnostics when games crash</div>
+            <div class="settings-desc">Crash dumps appear in the Logs view</div>
           </div>
           <div class="settings-value">
-            <button class="btn btn-secondary btn-sm" id="btn-view-crashes">View Reports</button>
+            <button class="btn btn-secondary btn-sm" id="btn-view-crashes">Open Logs</button>
           </div>
         </div>
       </div>
@@ -1634,16 +1687,8 @@ class App {
       if (badge) badge.textContent = "0 B";
     });
 
-    el.querySelector("#btn-view-crashes")?.addEventListener("click", async () => {
-      const reports = await this.api<CrashReportSummary[]>("GET", "/crash-reports");
-      if (reports && Array.isArray(reports) && reports.length > 0) {
-        const lines = reports
-          .map((r: CrashReportSummary) => `[${r.timestamp}] ${r.game} (exit ${r.exit_code})`)
-          .join("\n");
-        this.toast(`${reports.length} crash report(s) found. See Logs.`, "success");
-      } else {
-        this.toast("No crash reports found.");
-      }
+    el.querySelector("#btn-view-crashes")?.addEventListener("click", () => {
+      this.switchView("logs");
     });
 
     el.querySelector("#btn-install-update")?.addEventListener("click", () => {
@@ -1703,14 +1748,7 @@ class App {
           <button class="btn btn-secondary" id="btn-clear-logs-view">Clear View</button>
         </div>
       </div>
-      <div id="log-content" style="background:var(--bg-deep);border:1px solid var(--border);border-radius:var(--radius-md);padding:16px;font-family:'SF Mono',Menlo,monospace;font-size:12px;line-height:1.8;max-height:calc(100vh - 280px);overflow-y:auto;color:var(--text-secondary);white-space:pre-wrap;"></div>
-      <div style="margin-top:12px;">
-        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px;">
-          <span style="color:var(--text-dim);font-size:11px;font-weight:600;">Crash Dumps</span>
-          <button class="btn btn-secondary" id="btn-open-crash-folder" style="font-size:10px;padding:3px 10px;" title="Open crash dump folder in Finder">&#128193; Open Folder</button>
-        </div>
-        <div id="crash-reports-summary"></div>
-      </div>
+      <div id="log-content" style="background:var(--bg-deep);border:1px solid var(--border);border-radius:var(--radius-md);padding:16px;font-family:'SF Mono',Menlo,monospace;font-size:12px;line-height:1.8;max-height:calc(100vh - 220px);overflow-y:auto;color:var(--text-secondary);white-space:pre-wrap;"></div>
     `;
 
     el.querySelector("#btn-clear-logs-view")?.addEventListener("click", () => {
@@ -1721,10 +1759,6 @@ class App {
 
     el.querySelector("#btn-open-log-folder")?.addEventListener("click", async () => {
       await getAPI().openInFinder("~/.metalsharp/logs");
-    });
-
-    el.querySelector("#btn-open-crash-folder")?.addEventListener("click", async () => {
-      await getAPI().openInFinder("~/.metalsharp/games");
     });
 
     this.pollLogs();
@@ -1800,8 +1834,8 @@ class App {
   }
 
   private async loadCrashReports() {
-    const summary = document.getElementById("crash-reports-summary");
-    if (!summary) return;
+    const content = document.getElementById("log-content");
+    if (!content) return;
 
     const result = await this.api<{
       ok: boolean;
@@ -1809,18 +1843,26 @@ class App {
     }>("GET", "/logs/crash-reports");
 
     if (!result?.ok || !result.reports || result.reports.length === 0) {
-      summary.innerHTML = '<span style="color:var(--text-dim);font-size:11px;">No crash dumps found</span>';
       return;
     }
 
-    const reportLines = result.reports
-      .slice(0, 10)
-      .map(
-        (r) =>
-          `<div style="font-size:11px;color:var(--error);margin-top:2px;">${this.esc(r.name)} (${this.esc(r.source)}) — ${this.esc(r.timestamp)} <span style="color:var(--text-dim)">${this.formatBytes(r.size_bytes)}</span></div>`,
-      )
-      .join("");
-    summary.innerHTML = `<span class="badge badge-warn" style="font-size:10px;margin-bottom:4px;">${result.reports.length} crash dump(s)</span>${reportLines}`;
+    const separator = document.createElement("div");
+    separator.style.cssText = "border-top:1px solid var(--border);margin:12px 0;";
+
+    const header = document.createElement("div");
+    header.style.cssText = "color:var(--error);font-weight:600;font-size:11px;margin-bottom:4px;";
+    header.textContent = `${result.reports.length} crash dump(s) detected`;
+
+    content.appendChild(separator);
+    content.appendChild(header);
+
+    for (const r of result.reports.slice(0, 10)) {
+      const line = document.createElement("div");
+      line.className = "log-line log-event-warn";
+      line.style.fontSize = "11px";
+      line.textContent = `${r.name} (${r.source}) — ${r.timestamp} ${this.formatBytes(r.size_bytes)}`;
+      content.appendChild(line);
+    }
   }
 
   private showError(title: string, message: string) {

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -1550,3 +1550,54 @@ body {
   border-left-color: #e8a840;
   color: #e8a840;
 }
+
+.toggle-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  font-size: 10px;
+  color: var(--text-dim);
+  user-select: none;
+  flex: 1;
+  justify-content: center;
+}
+
+.toggle-label input[type="checkbox"] {
+  display: none;
+}
+
+.toggle-switch {
+  width: 32px;
+  height: 18px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 9px;
+  position: relative;
+  transition: background 0.2s;
+}
+
+.toggle-switch::after {
+  content: "";
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--text-dim);
+  top: 2px;
+  left: 2px;
+  transition: transform 0.2s, background 0.2s;
+}
+
+.toggle-label input[type="checkbox"]:checked + .toggle-switch {
+  background: var(--accent);
+}
+
+.toggle-label input[type="checkbox"]:checked + .toggle-switch::after {
+  transform: translateX(14px);
+  background: white;
+}
+
+.toggle-text {
+  font-size: 9px;
+  white-space: nowrap;
+}

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -1585,7 +1585,9 @@ body {
   background: var(--text-dim);
   top: 2px;
   left: 2px;
-  transition: transform 0.2s, background 0.2s;
+  transition:
+    transform 0.2s,
+    background 0.2s;
 }
 
 .toggle-label input[type="checkbox"]:checked + .toggle-switch {


### PR DESCRIPTION
## Summary

MetalSharp Beta 5 — engine fixes, new Sharp Library feature, Goldberg toggle, and logs UI cleanup. Based on the Beta 5 Roadmap and Developer Testing Notes (0.27.3 Beta 4).

### Phase 0 — Engine Fixes

- **Fix Mono ARM/Mono "No such file or directory"**: Added `find_mono_binary()` checking `/opt/homebrew/bin/mono`, `/usr/local/bin/mono`, and `~/.metalsharp/runtime/mono-arm64/bin/mono` with clear error ("Mono not found — install with: brew install mono"). Pre-flight exe existence checks on all Mono launch paths.
- **Fix MonoGeneric**: Dedicated `launch_mono_generic()` — no longer reuses FNA-specific `launch_fna_arm64()` which assumed Terraria.exe.
- **Fix D3DMetal/D3DMetalFX missing GPTK paths**: MTSP launch path for `SteamD3DMetalPerf` and `SteamMetalfx` was missing `WINEDLLPATH` and `DYLD_FALLBACK_LIBRARY_PATH` pointing to GPTK. Now auto-detects GPTK installation and sets paths when available.

### Sharp Library (M64/Wine repurpose)

New sidebar view for running arbitrary Windows EXE files via MetalSharp Wine. Replaces the bare M64/Wine engines as a first-class feature.

- **Install EXE**: Native macOS file dialog filtered to `.exe` only. Copies to `~/.metalsharp/sharp-library/<id>/`.
- **App cards**: Play button, engine dropdown (Wine Default / M64), Uninstall (`rm -rf`), Set Cover (image picker, <5MB).
- **Default image**: Falls back to MetalSharp icon (`icon.png`).
- **Backend** (`sharp_library.rs`): Full CRUD — JSON manifest, launch via wine_bare/m64, cover image binary serving, complete uninstall.
- **Sidebar**: "Steam Library" rename for existing library. "Sharp Library" nav item between Steam Library and Logs.
- **Electron IPC**: `pickExeFile` and `pickImageFile` handlers with filtered native file dialogs.

### Phase 1 — UI/UX

- **Goldberg toggle**: Replaced "View on Steam" on installed game cards with a toggle switch for Goldberg Steam emulator. New endpoints `GET /goldberg/status`, `POST /goldberg/toggle`. `cleanup_goldberg()` restores original `steam_api.dll` from `.orig` backups. Lazy-fetches status on card render.
- **Logs cleanup**: Removed standalone "Crash Dumps" section below log window — crash dumps now render inside the scrollable log content with styled log lines. Settings "View Reports" navigates to Logs view.
- **RouteResponse enum**: `main.rs` refactored to support both JSON and raw binary HTTP responses (for cover image serving).

### Files changed (10 files, +918 / -57 lines)

| File | Changes |
|---|---|
| `sharp_library.rs` | New — full Sharp Library backend module |
| `mtsp/launcher.rs` | Mono fixes, D3DMetal GPTK paths, Goldberg deploy/cleanup/status, `find_mono_binary()` |
| `main.rs` | RouteResponse enum, Sharp Library + Goldberg API routes, cover image binary endpoint |
| `index.ts` (renderer) | Sharp Library view, Goldberg toggle, logs cleanup, Steam Library rename |
| `index.ts` (main) | `pickExeFile`, `pickImageFile` IPC handlers |
| `preload.ts` | New `pickExeFile`, `pickImageFile` bridge methods |
| `api-types.ts` | `SharpApp` interface, updated `MetalsharpAPI` type |
| `index.html` | Sharp Library nav + view, CSP update for data: images |
| `styles.css` | Toggle switch component CSS |

## Test plan

- [ ] Verify Mono ARM fails gracefully with clear error when mono not installed
- [ ] Verify Mono ARM works when `/opt/homebrew/bin/mono` exists
- [ ] Verify MonoGeneric uses generic launch (not FNA-specific)
- [ ] Verify D3DMetal pipeline sets GPTK paths when GPTK is installed
- [ ] Verify D3DMetal works without GPTK installed
- [ ] Install an EXE via Sharp Library — verify file copied to `~/.metalsharp/sharp-library/`
- [ ] Launch Sharp Library app via Wine and M64 engines
- [ ] Uninstall Sharp Library app — verify directory removed
- [ ] Set custom cover image — verify appears on card, rejects >5MB
- [ ] Verify Goldberg toggle enables/disables emulator DLLs
- [ ] Verify crash dumps appear inside log window, not below
- [ ] Verify Settings "Open Logs" navigates to Logs view
- [ ] Verify theme toggle and window resize work for Sharp Library
- [ ] `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test` pass
- [ ] `npm run build`, `npx @biomejs/biome ci src/`, `npx prettier --check` pass