### PR TITLE
fix: write migration marker during update install so migration wizard runs on relaunch

### DIFF
--- a/app/src-rust/src/migrate.rs
+++ b/app/src-rust/src/migrate.rs
@@ -175,8 +175,12 @@ fn run_migration() {
             });
             let _ = fs::write(&setup_path, serde_json::to_string_pretty(&cfg).unwrap_or_default());
         }
+        let marker = ms_dir.join(".post-update-migration");
+        let _ = fs::remove_file(&marker);
         write_migrate_progress("complete", total_steps, total_steps, "Migration complete!", None);
     } else {
+        let marker = ms_dir.join(".post-update-migration");
+        let _ = fs::remove_file(&marker);
         write_migrate_progress(
             "warning",
             total_steps,

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -53,7 +53,30 @@ function ensureMetalsharpDirs() {
   }
 }
 
+function hasPostUpdateMigrationMarker(): { needed: boolean; targetVersion?: string } {
+  const markerPath = path.join(getMetalsharpDir(), ".post-update-migration");
+  try {
+    if (!fs.existsSync(markerPath)) return { needed: false };
+    const data = JSON.parse(fs.readFileSync(markerPath, "utf8"));
+    return { needed: data.needed === true, targetVersion: data.target_version };
+  } catch {
+    return { needed: false };
+  }
+}
+
+function clearPostUpdateMigrationMarker() {
+  const markerPath = path.join(getMetalsharpDir(), ".post-update-migration");
+  try {
+    fs.unlinkSync(markerPath);
+  } catch {}
+}
+
 async function checkNeedsMigration(): Promise<boolean> {
+  const marker = hasPostUpdateMigrationMarker();
+  if (marker.needed) {
+    return true;
+  }
+
   return new Promise((resolve) => {
     const req = http.get("http://127.0.0.1:9274/update/migrate/check", (res) => {
       const chunks: Buffer[] = [];
@@ -186,6 +209,7 @@ function registerIpc() {
   });
 
   ipcMain.handle("app:restart-after-migration", async () => {
+    clearPostUpdateMigrationMarker();
     app.relaunch();
     app.exit(0);
   });

--- a/app/updater/update.py
+++ b/app/updater/update.py
@@ -370,6 +370,15 @@ def main():
 
     write_status(sf, "installed", 80, "New version installed.", new_version=tv)
 
+    ms_dir = os.path.expanduser("~/.metalsharp")
+    os.makedirs(ms_dir, exist_ok=True)
+    migration_marker = os.path.join(ms_dir, ".post-update-migration")
+    try:
+        with open(migration_marker, "w") as f:
+            json.dump({"needed": True, "target_version": tv, "timestamp": time.time()}, f)
+    except Exception:
+        pass
+
     # ── 7. Unmount ───────────────────────────────────────────────────
     write_status(sf, "unmounting", 82, "Unmounting update disk...", new_version=tv)
     run(["hdiutil", "detach", mount_point, "-quiet"])

--- a/app/updater/update.sh
+++ b/app/updater/update.sh
@@ -133,6 +133,10 @@ fi
 
 write_status "installed" 80 "New version installed"
 
+MS_DIR="$HOME/.metalsharp"
+mkdir -p "$MS_DIR"
+printf '{"needed":true,"target_version":"%s","timestamp":%s}\n' "$TARGET_VERSION" "$(date +%s)" > "$MS_DIR/.post-update-migration" 2>/dev/null || true
+
 write_status "unmounting" 82 "Unmounting update disk..."
 hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null || true
 MOUNT_POINT=""


### PR DESCRIPTION
## Summary

The self-updater was swapping the app binary and relaunching without any signal that post-update migration was needed. The migration check in Electron depended on querying the Rust backend via HTTP (`/update/migrate/check`), which could race or fail if the backend wasn't ready yet — resolving to `false` (skip migration) and letting the app launch normally, bypassing the migration wizard entirely and nuking the user's Wine, settings, and Steam installation.

- `update.sh` and `update.py` now write `~/.metalsharp/.post-update-migration` marker file after installing the new binary, before relaunch
- Electron's `checkNeedsMigration()` checks this marker file first (filesystem, no backend dependency), then falls back to the HTTP API check
- `migrate.rs` cleans up the marker after migration completes (both success and warning paths)
- Marker is also cleaned up by the restart-after-migration IPC handler

## Test plan

- [x] Install an older MetalSharp version, then trigger the self-updater — verify the migration wizard overlay appears on relaunch
- [x] Verify `~/.metalsharp/.post-update-migration` is written after update install and removed after migration completes
- [x] Verify a fresh install (no update) does not trigger the migration wizard
- [x] `cargo fmt --check`, `cargo clippy`, `cargo test`, `biome check`, `tsc --noEmit` all pass