### PR TITLE
[codex] fix migration backend handoff

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metalsharp",
-  "version": "0.33.12",
+  "version": "0.33.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metalsharp",
-      "version": "0.33.12",
+      "version": "0.33.13",
       "dependencies": {
         "electron-store": "^10.0.0"
       },

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsharp",
-  "version": "0.33.12",
+  "version": "0.33.13",
   "description": "MetalSharp — D3D→Metal translation layer frontend",
   "author": "MetalSharp",
   "repository": {

--- a/app/src-rust/Cargo.lock
+++ b/app/src-rust/Cargo.lock
@@ -487,7 +487,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metalsharp-backend"
-version = "0.33.11"
+version = "0.33.13"
 dependencies = [
  "ctrlc",
  "dirs",

--- a/app/src-rust/Cargo.toml
+++ b/app/src-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metalsharp-backend"
-version = "0.33.11"
+version = "0.33.13"
 edition = "2021"
 
 [dependencies]

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -176,7 +176,10 @@ app.whenReady().then(async () => {
   ensureMetalsharpDirs();
   bridge = new RustBridge();
   updaterBridge = new UpdaterBridge(bridge.getPort());
-  await bridge.start();
+  const backendStart = await bridge.start();
+  if (!backendStart.ok) {
+    console.warn(`MetalSharp backend did not start during app launch: ${backendStart.error}`);
+  }
 
   const needsMigration = await checkNeedsMigration();
   migrationMode = needsMigration;
@@ -203,11 +206,52 @@ app.on("before-quit", () => {
   cleanup();
 });
 
+function backendErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return "Backend request failed";
+}
+
+async function requestBackend(
+  method: string,
+  url: string,
+  body?: Record<string, unknown>,
+  timeoutMs?: number,
+): Promise<unknown> {
+  const ready = await bridge.ensureRunning();
+  if (!ready.ok) {
+    return { ok: false, error: ready.error ?? "Backend is not available" };
+  }
+
+  try {
+    return await bridge.request(method, url, body, timeoutMs);
+  } catch (e) {
+    return { ok: false, error: backendErrorMessage(e) };
+  }
+}
+
+async function requestMigrationBackend(
+  method: string,
+  url: string,
+  body?: Record<string, unknown>,
+  timeoutMs?: number,
+): Promise<unknown> {
+  const ready = await bridge.ensureRunning(30000);
+  if (!ready.ok) {
+    return {
+      ok: false,
+      error: `Migration backend unavailable: ${ready.error ?? "could not start metalsharp-backend"}`,
+    };
+  }
+
+  return requestBackend(method, url, body, timeoutMs);
+}
+
 function registerIpc() {
   ipcMain.handle(
     "backend:request",
     async (_e, method: string, url: string, body?: Record<string, unknown>, timeoutMs?: number) => {
-      return bridge.request(method, url, body, timeoutMs);
+      return requestBackend(method, url, body, timeoutMs);
     },
   );
 
@@ -418,15 +462,15 @@ function registerIpc() {
   });
 
   ipcMain.handle("migrate:check", async () => {
-    return bridge.request("GET", "/update/migrate/check");
+    return requestMigrationBackend("GET", "/update/migrate/check");
   });
 
   ipcMain.handle("migrate:start", async () => {
-    return bridge.request("POST", "/update/migrate/start");
+    return requestMigrationBackend("POST", "/update/migrate/start", undefined, 10000);
   });
 
   ipcMain.handle("migrate:progress", async () => {
-    return bridge.request("GET", "/update/migrate/progress");
+    return requestMigrationBackend("GET", "/update/migrate/progress");
   });
 
   ipcMain.on("app:quit", () => {

--- a/app/src/main/rust-bridge.ts
+++ b/app/src/main/rust-bridge.ts
@@ -26,6 +26,7 @@ export class RustBridge {
   private proc: ChildProcess | null = null;
   private port: number = 9274;
   private base: string;
+  private startPromise: Promise<{ ok: boolean; error?: string }> | null = null;
 
   constructor() {
     this.port = parseInt(process.env.METALSHARP_PORT || "9274", 10);
@@ -36,11 +37,35 @@ export class RustBridge {
     return this.port;
   }
 
-  async start(): Promise<void> {
+  async start(): Promise<{ ok: boolean; error?: string }> {
+    if (this.startPromise) return this.startPromise;
+
+    this.startPromise = this.startInner().finally(() => {
+      this.startPromise = null;
+    });
+
+    return this.startPromise;
+  }
+
+  async ensureRunning(maxMs = 15000): Promise<{ ok: boolean; error?: string }> {
+    if (await this.isAlive()) return { ok: true };
+
+    const started = await this.start();
+    if (!started.ok) return started;
+
+    try {
+      await this.waitForReady(maxMs);
+      return { ok: true };
+    } catch (e) {
+      return { ok: false, error: (e as Error).message };
+    }
+  }
+
+  private async startInner(): Promise<{ ok: boolean; error?: string }> {
     const binPath = this.findBinary();
     if (!binPath) {
       console.warn("metalsharp-backend binary not found, running in offline mode");
-      return;
+      return { ok: false, error: "metalsharp-backend binary not found" };
     }
 
     const needsRestart = await this.shouldRestart(binPath);
@@ -50,11 +75,16 @@ export class RustBridge {
       await new Promise((r) => setTimeout(r, 500));
     } else if (await this.isAlive()) {
       console.log("Backend already running and up to date");
-      return;
+      return { ok: true };
     }
 
     this.spawnBackend(binPath);
-    await this.waitForReady();
+    try {
+      await this.waitForReady();
+      return { ok: true };
+    } catch (e) {
+      return { ok: false, error: (e as Error).message };
+    }
   }
 
   async restart(): Promise<{ ok: boolean; error?: string }> {
@@ -168,6 +198,11 @@ export class RustBridge {
     this.proc.stdout?.on("data", (d: Buffer) => process.stdout.write(d));
     this.proc.stderr?.on("data", (d: Buffer) => process.stderr.write(d));
 
+    this.proc.on("error", (e) => {
+      console.error(`metalsharp-backend failed to start: ${e.message}`);
+      this.proc = null;
+    });
+
     this.proc.on("exit", (code) => {
       console.log(`metalsharp-backend exited with code ${code}`);
       this.proc = null;
@@ -224,14 +259,14 @@ export class RustBridge {
 
     for (const c of candidates) {
       try {
-        fs.accessSync(c);
+        fs.accessSync(c, fs.constants.X_OK);
         return c;
       } catch {}
     }
     return null;
   }
 
-  private waitForReady(maxMs = 5000): Promise<void> {
+  private waitForReady(maxMs = 15000): Promise<void> {
     const start = Date.now();
     return new Promise((resolve, reject) => {
       const check = () => {
@@ -239,12 +274,24 @@ export class RustBridge {
           reject(new Error("backend did not start in time"));
           return;
         }
+        let settled = false;
         const req = http.get(`http://127.0.0.1:${this.port}/status`, (res) => {
+          if (settled) return;
+          settled = true;
           res.resume();
           resolve();
         });
-        req.on("error", () => setTimeout(check, 200));
-        req.setTimeout(1000);
+        req.on("error", () => {
+          if (settled) return;
+          settled = true;
+          setTimeout(check, 200);
+        });
+        req.setTimeout(1000, () => {
+          if (settled) return;
+          settled = true;
+          req.destroy();
+          setTimeout(check, 200);
+        });
       };
       setTimeout(check, 300);
     });

--- a/app/src/renderer/components/MigrationView.vue
+++ b/app/src/renderer/components/MigrationView.vue
@@ -28,29 +28,49 @@ const START_RETRY_DELAY_MS = 500;
 
 async function startMigration(retriesLeft = MAX_START_RETRIES) {
   try {
-    const res = await window.metalsharp.request("POST", "/update/migrate/start", undefined, 10000);
+    const res = await window.metalsharp.migrateStart();
     if (res?.ok) {
       message.value = "Migration started...";
       startPolling();
+    } else if (res?.error?.includes("migration already in progress")) {
+      message.value = "Migration already running...";
+      startPolling();
     } else {
-      error.value = res?.error ?? "Failed to start migration";
-      message.value = `Error: ${error.value}`;
+      const errorText = res?.error ?? "Failed to start migration";
+      if (retriesLeft > 0 && shouldRetryBackendError(errorText)) {
+        message.value = "Waiting for backend to start...";
+        await new Promise((r) => setTimeout(r, START_RETRY_DELAY_MS));
+        await startMigration(retriesLeft - 1);
+      } else {
+        error.value = errorText;
+        message.value = `Error: ${error.value}`;
+      }
     }
-  } catch (e: any) {
-    if (retriesLeft > 0 && (e.message?.includes("ECONNREFUSED") || e.message?.includes("timeout"))) {
+  } catch (e: unknown) {
+    const errorText = e instanceof Error ? e.message : "Network error";
+    if (retriesLeft > 0 && shouldRetryBackendError(errorText)) {
       message.value = "Waiting for backend to start...";
       await new Promise((r) => setTimeout(r, START_RETRY_DELAY_MS));
-      startMigration(retriesLeft - 1);
+      await startMigration(retriesLeft - 1);
     } else {
-      error.value = e.message ?? "Network error";
+      error.value = errorText;
       message.value = `Error: ${error.value}`;
     }
   }
 }
 
+function shouldRetryBackendError(errorText: string) {
+  return (
+    errorText.includes("ECONNREFUSED") ||
+    errorText.includes("timeout") ||
+    errorText.includes("did not start in time") ||
+    errorText.includes("Migration backend unavailable")
+  );
+}
+
 async function pollProgress() {
   try {
-    const res = await window.metalsharp.request("GET", "/update/migrate/progress");
+    const res = await window.metalsharp.migrateProgress();
     if (!res) return;
     const data = res.data ?? res;
     status.value = data.status ?? "idle";


### PR DESCRIPTION
## Summary
- ensure Electron starts or reconnects to metalsharp-backend before backend IPC requests
- route the migration wizard through dedicated migrate IPC handlers that verify backend readiness before check/start/progress calls
- keep migration startup retrying structured backend-unavailable responses instead of surfacing raw ECONNREFUSED remote-method failures

## Root cause
The migration view called the generic backend request bridge directly during the post-update handoff. If metalsharp-backend was missing, still starting, or had been killed during updater handoff, Electron forwarded the raw connection failure to the renderer and the wizard stopped on the first migration step.

## Validation
- npm run build
- npx biome check src/
- cargo fmt --all -- --check
- cargo test
- cargo clippy --all-targets -- -D warnings
- git diff --check
- git diff --cached --check