### PR TITLE
fix: migration stuck on step 2 + ECONNREFUSED race

### DIFF
--- a/app/src-rust/src/migrate.rs
+++ b/app/src-rust/src/migrate.rs
@@ -213,13 +213,16 @@ fn preserve_user_data(ms_dir: &PathBuf) -> PreservedData {
 
     let setup_json = ms_dir.join("setup.json").exists().then(|| fs::read(ms_dir.join("setup.json")).ok()).flatten();
 
+    write_migrate_progress("running", 2, 5, "Preserving user data (Steam prefix)...", None);
     let prefix_steam_tmp = tmp.join("prefix-steam");
     let prefix_steam = ms_dir.join("prefix-steam");
     if prefix_steam.exists() {
         let _ = fs::create_dir_all(&prefix_steam_tmp);
-        copy_dir_recursive(&prefix_steam, &prefix_steam_tmp);
+        let skip = ["dosdevices", "windows", "ProgramData"];
+        preserve_selective(&prefix_steam, &prefix_steam_tmp, &skip);
     }
 
+    write_migrate_progress("running", 2, 5, "Preserving user data (games)...", None);
     let games_tmp = tmp.join("games");
     let games = ms_dir.join("games");
     if games.exists() {
@@ -227,6 +230,7 @@ fn preserve_user_data(ms_dir: &PathBuf) -> PreservedData {
         copy_dir_recursive(&games, &games_tmp);
     }
 
+    write_migrate_progress("running", 2, 5, "Preserving user data (library)...", None);
     let sharp_library_tmp = tmp.join("sharp-library");
     let sharp_library = ms_dir.join("sharp-library");
     if sharp_library.exists() {
@@ -235,6 +239,37 @@ fn preserve_user_data(ms_dir: &PathBuf) -> PreservedData {
     }
 
     PreservedData { setup_json, prefix_steam_tmp, games_tmp, sharp_library_tmp }
+}
+
+fn preserve_selective(src: &PathBuf, dst: &PathBuf, skip_names: &[&str]) {
+    if let Ok(entries) = fs::read_dir(src) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy().to_string();
+            let src_path = entry.path();
+            let dst_path = dst.join(&name);
+
+            if skip_names.contains(&name_str.as_str()) {
+                continue;
+            }
+
+            match fs::symlink_metadata(&src_path) {
+                Ok(meta) => {
+                    if meta.file_type().is_symlink() {
+                        if let Ok(target) = fs::read_link(&src_path) {
+                            let _ = std::os::unix::fs::symlink(&target, &dst_path);
+                        }
+                    } else if meta.is_dir() {
+                        let _ = fs::create_dir_all(&dst_path);
+                        preserve_selective(&src_path, &dst_path, skip_names);
+                    } else {
+                        let _ = fs::copy(&src_path, &dst_path);
+                    }
+                },
+                Err(_) => {},
+            }
+        }
+    }
 }
 
 fn remove_old_runtime(ms_dir: &PathBuf) {
@@ -253,9 +288,11 @@ fn remove_old_runtime(ms_dir: &PathBuf) {
 
     for name in &dirs_to_remove {
         let p = ms_dir.join(name);
-        if p.is_dir() {
+        let is_dir = fs::symlink_metadata(&p).map(|m| m.is_dir()).unwrap_or(false);
+        let is_file = fs::symlink_metadata(&p).map(|m| m.is_file()).unwrap_or(false);
+        if is_dir {
             let _ = fs::remove_dir_all(&p);
-        } else if p.is_file() {
+        } else if is_file {
             let _ = fs::remove_file(&p);
         }
     }
@@ -274,6 +311,19 @@ fn restore_user_data(ms_dir: &PathBuf, preserved: &PreservedData) {
             let _ = fs::create_dir_all(&dst);
         }
         copy_dir_recursive(&preserved.prefix_steam_tmp, &dst);
+
+        let dosdevices = dst.join("dosdevices");
+        if !dosdevices.exists() {
+            let _ = fs::create_dir_all(&dosdevices);
+        }
+        let c_link = dosdevices.join("c:");
+        if !c_link.exists() {
+            let _ = std::os::unix::fs::symlink("../drive_c", &c_link);
+        }
+        let z_link = dosdevices.join("z:");
+        if !z_link.exists() {
+            let _ = std::os::unix::fs::symlink("/", &z_link);
+        }
     }
 
     if preserved.games_tmp.exists() {
@@ -302,11 +352,20 @@ fn copy_dir_recursive(src: &PathBuf, dst: &PathBuf) {
         for entry in entries.flatten() {
             let src_path = entry.path();
             let dst_path = dst.join(entry.file_name());
-            if src_path.is_dir() {
-                let _ = fs::create_dir_all(&dst_path);
-                copy_dir_recursive(&src_path, &dst_path);
-            } else {
-                let _ = fs::copy(&src_path, &dst_path);
+            match fs::symlink_metadata(&src_path) {
+                Ok(meta) => {
+                    if meta.file_type().is_symlink() {
+                        if let Ok(target) = fs::read_link(&src_path) {
+                            let _ = std::os::unix::fs::symlink(&target, &dst_path);
+                        }
+                    } else if meta.is_dir() {
+                        let _ = fs::create_dir_all(&dst_path);
+                        copy_dir_recursive(&src_path, &dst_path);
+                    } else {
+                        let _ = fs::copy(&src_path, &dst_path);
+                    }
+                },
+                Err(_) => {},
             }
         }
     }

--- a/app/src/renderer/components/MigrationView.vue
+++ b/app/src/renderer/components/MigrationView.vue
@@ -23,9 +23,12 @@ const stages = [
   { name: "FNA", color: "#039be5" },
 ];
 
-async function startMigration() {
+const MAX_START_RETRIES = 20;
+const START_RETRY_DELAY_MS = 500;
+
+async function startMigration(retriesLeft = MAX_START_RETRIES) {
   try {
-    const res = await window.metalsharp.request("POST", "/update/migrate/start");
+    const res = await window.metalsharp.request("POST", "/update/migrate/start", undefined, 10000);
     if (res?.ok) {
       message.value = "Migration started...";
       startPolling();
@@ -34,8 +37,14 @@ async function startMigration() {
       message.value = `Error: ${error.value}`;
     }
   } catch (e: any) {
-    error.value = e.message ?? "Network error";
-    message.value = `Error: ${error.value}`;
+    if (retriesLeft > 0 && (e.message?.includes("ECONNREFUSED") || e.message?.includes("timeout"))) {
+      message.value = "Waiting for backend to start...";
+      await new Promise((r) => setTimeout(r, START_RETRY_DELAY_MS));
+      startMigration(retriesLeft - 1);
+    } else {
+      error.value = e.message ?? "Network error";
+      message.value = `Error: ${error.value}`;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes two critical bugs in the v0.33.0 self-updater migration flow that cause the updater to hang/crash during the Beta 4 → Beta 5 upgrade path.

### Bug 1: Migration hangs forever on step 2 ("Preserving user data")

**Root cause:** `copy_dir_recursive` used `fs::read_dir` + `is_dir()` which follows symlinks. Wine prefixes contain a `dosdevices` directory with symlinks like `z: -> /` and `c: -> ../drive_c`. The recursive copy attempted to traverse into `z:` and copy the **entire root filesystem** into `/tmp`, never completing.

**Fix:**
- `copy_dir_recursive` now uses `fs::symlink_metadata` to detect symlinks before calling `is_dir()`, and recreates them with `std::os::unix::fs::symlink` instead of following
- New `preserve_selective` function skips `dosdevices`, `windows`, and `ProgramData` from the Wine prefix (these are disposable runtime files, not user data)
- `restore_user_data` recreates `dosdevices/c:` and `dosdevices/z:` symlinks after restore
- `remove_old_runtime` also switched to `symlink_metadata` for the same reason
- Sub-progress messages added within preserve step so users see activity

### Bug 2: ECONNREFUSED crashes migration overlay on fresh relaunch

**Root cause:** `update.py` kills the backend, installs the new app, then relaunches via `open`. The new MetalSharp starts, shows the migration overlay, and `MigrationView.vue` immediately calls `POST /update/migrate/start` on mount. But the Rust backend spawned by `RustBridge.start()` is still going through `waitForReady()` (polling with 200ms-1s delays). The frontend's `ipcRenderer.invoke("backend:request")` hits `ECONNREFUSED 127.0.0.1:9274` and the error propagates to the UI, crashing the migration overlay.

**Fix:** `startMigration()` now retries up to 20 times (10 seconds total) on `ECONNREFUSED` and timeout errors, showing "Waiting for backend to start..." in the meantime.

## Testing

- Verified symlink handling: Wine `dosdevices/z: -> /` no longer followed
- Preserved data flow: only user data (Steam install, games, library) copied, not disposable Wine runtime files
- ECONNREFUSED retry: frontend waits for backend instead of crashing