### PR TITLE
fix: post-update DMG cleanup and responsive library header

### DIFF
--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -104,6 +104,7 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
             Some(p) => resp(200, json!({"ok": true, "path": p})),
             None => resp(200, json!({"ok": false, "error": "no downloaded DMG"})),
         },
+        (Method::Post, "/update/cleanup") => resp(200, updater::cleanup_downloaded_dmgs()),
         (Method::Get, "/setup/state") => resp(200, setup::state()),
         (Method::Post, "/setup/save") => {
             let body = read_body(req);

--- a/app/src-rust/src/updater.rs
+++ b/app/src-rust/src/updater.rs
@@ -275,10 +275,9 @@ pub fn cleanup_downloaded_dmgs() -> serde_json::Value {
         for entry in entries.flatten() {
             let path = entry.path();
             if path.extension().map(|e| e == "dmg").unwrap_or(false) {
-                if let Ok(meta) = fs::metadata(&path) {
-                    bytes_freed += meta.len();
-                }
+                let size = fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
                 if fs::remove_file(&path).is_ok() {
+                    bytes_freed += size;
                     removed += 1;
                 }
             }

--- a/app/src-rust/src/updater.rs
+++ b/app/src-rust/src/updater.rs
@@ -257,6 +257,41 @@ fn download_with_progress(url: &str, dest: &PathBuf) -> Result<(), String> {
     Ok(())
 }
 
+pub fn cleanup_downloaded_dmgs() -> serde_json::Value {
+    let home = match dirs::home_dir() {
+        Some(h) => h,
+        None => return json!({"ok": false, "error": "no home dir"}),
+    };
+
+    let cache_dir = home.join(".metalsharp").join("cache").join("updates");
+    if !cache_dir.exists() {
+        return json!({"ok": true, "removed": 0, "bytes_freed": 0});
+    }
+
+    let mut removed = 0u32;
+    let mut bytes_freed: u64 = 0;
+
+    if let Ok(entries) = fs::read_dir(&cache_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().map(|e| e == "dmg").unwrap_or(false) {
+                if let Ok(meta) = fs::metadata(&path) {
+                    bytes_freed += meta.len();
+                }
+                if fs::remove_file(&path).is_ok() {
+                    removed += 1;
+                }
+            }
+        }
+    }
+
+    if removed > 0 {
+        app_log(&format!("Cleaned up {} downloaded DMG(s), freed {} bytes", removed, bytes_freed));
+    }
+
+    json!({"ok": true, "removed": removed, "bytes_freed": bytes_freed})
+}
+
 pub fn get_downloaded_dmg_path() -> Option<String> {
     let update_info = check_for_update();
     let latest_version = update_info.get("latest_version").and_then(|v| v.as_str())?;

--- a/app/src/renderer/index.ts
+++ b/app/src/renderer/index.ts
@@ -357,7 +357,10 @@ class App {
     if (!status || status.phase !== "complete") return;
 
     await getAPI().updaterClearStatus();
-    await this.api("POST", "/update/cleanup");
+
+    if (!status.error) {
+      await this.api("POST", "/update/cleanup");
+    }
 
     await new Promise((r) => setTimeout(r, 1500));
     await this.pollBackendHealth();

--- a/app/src/renderer/index.ts
+++ b/app/src/renderer/index.ts
@@ -357,6 +357,7 @@ class App {
     if (!status || status.phase !== "complete") return;
 
     await getAPI().updaterClearStatus();
+    await this.api("POST", "/update/cleanup");
 
     await new Promise((r) => setTimeout(r, 1500));
     await this.pollBackendHealth();

--- a/app/src/renderer/index.ts
+++ b/app/src/renderer/index.ts
@@ -947,15 +947,19 @@ class App {
 
       el.innerHTML = `
         <div class="library-header">
-          <div>
-            <h1>Library</h1>
-            <p class="subtitle">No games yet ${steamStatusBadge}</p>
+          <h1>Library</h1>
+          <div class="library-header-controls">
+            <div class="library-controls-left">
+              <button class="btn btn-secondary" id="btn-steam-launch" title="${this.wineSteamRunning ? "Stop Wine Steam" : "Start Wine Steam"}">${this.wineSteamRunning ? "Stop Steam" : "Start Steam"}</button>
+            </div>
+            <div class="library-controls-center">
+              <input class="control-input" type="text" id="library-search" placeholder="Search games..." />
+            </div>
+            <div class="library-controls-right">
+              <button class="btn btn-secondary" id="btn-scan">Refresh</button>
+            </div>
           </div>
-          <div class="header-actions">
-            <button class="btn btn-secondary" id="btn-steam-launch" title="${this.wineSteamRunning ? "Stop Wine Steam" : "Start Wine Steam"}">${this.wineSteamRunning ? "Stop Steam" : "Start Steam"}</button>
-            <input class="control-input" type="text" id="library-search" placeholder="Search games..." />
-            <button class="btn btn-secondary" id="btn-scan">Refresh</button>
-          </div>
+          <p class="subtitle library-header-stats">No games yet ${steamStatusBadge}</p>
         </div>
         <div class="empty-state">
           <div class="empty-state-icon">&#x1F3AE;</div>
@@ -979,20 +983,24 @@ class App {
 
     el.innerHTML = `
       <div class="library-header">
-        <div>
-          <h1>Library</h1>
-          <p class="subtitle">${lib.total} games &middot; ${installedGames.length} installed ${steamStatusBadge} <span class="backend-status-badge ${this.backendConnected ? "connected" : "error"}" id="backend-status-header">${this.backendConnected ? "Backend" : "Backend Offline"}</span></p>
+        <h1>Library</h1>
+        <div class="library-header-controls">
+          <div class="library-controls-left">
+            <button class="btn btn-secondary" id="btn-steam-launch" title="${this.wineSteamRunning ? "Stop Wine Steam" : "Start Wine Steam"}">${this.wineSteamRunning ? "Stop Steam" : "Start Steam"}</button>
+          </div>
+          <div class="library-controls-center">
+            <input class="control-input" type="text" id="library-search" placeholder="Search games..." />
+            <select class="control-input control-select" id="library-filter">
+              <option value="all">All Games</option>
+              <option value="installed">Installed</option>
+              <option value="not_installed">Not Installed</option>
+            </select>
+          </div>
+          <div class="library-controls-right">
+            <button class="btn btn-secondary" id="btn-scan">Refresh</button>
+          </div>
         </div>
-        <div class="header-actions">
-          <button class="btn btn-secondary" id="btn-steam-launch" title="${this.wineSteamRunning ? "Stop Wine Steam" : "Start Wine Steam"}">${this.wineSteamRunning ? "Stop Steam" : "Start Steam"}</button>
-          <input class="control-input" type="text" id="library-search" placeholder="Search games..." />
-          <select class="control-input control-select" id="library-filter">
-            <option value="all">All Games</option>
-            <option value="installed">Installed</option>
-            <option value="not_installed">Not Installed</option>
-          </select>
-          <button class="btn btn-secondary" id="btn-scan">Refresh</button>
-        </div>
+        <p class="subtitle library-header-stats">${lib.total} games &middot; ${installedGames.length} installed ${steamStatusBadge} <span class="backend-status-badge ${this.backendConnected ? "connected" : "error"}" id="backend-status-header">${this.backendConnected ? "Backend" : "Backend Offline"}</span></p>
       </div>
       <div class="game-grid" id="game-grid"></div>
     `;

--- a/app/src/renderer/index.ts
+++ b/app/src/renderer/index.ts
@@ -949,7 +949,7 @@ class App {
           : "";
 
       el.innerHTML = `
-        <div class="library-header">
+        <div class="library-header library-header-centered">
           <h1>Library</h1>
           <div class="library-header-controls">
             <div class="library-controls-left">
@@ -985,7 +985,7 @@ class App {
         : "";
 
     el.innerHTML = `
-      <div class="library-header">
+      <div class="library-header library-header-centered">
         <h1>Library</h1>
         <div class="library-header-controls">
           <div class="library-controls-left">

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -310,6 +310,9 @@ body {
 }
 
 .library-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   margin-bottom: 28px;
 }
 
@@ -317,6 +320,24 @@ body {
   font-size: 22px;
   font-weight: 700;
   letter-spacing: -0.5px;
+}
+
+.library-header .subtitle {
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-top: 4px;
+}
+
+.header-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.library-header-centered {
+  display: block;
+}
+
+.library-header-centered h1 {
   text-align: center;
   margin-bottom: 14px;
 }

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -295,6 +295,7 @@ body {
 
 #library-search {
   width: 220px;
+  min-width: 120px;
 }
 
 .control-select {
@@ -308,11 +309,7 @@ body {
   display: none;
 }
 
-/* Library header */
 .library-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
   margin-bottom: 28px;
 }
 
@@ -320,17 +317,64 @@ body {
   font-size: 22px;
   font-weight: 700;
   letter-spacing: -0.5px;
+  text-align: center;
+  margin-bottom: 14px;
 }
 
-.library-header .subtitle {
+.library-header-controls {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.library-controls-left {
+  display: flex;
+  justify-content: flex-start;
+  gap: 10px;
+}
+
+.library-controls-center {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.library-controls-right {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.library-header-stats {
+  text-align: center;
   font-size: 11px;
   color: var(--text-dim);
-  margin-top: 4px;
+  margin-top: 2px;
 }
 
-.header-actions {
-  display: flex;
-  gap: 10px;
+@media (max-width: 900px) {
+  .library-header-controls {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+
+  .library-controls-left,
+  .library-controls-right {
+    justify-content: center;
+  }
+
+  #library-search {
+    width: 100%;
+    max-width: 320px;
+  }
+
+  .control-select {
+    width: 100%;
+    max-width: 200px;
+  }
 }
 
 /* Buttons */


### PR DESCRIPTION
## Summary
- Adds `POST /update/cleanup` backend endpoint that removes all `.dmg` files from `~/.metalsharp/cache/updates/`
- Called automatically by `checkForInstallResult()` in the post-update flow, right after clearing the install status
- Prevents ~500MB DMG files from accumulating on every update
- Refactors library header into a responsive three-zone layout:
  - Title centered at top
  - Controls row: Steam button (left), search + filter (center), refresh (right)
  - Stats line centered below (game count, steam status, backend status)
- Collapses to single-column stack on narrow viewports (<900px)