### PR TITLE
Upload nested Linux release assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,5 +165,5 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: release/*
+          files: release/**/*
           generate_release_notes: true


### PR DESCRIPTION
## Summary
- update the tag release upload glob so nested Linux artifact files from actions/download-artifact are included

## Testing
- git diff --check
- verified v0.33.25 release artifact layout placed DEB assets under release/electron and runtime assets under release/packages
- manually uploaded missing v0.33.25 Linux assets to the release