### PR TITLE
fix: sidebar layout, drag area, steam api key preservation

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsharp",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "MetalSharp — D3D→Metal translation layer frontend",
   "author": "MetalSharp",
   "repository": {

--- a/app/src-rust/Cargo.toml
+++ b/app/src-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metalsharp-backend"
-version = "0.33.0"
+version = "0.33.1"
 edition = "2021"
 
 [dependencies]

--- a/app/src-rust/src/migrate.rs
+++ b/app/src-rust/src/migrate.rs
@@ -201,6 +201,7 @@ fn kill_steam_wine() {
 
 struct PreservedData {
     setup_json: Option<Vec<u8>>,
+    steam_config_json: Option<Vec<u8>>,
     prefix_steam_tmp: PathBuf,
     games_tmp: PathBuf,
     sharp_library_tmp: PathBuf,
@@ -212,6 +213,9 @@ fn preserve_user_data(ms_dir: &PathBuf) -> PreservedData {
     let _ = fs::create_dir_all(&tmp);
 
     let setup_json = ms_dir.join("setup.json").exists().then(|| fs::read(ms_dir.join("setup.json")).ok()).flatten();
+
+    let steam_config_path = ms_dir.join("cache").join("steam_config.json");
+    let steam_config_json = steam_config_path.exists().then(|| fs::read(&steam_config_path).ok()).flatten();
 
     write_migrate_progress("running", 2, 5, "Preserving user data (Steam prefix)...", None);
     let prefix_steam_tmp = tmp.join("prefix-steam");
@@ -238,7 +242,7 @@ fn preserve_user_data(ms_dir: &PathBuf) -> PreservedData {
         copy_dir_recursive(&sharp_library, &sharp_library_tmp);
     }
 
-    PreservedData { setup_json, prefix_steam_tmp, games_tmp, sharp_library_tmp }
+    PreservedData { setup_json, steam_config_json, prefix_steam_tmp, games_tmp, sharp_library_tmp }
 }
 
 fn preserve_selective(src: &PathBuf, dst: &PathBuf, skip_names: &[&str]) {
@@ -344,6 +348,12 @@ fn restore_user_data(ms_dir: &PathBuf, preserved: &PreservedData) {
 
     if let Some(ref data) = preserved.setup_json {
         let _ = fs::write(ms_dir.join("setup.json"), data);
+    }
+
+    if let Some(ref data) = preserved.steam_config_json {
+        let cache_dir = ms_dir.join("cache");
+        let _ = fs::create_dir_all(&cache_dir);
+        let _ = fs::write(cache_dir.join("steam_config.json"), data);
     }
 }
 

--- a/app/src/renderer/App.vue
+++ b/app/src/renderer/App.vue
@@ -167,6 +167,7 @@ onMounted(async () => {
       @toggle-theme="toggleTheme()"
     />
     <main class="content">
+      <div class="drag-strip"></div>
       <component :is="activeView" :key="currentView" />
     </main>
   </template>
@@ -174,10 +175,17 @@ onMounted(async () => {
 </template>
 
 <style>
+.drag-strip {
+  height: 38px;
+  -webkit-app-region: drag;
+  flex-shrink: 0;
+}
 .content {
   flex: 1;
   overflow-y: auto;
   padding: 0;
   min-width: 0;
+  display: flex;
+  flex-direction: column;
 }
 </style>

--- a/app/src/renderer/components/Sidebar.vue
+++ b/app/src/renderer/components/Sidebar.vue
@@ -48,9 +48,11 @@ const navItems = [
         <svg class="sidebar-nav-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" v-html="item.icon" />
         <span v-if="!collapsed" class="sidebar-nav-label">{{ item.label }}</span>
       </button>
+    </div>
 
+    <div class="sidebar-bottom">
       <button
-        class="sidebar-nav-item sidebar-theme-toggle"
+        class="sidebar-nav-item"
         @click="emit('toggleTheme')"
         :title="collapsed ? (theme === 'dark' ? 'Light Mode' : 'Dark Mode') : undefined"
       >
@@ -62,9 +64,6 @@ const navItems = [
         </svg>
         <span v-if="!collapsed" class="sidebar-nav-label">{{ theme === "dark" ? "Light Mode" : "Dark Mode" }}</span>
       </button>
-    </div>
-
-    <div class="sidebar-bottom">
       <button
         class="sidebar-nav-item"
         :class="{ active: currentView === 'settings' }"
@@ -100,7 +99,7 @@ const navItems = [
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 14px 12px 10px;
+  padding: 38px 12px 10px;
   border-bottom: 1px solid var(--border);
 }
 
@@ -192,5 +191,8 @@ const navItems = [
 .sidebar-bottom {
   padding: 6px;
   border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 </style>


### PR DESCRIPTION
## Summary

Four fixes for the v0.33.0 Beta 5 UI and migration:

1. **Sidebar title overlap with traffic lights** — `sidebar-top` padding bumped from `14px` to `38px` to clear the macOS close/minimize/maximize buttons (since `titleBarStyle: "hiddenInset"` overlays them on content).

2. **Theme toggle moved to sidebar-bottom** — Was in `sidebar-nav` after nav items, pushing layout up. Now sits directly above the Settings button in `sidebar-bottom` where it belongs.

3. **Extended window drag area** — Added a 38px `-webkit-app-region: drag` strip at the top of the main content area. Previously only the sidebar was draggable, requiring the user to find the tippy-top pixel to move the window.

4. **Steam API key not preserved through migration** — `steam_config.json` (containing API key + Steam ID) lives in `~/.metalsharp/cache/`, which `remove_old_runtime` deletes entirely. Added `steam_config_json` to `PreservedData` and restored it after the cache dir is recreated.

Bumps version to `0.33.1`.