### PR TITLE
[codex] Fix DOOM Eternal Steam launch

### DIFF
--- a/app/src-rust/src/launch.rs
+++ b/app/src-rust/src/launch.rs
@@ -52,26 +52,21 @@ pub fn launch_via_steam_with_env(
     let prefix = home.join(".metalsharp").join("prefix-steam");
     let prefix_str = prefix.to_string_lossy().to_string();
 
-    if extra_env.is_empty() {
-        if !crate::steam::is_wine_steam_running() {
+    crate::steam::ensure_game_launch_options(appid)?;
+    crate::steam::kill_known_game_processes(appid);
+
+    if !crate::steam::is_wine_steam_running() {
+        if extra_env.is_empty() {
             crate::steam::launch_wine_steam()?;
-            for _ in 0..30 {
-                std::thread::sleep(std::time::Duration::from_secs(2));
-                if crate::steam::is_wine_steam_running() {
-                    break;
-                }
-            }
-            std::thread::sleep(std::time::Duration::from_secs(5));
+        } else {
+            crate::steam::launch_wine_steam_with_env(extra_env)?;
         }
-    } else {
-        crate::steam::launch_wine_steam_with_env(extra_env)?;
-        for _ in 0..30 {
-            std::thread::sleep(std::time::Duration::from_secs(2));
+        for _ in 0..12 {
+            std::thread::sleep(std::time::Duration::from_secs(1));
             if crate::steam::is_wine_steam_running() {
                 break;
             }
         }
-        std::thread::sleep(std::time::Duration::from_secs(5));
     }
 
     let url = format!("steam://run/{}", appid);

--- a/app/src-rust/src/launch.rs
+++ b/app/src-rust/src/launch.rs
@@ -159,6 +159,7 @@ pub fn is_process_active(pid: i32) -> bool {
 }
 
 fn spawn_and_reap(mut cmd: Command) -> Result<u32, Box<dyn std::error::Error>> {
+    detach_process_group(&mut cmd);
     let mut child = cmd.spawn()?;
     let pid = child.id();
     std::thread::spawn(move || {
@@ -166,6 +167,15 @@ fn spawn_and_reap(mut cmd: Command) -> Result<u32, Box<dyn std::error::Error>> {
     });
     Ok(pid)
 }
+
+#[cfg(unix)]
+fn detach_process_group(cmd: &mut Command) {
+    use std::os::unix::process::CommandExt;
+    cmd.process_group(0);
+}
+
+#[cfg(not(unix))]
+fn detach_process_group(_cmd: &mut Command) {}
 
 pub fn get_config() -> Value {
     let native_available = find_metalsharp_native().is_ok();

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -4,6 +4,7 @@ use std::net::TcpStream;
 use std::path::PathBuf;
 use std::process::Command;
 use std::time::Duration;
+use walkdir::WalkDir;
 
 static BRIDGE_PORT: u16 = 18733;
 
@@ -255,12 +256,7 @@ fn launch_wine_bare(appid: u32, node: &PipelineNode) -> Result<(u32, &'static st
 }
 
 fn launch_steam(appid: u32) -> Result<(u32, &'static str), Box<dyn std::error::Error>> {
-    let home = dirs::home_dir().ok_or("no home dir")?;
-    let ms_root = home.join(".metalsharp").join("runtime").join("wine");
-    let node = get_pipeline(PipelineId::Steam);
-    let cache_paths = build_cache_paths(&home, node, appid);
-    let env = cache_env_pairs(node, cache_paths.as_ref(), &ms_root);
-    let pid = crate::launch::launch_via_steam_with_env(appid, &env)?;
+    let pid = crate::launch::launch_via_steam_with_env(appid, &[])?;
     Ok((pid, "steam"))
 }
 
@@ -410,22 +406,66 @@ fn cache_env_pairs(node: &PipelineNode, cache_paths: Option<&CachePaths>, ms_roo
 }
 
 fn resolve_game_exe(game_dir: &PathBuf) -> String {
-    if let Ok(entries) = std::fs::read_dir(game_dir) {
-        for entry in entries.flatten() {
-            let name = entry.file_name().to_string_lossy().to_lowercase();
-            if name.ends_with(".exe")
-                && !name.contains("setup")
-                && !name.contains("redist")
-                && !name.contains("uninstall")
-                && !name.contains("vcredist")
-                && !name.contains("installer")
-                && !name.contains("crashhandler")
-            {
-                return entry.path().to_string_lossy().to_string();
-            }
-        }
+    preferred_game_exe(game_dir).unwrap_or_else(|| game_dir.clone()).to_string_lossy().to_string()
+}
+
+fn preferred_game_exe(game_dir: &PathBuf) -> Option<PathBuf> {
+    let mut candidates: Vec<PathBuf> = WalkDir::new(game_dir)
+        .max_depth(3)
+        .into_iter()
+        .flatten()
+        .filter(|entry| entry.file_type().is_file())
+        .map(|entry| entry.into_path())
+        .filter(|path| path.extension().map(|ext| ext.to_string_lossy().eq_ignore_ascii_case("exe")).unwrap_or(false))
+        .collect();
+
+    candidates.sort_by_key(|path| executable_score(game_dir, path));
+    candidates.into_iter().next()
+}
+
+fn executable_score(game_dir: &PathBuf, path: &PathBuf) -> i32 {
+    let name = path.file_name().map(|n| n.to_string_lossy().to_lowercase()).unwrap_or_default();
+    let rel_depth = path.strip_prefix(game_dir).map(|p| p.components().count()).unwrap_or(10) as i32;
+    let parent_has_launcher = path
+        .parent()
+        .and_then(|p| p.file_name())
+        .map(|n| n.to_string_lossy().to_lowercase().contains("launcher"))
+        .unwrap_or(false);
+
+    let mut score = rel_depth * 10;
+    let directory_token = game_dir
+        .file_name()
+        .map(|n| n.to_string_lossy().chars().filter(|c| c.is_ascii_alphanumeric()).collect::<String>().to_lowercase())
+        .unwrap_or_default();
+    let name_token = name.chars().filter(|c| c.is_ascii_alphanumeric()).collect::<String>();
+
+    if !directory_token.is_empty() && name_token.contains(&directory_token) {
+        score -= 100;
     }
-    game_dir.to_string_lossy().to_string()
+    if name.contains("x64") || name.contains("win64") || name.contains("64") {
+        score -= 25;
+    }
+    if name.contains("shipping") {
+        score -= 10;
+    }
+
+    if parent_has_launcher || name.contains("launcher") {
+        score += 500;
+    }
+    if name.contains("sandbox") {
+        score += 100;
+    }
+    if name.contains("setup")
+        || name.contains("redist")
+        || name.contains("uninstall")
+        || name.contains("vcredist")
+        || name.contains("installer")
+        || name.contains("crashhandler")
+    {
+        score += 1000;
+    }
+
+    score
 }
 
 fn find_config(name: &str) -> String {
@@ -893,6 +933,33 @@ mod tests {
 
         assert_eq!(selected.len(), 1);
         assert_eq!(selected[0].source_subpath, "lib/wine/i386-windows");
+        let _ = std::fs::remove_dir_all(game_dir);
+    }
+
+    #[test]
+    fn executable_selection_prefers_real_doom_binary_over_launcher() {
+        let game_dir = test_game_dir("doom-exe");
+        let launcher_dir = game_dir.join("launcher");
+        std::fs::create_dir_all(&launcher_dir).expect("create launcher dir");
+        std::fs::write(game_dir.join("DOOM Launcher.exe"), []).expect("write launcher");
+        std::fs::write(launcher_dir.join("idTechLauncher.exe"), []).expect("write nested launcher");
+        std::fs::write(game_dir.join("DOOMEternalx64vk.exe"), []).expect("write game exe");
+
+        let selected = preferred_game_exe(&game_dir).expect("select exe");
+
+        assert_eq!(selected.file_name().and_then(|n| n.to_str()), Some("DOOMEternalx64vk.exe"));
+        let _ = std::fs::remove_dir_all(game_dir);
+    }
+
+    #[test]
+    fn executable_selection_can_fall_back_to_launcher_when_it_is_the_only_exe() {
+        let game_dir = test_game_dir("launcher-only");
+        std::fs::create_dir_all(&game_dir).expect("create test game dir");
+        std::fs::write(game_dir.join("Game Launcher.exe"), []).expect("write launcher");
+
+        let selected = preferred_game_exe(&game_dir).expect("select exe");
+
+        assert_eq!(selected.file_name().and_then(|n| n.to_str()), Some("Game Launcher.exe"));
         let _ = std::fs::remove_dir_all(game_dir);
     }
 

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -188,8 +188,8 @@ fn launch_dxmt_metal(appid: u32, node: &PipelineNode) -> Result<(u32, &'static s
     let game_dir = crate::setup::resolve_game_dir(appid).ok_or("game dir not found")?;
     let prefix = home.join(".metalsharp").join("prefix-steam");
     let prefix_str = prefix.to_string_lossy().to_string();
-    let exe = resolve_game_exe(&game_dir);
-    let exe_name = std::path::Path::new(&exe).file_name().unwrap_or_default().to_string_lossy().to_string();
+    let exe = resolve_pipeline_exe(appid, &game_dir, node);
+    let exe_arg = launch_arg_for_exe(&game_dir, &exe);
 
     deploy_dlls_for_pipeline(&game_dir, node);
 
@@ -214,7 +214,7 @@ fn launch_dxmt_metal(appid: u32, node: &PipelineNode) -> Result<(u32, &'static s
         cmd.env(ev.key, ev.value);
     }
 
-    cmd.arg(&exe_name);
+    cmd.arg(&exe_arg);
     cmd.args(&node.launch_args);
     let child = cmd.spawn()?;
     Ok((child.id(), node.id.to_legacy_method()))
@@ -232,8 +232,8 @@ fn launch_wine_bare(appid: u32, node: &PipelineNode) -> Result<(u32, &'static st
     let game_dir = crate::setup::resolve_game_dir(appid).ok_or("game dir not found")?;
     let prefix = home.join(".metalsharp").join("prefix-steam");
     let prefix_str = prefix.to_string_lossy().to_string();
-    let exe = resolve_game_exe(&game_dir);
-    let exe_name = std::path::Path::new(&exe).file_name().unwrap_or_default().to_string_lossy().to_string();
+    let exe = resolve_pipeline_exe(appid, &game_dir, node);
+    let exe_arg = launch_arg_for_exe(&game_dir, &exe);
 
     let dyld_path = build_dyld(&ms_root, &node.dyld_paths);
     let runtime_lib_key =
@@ -249,7 +249,7 @@ fn launch_wine_bare(appid: u32, node: &PipelineNode) -> Result<(u32, &'static st
     let cache_paths = build_cache_paths(&home, node, appid);
     apply_cache_env(&mut cmd, node, cache_paths.as_ref(), &ms_root);
 
-    cmd.arg(&exe_name);
+    cmd.arg(&exe_arg);
     cmd.args(&node.launch_args);
     let child = cmd.spawn()?;
     Ok((child.id(), node.id.to_legacy_method()))
@@ -403,6 +403,25 @@ fn cache_env_pairs(node: &PipelineNode, cache_paths: Option<&CachePaths>, ms_roo
     }
 
     env
+}
+
+fn resolve_pipeline_exe(appid: u32, game_dir: &PathBuf, node: &PipelineNode) -> PathBuf {
+    if appid == 782330 && node.id == PipelineId::M11 {
+        let launcher = game_dir.join("launcher").join("idTechLauncher.exe");
+        if launcher.exists() {
+            return launcher;
+        }
+    }
+
+    PathBuf::from(resolve_game_exe(game_dir))
+}
+
+fn launch_arg_for_exe(game_dir: &PathBuf, exe: &PathBuf) -> String {
+    if exe.parent() == Some(game_dir.as_path()) {
+        return exe.file_name().unwrap_or_default().to_string_lossy().to_string();
+    }
+
+    exe.to_string_lossy().to_string()
 }
 
 fn resolve_game_exe(game_dir: &PathBuf) -> String {
@@ -948,6 +967,21 @@ mod tests {
         let selected = preferred_game_exe(&game_dir).expect("select exe");
 
         assert_eq!(selected.file_name().and_then(|n| n.to_str()), Some("DOOMEternalx64vk.exe"));
+        let _ = std::fs::remove_dir_all(game_dir);
+    }
+
+    #[test]
+    fn doom_eternal_m11_uses_idtech_launcher_handoff() {
+        let game_dir = test_game_dir("doom-m11-launcher");
+        let launcher_dir = game_dir.join("launcher");
+        std::fs::create_dir_all(&launcher_dir).expect("create launcher dir");
+        std::fs::write(launcher_dir.join("idTechLauncher.exe"), []).expect("write launcher");
+        std::fs::write(game_dir.join("DOOMEternalx64vk.exe"), []).expect("write game exe");
+
+        let selected = resolve_pipeline_exe(782330, &game_dir, get_pipeline(PipelineId::M11));
+
+        assert_eq!(selected.file_name().and_then(|n| n.to_str()), Some("idTechLauncher.exe"));
+        assert_eq!(launch_arg_for_exe(&game_dir, &selected), selected.to_string_lossy());
         let _ = std::fs::remove_dir_all(game_dir);
     }
 

--- a/app/src-rust/src/mtsp/rules.rs
+++ b/app/src-rust/src/mtsp/rules.rs
@@ -10,8 +10,6 @@ fn load_rules() -> &'static std::collections::HashMap<u32, PipelineId> {
         let home = dirs::home_dir().unwrap_or_default();
 
         let mut candidates = vec![
-            home.join("metalsharp").join("configs").join("mtsp-rules.toml"),
-            home.join(".metalsharp").join("configs").join("mtsp-rules.toml"),
             home.join("repos").join("metalsharp").join("configs").join("mtsp-rules.toml"),
             PathBuf::from("configs/mtsp-rules.toml"),
         ];
@@ -27,6 +25,9 @@ fn load_rules() -> &'static std::collections::HashMap<u32, PipelineId> {
                 }
             }
         }
+
+        candidates.push(home.join("metalsharp").join("configs").join("mtsp-rules.toml"));
+        candidates.push(home.join(".metalsharp").join("configs").join("mtsp-rules.toml"));
 
         for path in &candidates {
             if path.exists() {

--- a/app/src-rust/src/steam.rs
+++ b/app/src-rust/src/steam.rs
@@ -261,10 +261,20 @@ fn spawn_wine_steam_with_env(args: &[&str], extra_env: &[(String, String)]) -> R
         cmd.env(key, val);
     }
 
+    detach_process_group(&mut cmd);
     let child = cmd.spawn()?;
 
     Ok(child.id())
 }
+
+#[cfg(unix)]
+fn detach_process_group(cmd: &mut Command) {
+    use std::os::unix::process::CommandExt;
+    cmd.process_group(0);
+}
+
+#[cfg(not(unix))]
+fn detach_process_group(_cmd: &mut Command) {}
 
 pub fn launch_wine_steam() -> Result<Value, Box<dyn std::error::Error>> {
     launch_wine_steam_with_env(&[])
@@ -464,127 +474,54 @@ pub fn launch_game_via_steam(appid: u32) -> Result<Value, Box<dyn std::error::Er
 }
 
 pub fn kill_known_game_processes(appid: u32) {
-    let patterns: &[&str] = match appid {
-        782330 => &["idTechLauncher.exe", "DOOMEternalx64vk.exe", "DOOMSandBox64vk.exe"],
-        _ => &[],
-    };
+    let patterns = known_game_process_patterns(appid);
+    if patterns.is_empty() {
+        return;
+    }
 
-    for pattern in patterns {
+    let this_pid = std::process::id();
+    let pids: Vec<u32> = process_lines()
+        .iter()
+        .filter_map(|line| parse_process_line(line))
+        .filter_map(|(pid, command)| {
+            if pid == this_pid || is_process_search_command(command) {
+                return None;
+            }
+            patterns.iter().any(|pattern| command.contains(pattern)).then_some(pid)
+        })
+        .collect();
+
+    for pid in pids {
         let _ = Command::new("pkill")
-            .args(["-f", pattern])
+            .args(["-9", "-P", &pid.to_string()])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+        let _ = Command::new("kill")
+            .args(["-9", &pid.to_string()])
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .status();
     }
 }
 
-pub fn ensure_game_launch_options(appid: u32) -> Result<(), Box<dyn std::error::Error>> {
-    let Some(options) = required_launch_options(appid) else {
-        return Ok(());
-    };
-
-    let userdata = steam_prefix().join("drive_c").join("Program Files (x86)").join("Steam").join("userdata");
-    if !userdata.exists() {
-        return Ok(());
-    }
-
-    for entry in std::fs::read_dir(userdata)?.flatten() {
-        let localconfig = entry.path().join("config").join("localconfig.vdf");
-        if localconfig.exists() {
-            upsert_app_launch_options(&localconfig, appid, &options)?;
-        }
-    }
-
-    Ok(())
-}
-
-fn required_launch_options(appid: u32) -> Option<String> {
+fn known_game_process_patterns(appid: u32) -> &'static [&'static str] {
     match appid {
-        782330 => {
-            let game_dir = crate::setup::resolve_game_dir(appid)?;
-            let exe = game_dir.join("DOOMEternalx64vk.exe");
-            if !exe.exists() {
-                return None;
-            }
-            let exe_path = windows_z_path(&exe);
-            Some(format!("\"{}\" %COMMAND% +com_skipIntroVideo 1", exe_path))
-        },
-        _ => None,
+        782330 => &["idTechLauncher.exe", "DOOMEternalx64vk.exe", "DOOMSandBox64vk.exe"],
+        _ => &[],
     }
 }
 
-fn windows_z_path(path: &Path) -> String {
-    let unix_path = path.to_string_lossy().replace('/', "\\");
-    if unix_path.starts_with('\\') {
-        format!("Z:{}", unix_path)
-    } else {
-        unix_path
-    }
+fn is_process_search_command(command: &str) -> bool {
+    command.contains(" rg ")
+        || command.contains("rg -i")
+        || command.contains("ps axo")
+        || command.contains("pkill")
+        || command.contains("pgrep")
 }
 
-fn upsert_app_launch_options(path: &Path, appid: u32, options: &str) -> Result<(), Box<dyn std::error::Error>> {
-    let original = std::fs::read_to_string(path)?;
-    let appid_line = format!("\"{}\"", appid);
-    let escaped_options = escape_vdf_value(options);
-    let option_line = format!("\t\t\t\t\t\t\t\"LaunchOptions\"\t\t\"{}\"", escaped_options);
-    let mut lines: Vec<String> = original.lines().map(|line| line.to_string()).collect();
-
-    let Some(appid_idx) = lines.iter().position(|line| line.trim() == appid_line) else {
-        return Ok(());
-    };
-
-    let Some(open_idx) =
-        lines.iter().enumerate().skip(appid_idx + 1).find_map(
-            |(idx, line)| {
-                if line.trim() == "{" {
-                    Some(idx)
-                } else {
-                    None
-                }
-            },
-        )
-    else {
-        return Ok(());
-    };
-
-    let mut depth = 0_i32;
-    let mut launch_idx = None;
-    let mut close_idx = None;
-    for (idx, line) in lines.iter().enumerate().skip(open_idx) {
-        match line.trim() {
-            "{" => depth += 1,
-            "}" => {
-                depth -= 1;
-                if depth == 0 {
-                    close_idx = Some(idx);
-                    break;
-                }
-            },
-            trimmed if depth == 1 && trimmed.starts_with("\"LaunchOptions\"") => {
-                launch_idx = Some(idx);
-            },
-            _ => {},
-        }
-    }
-
-    if let Some(idx) = launch_idx {
-        if lines[idx] != option_line {
-            lines[idx] = option_line;
-        }
-    } else if let Some(idx) = close_idx {
-        lines.insert(idx, option_line);
-    }
-
-    let updated = format!("{}\n", lines.join("\n"));
-    if updated != original {
-        std::fs::write(path, updated)?;
-    }
-
+pub fn ensure_game_launch_options(_appid: u32) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
-}
-
-fn escape_vdf_value(value: &str) -> String {
-    value.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
 pub fn view_game_in_steam(appid: u32) -> Result<Value, Box<dyn std::error::Error>> {
@@ -1379,40 +1316,5 @@ mod tests {
         assert!(!is_macos_steam_cleanup_command(
             "/bin/zsh -lc ps axo pid=,command= | rg -i \"Steam.app|steam_osx|ipcserver\"",
         ));
-    }
-
-    #[test]
-    fn windows_z_path_maps_unix_paths_for_wine_steam() {
-        assert_eq!(
-            windows_z_path(Path::new(
-                "/Volumes/AverySSD/SteamLibrary/steamapps/common/DOOMEternal/DOOMEternalx64vk.exe"
-            )),
-            "Z:\\Volumes\\AverySSD\\SteamLibrary\\steamapps\\common\\DOOMEternal\\DOOMEternalx64vk.exe"
-        );
-    }
-
-    #[test]
-    fn upsert_app_launch_options_updates_existing_app_block() {
-        let dir = std::env::temp_dir().join(format!("metalsharp-localconfig-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).expect("create temp dir");
-        let path = dir.join("localconfig.vdf");
-        std::fs::write(
-            &path,
-            "\"UserLocalConfigStore\"\n{\n\t\"Software\"\n\t{\n\t\t\"Valve\"\n\t\t{\n\t\t\t\"Steam\"\n\t\t\t{\n\t\t\t\t\"apps\"\n\t\t\t\t{\n\t\t\t\t\t\"782330\"\n\t\t\t\t\t{\n\t\t\t\t\t\t\"LaunchOptions\"\t\t\"-dx12\"\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n}\n",
-        )
-        .expect("write localconfig");
-
-        upsert_app_launch_options(
-            &path,
-            782330,
-            "\"Z:\\Volumes\\AverySSD\\SteamLibrary\\steamapps\\common\\DOOMEternal\\DOOMEternalx64vk.exe\" %COMMAND%",
-        )
-        .expect("upsert launch options");
-
-        let updated = std::fs::read_to_string(&path).expect("read updated localconfig");
-        assert!(updated.contains(
-            "\"LaunchOptions\"\t\t\"\\\"Z:\\\\Volumes\\\\AverySSD\\\\SteamLibrary\\\\steamapps\\\\common\\\\DOOMEternal\\\\DOOMEternalx64vk.exe\\\" %COMMAND%\""
-        ));
-        let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/app/src-rust/src/steam.rs
+++ b/app/src-rust/src/steam.rs
@@ -445,21 +445,146 @@ pub fn launch_game_via_steam(appid: u32) -> Result<Value, Box<dyn std::error::Er
     if !wine.exists() {
         return Err("MetalSharp Wine not found".into());
     }
+    ensure_game_launch_options(appid)?;
+    kill_known_game_processes(appid);
     if !is_wine_steam_running() {
         launch_wine_steam()?;
-        for _ in 0..30 {
-            std::thread::sleep(std::time::Duration::from_secs(2));
+        for _ in 0..12 {
+            std::thread::sleep(std::time::Duration::from_secs(1));
             if is_wine_steam_running() {
                 break;
             }
         }
-        std::thread::sleep(std::time::Duration::from_secs(5));
     }
 
     let url = format!("steam://run/{}", appid);
     let pid = spawn_wine_steam(&[&url])?;
 
     Ok(json!({"ok": true, "pid": pid, "appid": appid}))
+}
+
+pub fn kill_known_game_processes(appid: u32) {
+    let patterns: &[&str] = match appid {
+        782330 => &["idTechLauncher.exe", "DOOMEternalx64vk.exe", "DOOMSandBox64vk.exe"],
+        _ => &[],
+    };
+
+    for pattern in patterns {
+        let _ = Command::new("pkill")
+            .args(["-f", pattern])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+    }
+}
+
+pub fn ensure_game_launch_options(appid: u32) -> Result<(), Box<dyn std::error::Error>> {
+    let Some(options) = required_launch_options(appid) else {
+        return Ok(());
+    };
+
+    let userdata = steam_prefix().join("drive_c").join("Program Files (x86)").join("Steam").join("userdata");
+    if !userdata.exists() {
+        return Ok(());
+    }
+
+    for entry in std::fs::read_dir(userdata)?.flatten() {
+        let localconfig = entry.path().join("config").join("localconfig.vdf");
+        if localconfig.exists() {
+            upsert_app_launch_options(&localconfig, appid, &options)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn required_launch_options(appid: u32) -> Option<String> {
+    match appid {
+        782330 => {
+            let game_dir = crate::setup::resolve_game_dir(appid)?;
+            let exe = game_dir.join("DOOMEternalx64vk.exe");
+            if !exe.exists() {
+                return None;
+            }
+            let exe_path = windows_z_path(&exe);
+            Some(format!("\"{}\" %COMMAND% +com_skipIntroVideo 1", exe_path))
+        },
+        _ => None,
+    }
+}
+
+fn windows_z_path(path: &Path) -> String {
+    let unix_path = path.to_string_lossy().replace('/', "\\");
+    if unix_path.starts_with('\\') {
+        format!("Z:{}", unix_path)
+    } else {
+        unix_path
+    }
+}
+
+fn upsert_app_launch_options(path: &Path, appid: u32, options: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let original = std::fs::read_to_string(path)?;
+    let appid_line = format!("\"{}\"", appid);
+    let escaped_options = escape_vdf_value(options);
+    let option_line = format!("\t\t\t\t\t\t\t\"LaunchOptions\"\t\t\"{}\"", escaped_options);
+    let mut lines: Vec<String> = original.lines().map(|line| line.to_string()).collect();
+
+    let Some(appid_idx) = lines.iter().position(|line| line.trim() == appid_line) else {
+        return Ok(());
+    };
+
+    let Some(open_idx) =
+        lines.iter().enumerate().skip(appid_idx + 1).find_map(
+            |(idx, line)| {
+                if line.trim() == "{" {
+                    Some(idx)
+                } else {
+                    None
+                }
+            },
+        )
+    else {
+        return Ok(());
+    };
+
+    let mut depth = 0_i32;
+    let mut launch_idx = None;
+    let mut close_idx = None;
+    for (idx, line) in lines.iter().enumerate().skip(open_idx) {
+        match line.trim() {
+            "{" => depth += 1,
+            "}" => {
+                depth -= 1;
+                if depth == 0 {
+                    close_idx = Some(idx);
+                    break;
+                }
+            },
+            trimmed if depth == 1 && trimmed.starts_with("\"LaunchOptions\"") => {
+                launch_idx = Some(idx);
+            },
+            _ => {},
+        }
+    }
+
+    if let Some(idx) = launch_idx {
+        if lines[idx] != option_line {
+            lines[idx] = option_line;
+        }
+    } else if let Some(idx) = close_idx {
+        lines.insert(idx, option_line);
+    }
+
+    let updated = format!("{}\n", lines.join("\n"));
+    if updated != original {
+        std::fs::write(path, updated)?;
+    }
+
+    Ok(())
+}
+
+fn escape_vdf_value(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
 pub fn view_game_in_steam(appid: u32) -> Result<Value, Box<dyn std::error::Error>> {
@@ -1254,5 +1379,40 @@ mod tests {
         assert!(!is_macos_steam_cleanup_command(
             "/bin/zsh -lc ps axo pid=,command= | rg -i \"Steam.app|steam_osx|ipcserver\"",
         ));
+    }
+
+    #[test]
+    fn windows_z_path_maps_unix_paths_for_wine_steam() {
+        assert_eq!(
+            windows_z_path(Path::new(
+                "/Volumes/AverySSD/SteamLibrary/steamapps/common/DOOMEternal/DOOMEternalx64vk.exe"
+            )),
+            "Z:\\Volumes\\AverySSD\\SteamLibrary\\steamapps\\common\\DOOMEternal\\DOOMEternalx64vk.exe"
+        );
+    }
+
+    #[test]
+    fn upsert_app_launch_options_updates_existing_app_block() {
+        let dir = std::env::temp_dir().join(format!("metalsharp-localconfig-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let path = dir.join("localconfig.vdf");
+        std::fs::write(
+            &path,
+            "\"UserLocalConfigStore\"\n{\n\t\"Software\"\n\t{\n\t\t\"Valve\"\n\t\t{\n\t\t\t\"Steam\"\n\t\t\t{\n\t\t\t\t\"apps\"\n\t\t\t\t{\n\t\t\t\t\t\"782330\"\n\t\t\t\t\t{\n\t\t\t\t\t\t\"LaunchOptions\"\t\t\"-dx12\"\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n}\n",
+        )
+        .expect("write localconfig");
+
+        upsert_app_launch_options(
+            &path,
+            782330,
+            "\"Z:\\Volumes\\AverySSD\\SteamLibrary\\steamapps\\common\\DOOMEternal\\DOOMEternalx64vk.exe\" %COMMAND%",
+        )
+        .expect("upsert launch options");
+
+        let updated = std::fs::read_to_string(&path).expect("read updated localconfig");
+        assert!(updated.contains(
+            "\"LaunchOptions\"\t\t\"\\\"Z:\\\\Volumes\\\\AverySSD\\\\SteamLibrary\\\\steamapps\\\\common\\\\DOOMEternal\\\\DOOMEternalx64vk.exe\\\" %COMMAND%\""
+        ));
+        let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/configs/mtsp-rules.toml
+++ b/configs/mtsp-rules.toml
@@ -235,7 +235,7 @@ pipeline = "steam"
 name = "DOOM"
 
 [overrides.782330]
-pipeline = "steam"
+pipeline = "m11"
 name = "DOOM Eternal"
 
 [overrides.289070]

--- a/configs/mtsp-rules.toml
+++ b/configs/mtsp-rules.toml
@@ -231,12 +231,12 @@ pipeline = "m11"
 name = "LEGO Star Wars"
 
 [overrides.379720]
-pipeline = "m11"
-name = "Doom Eternal"
+pipeline = "steam"
+name = "DOOM"
 
 [overrides.782330]
-pipeline = "m11"
-name = "A Way Out"
+pipeline = "steam"
+name = "DOOM Eternal"
 
 [overrides.289070]
 pipeline = "m11"


### PR DESCRIPTION
## Summary
- route DOOM and DOOM Eternal to the Wine Steam pipeline instead of DXMT M11/M12 presets
- persist a DOOM Eternal Steam launch-option override that bypasses the invisible idTech launcher and starts `DOOMEternalx64vk.exe` through `%COMMAND%`
- keep Wine Steam running on subsequent Steam launches, killing only known DOOM game-side processes before relaunch
- update the tracked `app/src/main/metalsharp-backend` binary from the rebuilt release backend

## Root Cause
DOOM Eternal's current Steam config launches `launcher/idTechLauncher.exe`, which can remain as an invisible Wine window. The app was also passing cache env through the Steam pipeline, which caused Wine Steam to be stopped and relaunched before every game launch. That made the Electron request path prone to socket timeouts while Steam was restarting.

## Validation
- `cargo fmt --all -- --check`
- `cargo test` (32 passed)
- `cargo build --release`
- `git diff --cached --check`
