### PR TITLE
ci: reject empty bundle placeholders

### DIFF
--- a/tools/dmg/create-bundles.sh
+++ b/tools/dmg/create-bundles.sh
@@ -23,12 +23,12 @@ BUNDLES=(
 
 for bundle in "${BUNDLES[@]}"; do
     dest="$BUNDLE_DIR/$bundle"
-    if [ -s "$dest" ]; then
+    if [ -f "$dest" ] && [ -s "$dest" ]; then
         echo "SKIP: $bundle — already exists"
         continue
     elif [ -e "$dest" ]; then
         echo "Invalid existing $bundle — removing and downloading fresh copy"
-        rm -f "$dest"
+        rm -rf "$dest"
     fi
     echo "Downloading $bundle..."
     curl -fL -o "$dest" "https://github.com/$REPO/releases/download/$RELEASE_TAG/$bundle"
@@ -43,7 +43,7 @@ for bundle in "${BUNDLES[@]}"; do
 done
 
 for bundle in "${BUNDLES[@]}"; do
-    if [ ! -s "$BUNDLE_DIR/$bundle" ]; then
+    if [ ! -f "$BUNDLE_DIR/$bundle" ] || [ ! -s "$BUNDLE_DIR/$bundle" ]; then
         echo "Missing required bundle: $bundle"
         exit 1
     fi

--- a/tools/dmg/create-bundles.sh
+++ b/tools/dmg/create-bundles.sh
@@ -23,9 +23,12 @@ BUNDLES=(
 
 for bundle in "${BUNDLES[@]}"; do
     dest="$BUNDLE_DIR/$bundle"
-    if [ -f "$dest" ]; then
+    if [ -s "$dest" ]; then
         echo "SKIP: $bundle — already exists"
         continue
+    elif [ -e "$dest" ]; then
+        echo "Invalid existing $bundle — removing and downloading fresh copy"
+        rm -f "$dest"
     fi
     echo "Downloading $bundle..."
     curl -fL -o "$dest" "https://github.com/$REPO/releases/download/$RELEASE_TAG/$bundle"
@@ -35,6 +38,13 @@ for bundle in "${BUNDLES[@]}"; do
     else
         echo "  FAILED: $bundle"
         rm -f "$dest"
+        exit 1
+    fi
+done
+
+for bundle in "${BUNDLES[@]}"; do
+    if [ ! -s "$BUNDLE_DIR/$bundle" ]; then
+        echo "Missing required bundle: $bundle"
         exit 1
     fi
 done


### PR DESCRIPTION
## Summary
- fixes the review comment from #74 about zero-byte bundle placeholders surviving local packaging
- skips only non-empty existing bundle assets
- removes and re-downloads empty/invalid existing bundle paths
- validates all required bundle assets at the end of the downloader, so CI and local npm packaging use the same guard

## Review context
Addresses #74 review thread: https://github.com/aaf2tbz/metalsharp/pull/74#discussion_r3253065826

## Validation
- bash -n tools/dmg/create-bundles.sh
- git diff --check
- simulated a zero-byte steamwebhelper-wrapper.c placeholder and verified create-bundles.sh removed and re-downloaded it
- reran create-bundles.sh on valid assets and verified it skips non-empty files