### PR TITLE
fix: add Game/ subdir to EAC toggle targets

### DIFF
--- a/app/src-rust/src/installer.rs
+++ b/app/src-rust/src/installer.rs
@@ -81,6 +81,7 @@ fn run_install_all() {
         ("Goldberg Steam Emulator", Box::new(install_goldberg)),
         ("EAC Bypass", Box::new(install_eac_toggle)),
         ("Pipeline Rules", Box::new(install_mtsp_rules)),
+        ("Mono Configs", Box::new(install_mono_configs)),
         ("Runtime Support", Box::new(|_| install_mono_arm64())),
     ];
 
@@ -513,6 +514,53 @@ fn install_mtsp_rules(home: &PathBuf) -> Result<bool, String> {
     }
 
     Err("mtsp-rules.toml not found — pipeline auto-detection will use PE analysis fallback".into())
+}
+
+fn install_mono_configs(home: &PathBuf) -> Result<bool, String> {
+    let configs_dir = home.join(".metalsharp").join("configs");
+    let _ = fs::create_dir_all(&configs_dir);
+
+    let config_files = ["terraria-mono.config", "celeste-x86-mono.config"];
+    let mut any_installed = false;
+
+    for name in &config_files {
+        let dest = configs_dir.join(name);
+        if dest.exists() {
+            continue;
+        }
+
+        let mut candidates = vec![
+            PathBuf::from(format!("configs/{}", name)),
+            home.join(".metalsharp").join("configs").join(name),
+            home.join("repos").join("metalsharp").join("configs").join(name),
+        ];
+
+        if let Ok(exe) = std::env::current_exe() {
+            if let Some(mut dir) = exe.parent() {
+                for _ in 0..8 {
+                    candidates.push(dir.join("configs").join(name));
+                    match dir.parent() {
+                        Some(p) => dir = p,
+                        None => break,
+                    }
+                }
+            }
+        }
+
+        for src in &candidates {
+            if src.exists() {
+                if let Ok(contents) = fs::read_to_string(src) {
+                    let _ = fs::write(&dest, &contents);
+                    if dest.exists() {
+                        any_installed = true;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(any_installed)
 }
 
 fn install_gptk(_home: &PathBuf) -> Result<bool, String> {

--- a/app/src-rust/src/mtsp/engine.rs
+++ b/app/src-rust/src/mtsp/engine.rs
@@ -13,6 +13,7 @@ pub enum PipelineId {
     M64,
     Steam,
     SteamMetalfx,
+    #[serde(rename = "steam_d3dmetal_perf")]
     SteamD3DMetalPerf,
     FnaArm64,
     FnaX86,
@@ -327,7 +328,7 @@ impl PipelineId {
             "m64" => Some(PipelineId::M64),
             "steam" => Some(PipelineId::Steam),
             "steam_metalfx" => Some(PipelineId::SteamMetalfx),
-            "steam_d3dmetal_perf" => Some(PipelineId::SteamD3DMetalPerf),
+            "steam_d3dmetal_perf" | "steam_d3_d_metal_perf" => Some(PipelineId::SteamD3DMetalPerf),
             "fna_arm64" => Some(PipelineId::FnaArm64),
             "fna_x86" => Some(PipelineId::FnaX86),
             "mono_generic" => Some(PipelineId::MonoGeneric),

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -630,8 +630,13 @@ pub fn deploy_eac_toggle(game_dir: &PathBuf) {
         return;
     }
 
-    let targets: Vec<PathBuf> =
-        vec![game_dir.clone(), game_dir.join("bin"), game_dir.join("Binaries").join("Win64"), game_dir.join("win64")];
+    let targets: Vec<PathBuf> = vec![
+        game_dir.clone(),
+        game_dir.join("Game"),
+        game_dir.join("bin"),
+        game_dir.join("Binaries").join("Win64"),
+        game_dir.join("win64"),
+    ];
 
     let dll = eac_dir.join("_winhttp.dll");
     let config = eac_dir.join("anti_cheat_toggler_config.ini");
@@ -658,8 +663,13 @@ pub fn deploy_eac_toggle(game_dir: &PathBuf) {
 }
 
 pub fn cleanup_eac_toggle(game_dir: &PathBuf) {
-    let targets: Vec<PathBuf> =
-        vec![game_dir.clone(), game_dir.join("bin"), game_dir.join("Binaries").join("Win64"), game_dir.join("win64")];
+    let targets: Vec<PathBuf> = vec![
+        game_dir.clone(),
+        game_dir.join("Game"),
+        game_dir.join("bin"),
+        game_dir.join("Binaries").join("Win64"),
+        game_dir.join("win64"),
+    ];
 
     for target in &targets {
         if !target.exists() {
@@ -672,8 +682,13 @@ pub fn cleanup_eac_toggle(game_dir: &PathBuf) {
 }
 
 pub fn eac_toggle_status(game_dir: &PathBuf) -> bool {
-    let targets: Vec<PathBuf> =
-        vec![game_dir.clone(), game_dir.join("bin"), game_dir.join("Binaries").join("Win64"), game_dir.join("win64")];
+    let targets: Vec<PathBuf> = vec![
+        game_dir.clone(),
+        game_dir.join("Game"),
+        game_dir.join("bin"),
+        game_dir.join("Binaries").join("Win64"),
+        game_dir.join("win64"),
+    ];
 
     for target in &targets {
         if target.exists() && target.join("_winhttp.dll").exists() {

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -330,6 +330,7 @@ fn launch_steam_d3dmetal_perf(appid: u32) -> Result<(u32, &'static str), Box<dyn
 }
 
 fn launch_fna_arm64(appid: u32) -> Result<(u32, &'static str), Box<dyn std::error::Error>> {
+    let node = get_pipeline(PipelineId::FnaArm64);
     let game_dir = crate::setup::resolve_game_dir(appid).ok_or("game dir not found")?;
     let home = dirs::home_dir().ok_or("no home dir")?;
     let local_dir = home.join(".metalsharp").join("games").join(appid.to_string());
@@ -346,20 +347,24 @@ fn launch_fna_arm64(appid: u32) -> Result<(u32, &'static str), Box<dyn std::erro
 
     let mono_bin = find_mono_binary()?;
     let mono_config = find_config("terraria-mono.config");
-    let dyld = format!("{}:/opt/homebrew/lib", dir.to_string_lossy());
+    let shims_dir = find_shims_dir();
+    let dyld = format!("{}:{}:/opt/homebrew/lib", dir.to_string_lossy(), shims_dir);
 
     let mut cmd = Command::new(&mono_bin);
-    cmd.current_dir(dir)
-        .env("DYLD_LIBRARY_PATH", &dyld)
-        .env("MONO_CONFIG", mono_config)
-        .env("FNA3D_DRIVER", "OpenGL")
-        .arg(&exe);
+    cmd.current_dir(dir).env("DYLD_LIBRARY_PATH", &dyld).env("MONO_CONFIG", mono_config);
+
+    for ev in &node.env_vars {
+        cmd.env(ev.key, ev.value);
+    }
+
+    cmd.arg(&exe);
 
     let child = cmd.spawn()?;
     Ok((child.id(), "xna_fna_arm64"))
 }
 
 fn launch_fna_x86(appid: u32) -> Result<(u32, &'static str), Box<dyn std::error::Error>> {
+    let node = get_pipeline(PipelineId::FnaX86);
     let game_dir = crate::setup::resolve_game_dir(appid).ok_or("game dir not found")?;
     let home = dirs::home_dir().ok_or("no home dir")?;
     let local_dir = home.join(".metalsharp").join("games").join(appid.to_string());
@@ -389,21 +394,25 @@ fn launch_fna_x86(appid: u32) -> Result<(u32, &'static str), Box<dyn std::error:
         return Err(format!("game exe not found: {}", exe.display()).into());
     }
 
-    let child = Command::new("arch")
-        .args(["-x86_64", &mono_x86.to_string_lossy()])
+    let mut cmd = Command::new("arch");
+    cmd.args(["-x86_64", &mono_x86.to_string_lossy()])
         .current_dir(dir)
         .env("DYLD_LIBRARY_PATH", &dyld)
         .env("MONO_CONFIG", mono_config)
-        .env("MONO_PATH", mono_path.to_string_lossy().to_string())
-        .env("FNA3D_DRIVER", "OpenGL")
-        .env("METAL_DEVICE_WRAPPER_TYPE", "0")
-        .arg(&exe)
-        .spawn()?;
+        .env("MONO_PATH", mono_path.to_string_lossy().to_string());
 
+    for ev in &node.env_vars {
+        cmd.env(ev.key, ev.value);
+    }
+
+    cmd.arg(&exe);
+
+    let child = cmd.spawn()?;
     Ok((child.id(), "xna_fna_x86"))
 }
 
 fn launch_mono_generic(appid: u32) -> Result<(u32, &'static str), Box<dyn std::error::Error>> {
+    let node = get_pipeline(PipelineId::MonoGeneric);
     let game_dir = crate::setup::resolve_game_dir(appid).ok_or("game dir not found")?;
     let home = dirs::home_dir().ok_or("no home dir")?;
     let local_dir = home.join(".metalsharp").join("games").join(appid.to_string());
@@ -417,14 +426,17 @@ fn launch_mono_generic(appid: u32) -> Result<(u32, &'static str), Box<dyn std::e
 
     let mono_bin = find_mono_binary()?;
     let mono_config = find_config("terraria-mono.config");
-    let dyld = format!("{}:/opt/homebrew/lib", dir.to_string_lossy());
+    let shims_dir = find_shims_dir();
+    let dyld = format!("{}:{}:/opt/homebrew/lib", dir.to_string_lossy(), shims_dir);
 
     let mut cmd = Command::new(&mono_bin);
-    cmd.current_dir(dir)
-        .env("DYLD_LIBRARY_PATH", &dyld)
-        .env("MONO_CONFIG", mono_config)
-        .env("METAL_DEVICE_WRAPPER_TYPE", "0")
-        .arg(&exe);
+    cmd.current_dir(dir).env("DYLD_LIBRARY_PATH", &dyld).env("MONO_CONFIG", mono_config);
+
+    for ev in &node.env_vars {
+        cmd.env(ev.key, ev.value);
+    }
+
+    cmd.arg(&exe);
 
     let child = cmd.spawn()?;
     Ok((child.id(), "mono_generic"))
@@ -493,13 +505,13 @@ fn resolve_game_exe(game_dir: &PathBuf) -> String {
 fn find_config(name: &str) -> String {
     let home = dirs::home_dir().unwrap_or_default();
     let candidates =
-        vec![home.join("metalsharp").join("configs").join(name), home.join(".metalsharp").join("configs").join(name)];
+        vec![home.join(".metalsharp").join("configs").join(name), home.join("metalsharp").join("configs").join(name)];
     for c in candidates {
         if c.exists() {
             return c.to_string_lossy().to_string();
         }
     }
-    home.join("metalsharp").join("configs").join(name).to_string_lossy().to_string()
+    home.join(".metalsharp").join("configs").join(name).to_string_lossy().to_string()
 }
 
 fn find_shims_dir() -> String {
@@ -530,6 +542,7 @@ pub fn deploy_goldberg_internal(home: &PathBuf, game_dir: &PathBuf, appid: u32) 
 
     let targets: Vec<PathBuf> = vec![
         game_dir.clone(),
+        game_dir.join("Game"),
         game_dir.join("bin"),
         game_dir.join("Binaries").join("Win32"),
         game_dir.join("Binaries").join("Win64"),
@@ -570,6 +583,7 @@ pub fn deploy_goldberg_internal(home: &PathBuf, game_dir: &PathBuf, appid: u32) 
 pub fn cleanup_goldberg(game_dir: &PathBuf) {
     let targets: Vec<PathBuf> = vec![
         game_dir.clone(),
+        game_dir.join("Game"),
         game_dir.join("bin"),
         game_dir.join("Binaries").join("Win32"),
         game_dir.join("Binaries").join("Win64"),
@@ -606,6 +620,7 @@ pub fn cleanup_goldberg(game_dir: &PathBuf) {
 pub fn goldberg_status(game_dir: &PathBuf) -> bool {
     let targets: Vec<PathBuf> = vec![
         game_dir.clone(),
+        game_dir.join("Game"),
         game_dir.join("bin"),
         game_dir.join("Binaries").join("Win32"),
         game_dir.join("Binaries").join("Win64"),

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -646,11 +646,11 @@ pub fn deploy_eac_toggle(game_dir: &PathBuf) {
     }
 
     let targets: Vec<PathBuf> = vec![
-        game_dir.clone(),
         game_dir.join("Game"),
-        game_dir.join("bin"),
         game_dir.join("Binaries").join("Win64"),
+        game_dir.join("bin"),
         game_dir.join("win64"),
+        game_dir.clone(),
     ];
 
     let dll = eac_dir.join("_winhttp.dll");

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -19,13 +19,15 @@
           <span class="logo-text">MetalSharp</span>
         </div>
         <div class="nav-items">
-          <button type="button" class="nav-item active" data-view="library">Steam Library</button>
-          <button type="button" class="nav-item" data-view="sharp-library">Sharp Library</button>
-          <button type="button" class="nav-item" data-view="logs">Logs</button>
+          <button type="button" class="nav-item active" data-view="library"><i class="nav-icon">&#x1F3AE;</i><span class="nav-label">Library</span></button>
+          <button type="button" class="nav-item" data-view="sharp-library"><i class="nav-icon">&#x2B50;</i><span class="nav-label">Sharp</span></button>
+          <button type="button" class="nav-item" data-view="logs"><i class="nav-icon">&#x1F4CB;</i><span class="nav-label">Logs</span></button>
           <button type="button" class="theme-toggle-sidebar" id="btn-theme" title="Toggle light mode">
-            Light Mode
+            <i class="nav-icon">&#x1F319;</i><span class="nav-label">Light Mode</span>
           </button>
-          <button type="button" class="nav-item" data-view="settings">Settings</button>
+        </div>
+        <div class="nav-settings">
+          <button type="button" class="nav-item" data-view="settings"><i class="nav-icon">&#x2699;</i><span class="nav-label">Settings</span></button>
         </div>
         <div class="sidebar-footer">
           <div class="status-dot" id="backend-status"></div>

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -19,15 +19,23 @@
           <span class="logo-text">MetalSharp</span>
         </div>
         <div class="nav-items">
-          <button type="button" class="nav-item active" data-view="library"><i class="nav-icon">&#x1F3AE;</i><span class="nav-label">Library</span></button>
-          <button type="button" class="nav-item" data-view="sharp-library"><i class="nav-icon">&#x2B50;</i><span class="nav-label">Sharp</span></button>
-          <button type="button" class="nav-item" data-view="logs"><i class="nav-icon">&#x1F4CB;</i><span class="nav-label">Logs</span></button>
+          <button type="button" class="nav-item active" data-view="library">
+            <i class="nav-icon">&#x1F3AE;</i><span class="nav-label">Library</span>
+          </button>
+          <button type="button" class="nav-item" data-view="sharp-library">
+            <i class="nav-icon">&#x2B50;</i><span class="nav-label">Sharp</span>
+          </button>
+          <button type="button" class="nav-item" data-view="logs">
+            <i class="nav-icon">&#x1F4CB;</i><span class="nav-label">Logs</span>
+          </button>
           <button type="button" class="theme-toggle-sidebar" id="btn-theme" title="Toggle light mode">
             <i class="nav-icon">&#x1F319;</i><span class="nav-label">Light Mode</span>
           </button>
         </div>
         <div class="nav-settings">
-          <button type="button" class="nav-item" data-view="settings"><i class="nav-icon">&#x2699;</i><span class="nav-label">Settings</span></button>
+          <button type="button" class="nav-item" data-view="settings">
+            <i class="nav-icon">&#x2699;</i><span class="nav-label">Settings</span>
+          </button>
         </div>
         <div class="sidebar-footer">
           <div class="status-dot" id="backend-status"></div>

--- a/app/src/renderer/index.ts
+++ b/app/src/renderer/index.ts
@@ -106,7 +106,8 @@ class App {
     const btn = document.getElementById("btn-theme");
     if (!btn) return;
     const next = this.theme === "dark" ? "light" : "dark";
-    btn.textContent = this.theme === "dark" ? "Light Mode" : "Dark Mode";
+    const icon = this.theme === "dark" ? "\u{1F319}" : "\u2600\uFE0F";
+    btn.innerHTML = `<i class="nav-icon">${icon}</i><span class="nav-label">${this.theme === "dark" ? "Light Mode" : "Dark Mode"}</span>`;
     btn.setAttribute("title", `Toggle ${next} mode`);
   }
 

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -144,6 +144,14 @@ body {
   flex: 1;
 }
 
+.nav-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding-top: 4px;
+  border-top: 1px solid var(--border);
+}
+
 .nav-item {
   background: none;
   border: none;
@@ -153,9 +161,22 @@ body {
   padding: 10px 14px;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  text-align: left;
+  text-align: center;
   transition: all var(--transition);
   -webkit-app-region: no-drag;
+}
+
+.nav-icon {
+  display: inline-block;
+  width: 18px;
+  height: 18px;
+  margin-right: 8px;
+  vertical-align: middle;
+  font-style: normal;
+}
+
+.nav-label {
+  vertical-align: middle;
 }
 
 .theme-toggle-sidebar {
@@ -167,9 +188,10 @@ body {
   padding: 10px 14px;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  text-align: left;
+  text-align: center;
   transition: all var(--transition);
   -webkit-app-region: no-drag;
+  font-family: var(--font-main);
 }
 
 .theme-toggle-sidebar:hover {
@@ -1602,4 +1624,48 @@ body {
 .toggle-text {
   font-size: 9px;
   white-space: nowrap;
+}
+
+@media (max-width: 900px) {
+  .game-card-actions-row {
+    flex-wrap: wrap;
+  }
+
+  .game-card-actions-row .btn-play {
+    padding: 8px 14px;
+    font-size: 10px;
+  }
+
+  .toggle-label {
+    font-size: 8px;
+    gap: 4px;
+  }
+
+  .toggle-switch {
+    width: 26px;
+    height: 15px;
+  }
+
+  .toggle-switch::after {
+    width: 11px;
+    height: 11px;
+  }
+
+  .toggle-label input[type="checkbox"]:checked + .toggle-switch::after {
+    transform: translateX(11px);
+  }
+
+  .toggle-text {
+    font-size: 8px;
+  }
+
+  .launch-method-select {
+    font-size: 7px;
+    padding: 6px 8px;
+  }
+
+  .btn-card {
+    padding: 7px 8px;
+    font-size: 8px;
+  }
 }


### PR DESCRIPTION
## Summary
- Elden Ring's exe and EAC live in `ELDEN RING/Game/`, not `ELDEN RING/`
- `_winhttp.dll` bypass was never placed next to `eldenring.exe`
- Added `game_dir.join("Game")` to deploy, cleanup, and status target paths