### PR TITLE
[codex] Route M9 through DXMT launch family

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ app/bundles/SteamSetup.exe
 # Code intelligence
 .graphiq/
 metalsharp-*/
+
+# SQLite runtime sidecars
+*.db-shm
+*.db-wal

--- a/app/src-rust/src/launch.rs
+++ b/app/src-rust/src/launch.rs
@@ -35,9 +35,7 @@ pub fn launch_via_steam(appid: u32) -> Result<u32, Box<dyn std::error::Error>> {
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null());
     crate::platform::set_runtime_library_env(&mut cmd, &ms_root);
-    let child = cmd.spawn()?;
-
-    Ok(child.id())
+    spawn_and_reap(cmd)
 }
 
 pub fn launch_via_steam_with_env(
@@ -86,13 +84,15 @@ pub fn launch_via_steam_with_env(
         cmd.env(key, val);
     }
 
-    let child =
-        cmd.args(["start", &url]).stdout(std::process::Stdio::null()).stderr(std::process::Stdio::null()).spawn()?;
-
-    Ok(child.id())
+    cmd.args(["start", &url]).stdout(std::process::Stdio::null()).stderr(std::process::Stdio::null());
+    spawn_and_reap(cmd)
 }
 
 pub fn kill_process_tree(pid: i32) -> Result<(), Box<dyn std::error::Error>> {
+    if pid <= 0 {
+        return Ok(());
+    }
+
     let _ = Command::new("pkill")
         .args(["-9", "-P", &pid.to_string()])
         .stdout(std::process::Stdio::null())
@@ -117,7 +117,9 @@ pub fn kill_process_tree(pid: i32) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 pub fn kill_game_with_pid(appid: u32, pid: i32) -> Result<(), Box<dyn std::error::Error>> {
-    kill_process_tree(pid)?;
+    if pid > 0 {
+        kill_process_tree(pid)?;
+    }
 
     let home = dirs::home_dir().ok_or("no home dir")?;
     let game_dir = home.join(".metalsharp").join("games").join(appid.to_string());
@@ -145,6 +147,29 @@ pub fn kill_game_with_pid(appid: u32, pid: i32) -> Result<(), Box<dyn std::error
     let _ = Command::new("pkill").args(["-9", "-f", "UnityCrashHandler"]).status();
 
     Ok(())
+}
+
+pub fn is_process_active(pid: i32) -> bool {
+    if pid <= 0 {
+        return false;
+    }
+
+    match Command::new("ps").args(["-p", &pid.to_string(), "-o", "stat="]).output() {
+        Ok(output) if output.status.success() => {
+            let stat = String::from_utf8_lossy(&output.stdout);
+            !stat.trim().is_empty() && !stat.contains('Z')
+        },
+        _ => false,
+    }
+}
+
+fn spawn_and_reap(mut cmd: Command) -> Result<u32, Box<dyn std::error::Error>> {
+    let mut child = cmd.spawn()?;
+    let pid = child.id();
+    std::thread::spawn(move || {
+        let _ = child.wait();
+    });
+    Ok(pid)
 }
 
 pub fn get_config() -> Value {
@@ -325,4 +350,31 @@ fn launch_via_fna_mono(exe_path: &str) -> Result<u32, Box<dyn std::error::Error>
     let child = cmd.spawn()?;
 
     Ok(child.id())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn non_positive_pids_are_not_active() {
+        assert!(!is_process_active(0));
+        assert!(!is_process_active(-1));
+    }
+
+    #[test]
+    fn spawned_handoff_process_is_reaped_after_exit() {
+        let cmd = Command::new("/usr/bin/true");
+        let pid = spawn_and_reap(cmd).expect("spawn handoff process");
+
+        for _ in 0..20 {
+            if !is_process_active(pid as i32) {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        assert!(!is_process_active(pid as i32));
+    }
 }

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -55,6 +55,12 @@ fn get_game_pid(appid: u32) -> Option<i32> {
     running_games().lock().ok()?.get(&appid).copied()
 }
 
+fn prune_inactive_game_pids() {
+    if let Ok(mut map) = running_games().lock() {
+        map.retain(|_, &mut pid| launch::is_process_active(pid));
+    }
+}
+
 enum RouteResponse {
     Json(u16, Vec<u8>),
     Raw(u16, Vec<u8>, String),
@@ -658,6 +664,7 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
             }
         },
         (Method::Get, "/game/running") => {
+            prune_inactive_game_pids();
             let map = running_games().lock().unwrap_or_else(|e| e.into_inner());
             let running: Vec<serde_json::Value> =
                 map.iter().map(|(&appid, &pid)| json!({"appid": appid, "pid": pid})).collect();
@@ -711,6 +718,10 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
             } else {
                 pid_param
             };
+
+            if target_pid <= 0 {
+                return resp(400, json!({"ok": false, "error": "pid required"}));
+            }
 
             match launch::kill_process_tree(target_pid) {
                 Ok(_) => {

--- a/app/src-rust/src/mtsp/engine.rs
+++ b/app/src-rust/src/mtsp/engine.rs
@@ -140,23 +140,19 @@ pub fn pipelines() -> &'static Vec<PipelineNode> {
             PipelineNode {
                 id: PipelineId::M9,
                 name: "M9",
-                description: "D3D9 -> Metal via DXVK/MoltenVK",
-                backend: "dxvk",
+                description: "D3D9 -> Metal via DXMT launch family",
+                backend: "dxmt",
                 experimental: false,
                 requires_wine: true,
                 wine_overrides: Some("d3d9=n,b;gameoverlayrenderer,gameoverlayrenderer64=d"),
-                dyld_paths: vec!["lib/wine/x86_64-unix"],
-                deploy_dlls: vec![DllDeploy { source_subpath: "lib/dxvk/i386-windows", filename: "d3d9.dll" }],
-                env_vars: vec![],
-                launch_args: vec!["-dx9"],
-                alternatives: vec![
-                    PipelineId::M11,
-                    PipelineId::M10,
-                    PipelineId::M32,
-                    PipelineId::Steam,
-                    PipelineId::MacSteam,
-                    PipelineId::WineBare,
+                dyld_paths: vec!["lib/wine/x86_64-unix", "lib/dxmt/x86_64-unix"],
+                deploy_dlls: vec![DllDeploy { source_subpath: "lib/wine/x86_64-windows", filename: "d3d9.dll" }],
+                env_vars: vec![
+                    EnvVar { key: "DXMT_METALFX_SPATIAL_SWAPCHAIN", value: "1" },
+                    EnvVar { key: "DXMT_ASYNC_PIPELINE_COMPILE", value: "1" },
                 ],
+                launch_args: vec!["-dx9"],
+                alternatives: vec![PipelineId::M11, PipelineId::M10, PipelineId::Steam, PipelineId::MacSteam],
                 shader_cache_subdir: Some("m9"),
             },
             PipelineNode {
@@ -250,7 +246,7 @@ impl PipelineId {
         match method {
             "dxmt_metal" | "steam_d3dmetal_perf" | "steam_metalfx" => Some(PipelineId::M11),
             "dxmt_metal12" => Some(PipelineId::M12),
-            "d3d9_metal" | "dxvk_metal32" => Some(PipelineId::M9),
+            "d3d9_metal" => Some(PipelineId::M9),
             "wined3d_32" => Some(PipelineId::M32),
             "metalsharp_wine" => Some(PipelineId::WineBare),
             "steam" => Some(PipelineId::Steam),
@@ -268,7 +264,7 @@ impl PipelineId {
             "m11" | "steam_d3dmetal_perf" | "steam_metalfx" => Some(PipelineId::M11),
             "m12" => Some(PipelineId::M12),
             "m10" => Some(PipelineId::M10),
-            "m9" | "m9_gl" | "m32_vk" => Some(PipelineId::M9),
+            "m9" => Some(PipelineId::M9),
             "m32" | "m32_w" => Some(PipelineId::M32),
             "fna_arm64" | "fna_x86" | "mono_generic" => Some(PipelineId::FnaArm64),
             "steam" | "wine_steam" => Some(PipelineId::Steam),
@@ -290,5 +286,45 @@ impl PipelineId {
             PipelineId::MacSteam => "macos_steam",
             PipelineId::WineBare => "metalsharp_wine",
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn m9_is_dxmt_family_without_dxvk_or_wined3d_fallbacks() {
+        let m9 = get_pipeline(PipelineId::M9);
+
+        assert_eq!(m9.name, "M9");
+        assert_eq!(m9.description, "D3D9 -> Metal via DXMT launch family");
+        assert_eq!(m9.backend, "dxmt");
+        assert!(!m9.experimental);
+        assert_eq!(m9.launch_args, vec!["-dx9"]);
+        assert_eq!(m9.shader_cache_subdir, Some("m9"));
+        assert_eq!(m9.wine_overrides, Some("d3d9=n,b;gameoverlayrenderer,gameoverlayrenderer64=d"));
+
+        let m9_dlls: std::collections::HashSet<_> = m9.deploy_dlls.iter().map(|dll| dll.filename).collect();
+        assert_eq!(m9_dlls, std::collections::HashSet::from(["d3d9.dll"]));
+        assert_eq!(m9.deploy_dlls[0].source_subpath, "lib/wine/x86_64-windows");
+        assert!(m9.deploy_dlls.iter().all(|dll| !dll.source_subpath.contains("dxvk")));
+        assert!(m9.dyld_paths.contains(&"lib/dxmt/x86_64-unix"));
+
+        let m9_env: std::collections::HashSet<_> = m9.env_vars.iter().map(|env| env.key).collect();
+        assert!(m9_env.contains("DXMT_ASYNC_PIPELINE_COMPILE"));
+        assert!(m9_env.contains("DXMT_METALFX_SPATIAL_SWAPCHAIN"));
+
+        assert!(m9.alternatives.contains(&PipelineId::M11));
+        assert!(m9.alternatives.contains(&PipelineId::M10));
+        assert!(!m9.alternatives.contains(&PipelineId::M32));
+        assert!(!m9.alternatives.contains(&PipelineId::WineBare));
+    }
+
+    #[test]
+    fn legacy_dxvk_and_wined3d_m9_aliases_are_not_m9() {
+        assert_eq!(PipelineId::from_legacy_method("dxvk_metal32"), None);
+        assert_eq!(PipelineId::from_str_flexible("m9_gl"), None);
+        assert_eq!(PipelineId::from_str_flexible("m32_vk"), None);
     }
 }

--- a/app/src-rust/src/mtsp/engine.rs
+++ b/app/src-rust/src/mtsp/engine.rs
@@ -146,7 +146,10 @@ pub fn pipelines() -> &'static Vec<PipelineNode> {
                 requires_wine: true,
                 wine_overrides: Some("d3d9=n,b;gameoverlayrenderer,gameoverlayrenderer64=d"),
                 dyld_paths: vec!["lib/wine/x86_64-unix", "lib/dxmt/x86_64-unix"],
-                deploy_dlls: vec![DllDeploy { source_subpath: "lib/wine/x86_64-windows", filename: "d3d9.dll" }],
+                deploy_dlls: vec![
+                    DllDeploy { source_subpath: "lib/wine/x86_64-windows", filename: "d3d9.dll" },
+                    DllDeploy { source_subpath: "lib/wine/i386-windows", filename: "d3d9.dll" },
+                ],
                 env_vars: vec![
                     EnvVar { key: "DXMT_METALFX_SPATIAL_SWAPCHAIN", value: "1" },
                     EnvVar { key: "DXMT_ASYNC_PIPELINE_COMPILE", value: "1" },
@@ -305,9 +308,15 @@ mod tests {
         assert_eq!(m9.shader_cache_subdir, Some("m9"));
         assert_eq!(m9.wine_overrides, Some("d3d9=n,b;gameoverlayrenderer,gameoverlayrenderer64=d"));
 
-        let m9_dlls: std::collections::HashSet<_> = m9.deploy_dlls.iter().map(|dll| dll.filename).collect();
-        assert_eq!(m9_dlls, std::collections::HashSet::from(["d3d9.dll"]));
-        assert_eq!(m9.deploy_dlls[0].source_subpath, "lib/wine/x86_64-windows");
+        let m9_dlls: std::collections::HashSet<_> =
+            m9.deploy_dlls.iter().map(|dll| (dll.source_subpath, dll.filename)).collect();
+        assert_eq!(
+            m9_dlls,
+            std::collections::HashSet::from([
+                ("lib/wine/x86_64-windows", "d3d9.dll"),
+                ("lib/wine/i386-windows", "d3d9.dll"),
+            ])
+        );
         assert!(m9.deploy_dlls.iter().all(|dll| !dll.source_subpath.contains("dxvk")));
         assert!(m9.dyld_paths.contains(&"lib/dxmt/x86_64-unix"));
 

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -808,3 +808,23 @@ pub fn eac_toggle_status(game_dir: &PathBuf) -> bool {
     }
     false
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn m9_cache_env_uses_dxmt_family_not_dxvk() {
+        let node = get_pipeline(PipelineId::M9);
+        let cache = CachePaths { shader: "/tmp/m9-shaders".into(), pipeline: "/tmp/m9-pipelines".into() };
+
+        let env = cache_env_pairs(node, Some(&cache), &PathBuf::from("/tmp/metalsharp-runtime"));
+        let keys: std::collections::HashSet<_> = env.iter().map(|(key, _)| key.as_str()).collect();
+
+        assert!(keys.contains("DXMT_SHADER_CACHE_PATH"));
+        assert!(keys.contains("DXMT_PIPELINE_CACHE_PATH"));
+        assert!(!keys.contains("DXVK_STATE_CACHE_PATH"));
+        assert!(!keys.contains("DXVK_LOG_PATH"));
+        assert!(!keys.contains("VK_ICD_FILENAMES"));
+    }
+}

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -118,6 +118,8 @@ pub fn prepare_pipeline(appid: u32) -> Result<serde_json::Value, Box<dyn std::er
     let game_dir =
         crate::setup::resolve_game_dir(appid).ok_or_else(|| format!("game directory not found for appid {}", appid))?;
 
+    let deploy_dlls = selected_deploy_dlls_for_pipeline(&game_dir, node);
+    let deployed_sources: Vec<&str> = deploy_dlls.iter().map(|dll| dll.source_subpath).collect();
     deploy_dlls_for_pipeline(&game_dir, node);
 
     Ok(serde_json::json!({
@@ -125,7 +127,8 @@ pub fn prepare_pipeline(appid: u32) -> Result<serde_json::Value, Box<dyn std::er
         "appid": appid,
         "pipeline": node.id,
         "pipeline_name": node.name,
-        "deployed_dlls": node.deploy_dlls.len(),
+        "deployed_dlls": deploy_dlls.len(),
+        "deployed_sources": deployed_sources,
     }))
 }
 
@@ -877,6 +880,19 @@ mod tests {
         let sources: std::collections::HashSet<_> = selected.iter().map(|dll| dll.source_subpath).collect();
 
         assert_eq!(sources, std::collections::HashSet::from(["lib/wine/x86_64-windows"]));
+        let _ = std::fs::remove_dir_all(game_dir);
+    }
+
+    #[test]
+    fn selected_m9_deploy_count_matches_architecture_filter() {
+        let game_dir = test_game_dir("m9-count");
+        std::fs::create_dir_all(&game_dir).expect("create test game dir");
+        write_test_pe(&game_dir.join("portal2.exe"), 0x014c, 0x10b);
+
+        let selected = selected_deploy_dlls_for_pipeline(&game_dir, get_pipeline(PipelineId::M9));
+
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].source_subpath, "lib/wine/i386-windows");
         let _ = std::fs::remove_dir_all(game_dir);
     }
 

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -136,14 +136,40 @@ pub fn deploy_dlls_for_pipeline(game_dir: &PathBuf, node: &PipelineNode) {
 
     let home = dirs::home_dir().unwrap_or_default();
     let ms_root = home.join(".metalsharp").join("runtime").join("wine");
+    let deploy_dlls = selected_deploy_dlls_for_pipeline(game_dir, node);
 
-    for deploy in &node.deploy_dlls {
+    for deploy in deploy_dlls {
         let src = ms_root.join(deploy.source_subpath).join(deploy.filename);
         let dst = game_dir.join(deploy.filename);
         if src.exists() {
             let _ = std::fs::copy(&src, &dst);
         }
     }
+}
+
+fn selected_deploy_dlls_for_pipeline<'a>(
+    game_dir: &PathBuf,
+    node: &'a PipelineNode,
+) -> Vec<&'a super::engine::DllDeploy> {
+    if node.id != PipelineId::M9 {
+        return node.deploy_dlls.iter().collect();
+    }
+
+    let source_subpath = m9_d3d9_source_subpath(game_dir);
+    node.deploy_dlls.iter().filter(|dll| dll.source_subpath == source_subpath).collect()
+}
+
+fn m9_d3d9_source_subpath(game_dir: &PathBuf) -> &'static str {
+    let exe = PathBuf::from(resolve_game_exe(game_dir));
+    if let Ok(data) = std::fs::read(&exe) {
+        if let Some(pe) = super::pe::parse_pe_imports(&data) {
+            if !pe.is_64_bit {
+                return "lib/wine/i386-windows";
+            }
+        }
+    }
+
+    "lib/wine/x86_64-windows"
 }
 
 fn launch_dxmt_metal(appid: u32, node: &PipelineNode) -> Result<(u32, &'static str), Box<dyn std::error::Error>> {
@@ -826,5 +852,54 @@ mod tests {
         assert!(!keys.contains("DXVK_STATE_CACHE_PATH"));
         assert!(!keys.contains("DXVK_LOG_PATH"));
         assert!(!keys.contains("VK_ICD_FILENAMES"));
+    }
+
+    #[test]
+    fn m9_selects_i386_d3d9_for_32_bit_exes() {
+        let game_dir = test_game_dir("m9-32");
+        std::fs::create_dir_all(&game_dir).expect("create test game dir");
+        write_test_pe(&game_dir.join("portal2.exe"), 0x014c, 0x10b);
+
+        let selected = selected_deploy_dlls_for_pipeline(&game_dir, get_pipeline(PipelineId::M9));
+        let sources: std::collections::HashSet<_> = selected.iter().map(|dll| dll.source_subpath).collect();
+
+        assert_eq!(sources, std::collections::HashSet::from(["lib/wine/i386-windows"]));
+        let _ = std::fs::remove_dir_all(game_dir);
+    }
+
+    #[test]
+    fn m9_selects_x86_64_d3d9_for_64_bit_exes() {
+        let game_dir = test_game_dir("m9-64");
+        std::fs::create_dir_all(&game_dir).expect("create test game dir");
+        write_test_pe(&game_dir.join("valheim.exe"), 0x8664, 0x20b);
+
+        let selected = selected_deploy_dlls_for_pipeline(&game_dir, get_pipeline(PipelineId::M9));
+        let sources: std::collections::HashSet<_> = selected.iter().map(|dll| dll.source_subpath).collect();
+
+        assert_eq!(sources, std::collections::HashSet::from(["lib/wine/x86_64-windows"]));
+        let _ = std::fs::remove_dir_all(game_dir);
+    }
+
+    fn test_game_dir(name: &str) -> PathBuf {
+        let mut dir = std::env::temp_dir();
+        dir.push(format!("metalsharp-{}-{}-{}", name, std::process::id(), unique_suffix()));
+        dir
+    }
+
+    fn unique_suffix() -> u128 {
+        std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).expect("system time").as_nanos()
+    }
+
+    fn write_test_pe(path: &std::path::Path, machine: u16, optional_magic: u16) {
+        let mut data = vec![0_u8; 0x200];
+        data[0] = b'M';
+        data[1] = b'Z';
+        data[0x3c..0x40].copy_from_slice(&(0x80_u32).to_le_bytes());
+        data[0x80..0x84].copy_from_slice(b"PE\0\0");
+        data[0x84..0x86].copy_from_slice(&machine.to_le_bytes());
+        data[0x86..0x88].copy_from_slice(&(0_u16).to_le_bytes());
+        data[0x94..0x96].copy_from_slice(&(0xf0_u16).to_le_bytes());
+        data[0x98..0x9a].copy_from_slice(&optional_magic.to_le_bytes());
+        std::fs::write(path, data).expect("write test PE");
     }
 }

--- a/app/src-rust/src/mtsp/rules.rs
+++ b/app/src-rust/src/mtsp/rules.rs
@@ -80,18 +80,14 @@ pub fn resolve_pipeline(appid: u32) -> PipelineId {
                 return PipelineId::FnaArm64;
             }
 
-            if let Some(detected) = detect_from_directory(dir) {
-                return detected;
-            }
-        }
-    }
-
-    if let Some(ref dir) = game_dir {
-        if dir.exists() {
             if let Some(pe_info) = super::pe::analyze_game_exe(dir) {
                 if let Some(pipeline) = pe_info_to_pipeline(&pe_info) {
                     return pipeline;
                 }
+            }
+
+            if let Some(detected) = detect_from_directory(dir) {
+                return detected;
             }
         }
     }
@@ -182,5 +178,34 @@ fn pe_info_to_pipeline(pe: &PeInfo) -> Option<PipelineId> {
         D3dApi::D3D9 => Some(PipelineId::M9),
         D3dApi::D3D10 => Some(PipelineId::M10),
         D3dApi::Unknown => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn d3d9_pe_maps_to_m9() {
+        let pe = PeInfo {
+            machine_type: 0x8664,
+            is_64_bit: true,
+            imports: vec!["d3d9.dll".into()],
+            detected_api: D3dApi::D3D9,
+        };
+
+        assert_eq!(pe_info_to_pipeline(&pe), Some(PipelineId::M9));
+    }
+
+    #[test]
+    fn d3d9_pe_mapping_is_not_demoted_to_m11_by_heuristics() {
+        let pe = PeInfo {
+            machine_type: 0x8664,
+            is_64_bit: true,
+            imports: vec!["d3d9.dll".into(), "steam_api.dll".into()],
+            detected_api: D3dApi::D3D9,
+        };
+
+        assert_eq!(pe_info_to_pipeline(&pe), Some(PipelineId::M9));
     }
 }

--- a/app/src-rust/src/mtsp/shader_cache.rs
+++ b/app/src-rust/src/mtsp/shader_cache.rs
@@ -38,9 +38,8 @@ fn find_preset(home: &PathBuf, cache_subdir: &str, appid: u32) -> Option<PathBuf
 
 fn preset_lookup_subdirs(cache_subdir: &str) -> Vec<&str> {
     match cache_subdir {
-        "m10" | "m11" => vec![cache_subdir, "dxmt-metal"],
+        "m9" | "m10" | "m11" => vec![cache_subdir, "dxmt-metal"],
         "m12" => vec![cache_subdir, "dxmt-metal12"],
-        "m9" => vec![cache_subdir, "dxvk-metal9", "dxvk-metal32"],
         _ => vec![cache_subdir],
     }
 }
@@ -159,5 +158,15 @@ fn merge_preset_into_user(preset_db: &PathBuf, user_db: &PathBuf) -> Option<u64>
         Some(inserted)
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn m9_reuses_dxmt_preset_family() {
+        assert_eq!(preset_lookup_subdirs("m9"), vec!["m9", "dxmt-metal"]);
     }
 }

--- a/app/src-rust/src/setup.rs
+++ b/app/src-rust/src/setup.rs
@@ -226,7 +226,7 @@ pub fn dependencies() -> Value {
             {
                 "id": "wine_devel",
                 "name": "Wine (Devel)",
-                "desc": "No longer required — MetalSharp Wine handles all pipelines including DXVK D3D9 (Portal 2).",
+                "desc": "No longer required — MetalSharp Wine handles all pipelines including M9 D3D9 Metal (Portal 2).",
                 "installed": wine_devel,
                 "required": false,
                 "installCmd": "brew install --cask wine@devel",
@@ -395,7 +395,7 @@ pub fn prepare_game(appid: u32) -> Result<Value, Box<dyn std::error::Error>> {
         2050650 | 3164500 | 848450 => "dxmt_metal12",
         535520 => "wined3d_32",
         945360 | 1139900 => "steam",
-        620 | 265930 => "dxvk_metal32",
+        620 | 265930 => "d3d9_metal",
         _ => {
             if is_dotnet {
                 "xna_fna"

--- a/configs/mtsp-roadmap.md
+++ b/configs/mtsp-roadmap.md
@@ -39,9 +39,7 @@ TOML, not Rust code.
 |---|---|---|---|
 | M11 | DXMT D3D11 → Metal | dxmt | Primary pipeline for D3D11 games |
 | M12 | DXMT D3D12 → Metal | dxmt | WIP — compute works, graphics PSO in progress |
-| M9 | D3D9 → Metal (custom) | d3d9-metal | Custom via MojoShader, experimental |
-| M9Gl | WineD3D D3D9 → OpenGL | wined3d | CPU fallback |
-| M32Vk | DXVK D3D9 → MoltenVK | dxvk | 32-bit Vulkan translation |
+| M9 | D3D9 → Metal | dxmt | Primary D3D9 path under the DXMT launch family |
 | M32W | WineD3D 32-bit | wined3d | Without Vulkan |
 | M64 | Bare Wine 64-bit | wine | No translation layer |
 | Steam | Steam Native | steam | macOS native |

--- a/docs/GAMES-SUPPORTED.md
+++ b/docs/GAMES-SUPPORTED.md
@@ -13,7 +13,7 @@ Games were tested from an external 1TB M.2 SSD, roughly 5000 MB/s read/write ove
 | **M11** | D3D11 to Metal via DXMT |
 | **M12** | D3D12 to Metal via DXMT |
 | **M10** | D3D10 to Metal via DXMT |
-| **M9** | D3D9 via DXVK/MoltenVK |
+| **M9** | D3D9 via DXMT launch family |
 | **M32** | 32-bit Wine fallback |
 | **Native macOS** | FNA/XNA/Mono ARM64 native runtime |
 | **Steam** | Wine Steam |

--- a/docs/dxmt-vulkan-architecture.md
+++ b/docs/dxmt-vulkan-architecture.md
@@ -2,8 +2,8 @@
 
 MetalSharp has two graphics translation families:
 
-- **DXMT**: D3D10/D3D11/D3D12 to Metal
-- **DXVK + MoltenVK**: D3D9 to Vulkan to Metal
+- **DXMT launch family**: M9/M10/M11/M12 to Metal
+- **DXVK + MoltenVK**: Legacy fallback assets only; no longer selected by M9
 
 ## Pipeline Map
 
@@ -12,14 +12,14 @@ MetalSharp has two graphics translation families:
 | **M12** | D3D12 -> DXMT -> Metal |
 | **M11** | D3D11 -> DXMT -> Metal |
 | **M10** | D3D10 -> DXMT -> Metal |
-| **M9** | D3D9 -> DXVK -> MoltenVK -> Metal |
+| **M9** | D3D9 -> MetalSharp D3D9 -> DXMT launch family -> Metal |
 | **M32** | 32-bit Wine fallback |
 
 ## DXMT
 
-DXMT is used by M12, M11, and M10.
+The DXMT launch family is used by M12, M11, M10, and M9.
 
-DXMT DLLs:
+DXMT-family DLLs:
 
 | DLL | Used by |
 |---|---|
@@ -28,6 +28,7 @@ DXMT DLLs:
 | `dxgi.dll` | M12, M11, M10 |
 | `d3d10core.dll` | M12, M11, M10 |
 | `winemetal.dll` | M12, M11, M10 |
+| `d3d9.dll` | M9 |
 | `winemetal.so` | Unix Metal bridge |
 
 Basic flow:
@@ -47,30 +48,23 @@ DXMT uses per-game shader caches under:
 ~/.metalsharp/shader-cache/dxmt-metal12/<appid>/
 ```
 
-## DXVK + MoltenVK
+## M9 D3D9
 
-M9 uses DXVK 1.10.3 for D3D9.
+M9 does not select DXVK/MoltenVK. The pipeline deploys the D3D9 DLL from the bundled Wine runtime and uses the same DXMT launch/cache environment family as the other Metal pipelines.
 
 Basic flow:
 
 ```text
 Game
-  -> d3d9.dll from DXVK
-  -> Vulkan
-  -> MoltenVK
+  -> d3d9.dll
+  -> Wine / MetalSharp D3D9 handoff
   -> Metal
 ```
 
 M9 cache path:
 
 ```text
-~/.metalsharp/shader-cache/dxvk-metal9/<appid>/
-```
-
-MoltenVK ICD:
-
-```text
-~/.metalsharp/runtime/wine/etc/vulkan/icd.d/MoltenVK_icd.json
+~/.metalsharp/shader-cache/m9/<appid>/
 ```
 
 ## Current Game Notes
@@ -92,6 +86,6 @@ MoltenVK ICD:
 ## Notes
 
 - DXMT is the direct Metal path.
-- M9 has an extra Vulkan/MoltenVK hop.
+- M9 no longer has a Vulkan/MoltenVK hop in MTSP selection.
 - M12 is still marked experimental in source.
 - M32 is the fallback for 32-bit Wine cases.

--- a/docs/launch-architecture.md
+++ b/docs/launch-architecture.md
@@ -19,7 +19,7 @@ Play clicked
 | **M11** | DXMT | Direct Wine launch with D3D11/DXGI DXMT DLLs |
 | **M12** | DXMT | Direct Wine launch with D3D12/D3D11/DXGI DXMT DLLs |
 | **M10** | DXMT | Direct Wine launch with D3D10/D3D11/DXGI DXMT DLLs |
-| **M9** | DXVK/MoltenVK | Direct Wine launch with DXVK `d3d9.dll` |
+| **M9** | DXMT launch family | Direct Wine launch with bundled `d3d9.dll` and DXMT-family cache/env |
 | **M32** | Wine32 | 32-bit Wine fallback |
 | **Native macOS** | Mono/FNA | Native FNA/XNA/Mono runtime |
 | **Steam** | Wine Steam | Launch through Windows Steam in the Wine prefix |
@@ -31,9 +31,10 @@ Play clicked
 The resolver checks, in order:
 
 1. `configs/mtsp-rules.toml`
-2. Installed game directory markers
+2. Managed .NET/FNA eligibility
 3. PE header analysis
-4. M11 fallback
+4. Installed game directory markers
+5. M11 fallback
 
 Common marker behavior:
 
@@ -63,6 +64,8 @@ M12 also copies:
 M9 copies:
 
 - `d3d9.dll`
+
+M9 no longer accepts the legacy `dxvk_metal32`, `m9_gl`, or `m32_vk` aliases. D3D9 imports resolve to `[m9]`, and `[m9]` stays on the DXMT-family launch path instead of selecting DXVK/MoltenVK.
 
 Native macOS does not use Wine. Steam and MacOS Steam are separate paths.
 

--- a/docs/m9-pipeline-map.md
+++ b/docs/m9-pipeline-map.md
@@ -1,0 +1,37 @@
+# M9 Pipeline Map
+
+M9 is the D3D9 engine path. It now uses the same DXMT-family launcher, cache, and Metal handoff conventions as M10, M11, and M12 instead of selecting the old DXVK/MoltenVK labels.
+
+## Runtime Shape
+
+```text
+D3D9 game
+  -> Wine
+  -> bundled d3d9.dll
+  -> MetalSharp D3D9 / Wine handoff
+  -> DXMT-family launch environment
+  -> Metal
+```
+
+The current DXMT source tree provides D3D10, D3D11, D3D12, DXGI, and winemetal targets. It does not ship a separate DXMT `d3d9.dll`, so M9 keeps the D3D9 DLL boundary at the bundled Wine/MetalSharp D3D9 handoff while removing DXVK/MoltenVK selection from MTSP.
+
+## Engine Contract
+
+| Field | Value |
+|---|---|
+| Pipeline | `M9` |
+| Backend | `dxmt` |
+| Launch args | `-dx9` |
+| Wine overrides | `d3d9=n,b;gameoverlayrenderer,gameoverlayrenderer64=d` |
+| Shader cache subdir | `m9` |
+| Preset fallback family | `m9`, then `dxmt-metal` |
+
+M9 deploys:
+
+- `d3d9.dll`
+
+M9 does not deploy from `lib/dxvk`, does not set DXVK cache variables, and does not require a MoltenVK ICD in the MTSP launch path.
+
+## Selection Rules
+
+D3D9 PE imports resolve to `[m9]`. Legacy M9 variants such as `dxvk_metal32`, `m9_gl`, and `m32_vk` are no longer accepted as M9 aliases.

--- a/docs/wine-architecture.md
+++ b/docs/wine-architecture.md
@@ -25,8 +25,6 @@ It is used by M11, M12, M10, M9, M32, Steam, and Wine. Native macOS and MacOS St
 │   ├── dxmt/
 │   │   ├── x86_64-unix/
 │   │   └── x86_64-windows/
-│   └── dxvk/
-│       └── i386-windows/
 └── etc/
     ├── dxmt.conf
     └── vulkan/icd.d/MoltenVK_icd.json
@@ -49,7 +47,7 @@ Other runtime pieces live beside it:
 | M11 | Wine + DXMT D3D11/DXGI |
 | M12 | Wine + DXMT D3D12/D3D11/DXGI |
 | M10 | Wine + DXMT D3D10/D3D11/DXGI |
-| M9 | Wine + DXVK D3D9 + MoltenVK |
+| M9 | Wine + D3D9 Metal under the DXMT launch family |
 | M32 | Wine 32-bit fallback |
 | Steam | Wine Steam prefix |
 | Wine | Plain Wine |
@@ -109,8 +107,6 @@ Some prepared games can also use app-specific prefixes:
 | `WINEDLLOVERRIDES` | Selects injected/native DLL behavior |
 | `DXMT_SHADER_CACHE_PATH` | DXMT shader cache |
 | `DXMT_CONFIG_FILE` | DXMT config file |
-| `VK_ICD_FILENAMES` | MoltenVK ICD for M9 |
-| `DXVK_STATE_CACHE_PATH` | DXVK cache for M9 |
 
 ## Steam Wrapper
 


### PR DESCRIPTION
## Summary
- route M9 as a DXMT-family backend with DXMT cache/env handling instead of the old DXVK/MoltenVK path
- deploy M9 d3d9.dll from the bundled Wine/MetalSharp handoff and prevent lib/dxvk deploy/env selection
- remove legacy M9 aliases for dxvk_metal32, m9_gl, and m32_vk so [m9] is the only M9 tree
- resolve D3D9 PE imports before broad directory heuristics and document the M9 pipeline map

## Notes
- The AverySSD DXMT source tree has D3D10/D3D11/D3D12/DXGI/winemetal targets, but no separate DXMT d3d9.dll target. This PR keeps M9's D3D9 DLL boundary on the bundled Wine/MetalSharp D3D9 handoff while removing DXVK/MoltenVK from MTSP selection.

## Validation
- cargo fmt --all -- --check
- cargo test
- cargo clippy --all-targets -- -D warnings
- cmake --build build
- ctest --test-dir build --output-on-failure
- npm run build
- npx biome check src/
- git diff --check
- git diff --cached --check