### PR TITLE
feat: EAC bypass toggle (No EAC) for anti-cheat games

### DIFF
--- a/app/src-rust/Cargo.lock
+++ b/app/src-rust/Cargo.lock
@@ -449,7 +449,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metalsharp-backend"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "dirs",
  "rusqlite",

--- a/app/src-rust/src/installer.rs
+++ b/app/src-rust/src/installer.rs
@@ -79,6 +79,7 @@ fn run_install_all() {
         ("Runtime Assets", Box::new(install_metalsharp_bundle)),
         ("DXMT Metal Runtime", Box::new(install_dxmt_runtime)),
         ("Goldberg Steam Emulator", Box::new(install_goldberg)),
+        ("EAC Bypass", Box::new(install_eac_toggle)),
         ("Pipeline Rules", Box::new(install_mtsp_rules)),
         ("Runtime Support", Box::new(|_| install_mono_arm64())),
     ];
@@ -437,6 +438,41 @@ fn install_goldberg(home: &PathBuf) -> Result<bool, String> {
         Ok(true)
     } else {
         Err("Goldberg Steam emulator not found — goldberg.tar.zst missing from bundles".into())
+    }
+}
+
+fn install_eac_toggle(home: &PathBuf) -> Result<bool, String> {
+    let eac_dir = home.join(".metalsharp").join("runtime").join("eac-toggle");
+    let dll = eac_dir.join("x86_64-windows").join("_winhttp.dll");
+
+    if dll.exists() {
+        return Ok(false);
+    }
+
+    let _ = fs::create_dir_all(eac_dir.join("x86_64-windows"));
+
+    let bundled = find_bundled_archive("eac-toggle");
+    if let Some(archive) = bundled {
+        let tmp = std::env::temp_dir().join("metalsharp-eac-toggle-extract");
+        let _ = fs::remove_dir_all(&tmp);
+        let _ = fs::create_dir_all(&tmp);
+        extract_zst(&archive, &tmp, "eac-toggle")?;
+
+        let src_windows = tmp.join("x86_64-windows");
+        if src_windows.exists() {
+            for entry in fs::read_dir(&src_windows).map_err(|e| format!("read x86_64-windows: {}", e))? {
+                let entry = entry.map_err(|e| e.to_string())?;
+                let _ = fs::copy(entry.path(), eac_dir.join("x86_64-windows").join(entry.file_name()));
+            }
+        }
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    if eac_dir.join("x86_64-windows").join("_winhttp.dll").exists() {
+        Ok(true)
+    } else {
+        Ok(false)
     }
 }
 

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -407,6 +407,44 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
             }
         },
         (Method::Get, "/sharp-library") => resp(200, sharp_library::handle_get_library()),
+        (Method::Get, "/eac-toggle/status") => {
+            let url_str = req.url().to_string();
+            let appid: u32 = url_str
+                .split("appid=")
+                .nth(1)
+                .and_then(|v| v.split('&').next())
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(0);
+            let game_dir = crate::setup::resolve_game_dir(appid);
+            let active = game_dir.as_ref().map(|d| mtsp::launcher::eac_toggle_status(d)).unwrap_or(false);
+            resp(200, json!({"ok": true, "appid": appid, "eac_toggle_active": active}))
+        },
+        (Method::Post, "/eac-toggle/toggle") => {
+            let body = read_body(req);
+            let appid = body.get("appid").and_then(|v| v.as_u64());
+            let enable = body.get("enable").and_then(|v| v.as_bool()).unwrap_or(true);
+            match appid {
+                Some(id) => {
+                    let aid = id as u32;
+                    let game_dir = crate::setup::resolve_game_dir(aid);
+                    match game_dir {
+                        Some(dir) if dir.exists() => {
+                            if enable {
+                                mtsp::launcher::deploy_eac_toggle(&dir);
+                                app_log(&format!("[EAC-TOGGLE] enabled for appid {}", aid));
+                                resp(200, json!({"ok": true, "eac_toggle_active": true}))
+                            } else {
+                                mtsp::launcher::cleanup_eac_toggle(&dir);
+                                app_log(&format!("[EAC-TOGGLE] disabled for appid {}", aid));
+                                resp(200, json!({"ok": true, "eac_toggle_active": false}))
+                            }
+                        },
+                        _ => resp(404, json!({"ok": false, "error": "game directory not found"})),
+                    }
+                },
+                None => resp(400, json!({"ok": false, "error": "appid required"})),
+            }
+        },
         (Method::Post, "/sharp-library/install") => {
             let body = read_body(req);
             app_log(&format!("[SHARP-LIB] install: {}", body.get("srcPath").and_then(|v| v.as_str()).unwrap_or("?")));

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -622,3 +622,75 @@ pub fn goldberg_status(game_dir: &PathBuf) -> bool {
     }
     false
 }
+
+pub fn deploy_eac_toggle(game_dir: &PathBuf) {
+    let home = dirs::home_dir().unwrap_or_default();
+    let eac_dir = home.join(".metalsharp").join("runtime").join("eac-toggle");
+    if !eac_dir.exists() {
+        return;
+    }
+
+    let targets: Vec<PathBuf> = vec![
+        game_dir.clone(),
+        game_dir.join("bin"),
+        game_dir.join("Binaries").join("Win64"),
+        game_dir.join("win64"),
+    ];
+
+    let dll = eac_dir.join("_winhttp.dll");
+    let config = eac_dir.join("anti_cheat_toggler_config.ini");
+    let mod_list = eac_dir.join("anti_cheat_toggler_mod_list.txt");
+    if !dll.exists() {
+        return;
+    }
+
+    for target in &targets {
+        if !target.exists() {
+            continue;
+        }
+        if !target.join("_winhttp.dll").exists() {
+            let _ = std::fs::copy(&dll, target.join("_winhttp.dll"));
+        }
+        if !target.join("anti_cheat_toggler_config.ini").exists() {
+            let _ = std::fs::copy(&config, target.join("anti_cheat_toggler_config.ini"));
+        }
+        if !target.join("anti_cheat_toggler_mod_list.txt").exists() {
+            let _ = std::fs::copy(&mod_list, target.join("anti_cheat_toggler_mod_list.txt"));
+        }
+        break;
+    }
+}
+
+pub fn cleanup_eac_toggle(game_dir: &PathBuf) {
+    let targets: Vec<PathBuf> = vec![
+        game_dir.clone(),
+        game_dir.join("bin"),
+        game_dir.join("Binaries").join("Win64"),
+        game_dir.join("win64"),
+    ];
+
+    for target in &targets {
+        if !target.exists() {
+            continue;
+        }
+        let _ = std::fs::remove_file(target.join("_winhttp.dll"));
+        let _ = std::fs::remove_file(target.join("anti_cheat_toggler_config.ini"));
+        let _ = std::fs::remove_file(target.join("anti_cheat_toggler_mod_list.txt"));
+    }
+}
+
+pub fn eac_toggle_status(game_dir: &PathBuf) -> bool {
+    let targets: Vec<PathBuf> = vec![
+        game_dir.clone(),
+        game_dir.join("bin"),
+        game_dir.join("Binaries").join("Win64"),
+        game_dir.join("win64"),
+    ];
+
+    for target in &targets {
+        if target.exists() && target.join("_winhttp.dll").exists() {
+            return true;
+        }
+    }
+    false
+}

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -630,12 +630,8 @@ pub fn deploy_eac_toggle(game_dir: &PathBuf) {
         return;
     }
 
-    let targets: Vec<PathBuf> = vec![
-        game_dir.clone(),
-        game_dir.join("bin"),
-        game_dir.join("Binaries").join("Win64"),
-        game_dir.join("win64"),
-    ];
+    let targets: Vec<PathBuf> =
+        vec![game_dir.clone(), game_dir.join("bin"), game_dir.join("Binaries").join("Win64"), game_dir.join("win64")];
 
     let dll = eac_dir.join("_winhttp.dll");
     let config = eac_dir.join("anti_cheat_toggler_config.ini");
@@ -662,12 +658,8 @@ pub fn deploy_eac_toggle(game_dir: &PathBuf) {
 }
 
 pub fn cleanup_eac_toggle(game_dir: &PathBuf) {
-    let targets: Vec<PathBuf> = vec![
-        game_dir.clone(),
-        game_dir.join("bin"),
-        game_dir.join("Binaries").join("Win64"),
-        game_dir.join("win64"),
-    ];
+    let targets: Vec<PathBuf> =
+        vec![game_dir.clone(), game_dir.join("bin"), game_dir.join("Binaries").join("Win64"), game_dir.join("win64")];
 
     for target in &targets {
         if !target.exists() {
@@ -680,12 +672,8 @@ pub fn cleanup_eac_toggle(game_dir: &PathBuf) {
 }
 
 pub fn eac_toggle_status(game_dir: &PathBuf) -> bool {
-    let targets: Vec<PathBuf> = vec![
-        game_dir.clone(),
-        game_dir.join("bin"),
-        game_dir.join("Binaries").join("Win64"),
-        game_dir.join("win64"),
-    ];
+    let targets: Vec<PathBuf> =
+        vec![game_dir.clone(), game_dir.join("bin"), game_dir.join("Binaries").join("Win64"), game_dir.join("win64")];
 
     for target in &targets {
         if target.exists() && target.join("_winhttp.dll").exists() {

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -625,7 +625,7 @@ pub fn goldberg_status(game_dir: &PathBuf) -> bool {
 
 pub fn deploy_eac_toggle(game_dir: &PathBuf) {
     let home = dirs::home_dir().unwrap_or_default();
-    let eac_dir = home.join(".metalsharp").join("runtime").join("eac-toggle");
+    let eac_dir = home.join(".metalsharp").join("runtime").join("eac-toggle").join("x86_64-windows");
     if !eac_dir.exists() {
         return;
     }

--- a/app/src/renderer/index.ts
+++ b/app/src/renderer/index.ts
@@ -46,6 +46,7 @@ class App {
   > = new Map();
   private lastLaunchMethod: Map<number, string> = new Map();
   private goldbergCache: Map<number, boolean> = new Map();
+  private eacToggleCache: Map<number, boolean> = new Map();
   private sharpApps: SharpApp[] = [];
 
   private steamApiKey: string | null = null;
@@ -1041,6 +1042,14 @@ class App {
           }
         });
       }
+      if (!this.eacToggleCache.has(game.appid)) {
+        this.fetchEacToggleStatus(game.appid).then((active) => {
+          const toggle = grid.querySelector(`.eac-toggle[data-appid="${game.appid}"]`) as HTMLInputElement;
+          if (toggle && toggle.checked !== active) {
+            toggle.checked = active;
+          }
+        });
+      }
     }
   }
 
@@ -1085,6 +1094,7 @@ class App {
       actionHtml = `<div class="launching-indicator"><div class="spinner"></div><span class="launching-text">Preparing runtime and launching...</span></div>`;
     } else if (game.installed) {
       const goldbergActive = this.goldbergCache.get(game.appid) ?? false;
+      const eacToggleActive = this.eacToggleCache.get(game.appid) ?? false;
       actionHtml = `
         <div class="game-card-actions-stack">
           <div class="game-card-actions-row">
@@ -1093,6 +1103,11 @@ class App {
               <input type="checkbox" class="goldberg-toggle" data-appid="${game.appid}" ${goldbergActive ? "checked" : ""} />
               <span class="toggle-switch"></span>
               <span class="toggle-text">Goldberg</span>
+            </label>
+            <label class="toggle-label" title="Toggle EAC bypass (offline play only, disables anti-cheat)">
+              <input type="checkbox" class="eac-toggle" data-appid="${game.appid}" ${eacToggleActive ? "checked" : ""} />
+              <span class="toggle-switch"></span>
+              <span class="toggle-text">No EAC</span>
             </label>
           </div>
           <div class="game-card-actions-row subtle">
@@ -1150,6 +1165,14 @@ class App {
         const checkbox = e.currentTarget as HTMLInputElement;
         const enable = checkbox.checked;
         await this.toggleGoldberg(game.appid, enable);
+      });
+    });
+
+    card.querySelectorAll(".eac-toggle").forEach((el) => {
+      el.addEventListener("change", async (e) => {
+        const checkbox = e.currentTarget as HTMLInputElement;
+        const enable = checkbox.checked;
+        await this.toggleEacToggle(game.appid, enable);
       });
     });
 
@@ -1331,6 +1354,35 @@ class App {
       this.toast(enable ? "Goldberg enabled" : "Goldberg disabled", "success");
     } else {
       this.toast("Failed to toggle Goldberg", "error");
+      this.renderLibrary();
+    }
+  }
+
+  private async fetchEacToggleStatus(appid: number): Promise<boolean> {
+    if (this.eacToggleCache.has(appid)) return this.eacToggleCache.get(appid)!;
+    try {
+      const result = await this.api<{ ok: boolean; eac_toggle_active: boolean }>(
+        "GET",
+        `/eac-toggle/status?appid=${appid}`,
+      );
+      if (result?.ok) {
+        this.eacToggleCache.set(appid, result.eac_toggle_active);
+        return result.eac_toggle_active;
+      }
+    } catch {}
+    return false;
+  }
+
+  private async toggleEacToggle(appid: number, enable: boolean) {
+    const result = await this.api<{ ok: boolean; eac_toggle_active: boolean }>("POST", "/eac-toggle/toggle", {
+      appid,
+      enable,
+    });
+    if (result?.ok) {
+      this.eacToggleCache.set(appid, result.eac_toggle_active);
+      this.toast(enable ? "EAC bypass enabled (offline only)" : "EAC bypass disabled", "success");
+    } else {
+      this.toast("Failed to toggle EAC bypass", "error");
       this.renderLibrary();
     }
   }


### PR DESCRIPTION
## Summary

- Adds a per-game "No EAC" toggle in the game card UI (next to Goldberg)
- Deploys the Anti-Cheat Toggler mod (`_winhttp.dll` proxy + config) into the game directory to block EasyAntiCheat initialization
- Bundles `eac-toggle.tar.zst` (52KB) in the installer — no separate download step
- Reversible per-launch toggle, user-controlled, offline play only

## What it does

When enabled, drops `_winhttp.dll` into the game dir. This DLL proxy intercepts EAC's initialization calls and blocks them. The game loads without anti-cheat.

## Use case

Games like Elden Ring that use EasyAntiCheat — EAC has no macOS support, so this is the only way to launch them under Wine/Metal.

## Files changed

- `app/src-rust/src/mtsp/launcher.rs` — deploy/cleanup/status functions
- `app/src-rust/src/main.rs` — API endpoints (`GET /eac-toggle/status`, `POST /eac-toggle/toggle`)
- `app/src-rust/src/installer.rs` — install step to extract bundled archive
- `app/src/renderer/index.ts` — UI toggle checkbox + event handlers