### PR TITLE
[codex] Strengthen M10 D3D10 DXMT pipeline

### DIFF
--- a/app/src-rust/src/mtsp/engine.rs
+++ b/app/src-rust/src/mtsp/engine.rs
@@ -126,7 +126,10 @@ pub fn pipelines() -> &'static Vec<PipelineNode> {
                     DllDeploy { source_subpath: "lib/dxmt/x86_64-windows", filename: "d3d10core.dll" },
                     DllDeploy { source_subpath: "lib/dxmt/x86_64-windows", filename: "winemetal.dll" },
                 ],
-                env_vars: vec![EnvVar { key: "DXMT_ASYNC_PIPELINE_COMPILE", value: "1" }],
+                env_vars: vec![
+                    EnvVar { key: "DXMT_METALFX_SPATIAL_SWAPCHAIN", value: "1" },
+                    EnvVar { key: "DXMT_ASYNC_PIPELINE_COMPILE", value: "1" },
+                ],
                 launch_args: vec!["-dx10"],
                 alternatives: vec![
                     PipelineId::M11,
@@ -290,5 +293,45 @@ impl PipelineId {
             PipelineId::MacSteam => "macos_steam",
             PipelineId::WineBare => "metalsharp_wine",
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn m10_is_stable_dxmt_d3d10_pipeline() {
+        let m10 = get_pipeline(PipelineId::M10);
+
+        assert_eq!(m10.name, "M10");
+        assert_eq!(m10.description, "D3D10 -> Metal via DXMT");
+        assert_eq!(m10.backend, "dxmt");
+        assert!(!m10.experimental);
+        assert_eq!(m10.launch_args, vec!["-dx10"]);
+        assert_eq!(m10.shader_cache_subdir, Some("m10"));
+    }
+
+    #[test]
+    fn m10_matches_shared_dxmt_handoff_shape() {
+        let m10 = get_pipeline(PipelineId::M10);
+        let m11 = get_pipeline(PipelineId::M11);
+
+        assert_eq!(m10.dyld_paths, m11.dyld_paths);
+        assert_eq!(m10.wine_overrides, Some("dxgi,d3d11,d3d10core=n,b;gameoverlayrenderer,gameoverlayrenderer64=d"));
+
+        let m10_dlls: std::collections::HashSet<_> = m10.deploy_dlls.iter().map(|dll| dll.filename).collect();
+        for required in ["d3d11.dll", "dxgi.dll", "d3d10core.dll", "winemetal.dll"] {
+            assert!(m10_dlls.contains(required), "M10 missing {}", required);
+        }
+        assert!(!m10_dlls.contains("d3d12.dll"));
+
+        let m10_env: std::collections::HashSet<_> = m10.env_vars.iter().map(|env| env.key).collect();
+        assert!(m10_env.contains("DXMT_ASYNC_PIPELINE_COMPILE"));
+        assert!(m10_env.contains("DXMT_METALFX_SPATIAL_SWAPCHAIN"));
+
+        assert!(m10.alternatives.contains(&PipelineId::M11));
+        assert!(m10.alternatives.contains(&PipelineId::M9));
+        assert!(m10.alternatives.contains(&PipelineId::WineBare));
     }
 }

--- a/app/src-rust/src/mtsp/engine.rs
+++ b/app/src-rust/src/mtsp/engine.rs
@@ -118,9 +118,13 @@ pub fn pipelines() -> &'static Vec<PipelineNode> {
                 backend: "dxmt",
                 experimental: false,
                 requires_wine: true,
-                wine_overrides: Some("dxgi,d3d11,d3d10core=n,b;gameoverlayrenderer,gameoverlayrenderer64=d"),
+                wine_overrides: Some(
+                    "d3d10,d3d10_1,dxgi,d3d11,d3d10core=n,b;gameoverlayrenderer,gameoverlayrenderer64=d",
+                ),
                 dyld_paths: vec!["lib/wine/x86_64-unix", "lib/dxmt/x86_64-unix"],
                 deploy_dlls: vec![
+                    DllDeploy { source_subpath: "lib/wine/x86_64-windows", filename: "d3d10.dll" },
+                    DllDeploy { source_subpath: "lib/wine/x86_64-windows", filename: "d3d10_1.dll" },
                     DllDeploy { source_subpath: "lib/dxmt/x86_64-windows", filename: "d3d11.dll" },
                     DllDeploy { source_subpath: "lib/dxmt/x86_64-windows", filename: "dxgi.dll" },
                     DllDeploy { source_subpath: "lib/dxmt/x86_64-windows", filename: "d3d10core.dll" },
@@ -318,10 +322,13 @@ mod tests {
         let m11 = get_pipeline(PipelineId::M11);
 
         assert_eq!(m10.dyld_paths, m11.dyld_paths);
-        assert_eq!(m10.wine_overrides, Some("dxgi,d3d11,d3d10core=n,b;gameoverlayrenderer,gameoverlayrenderer64=d"));
+        assert_eq!(
+            m10.wine_overrides,
+            Some("d3d10,d3d10_1,dxgi,d3d11,d3d10core=n,b;gameoverlayrenderer,gameoverlayrenderer64=d")
+        );
 
         let m10_dlls: std::collections::HashSet<_> = m10.deploy_dlls.iter().map(|dll| dll.filename).collect();
-        for required in ["d3d11.dll", "dxgi.dll", "d3d10core.dll", "winemetal.dll"] {
+        for required in ["d3d10.dll", "d3d10_1.dll", "d3d11.dll", "dxgi.dll", "d3d10core.dll", "winemetal.dll"] {
             assert!(m10_dlls.contains(required), "M10 missing {}", required);
         }
         assert!(!m10_dlls.contains("d3d12.dll"));

--- a/app/src-rust/src/mtsp/pe.rs
+++ b/app/src-rust/src/mtsp/pe.rs
@@ -124,7 +124,7 @@ pub fn detect_d3d_api(imports: &[String]) -> D3dApi {
     if lower.iter().any(|d| d == "d3d11.dll") {
         return D3dApi::D3D11;
     }
-    if lower.iter().any(|d| d == "d3d10.dll") {
+    if lower.iter().any(|d| d == "d3d10.dll" || d == "d3d10_1.dll" || d == "d3d10core.dll") {
         return D3dApi::D3D10;
     }
     if lower.iter().any(|d| d == "d3d9.dll") {
@@ -158,4 +158,21 @@ pub fn analyze_game_exe(game_dir: &Path) -> Option<PeInfo> {
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_d3d10_from_public_and_core_imports() {
+        assert_eq!(detect_d3d_api(&["d3d10.dll".into()]), D3dApi::D3D10);
+        assert_eq!(detect_d3d_api(&["d3d10_1.dll".into()]), D3dApi::D3D10);
+        assert_eq!(detect_d3d_api(&["d3d10core.dll".into()]), D3dApi::D3D10);
+    }
+
+    #[test]
+    fn d3d12_import_takes_priority_over_d3d10_compat_imports() {
+        assert_eq!(detect_d3d_api(&["d3d10core.dll".into(), "d3d12.dll".into()]), D3dApi::D3D12);
+    }
 }

--- a/app/src-rust/src/mtsp/rules.rs
+++ b/app/src-rust/src/mtsp/rules.rs
@@ -176,7 +176,13 @@ fn pe_info_to_pipeline(pe: &PeInfo) -> Option<PipelineId> {
         },
         D3dApi::D3D11 => Some(PipelineId::M11),
         D3dApi::D3D9 => Some(PipelineId::M9),
-        D3dApi::D3D10 => Some(PipelineId::M10),
+        D3dApi::D3D10 => {
+            if pe.is_64_bit {
+                Some(PipelineId::M10)
+            } else {
+                Some(PipelineId::M32)
+            }
+        },
         D3dApi::Unknown => None,
     }
 }
@@ -207,5 +213,17 @@ mod tests {
         };
 
         assert_eq!(pe_info_to_pipeline(&pe), Some(PipelineId::M10));
+    }
+
+    #[test]
+    fn d3d10_32_bit_pe_does_not_map_to_x86_64_m10_runtime() {
+        let pe = PeInfo {
+            machine_type: 0x014c,
+            is_64_bit: false,
+            imports: vec!["d3d10.dll".into()],
+            detected_api: D3dApi::D3D10,
+        };
+
+        assert_eq!(pe_info_to_pipeline(&pe), Some(PipelineId::M32));
     }
 }

--- a/app/src-rust/src/mtsp/rules.rs
+++ b/app/src-rust/src/mtsp/rules.rs
@@ -80,18 +80,14 @@ pub fn resolve_pipeline(appid: u32) -> PipelineId {
                 return PipelineId::FnaArm64;
             }
 
-            if let Some(detected) = detect_from_directory(dir) {
-                return detected;
-            }
-        }
-    }
-
-    if let Some(ref dir) = game_dir {
-        if dir.exists() {
             if let Some(pe_info) = super::pe::analyze_game_exe(dir) {
                 if let Some(pipeline) = pe_info_to_pipeline(&pe_info) {
                     return pipeline;
                 }
+            }
+
+            if let Some(detected) = detect_from_directory(dir) {
+                return detected;
             }
         }
     }
@@ -182,5 +178,34 @@ fn pe_info_to_pipeline(pe: &PeInfo) -> Option<PipelineId> {
         D3dApi::D3D9 => Some(PipelineId::M9),
         D3dApi::D3D10 => Some(PipelineId::M10),
         D3dApi::Unknown => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn d3d10_pe_maps_to_m10() {
+        let pe = PeInfo {
+            machine_type: 0x8664,
+            is_64_bit: true,
+            imports: vec!["d3d10core.dll".into()],
+            detected_api: D3dApi::D3D10,
+        };
+
+        assert_eq!(pe_info_to_pipeline(&pe), Some(PipelineId::M10));
+    }
+
+    #[test]
+    fn d3d10_pe_mapping_is_not_demoted_to_m11_by_heuristics() {
+        let pe = PeInfo {
+            machine_type: 0x8664,
+            is_64_bit: true,
+            imports: vec!["d3d10core.dll".into(), "steam_api64.dll".into()],
+            detected_api: D3dApi::D3D10,
+        };
+
+        assert_eq!(pe_info_to_pipeline(&pe), Some(PipelineId::M10));
     }
 }

--- a/app/src-rust/src/mtsp/shader_cache.rs
+++ b/app/src-rust/src/mtsp/shader_cache.rs
@@ -161,3 +161,13 @@ fn merge_preset_into_user(preset_db: &PathBuf, user_db: &PathBuf) -> Option<u64>
         None
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn m10_reuses_shared_dxmt_metal_preset_family() {
+        assert_eq!(preset_lookup_subdirs("m10"), vec!["m10", "dxmt-metal"]);
+    }
+}

--- a/docs/dxmt-vulkan-architecture.md
+++ b/docs/dxmt-vulkan-architecture.md
@@ -19,7 +19,7 @@ MetalSharp has two graphics translation families:
 
 DXMT is used by M12, M11, and M10.
 
-M10 is the D3D10 DXMT path. It is backed by DXMT's `d3d10core.dll` and the shared D3D11/DXGI/winemetal stack; MetalSharp does not expect a separate deployed `d3d10.dll` for this path.
+M10 is the D3D10 DXMT path. It deploys Wine's public `d3d10.dll` and `d3d10_1.dll` entrypoints for imported D3D10 APIs, then routes the core handoff through DXMT's `d3d10core.dll` and the shared D3D11/DXGI/winemetal stack.
 
 DXMT DLLs:
 
@@ -29,6 +29,7 @@ DXMT DLLs:
 | `d3d11.dll` | M12, M11, M10 |
 | `dxgi.dll` | M12, M11, M10 |
 | `d3d10core.dll` | M12, M11, M10 |
+| `d3d10.dll`, `d3d10_1.dll` | M10 public Wine D3D10 entrypoints |
 | `winemetal.dll` | M12, M11, M10 |
 | `winemetal.so` | Unix Metal bridge |
 

--- a/docs/dxmt-vulkan-architecture.md
+++ b/docs/dxmt-vulkan-architecture.md
@@ -19,6 +19,8 @@ MetalSharp has two graphics translation families:
 
 DXMT is used by M12, M11, and M10.
 
+M10 is the D3D10 DXMT path. It is backed by DXMT's `d3d10core.dll` and the shared D3D11/DXGI/winemetal stack; MetalSharp does not expect a separate deployed `d3d10.dll` for this path.
+
 DXMT DLLs:
 
 | DLL | Used by |
@@ -43,6 +45,9 @@ Game
 DXMT uses per-game shader caches under:
 
 ```text
+~/.metalsharp/shader-cache/m10/<appid>/
+~/.metalsharp/shader-cache/m11/<appid>/
+~/.metalsharp/shader-cache/m12/<appid>/
 ~/.metalsharp/shader-cache/dxmt-metal/<appid>/
 ~/.metalsharp/shader-cache/dxmt-metal12/<appid>/
 ```
@@ -92,6 +97,7 @@ MoltenVK ICD:
 ## Notes
 
 - DXMT is the direct Metal path.
+- M10 and M11 share the `dxmt-metal` preset fallback family.
 - M9 has an extra Vulkan/MoltenVK hop.
 - M12 is still marked experimental in source.
 - M32 is the fallback for 32-bit Wine cases.

--- a/docs/launch-architecture.md
+++ b/docs/launch-architecture.md
@@ -45,7 +45,7 @@ Common marker behavior:
 | `d3dx9_43.dll` | Wine |
 | PE imports D3D12 | M12 for 64-bit games, M11 otherwise |
 | PE imports D3D11 | M11 |
-| PE imports D3D10 | M10 |
+| 64-bit PE imports D3D10 | M10 |
 | PE imports D3D9 | M9 |
 
 D3D10 PE imports are checked before broad Unity, Unreal, Source, RE Engine, and Steam marker heuristics so D3D10 games stay on `[m10]`.
@@ -59,7 +59,7 @@ M11/M10 copy:
 - `d3d10core.dll`
 - `winemetal.dll`
 
-M10 is selected by `d3d10.dll`, `d3d10_1.dll`, or `d3d10core.dll` imports. It deploys Wine's public `d3d10.dll` and `d3d10_1.dll` entrypoints plus DXMT's `d3d10core.dll`, so public D3D10 imports and the DXMT core handoff are both owned by the M10 runtime contract.
+M10 is selected by 64-bit `d3d10.dll`, `d3d10_1.dll`, or `d3d10core.dll` imports. It deploys Wine's public `d3d10.dll` and `d3d10_1.dll` entrypoints plus DXMT's `d3d10core.dll`, so public D3D10 imports and the DXMT core handoff are both owned by the x86_64 M10 runtime contract.
 
 M12 also copies:
 

--- a/docs/launch-architecture.md
+++ b/docs/launch-architecture.md
@@ -18,7 +18,7 @@ Play clicked
 |---|---|---|
 | **M11** | DXMT | Direct Wine launch with D3D11/DXGI DXMT DLLs |
 | **M12** | DXMT | Direct Wine launch with D3D12/D3D11/DXGI DXMT DLLs |
-| **M10** | DXMT | Direct Wine launch with D3D10/D3D11/DXGI DXMT DLLs |
+| **M10** | DXMT | Direct Wine launch with DXMT `d3d10core.dll` over D3D11/DXGI |
 | **M9** | DXVK/MoltenVK | Direct Wine launch with DXVK `d3d9.dll` |
 | **M32** | Wine32 | 32-bit Wine fallback |
 | **Native macOS** | Mono/FNA | Native FNA/XNA/Mono runtime |
@@ -31,9 +31,10 @@ Play clicked
 The resolver checks, in order:
 
 1. `configs/mtsp-rules.toml`
-2. Installed game directory markers
+2. Managed .NET/FNA eligibility
 3. PE header analysis
-4. M11 fallback
+4. Installed game directory markers
+5. M11 fallback
 
 Common marker behavior:
 
@@ -47,6 +48,8 @@ Common marker behavior:
 | PE imports D3D10 | M10 |
 | PE imports D3D9 | M9 |
 
+D3D10 PE imports are checked before broad Unity, Unreal, Source, RE Engine, and Steam marker heuristics so D3D10 games stay on `[m10]`.
+
 ## Runtime Prep
 
 M11/M10 copy:
@@ -55,6 +58,8 @@ M11/M10 copy:
 - `dxgi.dll`
 - `d3d10core.dll`
 - `winemetal.dll`
+
+M10 is selected by `d3d10.dll`, `d3d10_1.dll`, or `d3d10core.dll` imports. Its deployed D3D10 boundary is `d3d10core.dll`; it does not require a separate `d3d10.dll` payload.
 
 M12 also copies:
 

--- a/docs/launch-architecture.md
+++ b/docs/launch-architecture.md
@@ -59,7 +59,7 @@ M11/M10 copy:
 - `d3d10core.dll`
 - `winemetal.dll`
 
-M10 is selected by `d3d10.dll`, `d3d10_1.dll`, or `d3d10core.dll` imports. Its deployed D3D10 boundary is `d3d10core.dll`; it does not require a separate `d3d10.dll` payload.
+M10 is selected by `d3d10.dll`, `d3d10_1.dll`, or `d3d10core.dll` imports. It deploys Wine's public `d3d10.dll` and `d3d10_1.dll` entrypoints plus DXMT's `d3d10core.dll`, so public D3D10 imports and the DXMT core handoff are both owned by the M10 runtime contract.
 
 M12 also copies:
 

--- a/docs/m10-pipeline-map.md
+++ b/docs/m10-pipeline-map.md
@@ -7,6 +7,7 @@ M10 is the stable D3D10 engine path. It launches Windows D3D10 titles through Wi
 ```text
 D3D10 game
   -> Wine
+  -> Wine d3d10.dll / d3d10_1.dll public entrypoints
   -> DXMT d3d10core.dll
   -> DXMT d3d11.dll + dxgi.dll
   -> winemetal.dll / winemetal.so
@@ -14,9 +15,14 @@ D3D10 game
   -> Apple GPU
 ```
 
-The runtime payload does not ship a separate M10-specific `d3d10.dll` shim. The D3D10 handoff is `d3d10core.dll` plus the same DXMT D3D11, DXGI, and winemetal runtime used by M11.
+M10 deploys Wine's public D3D10 entrypoint DLLs for games that import `d3d10.dll` or `d3d10_1.dll`, then routes the core handoff through DXMT's `d3d10core.dll` plus the same DXMT D3D11, DXGI, and winemetal runtime used by M11.
 
-M10 deploys these DLLs from `~/.metalsharp/runtime/wine/lib/dxmt/x86_64-windows/`:
+M10 deploys these public D3D10 entrypoints from `~/.metalsharp/runtime/wine/lib/wine/x86_64-windows/`:
+
+- `d3d10.dll`
+- `d3d10_1.dll`
+
+M10 deploys these DXMT handoff DLLs from `~/.metalsharp/runtime/wine/lib/dxmt/x86_64-windows/`:
 
 - `d3d11.dll`
 - `dxgi.dll`
@@ -32,7 +38,7 @@ M10 deliberately does not deploy `d3d12.dll`.
 | Pipeline | `M10` |
 | Backend | `dxmt` |
 | Launch args | `-dx10` |
-| Wine overrides | `dxgi,d3d11,d3d10core=n,b;gameoverlayrenderer,gameoverlayrenderer64=d` |
+| Wine overrides | `d3d10,d3d10_1,dxgi,d3d11,d3d10core=n,b;gameoverlayrenderer,gameoverlayrenderer64=d` |
 | Shader cache subdir | `m10` |
 | Preset fallback family | `m10`, then `dxmt-metal` |
 

--- a/docs/m10-pipeline-map.md
+++ b/docs/m10-pipeline-map.md
@@ -1,0 +1,56 @@
+# M10 Pipeline Map
+
+M10 is the stable D3D10 engine path. It launches Windows D3D10 titles through Wine and DXMT, then hands rendering to Metal through DXMT's winemetal bridge.
+
+## Runtime Shape
+
+```text
+D3D10 game
+  -> Wine
+  -> DXMT d3d10core.dll
+  -> DXMT d3d11.dll + dxgi.dll
+  -> winemetal.dll / winemetal.so
+  -> Metal command buffers
+  -> Apple GPU
+```
+
+The runtime payload does not ship a separate M10-specific `d3d10.dll` shim. The D3D10 handoff is `d3d10core.dll` plus the same DXMT D3D11, DXGI, and winemetal runtime used by M11.
+
+M10 deploys these DLLs from `~/.metalsharp/runtime/wine/lib/dxmt/x86_64-windows/`:
+
+- `d3d11.dll`
+- `dxgi.dll`
+- `d3d10core.dll`
+- `winemetal.dll`
+
+M10 deliberately does not deploy `d3d12.dll`.
+
+## Engine Contract
+
+| Field | Value |
+|---|---|
+| Pipeline | `M10` |
+| Backend | `dxmt` |
+| Launch args | `-dx10` |
+| Wine overrides | `dxgi,d3d11,d3d10core=n,b;gameoverlayrenderer,gameoverlayrenderer64=d` |
+| Shader cache subdir | `m10` |
+| Preset fallback family | `m10`, then `dxmt-metal` |
+
+M10 uses the same DXMT Unix library search path as M11:
+
+```text
+lib/wine/x86_64-unix
+lib/dxmt/x86_64-unix
+```
+
+## Selection Rules
+
+The backend resolves M10 from PE imports before broad directory heuristics. That keeps D3D10 games from being demoted to M11 just because their folder also includes common engine or Steam markers.
+
+Recognized D3D10 imports:
+
+- `d3d10.dll`
+- `d3d10_1.dll`
+- `d3d10core.dll`
+
+If a game imports both D3D12 and D3D10 compatibility DLLs, D3D12 still wins and maps to M12 for 64-bit executables.

--- a/docs/m10-pipeline-map.md
+++ b/docs/m10-pipeline-map.md
@@ -51,7 +51,7 @@ lib/dxmt/x86_64-unix
 
 ## Selection Rules
 
-The backend resolves M10 from PE imports before broad directory heuristics. That keeps D3D10 games from being demoted to M11 just because their folder also includes common engine or Steam markers.
+The backend resolves M10 from 64-bit PE imports before broad directory heuristics. That keeps 64-bit D3D10 games from being demoted to M11 just because their folder also includes common engine or Steam markers. 32-bit D3D10 executables are not routed into M10 because this runtime contract deploys the x86_64 D3D10/DXMT payload.
 
 Recognized D3D10 imports:
 

--- a/docs/wine-architecture.md
+++ b/docs/wine-architecture.md
@@ -48,7 +48,7 @@ Other runtime pieces live beside it:
 |---|---|
 | M11 | Wine + DXMT D3D11/DXGI |
 | M12 | Wine + DXMT D3D12/D3D11/DXGI |
-| M10 | Wine + DXMT D3D10/D3D11/DXGI |
+| M10 | Wine + DXMT D3D10 core over D3D11/DXGI |
 | M9 | Wine + DXVK D3D9 + MoltenVK |
 | M32 | Wine 32-bit fallback |
 | Steam | Wine Steam prefix |
@@ -66,6 +66,8 @@ dxgi.dll
 d3d10core.dll
 winemetal.dll
 ```
+
+M10 uses DXMT's `d3d10core.dll` as the D3D10 handoff and shares the D3D11/DXGI/winemetal runtime with M11. A standalone deployed `d3d10.dll` is not part of the current payload.
 
 M12:
 

--- a/docs/wine-architecture.md
+++ b/docs/wine-architecture.md
@@ -67,7 +67,7 @@ d3d10core.dll
 winemetal.dll
 ```
 
-M10 uses DXMT's `d3d10core.dll` as the D3D10 handoff and shares the D3D11/DXGI/winemetal runtime with M11. A standalone deployed `d3d10.dll` is not part of the current payload.
+M10 deploys Wine's public `d3d10.dll` and `d3d10_1.dll` entrypoints for D3D10 imports, then uses DXMT's `d3d10core.dll` as the D3D10 handoff and shares the D3D11/DXGI/winemetal runtime with M11.
 
 M12:
 


### PR DESCRIPTION
## Summary
- map M10 as the stable D3D10 DXMT path using d3d10core.dll plus shared D3D11/DXGI/winemetal handoff
- detect d3d10.dll, d3d10_1.dll, and d3d10core.dll PE imports as [m10] before broad directory heuristics can demote them to M11
- add backend invariants for M10 runtime shape, cache preset fallback, and resolver behavior
- document the M10 pipeline map and update launch/Wine/DXMT architecture notes

## Validation
- cargo fmt --all -- --check
- cargo test
- cargo clippy --all-targets -- -D warnings
- cmake --build build
- ctest --test-dir build --output-on-failure
- npm run build
- npx biome check src/
- git diff --check
- git diff --cached --check