### PR TITLE
Fix Sharp Library routing and non-Steam shortcut discovery

### DIFF
--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -306,8 +306,37 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
             let appid = body.get("appid").and_then(|v| v.as_u64());
             match appid {
                 Some(id) => {
-                    app_log(&format!("Launching game via Wine Steam: appid {}", id));
-                    match steam::launch_game_via_steam(id as u32) {
+                    let launch_method = body.get("launchMethod").and_then(|v| v.as_str()).unwrap_or("steam");
+                    let route_pipeline = if launch_method.eq_ignore_ascii_case("steam") {
+                        None
+                    } else {
+                        Some(
+                            mtsp::engine::PipelineId::from_str_flexible(launch_method)
+                                .unwrap_or_else(|| mtsp::rules::resolve_pipeline(id as u32)),
+                        )
+                    };
+                    app_log(&format!("Launching game via Wine Steam: appid {}, route {}", id, launch_method));
+                    let launch_result = match route_pipeline {
+                        Some(pipeline) => {
+                            let (env, recipe) = match mtsp::launcher::prepare_steam_pipeline_env(id as u32, pipeline) {
+                                Ok(prepared) => prepared,
+                                Err(e) => return resp(500, json!({"ok": false, "error": e.to_string()})),
+                            };
+                            steam::launch_game_via_steam_with_env(id as u32, &env).map(|mut v| {
+                                if let Some(obj) = v.as_object_mut() {
+                                    obj.insert("pipeline".into(), json!(pipeline));
+                                    obj.insert("recipe".into(), json!(recipe));
+                                    obj.insert(
+                                        "env_handoff".into(),
+                                        json!(env.iter().map(|(k, _)| k).collect::<Vec<_>>()),
+                                    );
+                                }
+                                v
+                            })
+                        },
+                        None => steam::launch_game_via_steam(id as u32),
+                    };
+                    match launch_result {
                         Ok(v) => resp(200, v),
                         Err(e) => resp(500, json!({"ok": false, "error": e.to_string()})),
                     }

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -595,6 +595,10 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
             }
             resp(200, result)
         },
+        (Method::Post, "/sharp-library/doctor") => {
+            let body = read_body(req);
+            resp(200, sharp_library::handle_doctor(&body))
+        },
         (Method::Post, "/sharp-library/set-cover") => {
             let body = read_body(req);
             resp(200, sharp_library::handle_set_cover(&body))

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -307,13 +307,11 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
             match appid {
                 Some(id) => {
                     let launch_method = body.get("launchMethod").and_then(|v| v.as_str()).unwrap_or("steam");
-                    let route_pipeline = if launch_method.eq_ignore_ascii_case("steam") {
-                        None
-                    } else {
-                        Some(
-                            mtsp::engine::PipelineId::from_str_flexible(launch_method)
-                                .unwrap_or_else(|| mtsp::rules::resolve_pipeline(id as u32)),
-                        )
+                    let route_pipeline = match mtsp::engine::PipelineId::from_str_flexible(launch_method) {
+                        Some(mtsp::engine::PipelineId::Steam) => None,
+                        Some(pipeline) => Some(pipeline),
+                        None if launch_method.eq_ignore_ascii_case("steam") => None,
+                        None => Some(mtsp::rules::resolve_pipeline(id as u32)),
                     };
                     app_log(&format!("Launching game via Wine Steam: appid {}, route {}", id, launch_method));
                     let launch_result = match route_pipeline {

--- a/app/src-rust/src/mtsp/engine.rs
+++ b/app/src-rust/src/mtsp/engine.rs
@@ -71,7 +71,7 @@ pub fn pipelines() -> &'static Vec<PipelineNode> {
                     EnvVar { key: "DXMT_METALFX_TEMPORAL", value: "1" },
                     EnvVar { key: "DXMT_ASYNC_PIPELINE_COMPILE", value: "1" },
                 ],
-                launch_args: vec!["-dx12"],
+                launch_args: vec![],
                 alternatives: vec![
                     PipelineId::M11,
                     PipelineId::M10,
@@ -100,7 +100,7 @@ pub fn pipelines() -> &'static Vec<PipelineNode> {
                     EnvVar { key: "DXMT_METALFX_SPATIAL_SWAPCHAIN", value: "1" },
                     EnvVar { key: "DXMT_ASYNC_PIPELINE_COMPILE", value: "1" },
                 ],
-                launch_args: vec!["-dx11"],
+                launch_args: vec![],
                 alternatives: vec![
                     PipelineId::M12,
                     PipelineId::M10,
@@ -134,7 +134,7 @@ pub fn pipelines() -> &'static Vec<PipelineNode> {
                     EnvVar { key: "DXMT_METALFX_SPATIAL_SWAPCHAIN", value: "1" },
                     EnvVar { key: "DXMT_ASYNC_PIPELINE_COMPILE", value: "1" },
                 ],
-                launch_args: vec!["-dx10"],
+                launch_args: vec![],
                 alternatives: vec![
                     PipelineId::M11,
                     PipelineId::M9,
@@ -161,7 +161,7 @@ pub fn pipelines() -> &'static Vec<PipelineNode> {
                     EnvVar { key: "DXMT_METALFX_SPATIAL_SWAPCHAIN", value: "1" },
                     EnvVar { key: "DXMT_ASYNC_PIPELINE_COMPILE", value: "1" },
                 ],
-                launch_args: vec!["-dx9"],
+                launch_args: vec![],
                 alternatives: vec![PipelineId::M11, PipelineId::M10, PipelineId::Steam, PipelineId::MacSteam],
                 shader_cache_subdir: Some("m9"),
             },
@@ -272,10 +272,10 @@ impl PipelineId {
             return Some(p);
         }
         match normalized.as_str() {
-            "m11" | "steam_d3dmetal_perf" | "steam_metalfx" => Some(PipelineId::M11),
-            "m12" => Some(PipelineId::M12),
-            "m10" => Some(PipelineId::M10),
-            "m9" => Some(PipelineId::M9),
+            "m11" | "d3d11" | "dx11" | "steam_d3dmetal_perf" | "steam_metalfx" => Some(PipelineId::M11),
+            "m12" | "d3d12" | "dx12" => Some(PipelineId::M12),
+            "m10" | "d3d10" | "dx10" => Some(PipelineId::M10),
+            "m9" | "d3d9" | "dx9" => Some(PipelineId::M9),
             "m32" | "m32_w" => Some(PipelineId::M32),
             "fna_arm64" | "fna_x86" | "mono_generic" => Some(PipelineId::FnaArm64),
             "steam" | "wine_steam" => Some(PipelineId::Steam),
@@ -312,7 +312,7 @@ mod tests {
         let m12 = get_pipeline(PipelineId::M12);
         assert!(!m12.experimental);
         assert_eq!(m12.backend, "dxmt");
-        assert_eq!(m12.launch_args, vec!["-dx12"]);
+        assert!(m12.launch_args.is_empty());
         assert!(m12.deploy_dlls.iter().any(|dll| dll.filename == "d3d12.dll"));
         assert_eq!(m12.shader_cache_subdir, Some("m12"));
     }
@@ -351,7 +351,7 @@ mod tests {
         assert_eq!(m10.description, "D3D10 -> Metal via DXMT");
         assert_eq!(m10.backend, "dxmt");
         assert!(!m10.experimental);
-        assert_eq!(m10.launch_args, vec!["-dx10"]);
+        assert!(m10.launch_args.is_empty());
         assert_eq!(m10.shader_cache_subdir, Some("m10"));
     }
 
@@ -389,7 +389,7 @@ mod tests {
         assert_eq!(m9.description, "D3D9 -> Metal via DXMT launch family");
         assert_eq!(m9.backend, "dxmt");
         assert!(!m9.experimental);
-        assert_eq!(m9.launch_args, vec!["-dx9"]);
+        assert!(m9.launch_args.is_empty());
         assert_eq!(m9.shader_cache_subdir, Some("m9"));
         assert_eq!(m9.wine_overrides, Some("d3d9=n,b;gameoverlayrenderer,gameoverlayrenderer64=d"));
 
@@ -425,6 +425,8 @@ mod tests {
     #[test]
     fn launch_method_parsing_is_case_and_separator_tolerant() {
         assert_eq!(PipelineId::from_str_flexible(" M12 "), Some(PipelineId::M12));
+        assert_eq!(PipelineId::from_str_flexible("d3d12"), Some(PipelineId::M12));
+        assert_eq!(PipelineId::from_str_flexible("dx10"), Some(PipelineId::M10));
         assert_eq!(PipelineId::from_str_flexible("wine-steam"), Some(PipelineId::Steam));
         assert_eq!(PipelineId::from_legacy_method("DXMT_METAL"), Some(PipelineId::M11));
     }

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -135,13 +135,8 @@ pub fn prepare_steam_pipeline_env(
 ) -> Result<(Vec<(String, String)>, super::recipe::LaunchRecipe), Box<dyn std::error::Error>> {
     let node = get_pipeline(pipeline_id);
     match pipeline_id {
-        PipelineId::M9
-        | PipelineId::M10
-        | PipelineId::M11
-        | PipelineId::M12
-        | PipelineId::M32
-        | PipelineId::WineBare => {},
-        PipelineId::FnaArm64 | PipelineId::Steam | PipelineId::MacSteam => {
+        PipelineId::M9 | PipelineId::M10 | PipelineId::M11 | PipelineId::M12 | PipelineId::M32 => {},
+        PipelineId::FnaArm64 | PipelineId::Steam | PipelineId::MacSteam | PipelineId::WineBare => {
             return Err("Steam route handoff only supports Wine-backed MTSP pipelines".into());
         },
     }
@@ -1018,6 +1013,13 @@ mod tests {
         let overrides = env.iter().find(|(key, _)| key == "WINEDLLOVERRIDES").map(|(_, value)| value).unwrap();
         assert!(overrides.contains("d3d12"));
         let _ = std::fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn steam_pipeline_env_rejects_plain_wine_fallback() {
+        let error = prepare_steam_pipeline_env(1, PipelineId::WineBare).expect_err("wine_bare should not be handoff");
+
+        assert!(error.to_string().contains("Steam route handoff only supports Wine-backed MTSP pipelines"));
     }
 
     #[test]

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -190,6 +190,7 @@ pub fn launch_custom_with_pipeline(
     game_dir: &std::path::Path,
     exe_path: &std::path::Path,
     pipeline_id: PipelineId,
+    launch_args: &[String],
 ) -> Result<(u32, &'static str, super::recipe::LaunchRecipe), Box<dyn std::error::Error>> {
     let node = get_pipeline(pipeline_id);
     match pipeline_id {
@@ -211,7 +212,8 @@ pub fn launch_custom_with_pipeline(
         return Err("MetalSharp Wine not found — run setup first".into());
     }
 
-    let recipe = super::recipe::build_custom_launch_recipe(launch_id, node, game_dir, Some(exe_path))?;
+    let mut recipe = super::recipe::build_custom_launch_recipe(launch_id, node, game_dir, Some(exe_path))?;
+    recipe.launch_args.extend(launch_args.iter().cloned());
     if node.deploy_dlls.is_empty() {
         validate_recipe_runtime(&recipe)?;
     } else {
@@ -242,7 +244,7 @@ pub fn launch_custom_with_pipeline(
     }
 
     cmd.arg(&exe_name);
-    cmd.args(&node.launch_args);
+    cmd.args(&recipe.launch_args);
     let child = cmd.spawn()?;
     Ok((child.id(), node.id.to_legacy_method(), recipe))
 }

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -129,6 +129,34 @@ pub fn prepare_pipeline(appid: u32) -> Result<serde_json::Value, Box<dyn std::er
     }))
 }
 
+pub fn prepare_steam_pipeline_env(
+    appid: u32,
+    pipeline_id: PipelineId,
+) -> Result<(Vec<(String, String)>, super::recipe::LaunchRecipe), Box<dyn std::error::Error>> {
+    let node = get_pipeline(pipeline_id);
+    match pipeline_id {
+        PipelineId::M9
+        | PipelineId::M10
+        | PipelineId::M11
+        | PipelineId::M12
+        | PipelineId::M32
+        | PipelineId::WineBare => {},
+        PipelineId::FnaArm64 | PipelineId::Steam | PipelineId::MacSteam => {
+            return Err("Steam route handoff only supports Wine-backed MTSP pipelines".into());
+        },
+    }
+
+    let recipe = super::recipe::build_launch_recipe(appid, node)?;
+    validate_recipe_runtime(&recipe)?;
+    if !recipe.dlls.is_empty() {
+        deploy_recipe_dlls(&recipe)?;
+    }
+
+    let home = dirs::home_dir().ok_or("no home dir")?;
+    let env = steam_pipeline_env_pairs(&home, node, appid);
+    Ok((env, recipe))
+}
+
 pub fn deploy_recipe_dlls(recipe: &super::recipe::LaunchRecipe) -> Result<(), Box<dyn std::error::Error>> {
     validate_recipe_runtime(recipe)?;
 
@@ -472,6 +500,27 @@ fn build_cache_paths(home: &PathBuf, node: &PipelineNode, appid: u32) -> Option<
         shader: shader_base.to_string_lossy().to_string(),
         pipeline: pipeline_base.to_string_lossy().to_string(),
     })
+}
+
+fn steam_pipeline_env_pairs(home: &PathBuf, node: &PipelineNode, appid: u32) -> Vec<(String, String)> {
+    let ms_root = home.join(".metalsharp").join("runtime").join("wine");
+    let cache_paths = build_cache_paths(home, node, appid);
+    let mut env = Vec::new();
+
+    if !node.dyld_paths.is_empty() {
+        let runtime_lib_key =
+            crate::platform::runtime_library_env(&ms_root).map(|(key, _)| key).unwrap_or("LD_LIBRARY_PATH");
+        env.push((runtime_lib_key.to_string(), build_dyld(&ms_root, &node.dyld_paths)));
+    }
+    if let Some(overrides) = node.wine_overrides {
+        env.push(("WINEDLLOVERRIDES".to_string(), overrides.to_string()));
+    }
+    if node.backend == "dxmt" {
+        env.push(("DXMT_CONFIG_FILE".to_string(), ms_root.join("etc").join("dxmt.conf").to_string_lossy().to_string()));
+    }
+    env.extend(cache_env_pairs(node, cache_paths.as_ref(), &ms_root));
+    env.extend(node.env_vars.iter().map(|ev| (ev.key.to_string(), ev.value.to_string())));
+    env
 }
 
 fn apply_cache_env(cmd: &mut Command, node: &PipelineNode, cache_paths: Option<&CachePaths>, ms_root: &PathBuf) {
@@ -954,6 +1003,24 @@ mod tests {
     }
 
     #[test]
+    fn steam_pipeline_env_includes_route_overrides_and_cache_keys() {
+        let home = test_dir("steam-env");
+        let node = get_pipeline(PipelineId::M12);
+
+        let env = steam_pipeline_env_pairs(&home, node, 1583230);
+        let keys: std::collections::HashSet<_> = env.iter().map(|(key, _)| key.as_str()).collect();
+
+        assert!(keys.contains("WINEDLLOVERRIDES"));
+        assert!(keys.contains("DXMT_CONFIG_FILE"));
+        assert!(keys.contains("DXMT_SHADER_CACHE_PATH"));
+        assert!(keys.contains("DXMT_PIPELINE_CACHE_PATH"));
+        assert!(keys.contains("DXMT_ASYNC_PIPELINE_COMPILE"));
+        let overrides = env.iter().find(|(key, _)| key == "WINEDLLOVERRIDES").map(|(_, value)| value).unwrap();
+        assert!(overrides.contains("d3d12"));
+        let _ = std::fs::remove_dir_all(home);
+    }
+
+    #[test]
     fn no_dll_recipes_do_not_require_game_dir_for_deploy() {
         let recipe = super::super::recipe::LaunchRecipe {
             appid: 1,
@@ -980,5 +1047,15 @@ mod tests {
         let exe_path = game_dir.join("Engine").join("Binaries").join("Win64").join("Game-Win64-Shipping.exe");
 
         assert_eq!(launch_working_dir(&game_dir, &exe_path), exe_path.parent().unwrap());
+    }
+
+    fn test_dir(name: &str) -> PathBuf {
+        let mut dir = std::env::temp_dir();
+        dir.push(format!("metalsharp-launcher-{}-{}-{}", name, std::process::id(), unique_suffix()));
+        dir
+    }
+
+    fn unique_suffix() -> u128 {
+        std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).expect("system time").as_nanos()
     }
 }

--- a/app/src-rust/src/mtsp/recipe.rs
+++ b/app/src-rust/src/mtsp/recipe.rs
@@ -333,6 +333,10 @@ pub fn diagnose_recipe(recipe: LaunchRecipe) -> LaunchDoctorReport {
         push_check(&mut checks, "exe", "Executable", true, "Not required for this pipeline");
     }
 
+    if direct_wine_pipeline {
+        inspect_exe_route_compatibility(&recipe, &mut checks, &mut blockers, &mut warnings);
+    }
+
     let missing_assets: Vec<_> =
         recipe.runtime_assets.iter().filter(|asset| asset.required && !asset.present).collect();
     if missing_assets.is_empty() {
@@ -420,6 +424,101 @@ pub fn diagnose_recipe(recipe: LaunchRecipe) -> LaunchDoctorReport {
     };
 
     LaunchDoctorReport { ready, summary, blockers, warnings: dedupe_strings(warnings), checks, recipe }
+}
+
+fn inspect_exe_route_compatibility(
+    recipe: &LaunchRecipe,
+    checks: &mut Vec<LaunchDoctorCheck>,
+    blockers: &mut Vec<String>,
+    warnings: &mut Vec<String>,
+) {
+    let Some(exe_path) = recipe.exe_path.as_deref() else {
+        push_check(checks, "exe_route", "Route compatibility", false, "No executable to inspect");
+        return;
+    };
+    if !exe_path.is_file() {
+        push_check(
+            checks,
+            "exe_route",
+            "Route compatibility",
+            false,
+            "Selected executable is not available for route inspection",
+        );
+        return;
+    }
+
+    let Ok(data) = std::fs::read(exe_path) else {
+        push_check(checks, "exe_route", "Route compatibility", false, "Could not read selected executable");
+        warnings.push("Could not inspect selected executable headers".into());
+        return;
+    };
+    let Some(pe) = super::pe::parse_pe_imports(&data) else {
+        push_check(
+            checks,
+            "exe_route",
+            "Route compatibility",
+            true,
+            "Selected executable is not a readable PE file; route compatibility was not verified",
+        );
+        warnings.push("Selected executable headers could not be parsed; route compatibility was not verified".into());
+        return;
+    };
+
+    let arch = if pe.is_64_bit { "PE32+ x86_64" } else { "PE32 i386" };
+    let api = d3d_api_label(pe.detected_api);
+    let detail = format!("{} executable, imports {}", arch, api);
+
+    if !pe.is_64_bit && matches!(recipe.pipeline, PipelineId::M10 | PipelineId::M11 | PipelineId::M12) {
+        let message = format!(
+            "{} route requires a 64-bit Windows executable, but {} is 32-bit",
+            recipe.pipeline_name,
+            exe_path.display()
+        );
+        blockers.push(message.clone());
+        push_check(checks, "exe_route", "Route compatibility", false, format!("{}; {}", detail, message));
+        return;
+    }
+
+    if pe.is_64_bit && recipe.pipeline == PipelineId::M32 {
+        let message = format!("M32 is reserved for 32-bit Windows executables, but {} is 64-bit", exe_path.display());
+        blockers.push(message.clone());
+        push_check(checks, "exe_route", "Route compatibility", false, format!("{}; {}", detail, message));
+        return;
+    }
+
+    if route_api_mismatch(recipe.pipeline, pe.detected_api) {
+        warnings.push(format!(
+            "{} imports {}, which does not match the selected {} route",
+            exe_path.display(),
+            api,
+            recipe.pipeline_name
+        ));
+    }
+
+    push_check(checks, "exe_route", "Route compatibility", true, detail);
+}
+
+fn d3d_api_label(api: super::pe::D3dApi) -> &'static str {
+    match api {
+        super::pe::D3dApi::D3D9 => "D3D9",
+        super::pe::D3dApi::D3D10 => "D3D10",
+        super::pe::D3dApi::D3D11 => "D3D11",
+        super::pe::D3dApi::D3D12 => "D3D12",
+        super::pe::D3dApi::Unknown => "no Direct3D import",
+    }
+}
+
+fn route_api_mismatch(pipeline: PipelineId, api: super::pe::D3dApi) -> bool {
+    match (pipeline, api) {
+        (_, super::pe::D3dApi::Unknown) => false,
+        (PipelineId::WineBare, _) => false,
+        (PipelineId::M9, super::pe::D3dApi::D3D9) => false,
+        (PipelineId::M10, super::pe::D3dApi::D3D10) => false,
+        (PipelineId::M11, super::pe::D3dApi::D3D11) => false,
+        (PipelineId::M12, super::pe::D3dApi::D3D12) => false,
+        (PipelineId::M32, _) => false,
+        _ => true,
+    }
 }
 
 fn push_check(
@@ -747,6 +846,64 @@ mod tests {
         assert!(report.blockers.is_empty());
         assert!(report.checks.iter().any(|check| check.id == "game_dir" && check.ok));
         assert!(report.checks.iter().any(|check| check.id == "exe" && check.ok));
+    }
+
+    #[test]
+    fn doctor_blocks_32_bit_exe_on_64_bit_dxmt_route() {
+        let game_dir = test_dir("doctor-32-on-m11");
+        std::fs::create_dir_all(&game_dir).expect("create game dir");
+        let exe = game_dir.join("LegacyGame.exe");
+        write_test_pe(&exe, 0x014c, 0x10b);
+
+        let report = diagnose_recipe(LaunchRecipe {
+            appid: 1,
+            pipeline: PipelineId::M11,
+            pipeline_name: "M11".into(),
+            backend: "dxmt".into(),
+            game_dir: Some(game_dir.clone()),
+            exe_path: Some(exe),
+            exe_name: Some("LegacyGame.exe".into()),
+            launch_args: vec![],
+            env: vec![],
+            dlls: vec![],
+            runtime_assets: vec![],
+            anti_cheat: vec![],
+            warnings: vec![],
+        });
+
+        assert!(!report.ready);
+        assert!(report.blockers.iter().any(|blocker| blocker.contains("requires a 64-bit Windows executable")));
+        assert!(report.checks.iter().any(|check| check.id == "exe_route" && !check.ok));
+        let _ = std::fs::remove_dir_all(game_dir);
+    }
+
+    #[test]
+    fn doctor_blocks_64_bit_exe_on_m32_route() {
+        let game_dir = test_dir("doctor-64-on-m32");
+        std::fs::create_dir_all(&game_dir).expect("create game dir");
+        let exe = game_dir.join("ModernGame.exe");
+        write_test_pe(&exe, 0x8664, 0x20b);
+
+        let report = diagnose_recipe(LaunchRecipe {
+            appid: 1,
+            pipeline: PipelineId::M32,
+            pipeline_name: "M32".into(),
+            backend: "wine32".into(),
+            game_dir: Some(game_dir.clone()),
+            exe_path: Some(exe),
+            exe_name: Some("ModernGame.exe".into()),
+            launch_args: vec![],
+            env: vec![],
+            dlls: vec![],
+            runtime_assets: vec![],
+            anti_cheat: vec![],
+            warnings: vec![],
+        });
+
+        assert!(!report.ready);
+        assert!(report.blockers.iter().any(|blocker| blocker.contains("reserved for 32-bit Windows executables")));
+        assert!(report.checks.iter().any(|check| check.id == "exe_route" && !check.ok));
+        let _ = std::fs::remove_dir_all(game_dir);
     }
 
     #[test]

--- a/app/src-rust/src/mtsp/recipe.rs
+++ b/app/src-rust/src/mtsp/recipe.rs
@@ -509,16 +509,16 @@ fn d3d_api_label(api: super::pe::D3dApi) -> &'static str {
 }
 
 fn route_api_mismatch(pipeline: PipelineId, api: super::pe::D3dApi) -> bool {
-    match (pipeline, api) {
-        (_, super::pe::D3dApi::Unknown) => false,
-        (PipelineId::WineBare, _) => false,
-        (PipelineId::M9, super::pe::D3dApi::D3D9) => false,
-        (PipelineId::M10, super::pe::D3dApi::D3D10) => false,
-        (PipelineId::M11, super::pe::D3dApi::D3D11) => false,
-        (PipelineId::M12, super::pe::D3dApi::D3D12) => false,
-        (PipelineId::M32, _) => false,
-        _ => true,
-    }
+    !matches!(
+        (pipeline, api),
+        (_, super::pe::D3dApi::Unknown)
+            | (PipelineId::WineBare, _)
+            | (PipelineId::M9, super::pe::D3dApi::D3D9)
+            | (PipelineId::M10, super::pe::D3dApi::D3D10)
+            | (PipelineId::M11, super::pe::D3dApi::D3D11)
+            | (PipelineId::M12, super::pe::D3dApi::D3D12)
+            | (PipelineId::M32, _)
+    )
 }
 
 fn push_check(

--- a/app/src-rust/src/scan.rs
+++ b/app/src-rust/src/scan.rs
@@ -19,6 +19,7 @@ pub struct NonSteamShortcut {
     pub name: String,
     pub exe_path: PathBuf,
     pub start_dir: Option<PathBuf>,
+    pub launch_args: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -398,13 +399,15 @@ fn build_non_steam_shortcut(
         return None;
     }
 
-    let exe_path = clean_shortcut_path(&exe?)?;
+    let exe = exe?;
+    let exe_path = clean_shortcut_path(&exe)?;
     if exe_path.extension().map(|ext| ext.to_string_lossy().eq_ignore_ascii_case("exe")) != Some(true) {
         return None;
     }
 
     let start_dir = start_dir.and_then(|dir| clean_shortcut_path(&dir));
-    Some(NonSteamShortcut { name, exe_path, start_dir })
+    let launch_args = extract_shortcut_args(&exe);
+    Some(NonSteamShortcut { name, exe_path, start_dir, launch_args })
 }
 
 fn clean_shortcut_path(path: &str) -> Option<PathBuf> {
@@ -450,6 +453,58 @@ fn extract_shortcut_path(path: &str) -> Option<String> {
     }
 
     Some(trimmed.to_string())
+}
+
+fn extract_shortcut_args(command: &str) -> Vec<String> {
+    let Some(rest) = shortcut_args_suffix(command) else {
+        return Vec::new();
+    };
+    split_shortcut_args(rest)
+}
+
+fn shortcut_args_suffix(command: &str) -> Option<&str> {
+    let trimmed = command.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Some(rest) = trimmed.strip_prefix('"') {
+        let end = rest.find('"')?;
+        return Some(rest[end + 1..].trim());
+    }
+    if let Some(rest) = trimmed.strip_prefix('\'') {
+        let end = rest.find('\'')?;
+        return Some(rest[end + 1..].trim());
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    let idx = lower.find(".exe")?;
+    Some(trimmed[idx + 4..].trim())
+}
+
+fn split_shortcut_args(args: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut current = String::new();
+    let mut quote: Option<char> = None;
+
+    for ch in args.chars() {
+        match (quote, ch) {
+            (Some(q), c) if c == q => quote = None,
+            (None, '"' | '\'') => quote = Some(ch),
+            (None, c) if c.is_whitespace() => {
+                if !current.is_empty() {
+                    out.push(std::mem::take(&mut current));
+                }
+            },
+            (_, c) => current.push(c),
+        }
+    }
+
+    if !current.is_empty() {
+        out.push(current);
+    }
+
+    out
 }
 
 fn shortcut_id(name: &str, exe_path: &Path) -> u64 {
@@ -623,6 +678,7 @@ mod tests {
         assert_eq!(shortcuts.len(), 1);
         assert_eq!(shortcuts[0].name, "Joy of Creation");
         assert!(shortcuts[0].exe_path.ends_with("tmp/Joy/Joy.exe"));
+        assert!(shortcuts[0].launch_args.is_empty());
     }
 
     #[test]
@@ -640,6 +696,20 @@ mod tests {
 
         assert_eq!(shortcuts.len(), 1);
         assert!(shortcuts[0].exe_path.ends_with("tmp/DxGame/Game.exe"));
+        assert_eq!(shortcuts[0].launch_args, vec!["-d3d12"]);
+    }
+
+    #[test]
+    fn preserves_multiple_shortcut_launch_args() {
+        let data = test_shortcuts_vdf(
+            "DX12 Game",
+            "\"Z:\\tmp\\DxGame\\Game.exe\" -d3d12 -windowed \"-profile=high perf\"",
+            "Z:\\tmp\\DxGame",
+        );
+
+        let shortcuts = parse_shortcuts_vdf(&data);
+
+        assert_eq!(shortcuts[0].launch_args, vec!["-d3d12", "-windowed", "-profile=high perf"]);
     }
 
     fn test_shortcuts_vdf(name: &str, exe: &str, start_dir: &str) -> Vec<u8> {

--- a/app/src-rust/src/scan.rs
+++ b/app/src-rust/src/scan.rs
@@ -1,4 +1,5 @@
 use serde_json::{json, Value};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
@@ -11,6 +12,13 @@ pub struct Game {
     pub steam_app_id: Option<u32>,
     pub size_bytes: Option<u64>,
     pub metalsharp_compatible: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NonSteamShortcut {
+    pub name: String,
+    pub exe_path: PathBuf,
+    pub start_dir: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone)]
@@ -130,6 +138,18 @@ pub fn scan_all() -> Result<Value, Box<dyn std::error::Error>> {
         games.extend(local_games);
     }
 
+    for shortcut in scan_non_steam_shortcuts() {
+        games.push(Game {
+            id: format!("non_steam_{}", shortcut_id(&shortcut.name, &shortcut.exe_path)),
+            name: shortcut.name,
+            exe_path: shortcut.exe_path.to_string_lossy().to_string(),
+            platform: "non_steam".into(),
+            steam_app_id: None,
+            size_bytes: shortcut.start_dir.as_ref().and_then(dir_size),
+            metalsharp_compatible: true,
+        });
+    }
+
     let steam_status = super::steam::status();
     Ok(json!({
         "ok": true,
@@ -243,6 +263,201 @@ pub fn wine_steam_library_paths() -> Vec<PathBuf> {
     let mut paths = vec![wine_steamapps.clone()];
     paths.extend(parse_library_folders(&wine_steamapps));
     paths
+}
+
+pub fn scan_non_steam_shortcuts() -> Vec<NonSteamShortcut> {
+    let mut shortcuts = Vec::new();
+    let mut seen = HashSet::new();
+
+    for path in shortcut_vdf_paths() {
+        let Ok(data) = std::fs::read(&path) else {
+            continue;
+        };
+        for shortcut in parse_shortcuts_vdf(&data) {
+            let key = shortcut.exe_path.to_string_lossy().to_ascii_lowercase();
+            if shortcut.exe_path.exists() && seen.insert(key) {
+                shortcuts.push(shortcut);
+            }
+        }
+    }
+
+    shortcuts
+}
+
+fn shortcut_vdf_paths() -> Vec<PathBuf> {
+    let home = dirs::home_dir().unwrap_or_default();
+    let mut roots = vec![
+        home.join("Library/Application Support/Steam/userdata"),
+        home.join(".steam/steam/userdata"),
+        home.join(".local/share/Steam/userdata"),
+        home.join(".metalsharp")
+            .join("prefix-steam")
+            .join("drive_c")
+            .join("Program Files (x86)")
+            .join("Steam")
+            .join("userdata"),
+    ];
+
+    roots.retain(|root| root.exists());
+
+    let mut paths = Vec::new();
+    for root in roots {
+        let Ok(users) = std::fs::read_dir(root) else {
+            continue;
+        };
+        for user in users.flatten() {
+            let path = user.path().join("config").join("shortcuts.vdf");
+            if path.exists() {
+                paths.push(path);
+            }
+        }
+    }
+    paths
+}
+
+fn parse_shortcuts_vdf(data: &[u8]) -> Vec<NonSteamShortcut> {
+    let mut offset = 0usize;
+    let mut current_name: Option<String> = None;
+    let mut current_exe: Option<String> = None;
+    let mut current_start_dir: Option<String> = None;
+    let mut in_shortcut = false;
+    let mut shortcuts = Vec::new();
+
+    while offset < data.len() {
+        let field_type = data[offset];
+        offset += 1;
+
+        if field_type == 0x08 {
+            if in_shortcut {
+                if let Some(shortcut) =
+                    build_non_steam_shortcut(current_name.take(), current_exe.take(), current_start_dir.take())
+                {
+                    shortcuts.push(shortcut);
+                }
+                in_shortcut = false;
+            }
+            continue;
+        }
+
+        let Some(key) = read_c_string(data, &mut offset) else {
+            break;
+        };
+
+        match field_type {
+            0x00 => {
+                in_shortcut = key.as_bytes().iter().all(u8::is_ascii_digit);
+                if in_shortcut {
+                    current_name = None;
+                    current_exe = None;
+                    current_start_dir = None;
+                }
+            },
+            0x01 => {
+                let Some(value) = read_c_string(data, &mut offset) else {
+                    break;
+                };
+                if in_shortcut {
+                    match key.as_str() {
+                        "appname" => current_name = Some(value),
+                        "exe" => current_exe = Some(value),
+                        "StartDir" => current_start_dir = Some(value),
+                        _ => {},
+                    }
+                }
+            },
+            0x02 => {
+                offset = offset.saturating_add(4);
+            },
+            _ => break,
+        }
+    }
+
+    shortcuts
+}
+
+fn read_c_string(data: &[u8], offset: &mut usize) -> Option<String> {
+    let start = *offset;
+    while *offset < data.len() && data[*offset] != 0 {
+        *offset += 1;
+    }
+    if *offset >= data.len() {
+        return None;
+    }
+    let value = String::from_utf8_lossy(&data[start..*offset]).to_string();
+    *offset += 1;
+    Some(value)
+}
+
+fn build_non_steam_shortcut(
+    name: Option<String>,
+    exe: Option<String>,
+    start_dir: Option<String>,
+) -> Option<NonSteamShortcut> {
+    let name = name?.trim().to_string();
+    if name.is_empty() {
+        return None;
+    }
+
+    let exe_path = clean_shortcut_path(&exe?)?;
+    if exe_path.extension().map(|ext| ext.to_string_lossy().eq_ignore_ascii_case("exe")) != Some(true) {
+        return None;
+    }
+
+    let start_dir = start_dir.and_then(|dir| clean_shortcut_path(&dir));
+    Some(NonSteamShortcut { name, exe_path, start_dir })
+}
+
+fn clean_shortcut_path(path: &str) -> Option<PathBuf> {
+    let trimmed = extract_shortcut_path(path)?;
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let normalized = trimmed.replace('\\', "/");
+    let home = dirs::home_dir().unwrap_or_default();
+
+    if normalized.len() > 2 && normalized.as_bytes().get(1) == Some(&b':') {
+        let drive = normalized.chars().next()?.to_ascii_lowercase();
+        let rest = normalized[2..].trim_start_matches('/');
+        return match drive {
+            'z' => Some(PathBuf::from("/").join(rest)),
+            'c' => Some(home.join(".metalsharp").join("prefix-steam").join("drive_c").join(rest)),
+            _ => Some(PathBuf::from("/").join(rest)),
+        };
+    }
+
+    Some(PathBuf::from(normalized))
+}
+
+fn extract_shortcut_path(path: &str) -> Option<String> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Some(rest) = trimmed.strip_prefix('"') {
+        let end = rest.find('"').unwrap_or(rest.len());
+        return Some(rest[..end].trim().to_string());
+    }
+    if let Some(rest) = trimmed.strip_prefix('\'') {
+        let end = rest.find('\'').unwrap_or(rest.len());
+        return Some(rest[..end].trim().to_string());
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    if let Some(idx) = lower.find(".exe") {
+        return Some(trimmed[..idx + 4].trim().to_string());
+    }
+
+    Some(trimmed.to_string())
+}
+
+fn shortcut_id(name: &str, exe_path: &Path) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    name.hash(&mut hasher);
+    exe_path.hash(&mut hasher);
+    hasher.finish()
 }
 
 fn parse_acf(contents: &str) -> Option<(u32, String, String)> {
@@ -392,4 +607,64 @@ fn scan_local_exes() -> Result<Vec<Game>, Box<dyn std::error::Error>> {
     }
 
     Ok(games)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_binary_non_steam_shortcuts() {
+        let exe = if cfg!(windows) { "C:\\Games\\Joy\\Joy.exe" } else { "Z:\\tmp\\Joy\\Joy.exe" };
+        let data = test_shortcuts_vdf("Joy of Creation", exe, "Z:\\tmp\\Joy");
+
+        let shortcuts = parse_shortcuts_vdf(&data);
+
+        assert_eq!(shortcuts.len(), 1);
+        assert_eq!(shortcuts[0].name, "Joy of Creation");
+        assert!(shortcuts[0].exe_path.ends_with("tmp/Joy/Joy.exe"));
+    }
+
+    #[test]
+    fn ignores_shortcuts_without_exe_targets() {
+        let data = test_shortcuts_vdf("Native App", "/Applications/Foo.app", "/Applications");
+
+        assert!(parse_shortcuts_vdf(&data).is_empty());
+    }
+
+    #[test]
+    fn strips_shortcut_launch_args_from_quoted_exe_path() {
+        let data = test_shortcuts_vdf("DX12 Game", "\"Z:\\tmp\\DxGame\\Game.exe\" -d3d12", "Z:\\tmp\\DxGame");
+
+        let shortcuts = parse_shortcuts_vdf(&data);
+
+        assert_eq!(shortcuts.len(), 1);
+        assert!(shortcuts[0].exe_path.ends_with("tmp/DxGame/Game.exe"));
+    }
+
+    fn test_shortcuts_vdf(name: &str, exe: &str, start_dir: &str) -> Vec<u8> {
+        let mut data = Vec::new();
+        object(&mut data, "shortcuts");
+        object(&mut data, "0");
+        string_field(&mut data, "appname", name);
+        string_field(&mut data, "exe", exe);
+        string_field(&mut data, "StartDir", start_dir);
+        data.push(0x08);
+        data.push(0x08);
+        data
+    }
+
+    fn object(data: &mut Vec<u8>, key: &str) {
+        data.push(0x00);
+        data.extend_from_slice(key.as_bytes());
+        data.push(0);
+    }
+
+    fn string_field(data: &mut Vec<u8>, key: &str, value: &str) {
+        data.push(0x01);
+        data.extend_from_slice(key.as_bytes());
+        data.push(0);
+        data.extend_from_slice(value.as_bytes());
+        data.push(0);
+    }
 }

--- a/app/src-rust/src/scan.rs
+++ b/app/src-rust/src/scan.rs
@@ -321,7 +321,9 @@ fn parse_shortcuts_vdf(data: &[u8]) -> Vec<NonSteamShortcut> {
     let mut current_name: Option<String> = None;
     let mut current_exe: Option<String> = None;
     let mut current_start_dir: Option<String> = None;
-    let mut in_shortcut = false;
+    let mut current_launch_options: Option<String> = None;
+    let mut shortcut_depth: Option<usize> = None;
+    let mut depth = 0usize;
     let mut shortcuts = Vec::new();
 
     while offset < data.len() {
@@ -329,14 +331,18 @@ fn parse_shortcuts_vdf(data: &[u8]) -> Vec<NonSteamShortcut> {
         offset += 1;
 
         if field_type == 0x08 {
-            if in_shortcut {
-                if let Some(shortcut) =
-                    build_non_steam_shortcut(current_name.take(), current_exe.take(), current_start_dir.take())
-                {
+            if shortcut_depth == Some(depth) {
+                if let Some(shortcut) = build_non_steam_shortcut(
+                    current_name.take(),
+                    current_exe.take(),
+                    current_start_dir.take(),
+                    current_launch_options.take(),
+                ) {
                     shortcuts.push(shortcut);
                 }
-                in_shortcut = false;
+                shortcut_depth = None;
             }
+            depth = depth.saturating_sub(1);
             continue;
         }
 
@@ -346,22 +352,25 @@ fn parse_shortcuts_vdf(data: &[u8]) -> Vec<NonSteamShortcut> {
 
         match field_type {
             0x00 => {
-                in_shortcut = key.as_bytes().iter().all(u8::is_ascii_digit);
-                if in_shortcut {
+                depth += 1;
+                if depth == 2 && key.as_bytes().iter().all(u8::is_ascii_digit) {
+                    shortcut_depth = Some(depth);
                     current_name = None;
                     current_exe = None;
                     current_start_dir = None;
+                    current_launch_options = None;
                 }
             },
             0x01 => {
                 let Some(value) = read_c_string(data, &mut offset) else {
                     break;
                 };
-                if in_shortcut {
+                if shortcut_depth == Some(depth) {
                     match key.as_str() {
                         "appname" => current_name = Some(value),
                         "exe" => current_exe = Some(value),
                         "StartDir" => current_start_dir = Some(value),
+                        "LaunchOptions" => current_launch_options = Some(value),
                         _ => {},
                     }
                 }
@@ -393,6 +402,7 @@ fn build_non_steam_shortcut(
     name: Option<String>,
     exe: Option<String>,
     start_dir: Option<String>,
+    launch_options: Option<String>,
 ) -> Option<NonSteamShortcut> {
     let name = name?.trim().to_string();
     if name.is_empty() {
@@ -406,7 +416,10 @@ fn build_non_steam_shortcut(
     }
 
     let start_dir = start_dir.and_then(|dir| clean_shortcut_path(&dir));
-    let launch_args = extract_shortcut_args(&exe);
+    let mut launch_args = extract_shortcut_args(&exe);
+    if let Some(options) = launch_options {
+        launch_args.extend(split_shortcut_args(&options));
+    }
     Some(NonSteamShortcut { name, exe_path, start_dir, launch_args })
 }
 
@@ -671,7 +684,7 @@ mod tests {
     #[test]
     fn parses_binary_non_steam_shortcuts() {
         let exe = if cfg!(windows) { "C:\\Games\\Joy\\Joy.exe" } else { "Z:\\tmp\\Joy\\Joy.exe" };
-        let data = test_shortcuts_vdf("Joy of Creation", exe, "Z:\\tmp\\Joy");
+        let data = test_shortcuts_vdf("Joy of Creation", exe, "Z:\\tmp\\Joy", None, false);
 
         let shortcuts = parse_shortcuts_vdf(&data);
 
@@ -683,14 +696,15 @@ mod tests {
 
     #[test]
     fn ignores_shortcuts_without_exe_targets() {
-        let data = test_shortcuts_vdf("Native App", "/Applications/Foo.app", "/Applications");
+        let data = test_shortcuts_vdf("Native App", "/Applications/Foo.app", "/Applications", None, false);
 
         assert!(parse_shortcuts_vdf(&data).is_empty());
     }
 
     #[test]
     fn strips_shortcut_launch_args_from_quoted_exe_path() {
-        let data = test_shortcuts_vdf("DX12 Game", "\"Z:\\tmp\\DxGame\\Game.exe\" -d3d12", "Z:\\tmp\\DxGame");
+        let data =
+            test_shortcuts_vdf("DX12 Game", "\"Z:\\tmp\\DxGame\\Game.exe\" -d3d12", "Z:\\tmp\\DxGame", None, false);
 
         let shortcuts = parse_shortcuts_vdf(&data);
 
@@ -705,6 +719,8 @@ mod tests {
             "DX12 Game",
             "\"Z:\\tmp\\DxGame\\Game.exe\" -d3d12 -windowed \"-profile=high perf\"",
             "Z:\\tmp\\DxGame",
+            None,
+            false,
         );
 
         let shortcuts = parse_shortcuts_vdf(&data);
@@ -712,13 +728,54 @@ mod tests {
         assert_eq!(shortcuts[0].launch_args, vec!["-d3d12", "-windowed", "-profile=high perf"]);
     }
 
-    fn test_shortcuts_vdf(name: &str, exe: &str, start_dir: &str) -> Vec<u8> {
+    #[test]
+    fn preserves_launch_options_field() {
+        let data = test_shortcuts_vdf(
+            "Joy of Creation",
+            "\"Z:\\tmp\\Joy\\Joy.exe\"",
+            "Z:\\tmp\\Joy",
+            Some("-d3d12 -windowed"),
+            false,
+        );
+
+        let shortcuts = parse_shortcuts_vdf(&data);
+
+        assert_eq!(shortcuts.len(), 1);
+        assert_eq!(shortcuts[0].launch_args, vec!["-d3d12", "-windowed"]);
+    }
+
+    #[test]
+    fn nested_tags_do_not_cancel_shortcut_parsing() {
+        let data = test_shortcuts_vdf("Tagged Game", "Z:\\tmp\\Tagged\\Game.exe", "Z:\\tmp\\Tagged", None, true);
+
+        let shortcuts = parse_shortcuts_vdf(&data);
+
+        assert_eq!(shortcuts.len(), 1);
+        assert_eq!(shortcuts[0].name, "Tagged Game");
+        assert!(shortcuts[0].exe_path.ends_with("tmp/Tagged/Game.exe"));
+    }
+
+    fn test_shortcuts_vdf(
+        name: &str,
+        exe: &str,
+        start_dir: &str,
+        launch_options: Option<&str>,
+        include_tags: bool,
+    ) -> Vec<u8> {
         let mut data = Vec::new();
         object(&mut data, "shortcuts");
         object(&mut data, "0");
         string_field(&mut data, "appname", name);
         string_field(&mut data, "exe", exe);
         string_field(&mut data, "StartDir", start_dir);
+        if let Some(options) = launch_options {
+            string_field(&mut data, "LaunchOptions", options);
+        }
+        if include_tags {
+            object(&mut data, "tags");
+            string_field(&mut data, "0", "favorite");
+            data.push(0x08);
+        }
         data.push(0x08);
         data.push(0x08);
         data

--- a/app/src-rust/src/scan.rs
+++ b/app/src-rust/src/scan.rs
@@ -520,12 +520,13 @@ fn split_shortcut_args(args: &str) -> Vec<String> {
     out
 }
 
-fn shortcut_id(name: &str, exe_path: &Path) -> u64 {
-    use std::hash::{Hash, Hasher};
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    name.hash(&mut hasher);
-    exe_path.hash(&mut hasher);
-    hasher.finish()
+fn shortcut_id(name: &str, exe_path: &Path) -> String {
+    let mut hash = 0xcbf29ce484222325_u64;
+    for byte in name.as_bytes().iter().chain(b"\0").chain(exe_path.to_string_lossy().as_bytes()) {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{:016x}", hash)
 }
 
 fn parse_acf(contents: &str) -> Option<(u32, String, String)> {
@@ -753,6 +754,20 @@ mod tests {
         assert_eq!(shortcuts.len(), 1);
         assert_eq!(shortcuts[0].name, "Tagged Game");
         assert!(shortcuts[0].exe_path.ends_with("tmp/Tagged/Game.exe"));
+    }
+
+    #[test]
+    fn scan_shortcut_ids_use_explicit_stable_hex_hashes() {
+        let path = PathBuf::from("/tmp/Game/Game.exe");
+
+        let first = shortcut_id("Game", &path);
+        let second = shortcut_id("Game", &path);
+        let changed = shortcut_id("Game", Path::new("/tmp/Game/Other.exe"));
+
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 16);
+        assert!(first.chars().all(|ch| ch.is_ascii_hexdigit()));
+        assert_ne!(first, changed);
     }
 
     fn test_shortcuts_vdf(

--- a/app/src-rust/src/sharp_library.rs
+++ b/app/src-rust/src/sharp_library.rs
@@ -82,14 +82,59 @@ fn sync_non_steam_shortcuts(apps: &mut Vec<SharpApp>) -> bool {
 
 fn sync_non_steam_shortcut(apps: &mut Vec<SharpApp>, shortcut: crate::scan::NonSteamShortcut) -> bool {
     let id = format!("steam_shortcut_{}", stable_shortcut_id(&shortcut.name, &shortcut.exe_path));
-    if let Some(app) = apps.iter_mut().find(|app| app.id == id || app_absolute_exe_path(app) == shortcut.exe_path) {
+    let (install_dir, exe_path) = shortcut_library_paths(&shortcut);
+    let install_dir_string = install_dir.to_string_lossy().to_string();
+    let exe_path_string = exe_path.to_string_lossy().to_string();
+
+    if let Some(app) = apps.iter_mut().find(|app| {
+        app.id == id
+            || app_absolute_exe_path(app) == shortcut.exe_path
+            || (app.id.starts_with("steam_shortcut_") && app.name == shortcut.name)
+    }) {
+        let size_bytes = dir_size(&install_dir);
+        let mut changed = false;
+        if app.id != id {
+            app.id = id;
+            changed = true;
+        }
+        if app.name != shortcut.name {
+            app.name = shortcut.name.clone();
+            changed = true;
+        }
+        if app.install_dir != install_dir_string {
+            app.install_dir = install_dir_string.clone();
+            changed = true;
+        }
+        if app.exe_path != exe_path_string {
+            app.exe_path = exe_path_string.clone();
+            changed = true;
+        }
         if app.launch_args != shortcut.launch_args {
             app.launch_args = shortcut.launch_args;
-            return true;
+            changed = true;
         }
-        return false;
+        if app.size_bytes != size_bytes {
+            app.size_bytes = size_bytes;
+            changed = true;
+        }
+        return changed;
     }
 
+    apps.push(SharpApp {
+        id,
+        name: shortcut.name,
+        exe_path: exe_path_string,
+        install_dir: install_dir_string,
+        cover: None,
+        engine: "auto".to_string(),
+        launch_args: shortcut.launch_args,
+        installed_at: chrono_now(),
+        size_bytes: dir_size(&install_dir),
+    });
+    true
+}
+
+fn shortcut_library_paths(shortcut: &crate::scan::NonSteamShortcut) -> (PathBuf, PathBuf) {
     let install_dir = shortcut
         .start_dir
         .clone()
@@ -100,18 +145,7 @@ fn sync_non_steam_shortcut(apps: &mut Vec<SharpApp>, shortcut: crate::scan::NonS
     let exe_path = relative_path_string(&install_dir, &shortcut.exe_path)
         .unwrap_or_else(|_| shortcut.exe_path.to_string_lossy().to_string());
 
-    apps.push(SharpApp {
-        id,
-        name: shortcut.name,
-        exe_path,
-        install_dir: install_dir.to_string_lossy().to_string(),
-        cover: None,
-        engine: "auto".to_string(),
-        launch_args: shortcut.launch_args,
-        installed_at: chrono_now(),
-        size_bytes: dir_size(&install_dir),
-    });
-    true
+    (install_dir, PathBuf::from(exe_path))
 }
 
 fn app_absolute_exe_path(app: &SharpApp) -> PathBuf {
@@ -671,6 +705,45 @@ mod tests {
         assert!(changed);
         assert_eq!(apps.len(), 1);
         assert_eq!(apps[0].launch_args, vec!["-d3d12", "-windowed"]);
+    }
+
+    #[test]
+    fn non_steam_shortcut_sync_refreshes_existing_metadata_by_name() {
+        let old_root = test_dir("shortcut-old");
+        let new_root = test_dir("shortcut-new");
+        let new_exe = new_root.join("Renamed.exe");
+        let mut apps = vec![SharpApp {
+            id: "steam_shortcut_old_target_hash".into(),
+            name: "Game".into(),
+            exe_path: "Old.exe".into(),
+            install_dir: old_root.to_string_lossy().to_string(),
+            cover: Some("cover.png".into()),
+            engine: "m11".into(),
+            launch_args: vec!["-dx11".into()],
+            installed_at: chrono_now(),
+            size_bytes: 123,
+        }];
+
+        let changed = sync_non_steam_shortcut(
+            &mut apps,
+            crate::scan::NonSteamShortcut {
+                name: "Game".into(),
+                exe_path: new_exe,
+                start_dir: Some(new_root.clone()),
+                launch_args: vec!["-d3d12".into()],
+            },
+        );
+
+        assert!(changed);
+        assert_eq!(apps.len(), 1);
+        assert!(apps[0].id.starts_with("steam_shortcut_"));
+        assert_ne!(apps[0].id, "steam_shortcut_old_target_hash");
+        assert_eq!(apps[0].name, "Game");
+        assert_eq!(apps[0].install_dir, new_root.to_string_lossy());
+        assert_eq!(apps[0].exe_path, "Renamed.exe");
+        assert_eq!(apps[0].cover.as_deref(), Some("cover.png"));
+        assert_eq!(apps[0].engine, "m11");
+        assert_eq!(apps[0].launch_args, vec!["-d3d12"]);
     }
 
     #[test]

--- a/app/src-rust/src/sharp_library.rs
+++ b/app/src-rust/src/sharp_library.rs
@@ -250,6 +250,23 @@ pub fn launch_app(id: &str, engine: &str) -> Result<SharpLaunchResult, Box<dyn s
     })
 }
 
+pub fn diagnose_app(
+    id: &str,
+    engine: &str,
+) -> Result<crate::mtsp::recipe::LaunchDoctorReport, Box<dyn std::error::Error>> {
+    let library = load_library()?;
+    let app = library.iter().find(|a| a.id == id).ok_or("App not found")?.clone();
+
+    let work_dir = PathBuf::from(&app.install_dir);
+    let exe_path = work_dir.join(&app.exe_path);
+    let pipeline = resolve_sharp_pipeline(engine, &exe_path);
+    let node = crate::mtsp::engine::get_pipeline(pipeline);
+    let launch_id = stable_launch_id(&app.id);
+    let mut recipe = crate::mtsp::recipe::build_custom_launch_recipe(launch_id, node, &work_dir, Some(&exe_path))?;
+    recipe.launch_args.extend(app.launch_args.iter().cloned());
+    Ok(crate::mtsp::recipe::diagnose_recipe(recipe))
+}
+
 pub fn set_cover(id: &str, cover_path: &str) -> Result<(), Box<dyn std::error::Error>> {
     let src = PathBuf::from(cover_path);
     if !src.exists() {
@@ -541,6 +558,18 @@ pub fn handle_launch(body: &serde_json::Map<String, Value>) -> Value {
         Ok(result) => {
             json!({"ok": true, "pid": result.pid, "gameType": result.game_type, "pipeline": result.pipeline, "exePath": result.exe_path, "warnings": result.warnings})
         },
+        Err(e) => json!({"ok": false, "error": e.to_string()}),
+    }
+}
+
+pub fn handle_doctor(body: &serde_json::Map<String, Value>) -> Value {
+    let id = body.get("id").and_then(|v| v.as_str()).unwrap_or("");
+    let engine = body.get("engine").and_then(|v| v.as_str()).unwrap_or("auto");
+    if id.is_empty() {
+        return json!({"ok": false, "error": "id required"});
+    }
+    match diagnose_app(id, engine) {
+        Ok(report) => json!({"ok": true, "report": report}),
         Err(e) => json!({"ok": false, "error": e.to_string()}),
     }
 }

--- a/app/src-rust/src/sharp_library.rs
+++ b/app/src-rust/src/sharp_library.rs
@@ -49,11 +49,17 @@ fn ensure_base_dir() -> Result<(), Box<dyn std::error::Error>> {
 pub fn load_library() -> Result<Vec<SharpApp>, Box<dyn std::error::Error>> {
     ensure_base_dir()?;
     let path = manifest_path();
-    if !path.exists() {
-        return Ok(vec![]);
+    let mut apps: Vec<SharpApp> = if path.exists() {
+        let data = fs::read_to_string(&path)?;
+        serde_json::from_str(&data)?
+    } else {
+        Vec::new()
+    };
+
+    if sync_non_steam_shortcuts(&mut apps) {
+        save_library(&apps)?;
     }
-    let data = fs::read_to_string(&path)?;
-    let apps: Vec<SharpApp> = serde_json::from_str(&data)?;
+
     Ok(apps)
 }
 
@@ -62,6 +68,55 @@ fn save_library(apps: &[SharpApp]) -> Result<(), Box<dyn std::error::Error>> {
     let data = serde_json::to_string_pretty(apps)?;
     fs::write(manifest_path(), data)?;
     Ok(())
+}
+
+fn sync_non_steam_shortcuts(apps: &mut Vec<SharpApp>) -> bool {
+    let mut changed = false;
+    for shortcut in crate::scan::scan_non_steam_shortcuts() {
+        let id = format!("steam_shortcut_{}", stable_shortcut_id(&shortcut.name, &shortcut.exe_path));
+        if apps.iter().any(|app| app.id == id || app_absolute_exe_path(app) == shortcut.exe_path) {
+            continue;
+        }
+
+        let install_dir = shortcut
+            .start_dir
+            .clone()
+            .filter(|dir| shortcut.exe_path.starts_with(dir))
+            .or_else(|| shortcut.exe_path.parent().map(Path::to_path_buf))
+            .unwrap_or_else(|| shortcut.exe_path.clone());
+
+        let exe_path = relative_path_string(&install_dir, &shortcut.exe_path)
+            .unwrap_or_else(|_| shortcut.exe_path.to_string_lossy().to_string());
+
+        apps.push(SharpApp {
+            id,
+            name: shortcut.name,
+            exe_path,
+            install_dir: install_dir.to_string_lossy().to_string(),
+            cover: None,
+            engine: "auto".to_string(),
+            installed_at: chrono_now(),
+            size_bytes: dir_size(&install_dir),
+        });
+        changed = true;
+    }
+    changed
+}
+
+fn app_absolute_exe_path(app: &SharpApp) -> PathBuf {
+    PathBuf::from(&app.install_dir).join(&app.exe_path)
+}
+
+fn stable_shortcut_id(name: &str, exe_path: &Path) -> u32 {
+    let mut hasher = DefaultHasher::new();
+    name.hash(&mut hasher);
+    exe_path.hash(&mut hasher);
+    let hash = hasher.finish() as u32;
+    if hash == 0 {
+        1
+    } else {
+        hash
+    }
 }
 
 fn generate_id(name: &str) -> String {
@@ -213,7 +268,7 @@ pub fn set_cover(id: &str, cover_path: &str) -> Result<(), Box<dyn std::error::E
 }
 
 pub fn set_engine(id: &str, engine: &str) -> Result<(), Box<dyn std::error::Error>> {
-    let valid = ["auto", "wine_bare", "m64", "m9", "m10", "m11", "m12", "m32"];
+    let valid = ["auto", "wine_bare", "m64", "m9", "m10", "m11", "m12", "m32", "d3d9", "d3d10", "d3d11", "d3d12"];
     if engine != "auto" && crate::mtsp::engine::PipelineId::from_str_flexible(engine).is_none() {
         return Err(format!("Unknown engine: {}. Valid: {}", engine, valid.join(", ")).into());
     }
@@ -469,7 +524,7 @@ pub fn handle_uninstall(body: &serde_json::Map<String, Value>) -> Value {
 
 pub fn handle_launch(body: &serde_json::Map<String, Value>) -> Value {
     let id = body.get("id").and_then(|v| v.as_str()).unwrap_or("");
-    let engine = body.get("engine").and_then(|v| v.as_str()).unwrap_or("wine_bare");
+    let engine = body.get("engine").and_then(|v| v.as_str()).unwrap_or("auto");
     if id.is_empty() {
         return json!({"ok": false, "error": "id required"});
     }

--- a/app/src-rust/src/sharp_library.rs
+++ b/app/src-rust/src/sharp_library.rs
@@ -25,6 +25,8 @@ pub struct SharpApp {
     pub install_dir: String,
     pub cover: Option<String>,
     pub engine: String,
+    #[serde(default)]
+    pub launch_args: Vec<String>,
     pub installed_at: String,
     pub size_bytes: u64,
 }
@@ -95,6 +97,7 @@ fn sync_non_steam_shortcuts(apps: &mut Vec<SharpApp>) -> bool {
             install_dir: install_dir.to_string_lossy().to_string(),
             cover: None,
             engine: "auto".to_string(),
+            launch_args: shortcut.launch_args,
             installed_at: chrono_now(),
             size_bytes: dir_size(&install_dir),
         });
@@ -162,6 +165,7 @@ pub fn install_exe(src_path: &str, custom_name: Option<&str>) -> Result<SharpApp
         install_dir,
         cover: None,
         engine: "auto".to_string(),
+        launch_args: Vec::new(),
         installed_at,
         size_bytes,
     };
@@ -229,8 +233,13 @@ pub fn launch_app(id: &str, engine: &str) -> Result<SharpLaunchResult, Box<dyn s
 
     let pipeline = resolve_sharp_pipeline(engine, &exe_path);
     let launch_id = stable_launch_id(&app.id);
-    let (pid, game_type, recipe) =
-        crate::mtsp::launcher::launch_custom_with_pipeline(launch_id, &work_dir, &exe_path, pipeline)?;
+    let (pid, game_type, recipe) = crate::mtsp::launcher::launch_custom_with_pipeline(
+        launch_id,
+        &work_dir,
+        &exe_path,
+        pipeline,
+        &app.launch_args,
+    )?;
 
     Ok(SharpLaunchResult {
         pid,

--- a/app/src-rust/src/sharp_library.rs
+++ b/app/src-rust/src/sharp_library.rs
@@ -75,51 +75,56 @@ fn save_library(apps: &[SharpApp]) -> Result<(), Box<dyn std::error::Error>> {
 fn sync_non_steam_shortcuts(apps: &mut Vec<SharpApp>) -> bool {
     let mut changed = false;
     for shortcut in crate::scan::scan_non_steam_shortcuts() {
-        let id = format!("steam_shortcut_{}", stable_shortcut_id(&shortcut.name, &shortcut.exe_path));
-        if apps.iter().any(|app| app.id == id || app_absolute_exe_path(app) == shortcut.exe_path) {
-            continue;
-        }
-
-        let install_dir = shortcut
-            .start_dir
-            .clone()
-            .filter(|dir| shortcut.exe_path.starts_with(dir))
-            .or_else(|| shortcut.exe_path.parent().map(Path::to_path_buf))
-            .unwrap_or_else(|| shortcut.exe_path.clone());
-
-        let exe_path = relative_path_string(&install_dir, &shortcut.exe_path)
-            .unwrap_or_else(|_| shortcut.exe_path.to_string_lossy().to_string());
-
-        apps.push(SharpApp {
-            id,
-            name: shortcut.name,
-            exe_path,
-            install_dir: install_dir.to_string_lossy().to_string(),
-            cover: None,
-            engine: "auto".to_string(),
-            launch_args: shortcut.launch_args,
-            installed_at: chrono_now(),
-            size_bytes: dir_size(&install_dir),
-        });
-        changed = true;
+        changed |= sync_non_steam_shortcut(apps, shortcut);
     }
     changed
+}
+
+fn sync_non_steam_shortcut(apps: &mut Vec<SharpApp>, shortcut: crate::scan::NonSteamShortcut) -> bool {
+    let id = format!("steam_shortcut_{}", stable_shortcut_id(&shortcut.name, &shortcut.exe_path));
+    if let Some(app) = apps.iter_mut().find(|app| app.id == id || app_absolute_exe_path(app) == shortcut.exe_path) {
+        if app.launch_args != shortcut.launch_args {
+            app.launch_args = shortcut.launch_args;
+            return true;
+        }
+        return false;
+    }
+
+    let install_dir = shortcut
+        .start_dir
+        .clone()
+        .filter(|dir| shortcut.exe_path.starts_with(dir))
+        .or_else(|| shortcut.exe_path.parent().map(Path::to_path_buf))
+        .unwrap_or_else(|| shortcut.exe_path.clone());
+
+    let exe_path = relative_path_string(&install_dir, &shortcut.exe_path)
+        .unwrap_or_else(|_| shortcut.exe_path.to_string_lossy().to_string());
+
+    apps.push(SharpApp {
+        id,
+        name: shortcut.name,
+        exe_path,
+        install_dir: install_dir.to_string_lossy().to_string(),
+        cover: None,
+        engine: "auto".to_string(),
+        launch_args: shortcut.launch_args,
+        installed_at: chrono_now(),
+        size_bytes: dir_size(&install_dir),
+    });
+    true
 }
 
 fn app_absolute_exe_path(app: &SharpApp) -> PathBuf {
     PathBuf::from(&app.install_dir).join(&app.exe_path)
 }
 
-fn stable_shortcut_id(name: &str, exe_path: &Path) -> u32 {
-    let mut hasher = DefaultHasher::new();
-    name.hash(&mut hasher);
-    exe_path.hash(&mut hasher);
-    let hash = hasher.finish() as u32;
-    if hash == 0 {
-        1
-    } else {
-        hash
+fn stable_shortcut_id(name: &str, exe_path: &Path) -> String {
+    let mut hash = 0xcbf29ce484222325_u64;
+    for byte in name.as_bytes().iter().chain(b"\0").chain(exe_path.to_string_lossy().as_bytes()) {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
     }
+    format!("{:016x}", hash)
 }
 
 fn generate_id(name: &str) -> String {
@@ -635,6 +640,51 @@ mod tests {
         let exe = test_dir("unknown").join("Tool.exe");
 
         assert_eq!(resolve_sharp_pipeline("auto", &exe), crate::mtsp::engine::PipelineId::WineBare);
+    }
+
+    #[test]
+    fn non_steam_shortcut_sync_updates_existing_launch_args_by_path() {
+        let root = test_dir("shortcut-args");
+        let exe = root.join("Game.exe");
+        let mut apps = vec![SharpApp {
+            id: "steam_shortcut_old_runtime_hash".into(),
+            name: "Game".into(),
+            exe_path: "Game.exe".into(),
+            install_dir: root.to_string_lossy().to_string(),
+            cover: None,
+            engine: "auto".into(),
+            launch_args: vec!["-dx11".into()],
+            installed_at: chrono_now(),
+            size_bytes: 0,
+        }];
+
+        let changed = sync_non_steam_shortcut(
+            &mut apps,
+            crate::scan::NonSteamShortcut {
+                name: "Game".into(),
+                exe_path: exe,
+                start_dir: Some(root),
+                launch_args: vec!["-d3d12".into(), "-windowed".into()],
+            },
+        );
+
+        assert!(changed);
+        assert_eq!(apps.len(), 1);
+        assert_eq!(apps[0].launch_args, vec!["-d3d12", "-windowed"]);
+    }
+
+    #[test]
+    fn non_steam_shortcut_ids_use_explicit_stable_hex_hashes() {
+        let path = PathBuf::from("/tmp/Game/Game.exe");
+
+        let first = stable_shortcut_id("Game", &path);
+        let second = stable_shortcut_id("Game", &path);
+        let changed = stable_shortcut_id("Game", Path::new("/tmp/Game/Other.exe"));
+
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 16);
+        assert!(first.chars().all(|ch| ch.is_ascii_hexdigit()));
+        assert_ne!(first, changed);
     }
 
     fn test_dir(name: &str) -> PathBuf {

--- a/app/src-rust/src/steam.rs
+++ b/app/src-rust/src/steam.rs
@@ -440,12 +440,26 @@ pub fn install_game_via_steam(appid: u32) -> Result<Value, Box<dyn std::error::E
 }
 
 pub fn launch_game_via_steam(appid: u32) -> Result<Value, Box<dyn std::error::Error>> {
+    launch_game_via_steam_with_env(appid, &[])
+}
+
+pub fn launch_game_via_steam_with_env(
+    appid: u32,
+    extra_env: &[(String, String)],
+) -> Result<Value, Box<dyn std::error::Error>> {
     let wine = ms_wine();
     if !wine.exists() {
         return Err("MetalSharp Wine not found".into());
     }
-    if !is_wine_steam_running() {
-        launch_wine_steam()?;
+    let steam_running = is_wine_steam_running();
+    if steam_running && !extra_env.is_empty() {
+        return Err(
+            "Wine Steam is already running; route-specific environment cannot be inherited without restarting Steam"
+                .into(),
+        );
+    }
+    if !steam_running {
+        launch_wine_steam_with_env(extra_env)?;
         for _ in 0..30 {
             std::thread::sleep(std::time::Duration::from_secs(2));
             if is_wine_steam_running() {
@@ -456,7 +470,7 @@ pub fn launch_game_via_steam(appid: u32) -> Result<Value, Box<dyn std::error::Er
     }
 
     let url = format!("steam://run/{}", appid);
-    let pid = spawn_wine_steam(&[&url])?;
+    let pid = spawn_wine_steam_with_env(&[&url], extra_env)?;
 
     Ok(json!({"ok": true, "pid": pid, "appid": appid}))
 }

--- a/app/src/renderer/api-types.ts
+++ b/app/src/renderer/api-types.ts
@@ -73,6 +73,7 @@ interface SharpApp {
   install_dir: string;
   cover: string | null;
   engine: string;
+  launch_args: string[];
   installed_at: string;
   size_bytes: number;
 }

--- a/app/src/renderer/views/LibraryView.vue
+++ b/app/src/renderer/views/LibraryView.vue
@@ -51,6 +51,7 @@ function isMacSteamLaunch(launchMethod: string) {
 function isWineSteamRouteLaunch(launchMethod: string) {
   const method = launchMethod.toLowerCase();
   return [
+    "auto",
     "steam",
     "wine_steam",
     "m9",

--- a/app/src/renderer/views/LibraryView.vue
+++ b/app/src/renderer/views/LibraryView.vue
@@ -58,7 +58,6 @@ function isWineSteamRouteLaunch(launchMethod: string) {
     "m11",
     "m12",
     "m32",
-    "wine_bare",
     "dx9",
     "dx10",
     "dx11",

--- a/app/src/renderer/views/LibraryView.vue
+++ b/app/src/renderer/views/LibraryView.vue
@@ -48,10 +48,9 @@ function isMacSteamLaunch(launchMethod: string) {
   return launchMethod === "mac_steam" || launchMethod === "macos_steam" || launchMethod === "native_steam";
 }
 
-function isWineSteamRouteLaunch(launchMethod: string) {
+function isWineSteamRouteId(launchMethod: string) {
   const method = launchMethod.toLowerCase();
   return [
-    "auto",
     "steam",
     "wine_steam",
     "m9",
@@ -67,7 +66,24 @@ function isWineSteamRouteLaunch(launchMethod: string) {
     "d3d10",
     "d3d11",
     "d3d12",
+    "d3d9_metal",
+    "dxmt_metal",
+    "dxmt_metal12",
+    "wined3d_32",
   ].includes(method);
+}
+
+function recommendedLaunchMethod(game: SteamGame) {
+  return game.launch_method ?? game.available_pipelines?.find((pipeline) => pipeline.recommended)?.id;
+}
+
+function isWineSteamRouteLaunch(game: SteamGame, launchMethod: string) {
+  const method = launchMethod.toLowerCase();
+  if (method === "auto") {
+    const recommended = recommendedLaunchMethod(game);
+    return recommended ? isWineSteamRouteId(recommended) : false;
+  }
+  return isWineSteamRouteId(method);
 }
 
 function applyFilter() {
@@ -156,7 +172,8 @@ async function launchGame(game: SteamGame, launchMethod = "auto") {
   }
 
   launchingAppId.value = game.appid;
-  const launchEndpoint = isWineSteamRouteLaunch(launchMethod) ? "/steam/launch-game" : "/game/launch-auto";
+  const useWineSteamRoute = isWineSteamRouteLaunch(game, launchMethod);
+  const launchEndpoint = useWineSteamRoute ? "/steam/launch-game" : "/game/launch-auto";
   const launchResult = await api<{
     ok: boolean;
     pid?: number;
@@ -173,7 +190,7 @@ async function launchGame(game: SteamGame, launchMethod = "auto") {
   if (launchResult?.ok && launchResult.pid) {
     runningPid.value = launchResult.pid;
     runningAppId.value = game.appid;
-    if (isWineSteamRouteLaunch(launchMethod)) wineSteamRunning.value = true;
+    if (useWineSteamRoute) wineSteamRunning.value = true;
     if (isMacSteamLaunch(launchMethod) || launchResult.gameType === "macos_steam") macSteamRunning.value = true;
     toast.show(`Launched ${game.name}`, "success");
   } else {

--- a/app/src/renderer/views/LibraryView.vue
+++ b/app/src/renderer/views/LibraryView.vue
@@ -48,6 +48,28 @@ function isMacSteamLaunch(launchMethod: string) {
   return launchMethod === "mac_steam" || launchMethod === "macos_steam" || launchMethod === "native_steam";
 }
 
+function isWineSteamRouteLaunch(launchMethod: string) {
+  const method = launchMethod.toLowerCase();
+  return [
+    "steam",
+    "wine_steam",
+    "m9",
+    "m10",
+    "m11",
+    "m12",
+    "m32",
+    "wine_bare",
+    "dx9",
+    "dx10",
+    "dx11",
+    "dx12",
+    "d3d9",
+    "d3d10",
+    "d3d11",
+    "d3d12",
+  ].includes(method);
+}
+
 function applyFilter() {
   if (!library.value) {
     filteredGames.value = [];
@@ -134,19 +156,24 @@ async function launchGame(game: SteamGame, launchMethod = "auto") {
   }
 
   launchingAppId.value = game.appid;
+  const launchEndpoint = isWineSteamRouteLaunch(launchMethod) ? "/steam/launch-game" : "/game/launch-auto";
   const launchResult = await api<{
     ok: boolean;
     pid?: number;
     error?: string;
     engine?: string;
     gameType?: string;
-  }>("POST", "/game/launch-auto", { appid: game.appid, launchMethod });
+  }>("POST", launchEndpoint, {
+    appid: game.appid,
+    launchMethod,
+  });
 
   launchingAppId.value = null;
 
   if (launchResult?.ok && launchResult.pid) {
     runningPid.value = launchResult.pid;
     runningAppId.value = game.appid;
+    if (isWineSteamRouteLaunch(launchMethod)) wineSteamRunning.value = true;
     if (isMacSteamLaunch(launchMethod) || launchResult.gameType === "macos_steam") macSteamRunning.value = true;
     toast.show(`Launched ${game.name}`, "success");
   } else {

--- a/app/src/renderer/views/SharpView.vue
+++ b/app/src/renderer/views/SharpView.vue
@@ -4,8 +4,33 @@ import { useToast } from "../composables/useToast";
 import { api, getAPI } from "../composables/useApi";
 import type { SharpApp } from "../api-types";
 
+interface LaunchDoctorCheck {
+  id: string;
+  label: string;
+  ok: boolean;
+  detail: string;
+}
+
+interface LaunchDoctorReport {
+  ready: boolean;
+  summary: string;
+  blockers: string[];
+  warnings: string[];
+  checks: LaunchDoctorCheck[];
+  recipe: {
+    pipeline: string;
+    pipeline_name: string;
+    backend: string;
+    exe_name?: string | null;
+    launch_args: string[];
+  };
+}
+
 const toast = useToast();
 const apps = ref<SharpApp[]>([]);
+const doctorOpen = ref<Record<string, boolean>>({});
+const doctorLoading = ref<Record<string, boolean>>({});
+const doctorReports = ref<Record<string, LaunchDoctorReport | null>>({});
 const engineOptions = [
   { id: "auto", name: "Auto" },
   { id: "wine_bare", name: "Wine" },
@@ -73,6 +98,23 @@ async function setCover(id: string) {
   else toast.show(result?.error ?? "Failed to set cover", "error");
 }
 
+async function runDoctor(app: SharpApp) {
+  doctorOpen.value[app.id] = true;
+  doctorLoading.value[app.id] = true;
+  doctorReports.value[app.id] = null;
+  const result = await api<{ ok: boolean; report?: LaunchDoctorReport; error?: string }>("POST", "/sharp-library/doctor", {
+    id: app.id,
+    engine: app.engine,
+  });
+  doctorLoading.value[app.id] = false;
+
+  if (result?.ok && result.report) {
+    doctorReports.value[app.id] = result.report;
+  } else {
+    toast.show(result?.error ?? "Launch Doctor failed", "error");
+  }
+}
+
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
@@ -124,7 +166,42 @@ onMounted(load);
             </div>
             <div class="sharp-card-actions-row subtle">
               <button class="btn btn-secondary btn-sm" @click="setCover(app.id)">Set Cover</button>
+              <button class="btn btn-secondary btn-sm" :disabled="doctorLoading[app.id]" @click="runDoctor(app)">
+                {{ doctorLoading[app.id] ? "Checking" : "Doctor" }}
+              </button>
               <button class="btn btn-danger btn-sm" @click="uninstallApp(app.id)">Uninstall</button>
+            </div>
+            <div v-if="doctorOpen[app.id]" class="doctor-panel">
+              <div v-if="doctorLoading[app.id]" class="doctor-loading">Checking launch prerequisites...</div>
+              <template v-else-if="doctorReports[app.id]">
+                <div class="doctor-summary">
+                  <span class="badge" :class="doctorReports[app.id]?.ready ? 'badge-ok' : 'badge-warn'">
+                    {{ doctorReports[app.id]?.ready ? "Ready" : "Blocked" }}
+                  </span>
+                  <span>{{ doctorReports[app.id]?.summary }}</span>
+                </div>
+                <div class="doctor-checks">
+                  <div
+                    v-for="check in doctorReports[app.id]?.checks ?? []"
+                    :key="check.id"
+                    class="doctor-check"
+                    :class="{ failed: !check.ok }"
+                  >
+                    <span class="doctor-check-state">{{ check.ok ? "OK" : "!" }}</span>
+                    <span class="doctor-check-label">{{ check.label }}</span>
+                    <span class="doctor-check-detail">{{ check.detail }}</span>
+                  </div>
+                </div>
+                <div v-if="doctorReports[app.id]?.recipe.launch_args.length" class="doctor-notes">
+                  <div>Args: {{ doctorReports[app.id]?.recipe.launch_args.join(" ") }}</div>
+                </div>
+                <div v-if="doctorReports[app.id]?.blockers.length" class="doctor-notes blocked">
+                  <div v-for="blocker in doctorReports[app.id]?.blockers" :key="blocker">{{ blocker }}</div>
+                </div>
+                <div v-if="doctorReports[app.id]?.warnings.length" class="doctor-notes">
+                  <div v-for="warning in doctorReports[app.id]?.warnings" :key="warning">{{ warning }}</div>
+                </div>
+              </template>
             </div>
           </div>
         </div>
@@ -223,6 +300,58 @@ onMounted(load);
 }
 .sharp-card-actions-row.subtle {
   opacity: 0.7;
+}
+
+.doctor-panel {
+  margin-top: 2px;
+  padding: 10px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  font-size: 11px;
+}
+.doctor-loading {
+  color: var(--text-dim);
+}
+.doctor-summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  color: var(--text-secondary);
+}
+.doctor-checks {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.doctor-check {
+  display: grid;
+  grid-template-columns: 28px 74px 1fr;
+  gap: 6px;
+  align-items: start;
+  color: var(--text-dim);
+}
+.doctor-check.failed {
+  color: var(--text-primary);
+}
+.doctor-check-state {
+  font-size: 9px;
+  color: var(--text-dim);
+}
+.doctor-check-label {
+  color: var(--text-secondary);
+}
+.doctor-check-detail {
+  overflow-wrap: anywhere;
+}
+.doctor-notes {
+  margin-top: 8px;
+  color: var(--text-dim);
+  line-height: 1.4;
+}
+.doctor-notes.blocked {
+  color: var(--danger);
 }
 
 .empty-state {

--- a/docs/m10-pipeline-map.md
+++ b/docs/m10-pipeline-map.md
@@ -37,7 +37,7 @@ M10 deliberately does not deploy `d3d12.dll`.
 |---|---|
 | Pipeline | `M10` |
 | Backend | `dxmt` |
-| Launch args | `-dx10` |
+| Launch args | none by default; `dx10`/`d3d10` select M10 as route aliases |
 | Wine overrides | `d3d10,d3d10_1,dxgi,d3d11,d3d10core=n,b;gameoverlayrenderer,gameoverlayrenderer64=d` |
 | Shader cache subdir | `m10` |
 | Preset fallback family | `m10`, then `dxmt-metal` |

--- a/docs/m12-pipeline-map.md
+++ b/docs/m12-pipeline-map.md
@@ -13,7 +13,7 @@ uses for Wine-launched games.
 | --- | --- | --- | --- |
 | Game detection | `app/src-rust/src/mtsp/pe.rs`, `rules.rs` | D3D12 imports select `PipelineId::M12` for 64-bit games. | Present in current project |
 | Pipeline definition | `app/src-rust/src/mtsp/engine.rs` | M12 is named `D3D12 -> Metal via DXMT`, is the first stable pipeline, deploys DXMT DLLs, and sets D3D12/DXGI/D3D11 overrides. | Present in current project |
-| Launcher handoff | `app/src-rust/src/mtsp/launcher.rs` | M12 routes through `launch_dxmt_metal`, copies DLLs into the game directory, sets Wine/DYLD/cache env, and adds `-dx12`. | Present in current project |
+| Launcher handoff | `app/src-rust/src/mtsp/launcher.rs` | M12 routes through `launch_dxmt_metal`, copies DLLs into the game directory, and sets Wine/DYLD/cache env. | Present in current project |
 | Shader/cache routing | `app/src-rust/src/mtsp/shader_cache.rs` | M12 uses `m12` and `dxmt-metal12` cache directories. | Present in current project |
 | DXMT D3D12 implementation | External DXMT source tree | Conformance branch contains the real DXMT D3D12/DXIL/winemetal work used by M12 runtime DLLs. | External source tree |
 | Native D3D12 target | `include/metalsharp/D3D12Device.h`, `src/d3d/d3d12/*` | Builds `build/d3d12.dylib` and exposes `D3D12CreateDevice`. | In-tree, smoke-tested |
@@ -29,7 +29,7 @@ uses for Wine-launched games.
 4. M12 sets `WINEDLLOVERRIDES` so Wine prefers the deployed native DXMT DLLs.
 5. M12 adds DXMT/Wine unix library paths to `DYLD_FALLBACK_LIBRARY_PATH`.
 6. M12 sets shader and pipeline cache paths under the MetalSharp cache root.
-7. Wine launches the executable with the M12 launch args, including `-dx12`.
+7. Wine launches the executable without a forced DirectX command-line flag. `dx12` and `d3d12` are route aliases for selecting M12, not universal game args.
 8. DXMT handles D3D12/DXGI calls, compiles DXIL/MSL work, sends commands through
    `winemetal`, and presents through the Wine/macOS surface.
 

--- a/docs/m9-pipeline-map.md
+++ b/docs/m9-pipeline-map.md
@@ -21,7 +21,7 @@ The current DXMT source tree provides D3D10, D3D11, D3D12, DXGI, and winemetal t
 |---|---|
 | Pipeline | `M9` |
 | Backend | `dxmt` |
-| Launch args | `-dx9` |
+| Launch args | none by default; `dx9`/`d3d9` select M9 as route aliases |
 | Wine overrides | `d3d9=n,b;gameoverlayrenderer,gameoverlayrenderer64=d` |
 | Shader cache subdir | `m9` |
 | Preset fallback family | `m9`, then `dxmt-metal` |


### PR DESCRIPTION
## Summary
- stop treating M9-M12 DirectX flags as mandatory launch args, keeping route selection internal to MTSP DLL/env/cache setup
- accept `dx9`/`d3d9` through `dx12`/`d3d12` as route selector aliases for Sharp Library and launch-method parsing
- scan Steam `shortcuts.vdf` files for non-Steam `.exe` shortcuts and sync them into Sharp Library with `auto` routing
- preserve shortcut-specific launch arguments from both shortcut command strings and Steam `LaunchOptions` metadata
- keep non-Steam shortcut parsing stable across nested Steam metadata such as shortcut tags
- keep already-synced shortcut target, start directory, display name, size, and launch args refreshed when Steam shortcut metadata changes
- use explicit stable shortcut ids in both Sharp Library sync and `/scan` results instead of runtime-dependent hasher output
- add a Sharp Library Launch Doctor endpoint and per-card UI panel for route/runtime/DLL/exe verification
- harden Launch Doctor with selected-exe PE architecture checks so 32-bit/64-bit route mismatches block before launch
- pass optional MTSP routes through Wine Steam launches by preparing route DLLs/cache/env before `steam://run`
- route explicit Library MTSP/Wine Steam selections through the Wine Steam handoff endpoint, and route Auto there only when the recommended route is handoff-compatible
- keep the explicit plain Wine fallback on the direct launch path and reject it from the Steam handoff API
- update M9/M10/M12 pipeline docs to describe route aliases instead of forced game arguments

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (`60 passed`)
- `npm --prefix app run build`