### PR TITLE
ci: package required runtime assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,16 +54,17 @@ jobs:
 
       - name: Download bundles for DMG
         run: |
-          mkdir -p app/bundles
-          gh release download bundles \
-            --repo ${{ github.repository }} \
-            --pattern "*.tar.zst" \
-            --pattern "*.exe" \
-            --pattern "*.c" \
-            --dir app/bundles \
-            --clobber || echo "No bundles found — building without"
-          cp app/bundles/steamwebhelper-wrapper.c app/bundles/steamwebhelper-wrapper.c 2>/dev/null || true
-          ls -lh app/bundles/ 2>/dev/null || true
+          tools/dmg/create-bundles.sh
+          for required in \
+            metalsharp_bundle.tar.zst \
+            metalsharp_bundle2.tar.zst \
+            SteamSetup.exe \
+            steamwebhelper.exe \
+            steamwebhelper-wrapper.c
+          do
+            test -s "app/bundles/$required"
+          done
+          ls -lh app/bundles/
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/app/package.json
+++ b/app/package.json
@@ -17,7 +17,8 @@
     "rust:dev": "cd src-rust && cargo build",
     "build:all": "npm run rust:build && npm run build",
     "pack": "npm run build:all && electron-builder --dir",
-    "dist": "mkdir -p native bundles && for f in metalsharp metalsharp_launcher d3d11.dylib d3d12.dylib dxgi.dylib xaudio2_9.dylib xinput1_4.dylib; do [ -f native/$f ] || touch native/$f; done && for f in metalsharp_bundle.tar.zst SteamSetup.exe steamwebhelper.exe steamwebhelper-wrapper.c updater.tar.gz; do [ -f bundles/$f ] || touch bundles/$f; done && npm run build:all && electron-builder",
+    "fetch:bundles": "../tools/dmg/create-bundles.sh",
+    "dist": "mkdir -p native && for f in metalsharp metalsharp_launcher d3d11.dylib d3d12.dylib dxgi.dylib xaudio2_9.dylib xinput1_4.dylib; do [ -f native/$f ] || touch native/$f; done && npm run fetch:bundles && npm run build:all && electron-builder",
     "dmg": "npm run dist -- --mac dmg"
   },
   "dependencies": {
@@ -125,6 +126,10 @@
         "to": "bundles/metalsharp_bundle.tar.zst"
       },
       {
+        "from": "bundles/metalsharp_bundle2.tar.zst",
+        "to": "bundles/metalsharp_bundle2.tar.zst"
+      },
+      {
         "from": "bundles/SteamSetup.exe",
         "to": "bundles/SteamSetup.exe"
       },
@@ -143,6 +148,10 @@
       {
         "from": "updater/update.py",
         "to": "updater/update.py"
+      },
+      {
+        "from": "../configs",
+        "to": "configs"
       }
     ],
     "directories": {

--- a/tools/dmg/create-bundles.sh
+++ b/tools/dmg/create-bundles.sh
@@ -15,7 +15,10 @@ mkdir -p "$BUNDLE_DIR"
 
 BUNDLES=(
     "metalsharp_bundle.tar.zst"
+    "metalsharp_bundle2.tar.zst"
     "SteamSetup.exe"
+    "steamwebhelper.exe"
+    "steamwebhelper-wrapper.c"
 )
 
 for bundle in "${BUNDLES[@]}"; do
@@ -25,12 +28,14 @@ for bundle in "${BUNDLES[@]}"; do
         continue
     fi
     echo "Downloading $bundle..."
-    curl -sL -o "$dest" "https://github.com/$REPO/releases/download/$RELEASE_TAG/$bundle"
-    if [ -f "$dest" ]; then
+    curl -fL -o "$dest" "https://github.com/$REPO/releases/download/$RELEASE_TAG/$bundle"
+    if [ -s "$dest" ]; then
         size=$(du -sh "$dest" | cut -f1)
         echo "  -> $dest ($size)"
     else
         echo "  FAILED: $bundle"
+        rm -f "$dest"
+        exit 1
     fi
 done
 


### PR DESCRIPTION
## Summary
- package metalsharp_bundle2 and configs into the Electron app resources
- make the bundle downloader fetch the exact assets the setup wizard depends on
- make CI fail if required DMG install assets are missing instead of building without them
- repacked the bundles release metalsharp_bundle2 asset to include Goldberg, EAC toggle, Mono ARM64, DXMT add-ons, shims, and shader-cache content

## Asset audit
Required bundled assets now validated by CI:
- metalsharp_bundle.tar.zst
- metalsharp_bundle2.tar.zst
- SteamSetup.exe
- steamwebhelper.exe
- steamwebhelper-wrapper.c

Steam-based assets are preserved. Separate fallback assets on the bundles release were left in place because the installer can still download them individually.

## Validation
- node parsed app/package.json
- tools/dmg/create-bundles.sh downloaded required assets
- verified metalsharp_bundle2 contains goldberg/x86/steam_api.dll, goldberg/x64/steam_api64.dll, eac-toggle/x86_64-windows/_winhttp.dll, mono-arm64/bin/mono, DXMT d3d12.dll, and shims/libsteam_api.dylib
- npm run build
- npx electron-builder --dir --mac --publish never
- verified packaged app resources contain both bundles, Steam assets, and configs
- git diff --check