### PR TITLE
Add Wine 11.9 parity evidence tooling

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -109,6 +109,40 @@ jobs:
       - name: Shell check
         run: bash -n updater/update.sh
 
+  wine119-evidence:
+    name: Wine 11.9 Evidence CI
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Script syntax
+        run: |
+          bash -n \
+            scripts/fetch-wine119-release-assets.sh \
+            scripts/runtime-manifest.sh \
+            scripts/compare-runtime-manifests.sh \
+            scripts/prepare-wine119-candidate.sh \
+            scripts/prepare-wine119-parity-candidates.sh \
+            scripts/install-wine119-parity-home.sh \
+            scripts/probe-wine119-parity-backend.sh \
+            scripts/capture-steam-game-proof.sh \
+            scripts/run-wine119-live-control-suite.sh \
+            scripts/verify-wine119-live-control-suite.sh \
+            scripts/audit-wine119-readiness.sh \
+            scripts/audit-mscompatdb-hook-surface.sh \
+            scripts/audit-i386-winemetal-provenance.sh \
+            scripts/preflight-i386-winemetal-build.sh \
+            scripts/audit-wine119-objective-completion.sh \
+            scripts/test-wine119-live-suite-guards.sh \
+            scripts/test-wine119-objective-audit-guards.sh \
+            scripts/test-wine119-live-verifier-fixtures.sh
+
+      - name: Non-live evidence guard fixtures
+        run: |
+          scripts/test-wine119-live-suite-guards.sh
+          scripts/test-wine119-objective-audit-guards.sh
+          scripts/test-wine119-live-verifier-fixtures.sh
+
   native:
     name: C/C++/Obj-C CI
     runs-on: macos-14

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -115,6 +115,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install evidence tools
+        run: brew install ripgrep
+
       - name: Script syntax
         run: |
           bash -n \

--- a/app/src/renderer/views/LibraryView.vue
+++ b/app/src/renderer/views/LibraryView.vue
@@ -84,7 +84,9 @@ function isWineSteamRouteLaunch(game: SteamGame, launchMethod: string) {
   const method = launchMethod.toLowerCase();
   if (method === "auto") {
     const recommended = recommendedLaunchMethod(game);
-    return recommended ? isWineSteamRouteId(recommended) : false;
+    if (!recommended) return true;
+    if (isMacSteamLaunch(recommended)) return false;
+    return isWineSteamRouteId(recommended);
   }
   return isWineSteamRouteId(method);
 }

--- a/docs/wine-119-implementation-runbook.md
+++ b/docs/wine-119-implementation-runbook.md
@@ -103,6 +103,7 @@ Expected result:
 - Shell syntax passes.
 - Launcher tests pass.
 - No installed runtime files change.
+- Optional verifier fixture proves the live-suite verifier accepts surviving Wine Steam PIDs and rejects disappeared pre-existing Wine Steam PIDs.
 
 ## Pass 1: Runtime Candidate Preparation
 
@@ -198,6 +199,7 @@ Required pass conditions:
 - Schedule I launches with `launchMethod: "m11"`.
 - Subnautica Below Zero launches with `launchMethod: "m11"`.
 - Each game has a live game PID, not just a Steam URL/helper PID.
+- If Wine Steam was already running before a game launch, the pre-existing `Steam.exe` PID survives that launch.
 - `lsof` and launch summaries prove the expected DXMT/WineMetal/MoltenVK/cache paths.
 
 If `dxmt32` fails specifically on the i386 WineMetal artifact, repeat Passes 2

--- a/docs/wine-119-implementation-runbook.md
+++ b/docs/wine-119-implementation-runbook.md
@@ -139,6 +139,9 @@ Expected candidate meaning:
 - `clean`: must fail because release asset lacks i386 `winemetal.dll`.
 - `dxmt32`: primary test candidate, still release-blocked until live M9 proof.
 - `borrowed`: manifest-complete fallback experiment, not release-ready without live proof.
+- every prepared candidate must rewrite Vulkan ICD `library_path` entries to
+  its own runtime root and provide `lib/libMoltenVK.dylib`, otherwise proof can
+  accidentally borrow MoltenVK from the installed 11.5 runtime.
 
 ## Pass 2: Isolated Parity Home
 
@@ -201,6 +204,12 @@ Required pass conditions:
 - Each game has a live game PID, not just a Steam URL/helper PID.
 - If Wine Steam was already running before a game launch, the pre-existing `Steam.exe` PID survives that launch.
 - `lsof` and launch summaries prove the expected DXMT/WineMetal/MoltenVK/cache paths.
+- Before release, repeat or supplement this proof through the app-facing route:
+  confirm the renderer-selected launch method calls `/steam/launch-game` for
+  each configured M9/M11 control, or launch through Electron and capture the
+  same proof bundle.
+- M12 remains a mapped rebuild surface until a dedicated M12 control game has
+  passed with the same process/module/cache proof.
 
 If `dxmt32` fails specifically on the i386 WineMetal artifact, repeat Passes 2
 and 3 with the `borrowed` candidate. A borrowed i386 bridge is only acceptable

--- a/docs/wine-119-implementation-runbook.md
+++ b/docs/wine-119-implementation-runbook.md
@@ -189,6 +189,7 @@ Command:
 
 ```bash
 METALSHARP_RUN_LIVE_GAMES=1 \
+METALSHARP_REQUIRE_PREEXISTING_WINE_STEAM=1 \
 scripts/run-wine119-live-control-suite.sh \
   /private/tmp/metalsharp-home-wine119-dxmt32-state \
   /tmp/metalsharp-live-controls-dxmt32
@@ -208,7 +209,9 @@ Required pass conditions:
 - Schedule I launches with `launchMethod: "m11"`.
 - Subnautica Below Zero launches with `launchMethod: "m11"`.
 - Each game has a live game PID, not just a Steam URL/helper PID.
-- If Wine Steam was already running before a game launch, the pre-existing `Steam.exe` PID survives that launch.
+- Wine Steam is prestarted before the controls.
+- Each game launch has a pre-existing `Steam.exe` PID before launch.
+- The pre-existing `Steam.exe` PID survives each launch.
 - `lsof` and launch summaries prove the expected DXMT/WineMetal/MoltenVK/cache paths.
 - Before release, keep the app-facing route audit green and, if the packaged UI
   changes, repeat this proof through Electron before tag bump.

--- a/docs/wine-119-implementation-runbook.md
+++ b/docs/wine-119-implementation-runbook.md
@@ -81,6 +81,7 @@ Allowed files:
 - `scripts/audit-electron-launch-routes.mjs`
 - `scripts/audit-mscompatdb-hook-surface.sh`
 - `scripts/audit-i386-winemetal-provenance.sh`
+- `scripts/preflight-i386-winemetal-build.sh`
 - `scripts/capture-steam-game-proof.sh`
 - `scripts/run-wine119-live-control-suite.sh`
 - `scripts/verify-wine119-live-control-suite.sh`
@@ -103,6 +104,7 @@ bash -n scripts/runtime-manifest.sh \
   scripts/audit-wine119-readiness.sh \
   scripts/audit-mscompatdb-hook-surface.sh \
   scripts/audit-i386-winemetal-provenance.sh \
+  scripts/preflight-i386-winemetal-build.sh \
   scripts/audit-wine119-objective-completion.sh
 
 node --check scripts/audit-electron-launch-routes.mjs
@@ -147,6 +149,11 @@ scripts/audit-i386-winemetal-provenance.sh \
   /Volumes/AverySSD/metalsharp/dxmt-src \
   /Volumes/AverySSD/metalsharp/dxmt-src/build32/src/winemetal/winemetal.dll \
   /tmp/metalsharp-i386-winemetal-provenance-current
+
+scripts/preflight-i386-winemetal-build.sh \
+  /Volumes/AverySSD/metalsharp/dxmt-src \
+  /tmp/metalsharp-wine119-parity/candidates/dxmt32/wine \
+  /tmp/metalsharp-i386-winemetal-build-preflight-current
 ```
 
 Expected candidate meaning:
@@ -167,6 +174,11 @@ Expected candidate meaning:
   artifact is only an experiment if the audit reports a dirty source tree or
   Wine 11.5 linker inputs; it cannot satisfy the release-proven 11.9 i386
   requirement by itself.
+- i386 WineMetal build preflight must show the shaped 11.9 runtime has
+  `bin/winebuild`, `libwinecrt0.a`, `libntdll.a`, and `dbghelp.dll` for
+  `i386-windows`, plus local Meson/Ninja/i686 mingw tools. A failing
+  `source-clean` gate means the next branch must clean or fork DXMT source
+  before producing a release-grade 11.9 i386 artifact.
 - Pass 1 does not run readiness or objective completion audits; those require a
   Pass 2 parity home and backend probe.
 

--- a/docs/wine-119-implementation-runbook.md
+++ b/docs/wine-119-implementation-runbook.md
@@ -106,11 +106,13 @@ bash -n scripts/runtime-manifest.sh \
   scripts/audit-i386-winemetal-provenance.sh \
   scripts/preflight-i386-winemetal-build.sh \
   scripts/audit-wine119-objective-completion.sh \
-  scripts/test-wine119-live-suite-guards.sh
+  scripts/test-wine119-live-suite-guards.sh \
+  scripts/test-wine119-objective-audit-guards.sh
 
 node --check scripts/audit-electron-launch-routes.mjs
 
 scripts/test-wine119-live-suite-guards.sh
+scripts/test-wine119-objective-audit-guards.sh
 
 (cd app/src-rust && cargo test launcher::tests::)
 ```
@@ -123,6 +125,9 @@ Expected result:
 - Live-suite guard fixture proves the live runner accepts only the clean
   candidate preflight and refuses stale/dirty candidate wiring before backend,
   Steam, or game launch.
+- Objective-audit guard fixture proves stale readiness cannot satisfy non-live
+  completion unless it also proves clean `dxmt32` source and parity-home source
+  alignment.
 - Optional verifier fixture proves the live-suite verifier accepts surviving Wine Steam PIDs and rejects disappeared pre-existing Wine Steam PIDs.
 
 ## Pass 1: Runtime Candidate Preparation

--- a/docs/wine-119-implementation-runbook.md
+++ b/docs/wine-119-implementation-runbook.md
@@ -70,6 +70,7 @@ Allowed files:
 - `docs/wine-119-implementation-runbook.md`
 - `scripts/runtime-manifest.sh`
 - `scripts/compare-runtime-manifests.sh`
+- `scripts/fetch-wine119-release-assets.sh`
 - `scripts/prepare-wine119-candidate.sh`
 - `scripts/prepare-wine119-parity-candidates.sh`
 - `scripts/install-wine119-parity-home.sh`
@@ -84,6 +85,7 @@ Commands:
 ```bash
 bash -n scripts/runtime-manifest.sh \
   scripts/compare-runtime-manifests.sh \
+  scripts/fetch-wine119-release-assets.sh \
   scripts/prepare-wine119-candidate.sh \
   scripts/prepare-wine119-parity-candidates.sh \
   scripts/install-wine119-parity-home.sh \
@@ -110,15 +112,19 @@ preserving the 11.5 final runtime shape.
 Inputs:
 
 - Release asset: `bundles/metalsharp_bundle.tar.zst`
-- Current known local extraction source: `/tmp/metalsharp-wine-assets-IjmErR/metalsharp_bundle.tar.zst`
+- Reproducible local asset path after fetch: `/tmp/metalsharp-wine-assets/metalsharp_bundle.tar.zst`
 - Working baseline: `/Users/alexmondello/.metalsharp/runtime/wine`
 - DXMT i386 candidate: `/Volumes/AverySSD/metalsharp/dxmt-src/build32/src/winemetal/winemetal.dll`
 
 Commands:
 
 ```bash
+scripts/fetch-wine119-release-assets.sh \
+  /tmp/metalsharp-wine-assets \
+  metalsharp_bundle.tar.zst
+
 scripts/prepare-wine119-parity-candidates.sh \
-  /tmp/metalsharp-wine-assets-IjmErR/metalsharp_bundle.tar.zst \
+  /tmp/metalsharp-wine-assets/metalsharp_bundle.tar.zst \
   /tmp/metalsharp-wine119-parity
 
 scripts/audit-wine119-readiness.sh \
@@ -128,6 +134,7 @@ scripts/audit-wine119-readiness.sh \
 
 Expected candidate meaning:
 
+- fetch report must verify `metalsharp_bundle.tar.zst` against the GitHub release digest before candidate preparation
 - `clean`: must fail because release asset lacks i386 `winemetal.dll`.
 - `dxmt32`: primary test candidate, still release-blocked until live M9 proof.
 - `borrowed`: manifest-complete fallback experiment, not release-ready without live proof.
@@ -156,6 +163,7 @@ scripts/audit-wine119-readiness.sh \
 
 Required proof before live launch:
 
+- `/tmp/metalsharp-wine-assets/fetch-report.txt` verifies the GitHub `bundles/metalsharp_bundle.tar.zst` SHA256.
 - Wine reports `wine-11.9`.
 - Backend reports version `0.33.27`.
 - Active bottle/compatdata/config manifests have zero references to `/Users/alexmondello/.metalsharp`.

--- a/docs/wine-119-implementation-runbook.md
+++ b/docs/wine-119-implementation-runbook.md
@@ -27,23 +27,19 @@ Allowed direct replay candidates are diagnostic only:
 - `1148f57` Tighten mscompatdb readiness checks
 - `cfade4e` Read PE export and import directories separately
 - `f654c10` Add D3D12 surface extraction diagnostics
-- `1c0b788` Log direct MTSP runtime contracts
 - `38fed0a` Format D3D12 feature checks
 - `d269d74` Log D3D12 compute pipeline evidence
 - `e796968` Log D3D12 compute dispatch evidence
 - `1e54117` Log D3D12 draw execution evidence
 - `ddba26f` Log D3D12 feature query decisions
-- `e3c2a63` Track DXGI present count
-- `557cb14` Route DXMT D3D12 traces per launch
 - `05d7fd9` Harden DXMT patch preflight
 - `a514813` Fix EAC Proton asset evidence detection
 - `5e9a23c` Cover expanded DXGI factory surface
-- `1683b79` Cover DXGI factory implementation surface
 
 Before replaying any of these, inspect its patch. If it changes launch route
 selection, Steam handoff, migration, runtime install source, Wine DLL override
-semantics, or cache behavior, do not cherry-pick it. Rebuild only the diagnostic
-piece manually.
+semantics, launch environment, native runtime behavior, or cache behavior, do
+not cherry-pick it. Rebuild only the diagnostic piece manually.
 
 Never cherry-pick as-is:
 
@@ -55,7 +51,14 @@ Never cherry-pick as-is:
 - `e2dff52` WineMetal runtime binding
 - `c1dd812` native-only DirectX overrides
 - `c01180f` DXMT launch cache contract
+- `e3c2a63` DXGI present count runtime behavior
 - `230c2ec` and `c95024d` M9 config narrowing
+
+Source material only; rebuild manually after the relevant gate:
+
+- `1c0b788` direct MTSP launch-log context
+- `557cb14` DXMT D3D12 trace routing and env injection
+- `1683b79` expanded DXGI factory tests
 
 These commits are source material only. Rebuild their useful intent in smaller
 patches after the relevant gate.
@@ -75,10 +78,13 @@ Allowed files:
 - `scripts/prepare-wine119-parity-candidates.sh`
 - `scripts/install-wine119-parity-home.sh`
 - `scripts/probe-wine119-parity-backend.sh`
+- `scripts/audit-electron-launch-routes.mjs`
+- `scripts/audit-mscompatdb-hook-surface.sh`
 - `scripts/capture-steam-game-proof.sh`
 - `scripts/run-wine119-live-control-suite.sh`
 - `scripts/verify-wine119-live-control-suite.sh`
 - `scripts/audit-wine119-readiness.sh`
+- `scripts/audit-wine119-objective-completion.sh`
 
 Commands:
 
@@ -93,7 +99,11 @@ bash -n scripts/runtime-manifest.sh \
   scripts/capture-steam-game-proof.sh \
   scripts/run-wine119-live-control-suite.sh \
   scripts/verify-wine119-live-control-suite.sh \
-  scripts/audit-wine119-readiness.sh
+  scripts/audit-wine119-readiness.sh \
+  scripts/audit-mscompatdb-hook-surface.sh \
+  scripts/audit-wine119-objective-completion.sh
+
+node --check scripts/audit-electron-launch-routes.mjs
 
 (cd app/src-rust && cargo test launcher::tests::)
 ```
@@ -112,7 +122,10 @@ preserving the 11.5 final runtime shape.
 
 Inputs:
 
-- Release asset: `bundles/metalsharp_bundle.tar.zst`
+- Release repo: `aaf2tbz/metalsharp`
+- Release tag: `bundles`
+- Release asset: `metalsharp_bundle.tar.zst`
+- Expected asset SHA256: `833f63566b0c1b98fa917337716f57d689c42d0c2878204b4716ba29637d7372`
 - Reproducible local asset path after fetch: `/tmp/metalsharp-wine-assets/metalsharp_bundle.tar.zst`
 - Working baseline: `/Users/alexmondello/.metalsharp/runtime/wine`
 - DXMT i386 candidate: `/Volumes/AverySSD/metalsharp/dxmt-src/build32/src/winemetal/winemetal.dll`
@@ -127,24 +140,24 @@ scripts/fetch-wine119-release-assets.sh \
 scripts/prepare-wine119-parity-candidates.sh \
   /tmp/metalsharp-wine-assets/metalsharp_bundle.tar.zst \
   /tmp/metalsharp-wine119-parity
-
-scripts/audit-wine119-readiness.sh \
-  /private/tmp/metalsharp-home-wine119-dxmt32-state \
-  /tmp/metalsharp-wine119-readiness-current
-
-scripts/audit-wine119-objective-completion.sh \
-  /tmp/metalsharp-wine119-objective-audit
 ```
 
 Expected candidate meaning:
 
-- fetch report must verify `metalsharp_bundle.tar.zst` against the GitHub release digest before candidate preparation
+- fetch report must verify `repo=aaf2tbz/metalsharp`, `tag=bundles`,
+  `release_tag_name=bundles`, `asset=metalsharp_bundle.tar.zst`, the expected
+  SHA256 above, and `verified=1` before candidate preparation
 - `clean`: must fail because release asset lacks i386 `winemetal.dll`.
 - `dxmt32`: primary test candidate, still release-blocked until live M9 proof.
 - `borrowed`: manifest-complete fallback experiment, not release-ready without live proof.
 - every prepared candidate must rewrite Vulkan ICD `library_path` entries to
   its own runtime root and provide `lib/libMoltenVK.dylib`, otherwise proof can
   accidentally borrow MoltenVK from the installed 11.5 runtime.
+- every prepared candidate must write `provenance-report.txt` with bundle hash,
+  copied/original/borrowed bridge decisions, i386 WineMetal source path,
+  source/destination SHA256s, and Vulkan ICD before/after target proof.
+- Pass 1 does not run readiness or objective completion audits; those require a
+  Pass 2 parity home and backend probe.
 
 ## Pass 2: Isolated Parity Home
 
@@ -179,8 +192,14 @@ scripts/audit-wine119-readiness.sh \
 Required proof before live launch:
 
 - `/tmp/metalsharp-wine-assets/fetch-report.txt` verifies the GitHub `bundles/metalsharp_bundle.tar.zst` SHA256.
+- Candidate `provenance-report.txt` identifies whether `bin/metalsharp-wine`
+  and every WineMetal bridge was original, copied from DXMT, supplied from
+  AverySSD, or borrowed from 11.5.
 - Wine reports `wine-11.9`.
 - Backend reports version `0.33.27`.
+- Backend binary must be freshly built from this branch before probing:
+  `(cd app/src-rust && cargo build)`, then the probe must show `/status`
+  from the parity home and version `0.33.27`.
 - Active bottle/compatdata/config manifests have zero references to `/Users/alexmondello/.metalsharp`.
 - Copied historical `compatdata/*/logs` files are absent; empty log directories
   created by backend scans do not contaminate proof.
@@ -224,6 +243,15 @@ Required pass conditions:
 - Each game launch has a pre-existing `Steam.exe` PID before launch.
 - The pre-existing `Steam.exe` PID survives each launch.
 - `lsof` and launch summaries prove the expected DXMT/WineMetal/MoltenVK/cache paths.
+- Nidhogg 2 proof must include i386 `d3d11.dll`, `dxgi.dll`,
+  `winemetal.dll`, Unix `winemetal.so`, `dxmt.conf`, and
+  `shader-cache/m9/535520`.
+- Schedule I proof must include M11 DXMT route evidence, x86_64 `d3d11.dll`,
+  `dxgi.dll`, `winemetal.dll`, Unix `winemetal.so`, MoltenVK, `dxmt.conf`,
+  and `shader-cache/m11/3164500`.
+- Subnautica Below Zero proof must include M11 DXMT route evidence, x86_64
+  `d3d11.dll`, `dxgi.dll`, `winemetal.dll`, Unix `winemetal.so`, MoltenVK,
+  `dxmt.conf`, and `shader-cache/m11/848450`.
 - Before release, keep the app-facing route audit green and, if the packaged UI
   changes, repeat this proof through Electron before tag bump.
 - M12 remains a mapped rebuild surface until a dedicated M12 control game has
@@ -305,4 +333,7 @@ Each later experiment needs:
   - AverySSD DXMT i386 bridge,
   - or borrowed 11.5 i386 compatibility bridge.
 - Release notes explicitly say whether anti-cheat hook surface is enabled, diagnostic-only, or deferred.
+- First Wine 11.9 parity tag is allowed after Pass 3 only if anti-cheat hook
+  surface is explicitly diagnostic-only/deferred. A release claiming anti-cheat
+  readiness must also pass Passes 4 and 5 with separate protected-target proof.
 - GitHub release asset is verified after upload by re-downloading and re-running `scripts/runtime-manifest.sh`.

--- a/docs/wine-119-implementation-runbook.md
+++ b/docs/wine-119-implementation-runbook.md
@@ -160,6 +160,10 @@ scripts/probe-wine119-parity-backend.sh \
   /private/tmp/metalsharp-home-wine119-dxmt32-state \
   /private/tmp/metalsharp-home-wine119-dxmt32-state/backend-probe-main03327-guard-v2
 
+scripts/audit-mscompatdb-hook-surface.sh \
+  /private/tmp/metalsharp-home-wine119-dxmt32-state/.metalsharp/runtime/wine \
+  /private/tmp/metalsharp-home-wine119-dxmt32-state/backend-probe-main03327-guard-v2/mscompatdb-hook-surface
+
 node scripts/audit-electron-launch-routes.mjs \
   --library-json /private/tmp/metalsharp-home-wine119-dxmt32-state/backend-probe-main03327-guard-v2/steam-library.json \
   --out-dir /private/tmp/metalsharp-home-wine119-dxmt32-state/backend-probe-main03327-guard-v2/electron-launch-routes
@@ -179,6 +183,7 @@ Required proof before live launch:
   created by backend scans do not contaminate proof.
 - Nidhogg 2, Schedule I, and Subnautica BZ manifests point at the parity MetalSharp home.
 - Electron route audit proves renderer `auto` and explicit M9/M11 selections call `/steam/launch-game` for the control games.
+- mscompatdb hook audit proves the 11.9 `ntdll.so` contract symbols exist while keeping `hookReady=false` until protected runtime behavior is proven.
 - Readiness audit has only the live-suite failure remaining.
 
 ## Pass 3: Live Parity Gate

--- a/docs/wine-119-implementation-runbook.md
+++ b/docs/wine-119-implementation-runbook.md
@@ -1,0 +1,271 @@
+# Wine 11.9 Implementation Runbook
+
+This is the branch execution plan derived from `docs/wine-119-rebuild-forensics.md`.
+It is intentionally conservative: the first rebuild branch must prove Wine 11.9
+as a layout-compatible runtime before anti-cheat, Steam handoff, WineMetal
+relocation, native-only overrides, or Unity argument changes are allowed back in.
+
+## Branch Ground Rules
+
+- Start from current `main`, the rollback commit `cebf9362f47817580f5eceeb4000ef3987854b2e`.
+- Do not merge or cherry-pick `backup/main-before-v0.33.28-reset-20260521T223249Z` as a branch.
+- Do not cherry-pick merge/rollup commits:
+  - `875004e`
+  - `3dacbe7`
+  - `797db72`
+- Do not bump version or tag until all live gates pass.
+- Do not change installed `~/.metalsharp/runtime/wine` during parity work.
+- Use only `/tmp` or `/private/tmp` parity homes unless intentionally overriding with `METALSHARP_ALLOW_NON_TMP_PARITY_HOME=1`.
+
+## Commit Policy
+
+Allowed direct replay candidates are diagnostic only:
+
+- `65032f7` Track direct game anti-cheat crash evidence
+- `168d235` Add mscompatdb hook surface diagnostics
+- `ce2c008` Format mscompatdb hook sources
+- `1148f57` Tighten mscompatdb readiness checks
+- `cfade4e` Read PE export and import directories separately
+- `f654c10` Add D3D12 surface extraction diagnostics
+- `1c0b788` Log direct MTSP runtime contracts
+- `38fed0a` Format D3D12 feature checks
+- `d269d74` Log D3D12 compute pipeline evidence
+- `e796968` Log D3D12 compute dispatch evidence
+- `1e54117` Log D3D12 draw execution evidence
+- `ddba26f` Log D3D12 feature query decisions
+- `e3c2a63` Track DXGI present count
+- `557cb14` Route DXMT D3D12 traces per launch
+- `05d7fd9` Harden DXMT patch preflight
+- `a514813` Fix EAC Proton asset evidence detection
+- `5e9a23c` Cover expanded DXGI factory surface
+- `1683b79` Cover DXGI factory implementation surface
+
+Before replaying any of these, inspect its patch. If it changes launch route
+selection, Steam handoff, migration, runtime install source, Wine DLL override
+semantics, or cache behavior, do not cherry-pick it. Rebuild only the diagnostic
+piece manually.
+
+Never cherry-pick as-is:
+
+- `c95fd90` protected Steam handoff probes
+- `6e235de` Wine 11.9 runtime hook promotion
+- `14a5cb5` forced Wine 11.9 migration schema
+- `ef3377b` mscompatdb mutation checks
+- `10aeada` postinstall Steam handoff and migration restore
+- `e2dff52` WineMetal runtime binding
+- `c1dd812` native-only DirectX overrides
+- `c01180f` DXMT launch cache contract
+- `230c2ec` and `c95024d` M9 config narrowing
+
+These commits are source material only. Rebuild their useful intent in smaller
+patches after the relevant gate.
+
+## Pass 0: Evidence Branch Base
+
+Goal: add observability and candidate-prep tooling without changing runtime behavior.
+
+Allowed files:
+
+- `docs/wine-119-rebuild-forensics.md`
+- `docs/wine-119-implementation-runbook.md`
+- `scripts/runtime-manifest.sh`
+- `scripts/compare-runtime-manifests.sh`
+- `scripts/prepare-wine119-candidate.sh`
+- `scripts/prepare-wine119-parity-candidates.sh`
+- `scripts/install-wine119-parity-home.sh`
+- `scripts/probe-wine119-parity-backend.sh`
+- `scripts/capture-steam-game-proof.sh`
+- `scripts/run-wine119-live-control-suite.sh`
+- `scripts/verify-wine119-live-control-suite.sh`
+- `scripts/audit-wine119-readiness.sh`
+
+Commands:
+
+```bash
+bash -n scripts/runtime-manifest.sh \
+  scripts/compare-runtime-manifests.sh \
+  scripts/prepare-wine119-candidate.sh \
+  scripts/prepare-wine119-parity-candidates.sh \
+  scripts/install-wine119-parity-home.sh \
+  scripts/probe-wine119-parity-backend.sh \
+  scripts/capture-steam-game-proof.sh \
+  scripts/run-wine119-live-control-suite.sh \
+  scripts/verify-wine119-live-control-suite.sh \
+  scripts/audit-wine119-readiness.sh
+
+(cd app/src-rust && cargo test launcher::tests::)
+```
+
+Expected result:
+
+- Shell syntax passes.
+- Launcher tests pass.
+- No installed runtime files change.
+
+## Pass 1: Runtime Candidate Preparation
+
+Goal: build disposable Wine 11.9 runtime candidates from the release asset while
+preserving the 11.5 final runtime shape.
+
+Inputs:
+
+- Release asset: `bundles/metalsharp_bundle.tar.zst`
+- Current known local extraction source: `/tmp/metalsharp-wine-assets-IjmErR/metalsharp_bundle.tar.zst`
+- Working baseline: `/Users/alexmondello/.metalsharp/runtime/wine`
+- DXMT i386 candidate: `/Volumes/AverySSD/metalsharp/dxmt-src/build32/src/winemetal/winemetal.dll`
+
+Commands:
+
+```bash
+scripts/prepare-wine119-parity-candidates.sh \
+  /tmp/metalsharp-wine-assets-IjmErR/metalsharp_bundle.tar.zst \
+  /tmp/metalsharp-wine119-parity
+
+scripts/audit-wine119-readiness.sh \
+  /private/tmp/metalsharp-home-wine119-dxmt32-state \
+  /tmp/metalsharp-wine119-readiness-current
+```
+
+Expected candidate meaning:
+
+- `clean`: must fail because release asset lacks i386 `winemetal.dll`.
+- `dxmt32`: primary test candidate, still release-blocked until live M9 proof.
+- `borrowed`: manifest-complete fallback experiment, not release-ready without live proof.
+
+## Pass 2: Isolated Parity Home
+
+Goal: run backend and proof capture against Wine 11.9 without mutating the working install.
+
+Commands:
+
+```bash
+METALSHARP_CLONE_USER_STATE=1 \
+METALSHARP_COPY_MODE=clone \
+scripts/install-wine119-parity-home.sh \
+  /tmp/metalsharp-wine119-parity/candidates/dxmt32/wine \
+  /tmp/metalsharp-home-wine119-dxmt32-state
+
+scripts/probe-wine119-parity-backend.sh \
+  /private/tmp/metalsharp-home-wine119-dxmt32-state \
+  /private/tmp/metalsharp-home-wine119-dxmt32-state/backend-probe-main03327-guard-v2
+
+scripts/audit-wine119-readiness.sh \
+  /private/tmp/metalsharp-home-wine119-dxmt32-state \
+  /tmp/metalsharp-wine119-readiness-current
+```
+
+Required proof before live launch:
+
+- Wine reports `wine-11.9`.
+- Backend reports version `0.33.27`.
+- Active bottle/compatdata/config manifests have zero references to `/Users/alexmondello/.metalsharp`.
+- Copied historical `compatdata/*/logs` directories are absent.
+- Nidhogg 2, Schedule I, and Subnautica BZ manifests point at the parity MetalSharp home.
+- Readiness audit has only the live-suite failure remaining.
+
+## Pass 3: Live Parity Gate
+
+Goal: prove Wine 11.9 can run normal games before anti-cheat behavior is added.
+
+Command:
+
+```bash
+METALSHARP_RUN_LIVE_GAMES=1 \
+scripts/run-wine119-live-control-suite.sh \
+  /private/tmp/metalsharp-home-wine119-dxmt32-state \
+  /tmp/metalsharp-live-controls-dxmt32
+
+scripts/verify-wine119-live-control-suite.sh \
+  /tmp/metalsharp-live-controls-dxmt32
+
+METALSHARP_LIVE_SUITE_DIR=/tmp/metalsharp-live-controls-dxmt32 \
+scripts/audit-wine119-readiness.sh \
+  /private/tmp/metalsharp-home-wine119-dxmt32-state \
+  /tmp/metalsharp-wine119-readiness-current
+```
+
+Required pass conditions:
+
+- Nidhogg 2 launches with `launchMethod: "m9"`.
+- Schedule I launches with `launchMethod: "m11"`.
+- Subnautica Below Zero launches with `launchMethod: "m11"`.
+- Each game has a live game PID, not just a Steam URL/helper PID.
+- `lsof` and launch summaries prove the expected DXMT/WineMetal/MoltenVK/cache paths.
+
+If `dxmt32` fails specifically on the i386 WineMetal artifact, repeat Passes 2
+and 3 with the `borrowed` candidate. A borrowed i386 bridge is only acceptable
+as a compatibility artifact after live M9 proof and an explicit rationale.
+
+## Pass 4: Anti-Cheat Hook Surface
+
+Allowed only after Pass 3.
+
+Goal: add hook symbols and readiness checks without changing normal route behavior.
+
+Allowed intent:
+
+- Rebuild the mscompatdb hook contract from `2644948`.
+- Rebuild dylib parity from `d86fd03`.
+- Rebuild readiness probes from `1148f57`.
+
+Not allowed:
+
+- Runtime schema bump.
+- Prefix/game migration.
+- Global Steam handoff replacement.
+- Mutation during normal-game routes.
+
+Required proof:
+
+- `ntdll.so` exports `_MetalSharpGetMscompatdbHookContract`.
+- `ntdll.so` exports `_MetalSharpGetMscompatdbHookContractVersion`.
+- Runtime endpoint distinguishes `loaded`, `symbol_present`, and `hook_ready`.
+- The three normal control games still pass Pass 3 after hook surface lands.
+
+## Pass 5: Protected Steam Handoff
+
+Allowed only after Pass 4.
+
+Goal: support explicit anti-cheat recipes without changing normal game launches.
+
+Rules:
+
+- Protected handoff is opt-in per anti-cheat recipe.
+- Already-running Wine Steam must not be stopped for normal M9/M11/M12 launches.
+- Normal `/steam/launch-game` must keep 0.33.27 attach semantics.
+- Any delegated helper PID must be labeled as delegated and must not satisfy game PID proof.
+
+Required proof:
+
+- Protected route logs show why a game opted in.
+- Normal Nidhogg 2, Schedule I, and Subnautica BZ still pass Pass 3.
+- A protected anti-cheat target has separate evidence and does not borrow normal-game proof.
+
+## Pass 6: Later Experiments
+
+These are not part of the first Wine 11.9 parity release:
+
+- WineMetal prefix/runtime relocation from `e2dff52` and `2f0d9c6`.
+- Native-only DirectX overrides from `c1dd812`.
+- Cache contract rewrite from `c01180f`.
+- Unity route/argument changes from `f548c5e`, `03c0826`, `4e3afde`, and `610411d`.
+- D3D12/DXGI runtime behavior patches.
+
+Each later experiment needs:
+
+- a feature flag or route-level toggle,
+- before/after launch logs,
+- fresh live control proof,
+- an automatic fallback to the proven parity model.
+
+## Final Release Checklist
+
+- Readiness audit passes with `METALSHARP_LIVE_SUITE_DIR` set.
+- Version bump is created fresh, not replayed from deleted releases.
+- New tag is created only after the live suite passes.
+- Release notes identify the candidate type:
+  - true 11.9 i386 WineMetal,
+  - AverySSD DXMT i386 bridge,
+  - or borrowed 11.5 i386 compatibility bridge.
+- Release notes explicitly say whether anti-cheat hook surface is enabled, diagnostic-only, or deferred.
+- GitHub release asset is verified after upload by re-downloading and re-running `scripts/runtime-manifest.sh`.

--- a/docs/wine-119-implementation-runbook.md
+++ b/docs/wine-119-implementation-runbook.md
@@ -133,6 +133,8 @@ Inputs:
 - Reproducible local asset path after fetch: `/tmp/metalsharp-wine-assets/metalsharp_bundle.tar.zst`
 - Working baseline: `/Users/alexmondello/.metalsharp/runtime/wine`
 - DXMT i386 candidate: `/Volumes/AverySSD/metalsharp/dxmt-src/build32/src/winemetal/winemetal.dll`
+- Clean 11.9-linked i386 candidate, when present:
+  `/tmp/metalsharp-dxmt-clean-build32-wine119/src/winemetal/winemetal.dll`
 
 Commands:
 
@@ -154,6 +156,16 @@ scripts/preflight-i386-winemetal-build.sh \
   /Volumes/AverySSD/metalsharp/dxmt-src \
   /tmp/metalsharp-wine119-parity/candidates/dxmt32/wine \
   /tmp/metalsharp-i386-winemetal-build-preflight-current
+
+scripts/preflight-i386-winemetal-build.sh \
+  /tmp/metalsharp-dxmt-clean-f520cb8 \
+  /tmp/metalsharp-wine119-parity/candidates/dxmt32/wine \
+  /tmp/metalsharp-i386-winemetal-build-preflight-clean-f520cb8
+
+scripts/audit-i386-winemetal-provenance.sh \
+  /tmp/metalsharp-dxmt-clean-f520cb8 \
+  /tmp/metalsharp-dxmt-clean-build32-wine119/src/winemetal/winemetal.dll \
+  /tmp/metalsharp-clean-i386-winemetal-provenance-119
 ```
 
 Expected candidate meaning:
@@ -163,6 +175,8 @@ Expected candidate meaning:
   SHA256 above, and `verified=1` before candidate preparation
 - `clean`: must fail because release asset lacks i386 `winemetal.dll`.
 - `dxmt32`: primary test candidate, still release-blocked until live M9 proof.
+  Prefer the clean 11.9-linked i386 WineMetal artifact over the older dirty
+  AverySSD `build32` artifact whenever it has a clean provenance report.
 - `borrowed`: manifest-complete fallback experiment, not release-ready without live proof.
 - every prepared candidate must rewrite Vulkan ICD `library_path` entries to
   its own runtime root and provide `lib/libMoltenVK.dylib`, otherwise proof can
@@ -179,6 +193,11 @@ Expected candidate meaning:
   `i386-windows`, plus local Meson/Ninja/i686 mingw tools. A failing
   `source-clean` gate means the next branch must clean or fork DXMT source
   before producing a release-grade 11.9 i386 artifact.
+- A clean detached DXMT worktree at `f520cb84159ef7db1cdbd364d51738ef7effb0a6`
+  can produce a PE32 i386 `winemetal.dll` linked against the shaped Wine 11.9
+  runtime. This is stronger than the dirty AverySSD artifact, but it is still
+  not a release gate by itself; live Nidhogg 2/M9 module proof is required
+  before it can be blessed.
 - Pass 1 does not run readiness or objective completion audits; those require a
   Pass 2 parity home and backend probe.
 

--- a/docs/wine-119-implementation-runbook.md
+++ b/docs/wine-119-implementation-runbook.md
@@ -105,9 +105,12 @@ bash -n scripts/runtime-manifest.sh \
   scripts/audit-mscompatdb-hook-surface.sh \
   scripts/audit-i386-winemetal-provenance.sh \
   scripts/preflight-i386-winemetal-build.sh \
-  scripts/audit-wine119-objective-completion.sh
+  scripts/audit-wine119-objective-completion.sh \
+  scripts/test-wine119-live-suite-guards.sh
 
 node --check scripts/audit-electron-launch-routes.mjs
+
+scripts/test-wine119-live-suite-guards.sh
 
 (cd app/src-rust && cargo test launcher::tests::)
 ```
@@ -117,6 +120,9 @@ Expected result:
 - Shell syntax passes.
 - Launcher tests pass.
 - No installed runtime files change.
+- Live-suite guard fixture proves the live runner accepts only the clean
+  candidate preflight and refuses stale/dirty candidate wiring before backend,
+  Steam, or game launch.
 - Optional verifier fixture proves the live-suite verifier accepts surviving Wine Steam PIDs and rejects disappeared pre-existing Wine Steam PIDs.
 
 ## Pass 1: Runtime Candidate Preparation

--- a/docs/wine-119-implementation-runbook.md
+++ b/docs/wine-119-implementation-runbook.md
@@ -80,6 +80,7 @@ Allowed files:
 - `scripts/probe-wine119-parity-backend.sh`
 - `scripts/audit-electron-launch-routes.mjs`
 - `scripts/audit-mscompatdb-hook-surface.sh`
+- `scripts/audit-i386-winemetal-provenance.sh`
 - `scripts/capture-steam-game-proof.sh`
 - `scripts/run-wine119-live-control-suite.sh`
 - `scripts/verify-wine119-live-control-suite.sh`
@@ -101,6 +102,7 @@ bash -n scripts/runtime-manifest.sh \
   scripts/verify-wine119-live-control-suite.sh \
   scripts/audit-wine119-readiness.sh \
   scripts/audit-mscompatdb-hook-surface.sh \
+  scripts/audit-i386-winemetal-provenance.sh \
   scripts/audit-wine119-objective-completion.sh
 
 node --check scripts/audit-electron-launch-routes.mjs
@@ -140,6 +142,11 @@ scripts/fetch-wine119-release-assets.sh \
 scripts/prepare-wine119-parity-candidates.sh \
   /tmp/metalsharp-wine-assets/metalsharp_bundle.tar.zst \
   /tmp/metalsharp-wine119-parity
+
+scripts/audit-i386-winemetal-provenance.sh \
+  /Volumes/AverySSD/metalsharp/dxmt-src \
+  /Volumes/AverySSD/metalsharp/dxmt-src/build32/src/winemetal/winemetal.dll \
+  /tmp/metalsharp-i386-winemetal-provenance-current
 ```
 
 Expected candidate meaning:
@@ -156,6 +163,10 @@ Expected candidate meaning:
 - every prepared candidate must write `provenance-report.txt` with bundle hash,
   copied/original/borrowed bridge decisions, i386 WineMetal source path,
   source/destination SHA256s, and Vulkan ICD before/after target proof.
+- i386 WineMetal provenance audit must be archived. The current AverySSD
+  artifact is only an experiment if the audit reports a dirty source tree or
+  Wine 11.5 linker inputs; it cannot satisfy the release-proven 11.9 i386
+  requirement by itself.
 - Pass 1 does not run readiness or objective completion audits; those require a
   Pass 2 parity home and backend probe.
 

--- a/docs/wine-119-implementation-runbook.md
+++ b/docs/wine-119-implementation-runbook.md
@@ -160,6 +160,10 @@ scripts/probe-wine119-parity-backend.sh \
   /private/tmp/metalsharp-home-wine119-dxmt32-state \
   /private/tmp/metalsharp-home-wine119-dxmt32-state/backend-probe-main03327-guard-v2
 
+node scripts/audit-electron-launch-routes.mjs \
+  --library-json /private/tmp/metalsharp-home-wine119-dxmt32-state/backend-probe-main03327-guard-v2/steam-library.json \
+  --out-dir /private/tmp/metalsharp-home-wine119-dxmt32-state/backend-probe-main03327-guard-v2/electron-launch-routes
+
 scripts/audit-wine119-readiness.sh \
   /private/tmp/metalsharp-home-wine119-dxmt32-state \
   /tmp/metalsharp-wine119-readiness-current
@@ -171,8 +175,10 @@ Required proof before live launch:
 - Wine reports `wine-11.9`.
 - Backend reports version `0.33.27`.
 - Active bottle/compatdata/config manifests have zero references to `/Users/alexmondello/.metalsharp`.
-- Copied historical `compatdata/*/logs` directories are absent.
+- Copied historical `compatdata/*/logs` files are absent; empty log directories
+  created by backend scans do not contaminate proof.
 - Nidhogg 2, Schedule I, and Subnautica BZ manifests point at the parity MetalSharp home.
+- Electron route audit proves renderer `auto` and explicit M9/M11 selections call `/steam/launch-game` for the control games.
 - Readiness audit has only the live-suite failure remaining.
 
 ## Pass 3: Live Parity Gate
@@ -204,10 +210,8 @@ Required pass conditions:
 - Each game has a live game PID, not just a Steam URL/helper PID.
 - If Wine Steam was already running before a game launch, the pre-existing `Steam.exe` PID survives that launch.
 - `lsof` and launch summaries prove the expected DXMT/WineMetal/MoltenVK/cache paths.
-- Before release, repeat or supplement this proof through the app-facing route:
-  confirm the renderer-selected launch method calls `/steam/launch-game` for
-  each configured M9/M11 control, or launch through Electron and capture the
-  same proof bundle.
+- Before release, keep the app-facing route audit green and, if the packaged UI
+  changes, repeat this proof through Electron before tag bump.
 - M12 remains a mapped rebuild surface until a dedicated M12 control game has
   passed with the same process/module/cache proof.
 

--- a/docs/wine-119-implementation-runbook.md
+++ b/docs/wine-119-implementation-runbook.md
@@ -107,12 +107,14 @@ bash -n scripts/runtime-manifest.sh \
   scripts/preflight-i386-winemetal-build.sh \
   scripts/audit-wine119-objective-completion.sh \
   scripts/test-wine119-live-suite-guards.sh \
-  scripts/test-wine119-objective-audit-guards.sh
+  scripts/test-wine119-objective-audit-guards.sh \
+  scripts/test-wine119-live-verifier-fixtures.sh
 
 node --check scripts/audit-electron-launch-routes.mjs
 
 scripts/test-wine119-live-suite-guards.sh
 scripts/test-wine119-objective-audit-guards.sh
+scripts/test-wine119-live-verifier-fixtures.sh
 
 (cd app/src-rust && cargo test launcher::tests::)
 ```
@@ -128,7 +130,9 @@ Expected result:
 - Objective-audit guard fixture proves stale readiness cannot satisfy non-live
   completion unless it also proves clean `dxmt32` source and parity-home source
   alignment.
-- Optional verifier fixture proves the live-suite verifier accepts surviving Wine Steam PIDs and rejects disappeared pre-existing Wine Steam PIDs.
+- Live verifier fixture proves the live-suite verifier accepts complete
+  synthetic route/module/cache proof, rejects disappeared pre-existing Wine
+  Steam PIDs, and rejects log-only game proof.
 
 ## Pass 1: Runtime Candidate Preparation
 

--- a/docs/wine-119-implementation-runbook.md
+++ b/docs/wine-119-implementation-runbook.md
@@ -131,6 +131,9 @@ scripts/prepare-wine119-parity-candidates.sh \
 scripts/audit-wine119-readiness.sh \
   /private/tmp/metalsharp-home-wine119-dxmt32-state \
   /tmp/metalsharp-wine119-readiness-current
+
+scripts/audit-wine119-objective-completion.sh \
+  /tmp/metalsharp-wine119-objective-audit
 ```
 
 Expected candidate meaning:
@@ -185,6 +188,9 @@ Required proof before live launch:
 - Electron route audit proves renderer `auto` and explicit M9/M11 selections call `/steam/launch-game` for the control games.
 - mscompatdb hook audit proves the 11.9 `ntdll.so` contract symbols exist while keeping `hookReady=false` until protected runtime behavior is proven.
 - Readiness audit has only the live-suite failure remaining.
+- Objective completion audit still fails only on truly unresolved end-state
+  requirements such as live controls, i386 WineMetal provenance, or protected
+  hook runtime readiness.
 
 ## Pass 3: Live Parity Gate
 

--- a/docs/wine-119-implementation-runbook.md
+++ b/docs/wine-119-implementation-runbook.md
@@ -145,7 +145,7 @@ scripts/fetch-wine119-release-assets.sh \
 
 scripts/prepare-wine119-parity-candidates.sh \
   /tmp/metalsharp-wine-assets/metalsharp_bundle.tar.zst \
-  /tmp/metalsharp-wine119-parity
+  /Volumes/AverySSD/metalsharp/wine119-parity-clean-i386
 
 scripts/audit-i386-winemetal-provenance.sh \
   /Volumes/AverySSD/metalsharp/dxmt-src \
@@ -175,8 +175,10 @@ Expected candidate meaning:
   SHA256 above, and `verified=1` before candidate preparation
 - `clean`: must fail because release asset lacks i386 `winemetal.dll`.
 - `dxmt32`: primary test candidate, still release-blocked until live M9 proof.
-  Prefer the clean 11.9-linked i386 WineMetal artifact over the older dirty
-  AverySSD `build32` artifact whenever it has a clean provenance report.
+  The orchestrator now prefers the clean 11.9-linked i386 WineMetal artifact
+  over the older dirty AverySSD `build32` artifact whenever the clean artifact
+  exists. Use `METALSHARP_I386_WINEMETAL_SOURCE` only for an explicit
+  diagnostic override.
 - `borrowed`: manifest-complete fallback experiment, not release-ready without live proof.
 - every prepared candidate must rewrite Vulkan ICD `library_path` entries to
   its own runtime root and provide `lib/libMoltenVK.dylib`, otherwise proof can

--- a/docs/wine-119-implementation-runbook.md
+++ b/docs/wine-119-implementation-runbook.md
@@ -212,25 +212,28 @@ Commands:
 ```bash
 METALSHARP_CLONE_USER_STATE=1 \
 METALSHARP_COPY_MODE=clone \
+METALSHARP_ALLOW_NON_TMP_PARITY_HOME=1 \
 scripts/install-wine119-parity-home.sh \
-  /tmp/metalsharp-wine119-parity/candidates/dxmt32/wine \
-  /tmp/metalsharp-home-wine119-dxmt32-state
+  /Volumes/AverySSD/metalsharp/wine119-parity-clean-i386/candidates/dxmt32/wine \
+  /Volumes/AverySSD/metalsharp/home-wine119-dxmt32-clean-state
 
+METALSHARP_ALLOW_NON_TMP_PARITY_HOME=1 \
 scripts/probe-wine119-parity-backend.sh \
-  /private/tmp/metalsharp-home-wine119-dxmt32-state \
-  /private/tmp/metalsharp-home-wine119-dxmt32-state/backend-probe-main03327-guard-v2
+  /Volumes/AverySSD/metalsharp/home-wine119-dxmt32-clean-state \
+  /Volumes/AverySSD/metalsharp/home-wine119-dxmt32-clean-state/backend-probe-main03327-guard-v2
 
 scripts/audit-mscompatdb-hook-surface.sh \
-  /private/tmp/metalsharp-home-wine119-dxmt32-state/.metalsharp/runtime/wine \
-  /private/tmp/metalsharp-home-wine119-dxmt32-state/backend-probe-main03327-guard-v2/mscompatdb-hook-surface
+  /Volumes/AverySSD/metalsharp/home-wine119-dxmt32-clean-state/.metalsharp/runtime/wine \
+  /Volumes/AverySSD/metalsharp/home-wine119-dxmt32-clean-state/backend-probe-main03327-guard-v2/mscompatdb-hook-surface
 
 node scripts/audit-electron-launch-routes.mjs \
-  --library-json /private/tmp/metalsharp-home-wine119-dxmt32-state/backend-probe-main03327-guard-v2/steam-library.json \
-  --out-dir /private/tmp/metalsharp-home-wine119-dxmt32-state/backend-probe-main03327-guard-v2/electron-launch-routes
+  --library-json /Volumes/AverySSD/metalsharp/home-wine119-dxmt32-clean-state/backend-probe-main03327-guard-v2/steam-library.json \
+  --out-dir /Volumes/AverySSD/metalsharp/home-wine119-dxmt32-clean-state/backend-probe-main03327-guard-v2/electron-launch-routes
 
+METALSHARP_WINE119_CANDIDATE_WORK_DIR=/Volumes/AverySSD/metalsharp/wine119-parity-clean-i386 \
 scripts/audit-wine119-readiness.sh \
-  /private/tmp/metalsharp-home-wine119-dxmt32-state \
-  /tmp/metalsharp-wine119-readiness-current
+  /Volumes/AverySSD/metalsharp/home-wine119-dxmt32-clean-state \
+  /tmp/metalsharp-wine119-readiness-clean-current
 ```
 
 Required proof before live launch:
@@ -240,6 +243,11 @@ Required proof before live launch:
   and every WineMetal bridge was original, copied from DXMT, supplied from
   AverySSD, or borrowed from 11.5.
 - Wine reports `wine-11.9`.
+- The parity install report source matches
+  `/Volumes/AverySSD/metalsharp/wine119-parity-clean-i386/candidates/dxmt32/wine`.
+- Readiness proves `dxmt32_source_kind: clean-11.9-linked-default` and the
+  clean i386 WineMetal source/destination SHA256
+  `12b9343459d28dfe1d7668a31a58a0c3506948d7c533507fdaec65d59c6697ab`.
 - Backend reports version `0.33.27`.
 - Backend binary must be freshly built from this branch before probing:
   `(cd app/src-rust && cargo build)`, then the probe must show `/status`
@@ -264,17 +272,20 @@ Command:
 ```bash
 METALSHARP_RUN_LIVE_GAMES=1 \
 METALSHARP_REQUIRE_PREEXISTING_WINE_STEAM=1 \
+METALSHARP_ALLOW_NON_TMP_PARITY_HOME=1 \
+METALSHARP_WINE119_CANDIDATE_WORK_DIR=/Volumes/AverySSD/metalsharp/wine119-parity-clean-i386 \
 scripts/run-wine119-live-control-suite.sh \
-  /private/tmp/metalsharp-home-wine119-dxmt32-state \
-  /tmp/metalsharp-live-controls-dxmt32
+  /Volumes/AverySSD/metalsharp/home-wine119-dxmt32-clean-state \
+  /Volumes/AverySSD/metalsharp/home-wine119-dxmt32-clean-state/live-controls-clean-dxmt32
 
 scripts/verify-wine119-live-control-suite.sh \
-  /tmp/metalsharp-live-controls-dxmt32
+  /Volumes/AverySSD/metalsharp/home-wine119-dxmt32-clean-state/live-controls-clean-dxmt32
 
-METALSHARP_LIVE_SUITE_DIR=/tmp/metalsharp-live-controls-dxmt32 \
+METALSHARP_LIVE_SUITE_DIR=/Volumes/AverySSD/metalsharp/home-wine119-dxmt32-clean-state/live-controls-clean-dxmt32 \
+METALSHARP_WINE119_CANDIDATE_WORK_DIR=/Volumes/AverySSD/metalsharp/wine119-parity-clean-i386 \
 scripts/audit-wine119-readiness.sh \
-  /private/tmp/metalsharp-home-wine119-dxmt32-state \
-  /tmp/metalsharp-wine119-readiness-current
+  /Volumes/AverySSD/metalsharp/home-wine119-dxmt32-clean-state \
+  /tmp/metalsharp-wine119-readiness-clean-current
 ```
 
 Required pass conditions:
@@ -284,6 +295,9 @@ Required pass conditions:
 - Subnautica Below Zero launches with `launchMethod: "m11"`.
 - Each game has a live game PID, not just a Steam URL/helper PID.
 - Wine Steam is prestarted before the controls.
+- The live runner refuses to proceed unless the parity home was installed from
+  the audited clean `dxmt32` candidate and the candidate provenance proves the
+  clean i386 WineMetal SHA256 copy.
 - Each game launch has a pre-existing `Steam.exe` PID before launch.
 - The pre-existing `Steam.exe` PID survives each launch.
 - `lsof` and launch summaries prove the expected DXMT/WineMetal/MoltenVK/cache paths.

--- a/docs/wine-119-rebuild-forensics.md
+++ b/docs/wine-119-rebuild-forensics.md
@@ -883,12 +883,16 @@ Backend parity preflight is handled by `scripts/probe-wine119-parity-backend.sh`
 Live control suite orchestration is handled by `scripts/run-wine119-live-control-suite.sh`:
 
 - guarded command:
-  - `METALSHARP_RUN_LIVE_GAMES=1 scripts/run-wine119-live-control-suite.sh /tmp/metalsharp-home-wine119-dxmt32 /tmp/metalsharp-live-controls-dxmt32`
+  - `METALSHARP_RUN_LIVE_GAMES=1 METALSHARP_REQUIRE_PREEXISTING_WINE_STEAM=1 METALSHARP_ALLOW_NON_TMP_PARITY_HOME=1 METALSHARP_WINE119_CANDIDATE_WORK_DIR=/Volumes/AverySSD/metalsharp/wine119-parity-clean-i386 scripts/run-wine119-live-control-suite.sh /Volumes/AverySSD/metalsharp/home-wine119-dxmt32-clean-state /Volumes/AverySSD/metalsharp/home-wine119-dxmt32-clean-state/live-controls-clean-dxmt32`
 - hard guard:
   - the script refuses to launch anything unless `METALSHARP_RUN_LIVE_GAMES=1` is set
 - active-state guard:
   - before launching, the script reads the parity install report or `METALSHARP_PARITY_SOURCE_HOME`
   - source-home metadata is mandatory for cloned-state live runs
+  - it refuses to continue unless the parity install report points at the
+    audited clean `dxmt32` candidate under the selected candidate work dir
+  - it refuses to continue unless `dxmt32` summary/provenance prove the clean
+    i386 WineMetal SHA256 copy
   - it refuses to continue if active cloned JSON/TOML/CONF/ENV manifests under bottles, compatdata, or configs still reference the source MetalSharp home
   - it requires the three control-game bottle and compatdata manifests to reference the parity MetalSharp home
   - it refuses to run if copied historical `compatdata/*/logs` directories are present
@@ -917,7 +921,7 @@ This script is the release-candidate gate runner. It should be run first against
 Live control verification is handled by `scripts/verify-wine119-live-control-suite.sh`:
 
 - command:
-  - `scripts/verify-wine119-live-control-suite.sh /tmp/metalsharp-live-controls-dxmt32`
+  - `scripts/verify-wine119-live-control-suite.sh /Volumes/AverySSD/metalsharp/home-wine119-dxmt32-clean-state/live-controls-clean-dxmt32`
 - behavior:
   - requires parity runtime identity to report Wine 11.9
   - requires backend `/status` to report current-main version `0.33.27`

--- a/docs/wine-119-rebuild-forensics.md
+++ b/docs/wine-119-rebuild-forensics.md
@@ -1,0 +1,1077 @@
+# Wine 11.9 Rebuild Forensics
+
+Date: 2026-05-21
+
+This document records the evidence gathered after rolling `main` back to `v0.33.27`, the last confirmed working release. It is intended to be the rebuild contract for reintroducing Wine 11.9 without repeating the regressions that broke Nidhogg 2, Schedule I, Subnautica Below Zero routing confidence, Steam attach behavior, and shader-cache behavior.
+
+## Current Truth
+
+- `main` is intentionally reverted to the `v0.33.27` tree at rollback commit `cebf9362f47817580f5eceeb4000ef3987854b2e`.
+- Last working tag: `v0.33.27` at `13228f20af6bff6be718f4520c423c76076d3985`.
+- The preserved post-11.9 regression branch is `backup/main-before-v0.33.28-reset-20260521T223249Z` at `797db720c852b7f46356fa2541fb4dac81afcc69`.
+- The public `v0.33.28`, `v0.33.29`, and `v0.33.30` releases/tags were deleted. Their code is still recoverable from local branch history and backups.
+- Installed working app is MetalSharp `0.33.27`.
+- Installed working Wine runtime is bundled Wine `11.5`, not system Wine.
+
+## Live Control Sample: Nidhogg 2
+
+Nidhogg 2 was running successfully on the rollback stack during this investigation.
+
+Captured evidence:
+
+- Process snapshot: `~/.metalsharp/diagnostics/live-nidhogg2-20260521T230054Z/`
+- Fixed `lsof` snapshot: `~/.metalsharp/diagnostics/live-nidhogg2-20260521T230128Z-lsof-fixed/`
+- Launch log: `~/.metalsharp/compatdata/535520/logs/launch-1779404379.log`
+- Bottle manifest: `~/.metalsharp/bottles/steam_535520/bottle.json`
+- Compatdata manifest: `~/.metalsharp/compatdata/535520/metalsharp-compatdata.json`
+
+Facts from the live run:
+
+- AppID: `535520`
+- Game: `Nidhogg_2.exe`
+- Runtime profile: `m9`
+- Launch pipeline: `d3d9_metal`
+- Steam identity mode: `wine_steam_background`
+- Wine prefix: `~/.metalsharp/prefix-steam`
+- Wine runtime: `~/.metalsharp/runtime/wine`
+- Process: `C:\Program Files (x86)\Steam\steamapps\common\Nidhogg 2\Nidhogg_2.exe`
+- It launched through Wine Steam, not native Steam.
+
+Loaded files from the running process prove the working contract:
+
+- `~/.metalsharp/runtime/wine/lib/wine/i386-windows/winemetal.dll`
+- `~/.metalsharp/runtime/wine/lib/wine/i386-windows/dxgi.dll`
+- `~/.metalsharp/runtime/wine/lib/wine/i386-windows/d3d11.dll`
+- `~/.metalsharp/runtime/wine/lib/wine/x86_64-unix/winemetal.so`
+- `~/.metalsharp/runtime/wine/lib/wine/x86_64-unix/libMoltenVK.1.dylib`
+- `~/.metalsharp/shader-cache/m9/535520/shaders_320.db`
+- `/private/var/folders/.../C/dxmt/Nidhogg_2.exe/com.apple.metal/...`
+
+This means working Nidhogg 2 is not a plain M32 fallback. It is a 32-bit game under the M9 DXMT family, with Wine/DXMT builtins loaded from the runtime and shader cache under `m9/535520`.
+
+The working launch log also shows:
+
+- `pipeline=M9`
+- `steam_identity_mode=wine_steam_background`
+- `info: Found config file: ~/.metalsharp/runtime/wine/etc/dxmt.conf`
+- `DirectX11: Using hardware device`
+- `Entering main loop`
+- `entered room r_Title_Screen`
+- `entered room r_Level_Select`
+
+## Live Control Sample: Schedule I
+
+Schedule I was also launched successfully on the rollback stack during this investigation.
+
+Captured evidence:
+
+- Process snapshot: `~/.metalsharp/diagnostics/live-schedule-i-20260521T230550Z/`
+- Log snapshot: `~/.metalsharp/diagnostics/live-schedule-i-20260521T230550Z-logs/`
+- Loaded-file snapshot: `~/.metalsharp/diagnostics/live-schedule-i-20260521T230603Z-lsof/`
+- Launch log: `~/.metalsharp/compatdata/3164500/logs/launch-1779404663.log`
+- Bottle manifest: `~/.metalsharp/bottles/steam_3164500/bottle.json`
+- Compatdata manifest: `~/.metalsharp/compatdata/3164500/metalsharp-compatdata.json`
+
+Facts from the live run:
+
+- AppID: `3164500`
+- Game: `Schedule I.exe`
+- Runtime profile: `m11`
+- Launch pipeline: `dxmt_metal`
+- Steam identity mode: `wine_steam_background`
+- Wine prefix: `~/.metalsharp/prefix-steam`
+- Wine runtime: `~/.metalsharp/runtime/wine`
+- Process: `C:\Program Files (x86)\Steam\steamapps\common\Schedule I\Schedule I.exe`
+- Unity crash handler: `UnityCrashHandler64.exe --attach ...`
+
+Loaded files from the running process prove the working M11 contract:
+
+- `~/.metalsharp/runtime/wine/lib/wine/x86_64-unix/winemetal.so`
+- `~/.metalsharp/runtime/wine/lib/wine/x86_64-unix/libMoltenVK.1.dylib`
+- `~/.metalsharp/runtime/wine/lib/wine/x86_64-unix/opengl32.so`
+- `~/.metalsharp/runtime/wine/lib/wine/x86_64-windows/opengl32.dll`
+- `~/.metalsharp/shader-cache/m11/3164500/shaders_320.db-shm`
+- `/private/var/folders/.../C/org.winehq.wine/com.apple.metal/...`
+- `~/.metalsharp/prefix-steam/drive_c/users/alexmondello/AppData/LocalLow/TVGS/Schedule I/Player.log`
+
+The working launch log also shows:
+
+- `pipeline=M11`
+- `steam_identity_mode=wine_steam_background`
+- `info: Failed to set Metal cache path, fallback to system default`
+- `info: Found config file: ~/.metalsharp/runtime/wine/etc/dxmt.conf`
+- `info: Maximum supported feature level: D3D_FEATURE_LEVEL_12_1`
+- `info: Using feature level D3D_FEATURE_LEVEL_11_1`
+- `info: Using feature level D3D_FEATURE_LEVEL_11_0`
+- `warn: CreateSwapChain: unsupported swap effect 3 with backbuffer size 2`
+
+This means working Schedule I is M11/DXMT, not M12, and not a Steam relaunch/protected-handoff path. It also shows that system-default Metal cache fallback is part of the current working behavior and must not be mistaken for a failure by itself.
+
+## Live Control Sample: Subnautica Below Zero
+
+Subnautica Below Zero was launched successfully on the rollback stack during this investigation.
+
+Captured evidence:
+
+- Process/log/loaded-file snapshot: `~/.metalsharp/diagnostics/live-subnautica-bz-20260521T230918Z/`
+- Launch log: `~/.metalsharp/compatdata/848450/logs/launch-1779404936.log`
+- Bottle manifest: `~/.metalsharp/bottles/steam_848450/bottle.json`
+- Compatdata manifest: `~/.metalsharp/compatdata/848450/metalsharp-compatdata.json`
+
+Facts from the live run:
+
+- AppID: `848450`
+- Game: `SubnauticaZero.exe`
+- Runtime profile: `m11`
+- Launch pipeline: `dxmt_metal`
+- Steam identity mode: `wine_steam_background`
+- Wine prefix: `~/.metalsharp/prefix-steam`
+- Wine runtime: `~/.metalsharp/runtime/wine`
+- Process: `SubnauticaZero.exe`
+- Parent process: `metalsharp-backend`, while Wine Steam remains running as the background identity process
+- Unity crash handler: `UnityCrashHandler64.exe --attach ...`
+
+Loaded files from the running process prove the working M11/DXMT contract:
+
+- `~/.metalsharp/runtime/wine/lib/wine/x86_64-windows/d3d11.dll`
+- `~/.metalsharp/runtime/wine/lib/wine/x86_64-windows/dxgi.dll`
+- `~/.metalsharp/runtime/wine/lib/wine/x86_64-windows/winemetal.dll`
+- `~/.metalsharp/runtime/wine/lib/wine/x86_64-unix/winemetal.so`
+- `~/.metalsharp/runtime/wine/lib/wine/x86_64-unix/libMoltenVK.1.dylib`
+- `~/.metalsharp/runtime/wine/lib/wine/x86_64-unix/opengl32.so`
+- `~/.metalsharp/runtime/wine/lib/wine/x86_64-windows/opengl32.dll`
+- `~/.metalsharp/shader-cache/m11/848450/shaders_320.db`
+- `/private/var/folders/.../C/org.winehq.wine/com.apple.metal/...`
+- `~/.metalsharp/prefix-steam/drive_c/users/alexmondello/AppData/LocalLow/Unknown Worlds/Subnautica Below Zero/Player.log`
+
+The working launch log also shows:
+
+- `pipeline=M11`
+- `steam_identity_mode=wine_steam_background`
+- `info: Found config file: ~/.metalsharp/runtime/wine/etc/dxmt.conf`
+- `info: Maximum supported feature level: D3D_FEATURE_LEVEL_12_1`
+- `info: Using feature level D3D_FEATURE_LEVEL_11_1`
+- `info: Using feature level D3D_FEATURE_LEVEL_11_0`
+- `warn: CreateSwapChain: unsupported swap effect 3 with backbuffer size 2`
+- `warn: Emulate stream output`
+
+This means working Subnautica Below Zero is confirmed on the M11/DXMT path. It is not just rendering through an unproven fallback: the live `SubnauticaZero.exe` process has the DXMT/WineMetal/DXGI/D3D11 runtime DLLs and Unix bridge loaded, and it is actively touching the M11 shader cache.
+
+## Release Asset Evidence
+
+Surviving GitHub Releases:
+
+- `v0.33.27`: `MetalSharp-0.33.27-arm64.dmg`, size `797822705`, SHA256 `55b94b1c27d687af4b87ae92560113353bf17541a1da0cf4f1e718f0c7161176`
+- `v0.33.26`: `MetalSharp-0.33.26-arm64.dmg`, size `797640027`, plus Linux `.deb`
+
+Deleted release/tag state:
+
+- `v0.33.28`: release/tag now 404; successful CI push run `26193479278`; DMG artifact size `1545677108`
+- `v0.33.29`: release/tag now 404; successful CI push run `26195067092`; DMG artifact size `1545679918`
+- `v0.33.30`: release/tag now 404; successful CI push run `26252075822`; DMG artifact size `1545720985`
+
+Additional recovered asset from the deleted/working investigation path:
+
+- `/tmp/metalsharp-wine-assets-IjmErR/metalsharp_bundle.tar.zst`, size `382242232`, SHA256 `833f63566b0c1b98fa917337716f57d689c42d0c2878204b4716ba29637d7372`
+- GitHub source: special release/tag `bundles`, asset `metalsharp_bundle.tar.zst`
+- Bundle root: `wine-11.9`
+- `wine.inf` says `Version: Wine 11.9`
+- `wine-11.9/bin/wine` SHA256: `8ac73223a37653b39212545a4d97c6302d5ea4e516f7b1ea5991dfc6848a90a4`
+- `wine-11.9/etc/dxmt.conf` SHA256: `166e2fe829de03d64b225c65fa1682162e198852df51e9520adc3f3b37244621`
+- `wine-11.9/share/wine/wine.inf` SHA256: `a4db2eb9c9746ec670dd982e306e419dda2fcb5625de577fddc109d8e6e888b6`
+- `wine --version` from the minimally extracted bundle returns `wine-11.9`
+- Release/upload tar listing contains `wine-11.9/lib/dxmt/x86_64-windows/winemetal.dll` and `wine-11.9/lib/dxmt/x86_64-unix/winemetal.so`.
+- Release/upload tar listing does not contain `wine-11.9/lib/wine/i386-windows/winemetal.dll`.
+
+The same `bundles` release also has `metalsharp_bundle2.tar.zst`:
+
+- Local download: `/tmp/metalsharp-bundle2-aSicSS/metalsharp_bundle2.tar.zst`
+- Size: `1047321594`
+- SHA256: `c0cc9e4e0503b52076ab9dcb9b16a9baafb017778f987d20ec5a25126c374455`
+- It is not a second Wine runtime bundle. Its archive contains dependency payloads and metadata.
+- Metadata file: `./metadata/metalsharp-wine-11.9-candidate.txt`
+- Metadata says:
+  - Built: `2026-05-20T20:46:26Z`
+  - Source: `Wine 11.9`
+  - Stage: `/Volumes/AverySSD/MetalSharpWine119/stage-20260520-1354`
+  - Patch: `mscompatdb hook contract exported from Unix ntdll.so; PE ntdll copy inert`
+- The referenced `/Volumes/AverySSD/MetalSharpWine119/stage-20260520-1354` path is not currently present, so the metadata is provenance evidence but not a live runtime source.
+
+The surviving `v0.33.30` Actions DMG artifact embeds that exact Wine 11.9 bundle:
+
+- Local artifact: `/tmp/metalsharp-wine-assets-IjmErR/v0.33.30-artifact-dmg/MetalSharp-0.33.30-arm64.dmg`
+- DMG size: `1547350844`
+- DMG SHA256: `de5922406ed03cc7b3d4231905b3c3767e157a6ff38204f268bb18549140f037`
+- Embedded `metalsharp_bundle.tar.zst` SHA256: `833f63566b0c1b98fa917337716f57d689c42d0c2878204b4716ba29637d7372`
+
+For comparison, the 0.33.27 DMG contains:
+
+- Embedded `metalsharp_bundle.tar.zst` SHA256: `1f18186f010d4f8dcbb0a0d786c807cfd7e01652cc272477ff736d5f78ede835`
+- Bundle root: `wine-11.5`
+- `wine-11.5/bin/wine` SHA256: `e621bf88dd07872b391198aee50bf1503fe18d43b7a9c0183fa23075efc61395`
+- `wine-11.5/bin/metalsharp-wine` SHA256: `6873d7f19ff16c707b76806732f531f06cd2b5305231f7142d12b3ebc8ad9cd0`
+- `wine-11.5/share/wine/wine.inf` SHA256: `14f55c9a641549b253445ffabc2fccf4ede4852f2ffc5aaea780f2c5da19c763`
+
+The recovered Wine 11.9 bundle should be treated as the candidate source asset, but not as automatically valid. It still needs a parity audit against the 11.5 runtime layout.
+
+## Wine 11.9 Internal Map Against Working Wine 11.5
+
+The working 0.33.27 install is not just "some Wine 11.5". It is a shaped MetalSharp runtime rooted at `~/.metalsharp/runtime/wine`, with route-critical DXMT/WineMetal files already present in `lib/wine`, not only staged under `lib/dxmt`.
+
+Runtime file-count snapshot:
+
+- Installed working Wine 11.5 runtime: `2349` files under `~/.metalsharp/runtime/wine`
+- Wine 11.9 bundle asset: `3935` files under archive root `wine-11.9`
+- Difference driver: Wine 11.9 includes `include/wine/...` headers, but is missing several MetalSharp-shaped runtime bindings that exist in the working install.
+- The partial extraction folders under `/tmp/metalsharp-wine-assets-IjmErR/extracted-evidence/` and `/tmp/metalsharp-wine-assets-IjmErR/v0.33.30-evidence/` are evidence scratch dirs only. They are not complete runnable Wine 11.9 runtime candidates.
+- No architecture mismatch was found in the sampled route-critical binaries: both installed 11.5 and recovered 11.9 binaries are Mach-O `x86_64`, and both have `i386-windows`, `x86_64-windows`, and `x86_64-unix` runtime directories in the complete file lists.
+
+Top-level/runtime-shape comparison:
+
+| Surface | Working Wine 11.5 install | Wine 11.9 bundle asset | Rebuild requirement |
+| --- | --- | --- | --- |
+| Archive/install root | installed as `~/.metalsharp/runtime/wine` | archive root is `wine-11.9` | installer may extract from `wine-11.9`, but final runtime root must still be `~/.metalsharp/runtime/wine` unless all code is updated and tested |
+| `bin/wine` | present, SHA256 `e621bf88dd07872b391198aee50bf1503fe18d43b7a9c0183fa23075efc61395` | present, SHA256 `8ac73223a37653b39212545a4d97c6302d5ea4e516f7b1ea5991dfc6848a90a4` | expected version change |
+| `bin/wineserver` | present, SHA256 `fbd59b533e8db0e05015d623dca24919ec65a8a4a7e1487d8725b1efce1e7ee5` | present, SHA256 `a970f075a950f413a7b01b9cca7a4a21e473bc78111f893640a28374b04c2bb2` | expected version change |
+| `bin/metalsharp-wine` | present shell wrapper, SHA256 `6873d7f19ff16c707b76806732f531f06cd2b5305231f7142d12b3ebc8ad9cd0` | missing | must be regenerated or carried forward; launcher prefers this wrapper when present |
+| `etc/dxmt.conf` | present, SHA256 `166e2fe829de03d64b225c65fa1682162e198852df51e9520adc3f3b37244621` | present, same SHA256 | preserve path and visibility for M9/M11/M12 |
+| `etc/mscompatdb_rules.toml` | present, SHA256 `7b17e2feafa3453e79a43ab0cfe246faecc70ec8c3427a1128eb8bd1fd375e87` | present, same SHA256 | not a differentiator by itself |
+| `etc/vulkan/icd.d/MoltenVK_icd.json` | present, SHA256 `61d212ba97b02155cd8a16ef3e1be0ef7bf7a8c93e9f20c30506550f69a673ae` | present, same SHA256 | preserve |
+| `etc/vulkan/icd.d/MoltenVK_x86_64_icd.json` | present, SHA256 `7ce881b47fd3adbc29855703c147566e7ffebf514bf7191e6f7903b4eb433af8` | present, same SHA256 | preserve |
+| Wine version marker | `share/wine/wine.inf` says Wine 11.5, SHA256 `14f55c9a641549b253445ffabc2fccf4ede4852f2ffc5aaea780f2c5da19c763` | says Wine 11.9, SHA256 `a4db2eb9c9746ec670dd982e306e419dda2fcb5625de577fddc109d8e6e888b6` | expected version change |
+
+DXMT/WineMetal internal comparison:
+
+| Surface | Working Wine 11.5 install | Wine 11.9 bundle asset | Rebuild requirement |
+| --- | --- | --- | --- |
+| `lib/dxmt/x86_64-windows/d3d11.dll` | present, SHA256 `15785d6c75d4ae5f0e3ab9b61f56b534d933ab6b691ffbc02eae30cee25b5bbc` | present, same SHA256 | unchanged |
+| `lib/dxmt/x86_64-windows/winemetal.dll` | present, SHA256 `d357ed7a83df000f98f7e4fe5e2da99f0e36561457d2dfc30e90f09504880fc8` | present, same SHA256 | unchanged |
+| `lib/dxmt/x86_64-windows/dxgi.dll` | present, SHA256 `4c86d66ac32248f80f42c2e0b86bb245e1295ef6f1b67ad522562b9fa81eb05d` | present, but SHA256 `dd2b6544c51d5e6b97df5ba9dc85863e07963962474f4ba2af5794cf71997c71` | audit DXGI behavior before parity claim |
+| `lib/dxmt/x86_64-windows/d3d12.dll` | present, SHA256 `5a512873e328e7100c59968441bcea6a22a616c1653cb632bb221d215308896d` | present, SHA256 `388b4aa4418d54ed9efd3a6c8d853dc3c0e948990de80b368cdd60c43535003a` | expected D3D12 change; isolate from M9/M11 parity |
+| `lib/dxmt/x86_64-unix/winemetal.so` | present, SHA256 `f01cfe25619faf85f3b840d527f6724c9efc444a9137882e9b22daa78a8a2c9c` | present, SHA256 `77f4d0b4b0b7ce867c1091ab6ae6951ff993489c84f26e7139886560a4814915` | expected WineMetal bridge change; must be tested directly |
+| `lib/wine/x86_64-unix/winemetal.so` | present, SHA256 `2e80f62162ed3b66d905463ba0b7a2737e1c85cd740febabe3ceae87db24d723` | missing | must copy/bind from `lib/dxmt/x86_64-unix/winemetal.so` if preserving 11.5 route contract |
+| `lib/wine/x86_64-windows/winemetal.dll` | present, SHA256 `9bf08a8d583a2b13f23765221238b6d4406467e8bae23b5bde4f5eed717f6e5b` | missing | must copy/bind from `lib/dxmt/x86_64-windows/winemetal.dll` or keep game-local deployment |
+| `lib/wine/i386-windows/winemetal.dll` | present, SHA256 `20a6865facebdaac92b6c06fadf37d2efb5a242b22ca1c349bb57d7ad43df8e3` | missing | high-risk for Nidhogg 2; must restore or prove equivalent 32-bit route |
+| `lib/wine/x86_64-windows/d3d11.dll` | present, SHA256 `c332d17219b5119ff16658950a4138e916ae024409e15331e341dbe600ae976d` | present, SHA256 `8bebdfd74251bcfbc4bb8f56f2e7e3db9c49ad81d0c798a64cd3e93175d3d64c` | expected Wine builtin change; do not switch override policy at the same time |
+| `lib/wine/i386-windows/d3d11.dll` | present, SHA256 `9afc2b3419818618c4c87274435a28935b0df002caa4b9a8d3a88d3dc846b17d` | present, SHA256 `f8db6043b772cef94794524a247617800d3331dbae5f47a5fc283330e03669d5` | expected Wine builtin change; must be tested by Nidhogg 2 |
+| `lib/wine/x86_64-windows/dxgi.dll` | present, SHA256 `69e0aa0ed177aa2b0e6ccca01b5d4bdee8317082b3d6dd42fba47d288c219bbf` | present, SHA256 `05e3959f3075fa4f3e22a54f6d659bbe8e07e0aa491a1b849cf6a7740a6b333c` | expected Wine builtin change; do not combine with native-only override narrowing |
+| `lib/wine/i386-windows/dxgi.dll` | present, SHA256 `7df8cdf66e12a108410002abc77b01f70aa59b8a36a70fa0bc6ae3b056841319` | present, SHA256 `1bcba37120961191e27c5aa6f0c104dba2cd84dc08dd06e6ff3bb2436403606e` | expected Wine builtin change; Nidhogg 2 gate |
+
+Anti-cheat/mscompatdb internal comparison:
+
+| Surface | Working Wine 11.5 install | Wine 11.9 bundle asset | Rebuild requirement |
+| --- | --- | --- | --- |
+| `lib/wine/x86_64-unix/mscompatdb.so` | present, SHA256 `3d08163039ec14b6acc5ebd6aa02e5c5776e3dcd38e13f2ac512611f4025be84` | present, SHA256 `a90138f3b1c5ac7cc08fdd7f85aac8afe435423db9f98efd9171f6c303cd4739` | expected anti-cheat surface change; must be symbol-probed |
+| `lib/wine/x86_64-unix/mscompatdb.dylib` | missing | present, SHA256 `5dda648f35863e3029f5d9ce550f1904a659771ef4b8a82c9a0dffa4393b18a5` | new 11.9 artifact; packaging must define whether `.so`, `.dylib`, or both are loaded |
+| `nm -gU` hook evidence | 11.5 `ntdll.so` does not expose the MetalSharp hook contract; live logs still show `couldn't find KeServiceDescriptorTable` while games work | 11.9 `ntdll.so` exposes `_MetalSharpGetMscompatdbHookContract` and `_MetalSharpGetMscompatdbHookContractVersion`; selected `mscompatdb.so` and `mscompatdb.dylib` expose no public symbols under this probe | hook readiness must check `ntdll.so` contract plus runtime load behavior; do not treat mscompatdb file presence as success |
+| Runtime log behavior | Nidhogg/Schedule/Subnautica all log `mscompatdb:error: couldn't find KeServiceDescriptorTable` and still work | not yet parity tested | hook readiness must be a separate probe/gate from game launch parity |
+
+Critical internal mismatches found by file-list comparison:
+
+- Wine 11.9 asset is missing `wine/bin/metalsharp-wine`.
+- Wine 11.9 asset is missing `wine/lib/wine/x86_64-unix/winemetal.so`.
+- Wine 11.9 asset is missing `wine/lib/wine/x86_64-windows/winemetal.dll`.
+- Wine 11.9 asset is missing `wine/lib/wine/i386-windows/winemetal.dll`.
+- Wine 11.9 asset is missing the working install's `.dxvk` and `.wine-builtin` backup filenames under `lib/wine`, including `d3d11.dll.dxvk`, `d3d11.dll.wine-builtin`, and `winevulkan.dll.115`.
+- Wine 11.9 asset adds `wine/lib/wine/x86_64-unix/mscompatdb.dylib`.
+- Wine 11.9 asset adds headers under `include/wine/...`, which are useful for building but do not prove runtime parity.
+
+Internal rebuild contract:
+
+1. Build or package Wine 11.9 into the same final runtime root shape as 11.5.
+2. Restore `bin/metalsharp-wine` or update and test every code path that chooses it.
+3. Pre-bind or deploy `winemetal.so`/`winemetal.dll` into the locations the 0.33.27 live games actually loaded.
+4. Keep `lib/dxmt` as the source-of-truth payload, but do not assume route loaders search it directly.
+5. Preserve `etc/dxmt.conf`, Vulkan ICD paths, and `mscompatdb_rules.toml`.
+6. Treat `mscompatdb.dylib` as a new 11.9 anti-cheat artifact that needs an explicit load/symbol contract.
+7. Only after the internal runtime map matches the 11.5 contract should Wine 11.9 be tested against Nidhogg 2, Schedule I, and Subnautica BZ.
+
+## Regression Map
+
+### 1. Wine Steam Attach vs Relaunch Changed First
+
+Commit `c95fd904812190809748feae0dacd8fcd8584c79` introduced protected handoff routing. It changed `/steam/launch-game` so anti-cheat-detected games route through `launch_game_via_steam_with_protected_env`.
+
+Initial behavior stopped and relaunched Wine Steam to inherit env. That explains the observed regression where the app relaunched Steam instead of attaching to the existing Wine Steam process.
+
+Commit `10aeada4004fc9918e55f5289896cdb4d3c01634` removed the destructive stop/restart path, but left a split:
+
+- If Wine Steam is not running, Steam can inherit route env.
+- If Wine Steam is already running, only the transient `steam://run/<appid>` helper gets env.
+
+Any pipeline requiring route env to be inherited by the already-running Steam client remains suspect.
+
+### 2. Runtime Migration Switched the Substrate Too Early
+
+Commit `6e235de53e717f106d4b61e2f2e29f00e21bcba3` changed installer/runtime language toward Wine 11.9 and mscompatdb hook support.
+
+Commit `14a5cb5a3c70a8a9cf1eb947427aff2f89b14e04` bumped migration schema and forced runtime repair/migration for Wine 11.9.
+
+This changed too much at once:
+
+- Wine version
+- runtime install source selection
+- prefix repair/migration behavior
+- mscompatdb hook expectations
+- launch handoff evidence
+
+Wine 11.9 should have been introduced as a 1:1 Wine 11.5 runtime replacement first, before anti-cheat hooks or route semantics changed.
+
+### 3. DXMT Winedll/Unix Bridge Model Changed Under Working Games
+
+Commit `e2dff524f35604164ca5ab7f99bcd7b31a8f732e` introduced the most suspicious DXMT contract change.
+
+`v0.33.27` deploys `winemetal.dll` beside games for M10/M11/M12 and uses `=n,b` overrides. Current `v0.33.27` pipeline definitions show this in `app/src-rust/src/mtsp/engine.rs`:
+
+- M12 deploys `d3d12.dll`, `d3d11.dll`, `dxgi.dll`, `d3d10core.dll`, `winemetal.dll`
+- M11 deploys `d3d11.dll`, `dxgi.dll`, `d3d10core.dll`, `winemetal.dll`
+- M10 deploys Wine D3D10 DLLs plus DXMT `d3d11.dll`, `dxgi.dll`, `d3d10core.dll`, `winemetal.dll`
+- M9 deploys Wine runtime `d3d9.dll` for x86_64 and i386
+
+The post-11.9 branch changed M10/M11/M12 to remove game-local `winemetal.dll`, use `winemetal=n,b`, copy `winemetal.dll` into prefix `system32`, copy `winemetal.so` into Wine `x86_64-unix`, and remove game-local `winemetal.*`.
+
+That is a real route contract change, not just a Wine update. It is high risk for the exact symptoms we saw: black/no-window Nidhogg, DXMT uncertainty, and launch paths that appear to render through the wrong split process.
+
+### 4. Native-Only DirectX Overrides Narrowed the Loader Path
+
+Commit `c1dd81285c32fd6bdedf9b6946f3c2f2c6c6aba2` moved DXMT routes toward native-only DirectX overrides:
+
+- Post branch M12: `d3d12,dxgi,d3d11,d3d10core=n;winemetal=n,b`
+- Post branch M11: `dxgi,d3d11,d3d10core=n;winemetal=n,b`
+- v0.33.27 M12: `d3d12,dxgi,d3d11,d3d10core=n,b`
+- v0.33.27 M11: `dxgi,d3d11,d3d10core=n,b`
+
+The working Nidhogg process loaded builtin i386 Wine/DXMT DLLs from `lib/wine/i386-windows`, so native-only narrowing must be treated as a possible break in 32-bit routing and WoW64 thunk loading.
+
+### 5. M9/M10 DXMT Config Was Narrowed Away
+
+Commits `230c2ec517937945849257646d3b5deeb3f7b6d5` and `c95024d9c03552035750c2f861f57d7e0c44efba` scoped DXMT config to M11/M12.
+
+The live Nidhogg M9 control log proves M9 still finds and uses `~/.metalsharp/runtime/wine/etc/dxmt.conf`. Removing or narrowing `DXMT_CONFIG_FILE`/DXMT config behavior from M9/M10 is a direct suspect for Nidhogg 2 and other 32-bit/D3D9-family regressions.
+
+### 6. Unity Launch Args Churned During Schedule I/Subnautica Work
+
+Commits `f548c5eac3258dc1d24852799a6afadfb8b70522`, `4e3afdea6895340d1cb46a123f7ba560a1cc3557`, and `610411d297140e15718c4639a0514d51d5fee4c1` changed Unity renderer args:
+
+- add `-force-d3d12` for explicit M12
+- broaden to M12 Unity launches
+- later gate away from configured M10/M11
+
+This is likely related to Schedule I and Subnautica BZ ambiguity. Wine 11.9 rebuild must preserve configured route authority: M11 must not accidentally force D3D12, and M12 must not be inferred from Unity alone.
+
+## Code Yin/Yang Map
+
+`git diff v0.33.27..main` is empty after the rollback, so the authoritative code comparison is:
+
+- Yin: current `main`, tree-equivalent to `v0.33.27`
+- Yang: `backup/main-before-v0.33.28-reset-20260521T223249Z` at `797db720c852b7f46356fa2541fb4dac81afcc69`
+
+Code surfaces that changed between yin and yang:
+
+| Area | Yin behavior | Yang behavior | Evidence | Rebuild rule |
+| --- | --- | --- | --- | --- |
+| Bundle source selection | installer can install the 11.5-shaped runtime | installer prefers `wine-11.9`, then `wine-11.5`, then `wine` | commit `6e235de`, `app/src-rust/src/installer.rs::install_metalsharp_bundle` | keep 11.9 source selection, but only if final extracted shape matches the 11.5 runtime contract |
+| Setup dependency contract | setup language describes Wine 11.5 runtime | setup language describes Wine 11.9, DXMT/DXVK, WoW64, and mscompatdb hook contract | commit `6e235de`, `app/src-rust/src/setup.rs::dependencies` | update text only after internal layout and hook readiness are true |
+| Runtime migration | schema version `2` | schema version `3`; migration forced when current schema is older | commit `14a5cb5`, `app/src-rust/src/migrate.rs::MIGRATE_SCHEMA_VERSION` and `migration_needed_for_setup` | do not force prefix/runtime migration until 11.9 parity is proven |
+| Migration restore | narrower restore behavior | panic handling and restore behavior changed for `prefix-steam`, `games`, `sharp-library`, `bottles`, and `compatdata` | commit `10aeada`, `app/src-rust/src/migrate.rs` | test restore behavior separately from Wine bump |
+| Steam handoff route | `/steam/launch-game` launches through normal bottle/pipeline path | anti-cheat recipes route through protected Steam handoff | commit `c95fd90`, `app/src-rust/src/main.rs::route`, `/steam/launch-game` | keep protected handoff anti-cheat-only and off the parity path |
+| Steam attach/relaunch | Wine Steam remains the background identity process | early yang stopped/relaunched Wine Steam for env inheritance; later yang stopped relaunching but env only reaches transient helper if Steam is already running | commits `c95fd90`, `10aeada`, `app/src-rust/src/steam.rs::launch_game_via_steam_with_env_options` | preserve 0.33.27 attach semantics; never rely on already-running Steam inheriting new env |
+| Game pid accounting | launch state records process directly | delegated Steam URL helper no longer counted as game pid | commit `63867b1`, `app/src-rust/src/bottles.rs::set_launch_delegated` | keep this diagnostic distinction, but do not let it mask missing real game pids |
+| DXMT config env | DXMT launcher sets `DXMT_CONFIG_FILE` for DXMT routes | cache/env contract expanded with `DXMT_CONFIG`, `DXMT_SHADER_CACHE_PATH`, `DXMT_PIPELINE_CACHE_PATH`, `MTL_SHADER_CACHE_DIR`, and logs | commit `c01180f`, `app/src-rust/src/mtsp/launcher.rs` | keep added diagnostics/cache env only if M9/M10 visibility remains intact |
+| M9/M10 config visibility | M9 can still find `~/.metalsharp/runtime/wine/etc/dxmt.conf` during live Nidhogg 2 run | `dxmt_config_applies` narrowed to `M11 | M12`; recipe asset requirement removed from M9/M10 | commits `230c2ec`, `c95024d`, `app/src-rust/src/mtsp/launcher.rs`, `app/src-rust/src/mtsp/recipe.rs` | restore/keep M9 config visibility for parity |
+| Winemetal deployment | M10/M11/M12 deploy `winemetal.dll` game-local from `lib/dxmt/x86_64-windows` | game-local `winemetal.dll` removed; runtime/prefix binding added | commit `e2dff52`, `app/src-rust/src/mtsp/engine.rs`, `app/src-rust/src/mtsp/launcher.rs::ensure_dxmt_winemetal_runtime` | keep game-local deployment during 11.9 parity; test relocation later |
+| Unix WineMetal bridge | route depends on existing runtime/game-local resolution | copies `lib/dxmt/x86_64-unix/winemetal.so` into `lib/wine/x86_64-unix` and sets `DXMT_WINEMETAL_UNIXLIB=winemetal.so` | commits `e2dff52`, `2f0d9c6`, `app/src-rust/src/mtsp/launcher.rs` | make binding explicit in logs and prove with `lsof` |
+| DLL overrides | M12/M11/M10 use DirectX `=n,b` overrides | DirectX overrides narrowed to native-only `=n`; `winemetal=n,b` added | commit `c1dd812`, `app/src-rust/src/mtsp/engine.rs` | keep `=n,b` for first 11.9 parity; native-only is a later experiment |
+| WINEDLLPATH | no central DXMT dll path injection for this change | `mtsp/launcher.rs::dxmt_wine_dll_path` adds `WINEDLLPATH` | commit `c1dd812`, `app/src-rust/src/mtsp/launcher.rs` | useful diagnostic/control only after route parity |
+| Route selection | D3D12 PE routes to M12 if 64-bit; D3D11 routes to M11; D3D9 routes to M9; Unity/directory heuristics prefer M11 | mostly stable route detection, but configured pipeline is consulted for launch args | `app/src-rust/src/mtsp/rules.rs`, `app/src-rust/src/mtsp/recipe.rs::launch_args_for_recipe` | preserve route authority; do not infer M12 from Unity alone |
+| Unity args | no broad force-D3D churn in first working contract | screen defaults, `-force-d3d11`, and `-force-d3d12` churn across M10/M11/M12 | commits `f548c5e`, `03c0826`, `4e3afde`, `610411d` | keep Unity arg changes out of first Wine 11.9 parity build |
+| Auto launch args | auto route launches selected pipeline | `/game/launch-auto` can pass request-supplied args through `launch_with_pipeline_and_args` | `app/src-rust/src/main.rs` | useful later, but parity runs should use empty args unless game-specific evidence requires otherwise |
+
+The code map matches the runtime evidence: yang moved several loader and launch contracts at the same time as the Wine version. The rebuild must therefore split "Wine 11.9 internals" from "MetalSharp route behavior changes" and prove each layer separately.
+
+Commit replay guidance:
+
+- Do not replay merge commit `797db720c852b7f46356fa2541fb4dac81afcc69` as a unit.
+- Do not cherry-pick `e2dff524f35604164ca5ab7f99bcd7b31a8f732e` as-is. It mixed WineMetal deployment model changes into the same regression cluster.
+- Do not cherry-pick the mscompatdb/protected-handoff cluster as-is. Commits `c95fd904812190809748feae0dacd8fcd8584c79`, `6e235de`, `8e83923`, `ef3377b`, and `10aeada` must be rebuilt as separately gated behavior.
+- Replay only the clean observability subset directly: `65032f7`, `168d235`, `ce2c008`, `1148f57`, `cfade4e`, `f654c10`, `1c0b788`, `38fed0a`, `d269d74`, `e796968`, `1e54117`, `ddba26f`, `e3c2a63`, `557cb14`, `05d7fd9`, `a514813`, `5e9a23c`, and `1683b79`.
+- Reimplement mixed evidence/behavior commits manually instead of replaying them: `df728e3`, `d86fd03`, `2644948`, `63867b1`, `ab719e3`, `b5e4e28`, `f9aa3bd`, and `610411d`.
+- Rebuild route parsing and custom launch args next, but preserve configured route authority.
+- Rebuild DXMT file deployment for direct/non-Steam launches before touching Steam handoff.
+- Rebuild cache/config next, and keep the live-proven M9 config visibility intact.
+- Add Steam env propagation only after direct launch proof.
+- Delay protected Steam handoff and syscall mutation until all normal M9/M11/M12 controls pass.
+- Replay native D3D/DXGI compatibility patches only after launch plumbing is stable, one proof loop per route.
+
+## Commit Replay Ledger
+
+This ledger is intentionally stricter than normal cherry-pick guidance. The next Wine 11.9 branch should not replay the post-0.33.27 history in chronological order. Each commit must be either replayed as diagnostics, rebuilt manually in a smaller pass, quarantined until live parity passes, or ignored as version-only release metadata.
+
+Classification meanings:
+
+- `safe-diagnostic`: may be replayed early if it does not change route, runtime, migration, or Steam handoff behavior.
+- `rebuild-manually`: useful intent, but must be reimplemented in a narrower patch because the original commit couples too many behaviors.
+- `quarantine-until-parity`: do not apply until the three Wine 11.9 control games pass with 0.33.27 semantics.
+- `never-as-is`: known regression cluster; only salvage small pieces after new tests and proof exist.
+- `version-only`: do not replay while rebuilding; create a fresh version/tag only after gates pass.
+
+| Commit | Subject | Classification | Reason |
+| --- | --- | --- | --- |
+| `df728e3` | Diagnose D3D12 ordinal and EAC evidence targets | `rebuild-manually` | Useful PE/export probing, but also touches route recipe behavior; split evidence from route logic. |
+| `65032f7` | Track direct game anti-cheat crash evidence | `safe-diagnostic` | Evidence endpoint/log parsing only; good early observability. |
+| `c95fd90` | Add protected Steam handoff probes | `never-as-is` | Couples protected Steam handoff, PID tracking, backend routes, and Steam process behavior. |
+| `168d235` | Add mscompatdb hook surface diagnostics | `safe-diagnostic` | Diagnostic surface only; keep behind read-only evidence endpoints. |
+| `d86fd03` | Prepare mscompatdb dylib parity | `rebuild-manually` | Good parity idea, but runtime/dylib assumptions must be rebuilt against actual 11.9 assets. |
+| `2644948` | Define mscompatdb hook contract target | `rebuild-manually` | Keep the contract design, but revalidate ABI against actual Wine 11.9 before hook phase. |
+| `070b27e` | Seed Wine mscompatdb contract export | `quarantine-until-parity` | Wine source hook belongs after runtime parity and symbol proof. |
+| `6e235de` | Promote Wine 11.9 runtime hook surface | `never-as-is` | Mixes installer/setup/migration/runtime promotion with hook source changes. |
+| `ce2c008` | Format mscompatdb hook sources | `safe-diagnostic` | Formatting-only for hook sources; harmless if retained with later hook sources. |
+| `1148f57` | Tighten mscompatdb readiness checks | `safe-diagnostic` | Readiness checks are useful if they stay non-mutating and distinguish file presence from hook readiness. |
+| `63867b1` | Avoid recording Steam handoff pid as game pid | `rebuild-manually` | Correct idea, but tied to Steam handoff semantics; replay only after attach behavior is redesigned. |
+| `8e83923` | Restore mscompatdb syscall table protections | `quarantine-until-parity` | Low-level hook mutation; needs isolated Wine 11.9 proof first. |
+| `14a5cb5` | Force migration for Wine 11.9 runtime schema | `never-as-is` | Forced migration is exactly the state disruption that regressed working installs. |
+| `ab719e3` | Polish migration window and handoff evidence | `rebuild-manually` | UI/evidence pieces may help, but migration/handoff coupling needs separation. |
+| `ef3377b` | Gate mscompatdb mutation and exported contract checks | `never-as-is` | Still introduces gated mutation into runtime path before parity is proven. |
+| `cfade4e` | Read PE export and import directories separately | `safe-diagnostic` | Parser improvement; useful for evidence and patch validation. |
+| `c2eb975` | Bump version to 0.33.28 | `version-only` | Release metadata must be regenerated after gates, not replayed. |
+| `875004e` | Merge pull request #98 from aaf2tbz/codex/eac-proof-target-filtering | `never-as-is` | Merge commit; replay selected children only. |
+| `10aeada` | Fix postinstall Steam handoff and migration restore | `never-as-is` | Postinstall Steam relaunch/restore logic is implicated in broken Steam attachment behavior. |
+| `3eff2f4` | Bump version to 0.33.29 | `version-only` | Release metadata must be regenerated after gates, not replayed. |
+| `3dacbe7` | Merge pull request #103 from aaf2tbz/codex/fix-postinstall-steam-migration | `never-as-is` | Merge commit; replay selected children only. |
+| `e2dff52` | Bind DXMT winemetal through Wine runtime | `never-as-is` | Core DXMT/WineMetal binding changed too much at once and hit M9/M11 regressions. |
+| `f8dfa3f` | Record DXMT DXGI private device export patch | `quarantine-until-parity` | Patch asset may matter, but only after clean DXMT parity build. |
+| `c1dd812` | Force DXMT routes to native DirectX DLLs | `never-as-is` | Forced native overrides can break working M9/M11 routing and cache behavior. |
+| `2f0d9c6` | Fix DXMT winemetal Unix bridge loading | `quarantine-until-parity` | Probably needed for 11.9, but must be tested in isolated candidate first. |
+| `f548c5e` | Tighten M12 Unity launch probes | `quarantine-until-parity` | M12 launch behavior should not land before M9/M11 parity gates pass. |
+| `03c0826` | Harden Unity DXMT launch defaults | `quarantine-until-parity` | Launch default changes are risky until route authority is proven. |
+| `f654c10` | Add D3D12 surface extraction diagnostics | `safe-diagnostic` | Standalone diagnostic script/docs; good to keep. |
+| `bd3cb30` | Expand D3D12 runtime compatibility | `quarantine-until-parity` | Runtime ABI/surface expansion; test after base Wine/DXMT launch parity. |
+| `d34f964` | Improve D3D12 descriptor object behavior | `quarantine-until-parity` | D3D12 implementation change; not part of first Wine 11.9 bootstrapping. |
+| `8f3ec06` | Add D3D12 resource allocation info | `quarantine-until-parity` | ABI/runtime expansion; hold until M12 phase. |
+| `840f7e7` | Add DXGI2 D3D12 swapchain path | `quarantine-until-parity` | Swapchain implementation risk; hold until D3D12 pass. |
+| `5fc0edb` | Return D3D12 swapchain backbuffers | `quarantine-until-parity` | Presentation/runtime behavior; needs live M12 proof. |
+| `82e46e0` | Stabilize M12 runtime contract | `quarantine-until-parity` | M12 contract work belongs after M9/M11 parity. |
+| `fe3164a` | Make D3D12 descriptor copies overlap-safe | `quarantine-until-parity` | Likely valid fix, but still D3D12 runtime mutation. |
+| `7ae7ce7` | Report D3D12 capabilities conservatively | `quarantine-until-parity` | Capability reporting can affect game decisions; prove later. |
+| `1c0b788` | Log direct MTSP runtime contracts | `safe-diagnostic` | Logging-only; useful for future rebuild verification. |
+| `38fed0a` | Format D3D12 feature checks | `safe-diagnostic` | Test formatting only. |
+| `d269d74` | Log D3D12 compute pipeline evidence | `safe-diagnostic` | Logging-only in D3D12 path; acceptable as diagnostics. |
+| `e796968` | Log D3D12 compute dispatch evidence | `safe-diagnostic` | Logging-only. |
+| `1e54117` | Log D3D12 draw execution evidence | `safe-diagnostic` | Logging-only. |
+| `194c66f` | Preserve swapchain drawable presentation | `quarantine-until-parity` | Presentation behavior change; validate in M12 pass. |
+| `ddba26f` | Log D3D12 feature query decisions | `safe-diagnostic` | Logging-only. |
+| `e3c2a63` | Track DXGI present count | `safe-diagnostic` | Counter/test evidence; useful for live proof. |
+| `4e3afde` | Make explicit M12 Unity launches force D3D12 | `quarantine-until-parity` | Route-forcing must wait until base M11/M12 split is proven. |
+| `557cb14` | Route DXMT D3D12 traces per launch | `safe-diagnostic` | Trace file routing is good observability if non-invasive. |
+| `05d7fd9` | Harden DXMT patch preflight | `safe-diagnostic` | Patch preflight/docs are useful before applying anything. |
+| `c01180f` | Harden DXMT launch cache contract | `never-as-is` | Cache contract changes are implicated in shader-cache regression; rebuild in a smaller route-cache pass. |
+| `b5e4e28` | Capture launcher installer evidence | `rebuild-manually` | Evidence is useful, but original touches launcher/install surfaces too broadly. |
+| `a514813` | Fix EAC Proton asset evidence detection | `safe-diagnostic` | Evidence detection fix; safe if read-only. |
+| `f9aa3bd` | Preserve DXMT config during contract repair | `rebuild-manually` | Correct direction, but should be rebuilt around explicit M9/M11/M12 config ownership. |
+| `610411d` | Gate Unity D3D12 launch arg by configured route | `rebuild-manually` | Good principle, but reimplement after route model is cleaned up. |
+| `e80ee5b` | Apply Steam identity to Wine fallback launches | `quarantine-until-parity` | Steam identity/env propagation can affect attach vs relaunch behavior. |
+| `5e9a23c` | Cover expanded DXGI factory surface | `safe-diagnostic` | Test coverage only. |
+| `230c2ec` | Scope DXMT config contract to M11 M12 | `never-as-is` | Explicitly narrows DXMT config away from M9, conflicting with working Nidhogg 2 evidence. |
+| `51e1417` | Preserve D3D12 device ABI method order | `quarantine-until-parity` | ABI fix may be valid, but belongs in later D3D12 pass. |
+| `c95024d` | Scope DXMT config recipe asset to M11 M12 | `never-as-is` | Same M9 exclusion risk as `230c2ec`; likely breaks M9 DXMT-family path. |
+| `1683b79` | Cover DXGI factory implementation surface | `safe-diagnostic` | Test/coverage around DXGI surface; safe as evidence. |
+| `79cc6fb` | Bump version to 0.33.30 | `version-only` | Release metadata only. |
+| `797db72` | Bind DXMT winemetal through Wine runtime | `never-as-is` | PR merge/rollup with mixed runtime, launcher, D3D12, patch, and version changes. |
+
+The first implementation branch should start with only the `safe-diagnostic` subset plus the new candidate preparation/audit scripts in this document. The `rebuild-manually` set should be applied as small new patches in the pass order below. The `quarantine-until-parity` set is allowed only after the readiness audit can point to a passing live suite. The `never-as-is` set should never be cherry-picked directly.
+
+The concrete branch execution runbook is tracked separately in `docs/wine-119-implementation-runbook.md`. Use that file for pass-by-pass commands, allowed write scopes, final release checklist, and the exact point where live controls must be run.
+
+## Wine 11.9 Rebuild Design
+
+### Phase 0: Freeze the Working 11.5 Contract
+
+Before changing Wine, create a machine-readable contract from the live 0.33.27 runtime:
+
+- runtime tree manifest for `~/.metalsharp/runtime/wine`
+- hashes for `bin/wine`, `bin/wineserver`, `bin/metalsharp-wine`
+- hashes for `lib/wine/{x86_64-unix,x86_64-windows,i386-windows}`
+- hashes for `lib/dxmt/{x86_64-unix,x86_64-windows,i386-windows}` if present
+- `file` and `otool -L` output for `wine`, `wineserver`, `ntdll.so`, `win32u.so`, `mscompatdb.so`, `winemetal.so`, `libMoltenVK.1.dylib`
+- launch contract logs for Nidhogg 2, Schedule I, and Subnautica BZ
+
+This is the yin baseline.
+
+### Phase 1: Build Wine 11.9 as a Layout-Compatible Runtime
+
+Use the recovered `wine-11.9` bundle as the candidate, but rebuild/package it to match Wine 11.5 structure:
+
+- `bin/wine`
+- `bin/wineserver`
+- `bin/metalsharp-wine`
+- `lib/wine/x86_64-unix`
+- `lib/wine/x86_64-windows`
+- `lib/wine/i386-windows`
+- `lib/dxmt/x86_64-unix`
+- `lib/dxmt/x86_64-windows`
+- `lib/dxmt/i386-windows` when 32-bit DXMT assets exist
+- `etc/dxmt.conf`
+- `etc/vulkan/icd.d/MoltenVK_icd.json`
+- Gecko/Mono redists where installer expects them
+
+The installer may prefer `wine-11.9`, but the extracted contents copied into `~/.metalsharp/runtime/wine` must present the same final shape as 11.5.
+
+### Phase 2: Parity Launches Before Anti-Cheat Hooks
+
+Do not enable mscompatdb hook mutation yet.
+
+Run Wine 11.9 with 0.33.27 launch semantics:
+
+- Keep M9 config visible.
+- Keep M9 as `d3d9=n,b`.
+- Keep M11/M12 `=n,b` DirectX overrides until parity is proven.
+- Keep game-local `winemetal.dll` deployment for routes that previously used it.
+- Keep per-route cache paths:
+  - `~/.metalsharp/shader-cache/<route>/<appid>/`
+  - `~/.metalsharp/pipeline-cache/<route>/<appid>/`
+- Keep `SteamAppId` and `SteamGameId` in Wine Steam handoff env.
+- Keep Wine Steam attach behavior: do not stop/relaunch Steam for game launch env.
+
+Required control games:
+
+- Nidhogg 2: must run under M9 and load i386 `d3d11.dll`, `dxgi.dll`, `winemetal.dll`, Unix `winemetal.so`, and shader cache under `m9/535520`.
+- Schedule I: must run under M11, load Unix `winemetal.so`, `libMoltenVK.1.dylib`, use `dxmt.conf`, and keep shader cache under `m11/3164500`.
+- Subnautica Below Zero: must run under M11 and prove actual DX11 to DXMT runtime use by loading `d3d11.dll`, `dxgi.dll`, `winemetal.dll`, Unix `winemetal.so`, `libMoltenVK.1.dylib`, and shader cache under `m11/848450`.
+
+### Phase 3: Add Anti-Cheat Hook Surface Behind Gates
+
+Only after parity:
+
+- Add `MscompatdbHookContract.h`.
+- Add the ntdll/mscompatdb hook exports.
+- Require `nm`/symbol evidence that `ntdll.so` exports the expected contract.
+- Require a runtime probe endpoint to report `hook_surface_ready`.
+- Keep mutation and dylib prep gated to setup/migration context.
+- Do not treat `mscompatdb.so loaded` as success. Current live 0.33.27 logs show `mscompatdb:error: couldn't find KeServiceDescriptorTable` while Nidhogg still works; presence alone is not proof.
+
+### Phase 4: Revisit the Safer Winedll Binding Model Separately
+
+The later winemetal relocation may still be desirable, but it must be a separate PR/phase after Wine 11.9 parity:
+
+- Add prefix `system32/winemetal.dll` binding only behind a feature flag or route-level experiment.
+- Keep game-local deployment available as fallback.
+- Log which model is active for every launch.
+- Test Nidhogg 2, Schedule I, and Subnautica BZ under both models.
+
+## Required Tests and Gates
+
+Repo-level tests:
+
+- MTSP route tests for M9/M10/M11/M12 overrides.
+- M9 test must assert DXMT config remains visible.
+- M11/M12 tests must assert DXMT config, cache env, and DirectX overrides.
+- Steam handoff tests must assert no Steam relaunch when Wine Steam is already running.
+- Migration tests must not destroy prefix/game installs without an explicit runtime schema transition.
+- mscompatdb tests must distinguish loaded vs hook-ready.
+
+Runtime probes:
+
+- `wine --version`
+- `wineserver --version`
+- `file` on Wine binaries and DXMT binaries.
+- `otool -L` on Unix dylibs/so files.
+- `nm -gU` on `ntdll.so`, `mscompatdb.so`, and host runtime dylib.
+- `lsof -p <game_pid>` for loaded D3D/DXMT/MoltenVK/Metal/cache files.
+- Launch log contract emitted before Wine output:
+  - pipeline
+  - prefix
+  - runtime root
+  - working directory
+  - exe
+  - args
+  - `WINEDLLOVERRIDES`
+  - runtime library env
+  - `DXMT_CONFIG_FILE`
+  - shader/pipeline cache paths
+  - winemetal binding model
+  - Steam identity mode
+
+Release gates:
+
+- Do not bump/tag until Nidhogg 2, Schedule I, and Subnautica BZ route evidence is captured.
+- Do not publish a Wine 11.9 release whose only proof is installer success.
+- Do not combine Wine 11.9, mscompatdb mutation, winemetal relocation, Steam handoff changes, and Unity renderer changes in one release again.
+
+## Immediate Next Implementation Path
+
+1. Create a Wine 11.9 parity branch from `main`/`v0.33.27`.
+2. Add diagnostics/manifests first, without changing runtime behavior.
+3. Package Wine 11.9 into the 11.5-compatible runtime layout.
+4. Prepare two M9 candidate variants:
+   - 11.9 bundle plus `/Volumes/AverySSD/metalsharp/dxmt-src/build32/src/winemetal/winemetal.dll`
+   - 11.9 bundle plus borrowed 11.5 i386 `winemetal.dll` as a compatibility fallback experiment
+5. Install candidates only into a disposable `~/.metalsharp-119-parity` or alternate runtime root first.
+6. Run the three control games with the exact 0.33.27 route semantics.
+7. Only after parity, cherry-pick or reimplement anti-cheat hook commits in isolation.
+8. Leave winemetal relocation and native-only override narrowing for a later isolated experiment.
+
+## Pass-by-Pass Rebuild Matrix
+
+The next Wine 11.9 attempt should be built as multiple small passes. Each pass has one allowed behavior change family and one proof bundle. If a pass fails, revert only that pass instead of chasing all regressions together.
+
+| Pass | Allowed changes | Explicitly not allowed | Proof required before next pass |
+| --- | --- | --- | --- |
+| A: Baseline diagnostics on 11.5 | add manifest generation, launch contract logging, route/cache/env introspection, and `lsof` capture helpers | no Wine version change, no route behavior change, no migration bump | 11.5 controls still launch; logs include pipeline, runtime root, `WINEDLLOVERRIDES`, config/cache paths, winemetal binding model, and Steam identity mode |
+| B: Wine 11.9 asset packaging | install from `bundles/metalsharp_bundle.tar.zst`; normalize archive root `wine-11.9` into final runtime root `~/.metalsharp/runtime/wine`; regenerate/carry `bin/metalsharp-wine` | no protected Steam handoff, no winemetal relocation, no native-only DirectX overrides, no Unity arg changes | runtime manifest shows complete 11.9 file tree plus 11.5-compatible final paths; `wine --version` and `wineserver --version` return 11.9; `bin/metalsharp-wine` exists or all callers are updated |
+| C1: 11.9 parity with explicit DXMT i386 WineMetal | run M9/M11/M12 routes using 0.33.27 overrides, config visibility, game-local deployment, and Steam attach semantics; source i386 WineMetal from `/Volumes/AverySSD/metalsharp/dxmt-src/build32/src/winemetal/winemetal.dll` | no mscompatdb hook mutation, no schema-forced prefix migration, no Steam handoff changes | Nidhogg 2, Schedule I, and Subnautica BZ match the control matrix below under Wine 11.9; i386 artifact provenance is logged |
+| C2: 11.9 parity with borrowed 11.5 i386 fallback | only if C1 fails specifically on i386 WineMetal compatibility, test the borrowed 11.5 i386 `winemetal.dll` as a compatibility artifact | no release blessing without live M9 proof and an explicit compatibility rationale | Nidhogg 2 proves whether the 11.5 i386 bridge can safely pair with Wine 11.9, or the path is rejected |
+| D: Anti-cheat hook surface | add hook headers/exports/probes and mscompatdb readiness reporting | no route behavior changes; no Steam relaunch for normal routes | symbol probe proves hook contract; runtime endpoint reports hook readiness; non-anti-cheat control games still match pass C |
+| E: Protected Steam handoff | enable protected handoff only for explicit anti-cheat recipes | no global Steam launch path replacement | logs prove protected handoff is used only for opted-in games; already-running Wine Steam is not killed for normal routes |
+| F: Winemetal relocation experiment | test prefix/system32 and runtime-bound `winemetal` model behind a feature flag | no removal of fallback game-local deployment | both binding models are logged; controls pass or fallback remains automatic |
+| G: Native-only override experiment | test `=n` DirectX overrides and `winemetal=n,b` separately | no Unity arg inference or route remapping in same pass | controls pass under native-only, or experiment remains disabled |
+| H: Unity launch args | add game/route-specific Unity args only with per-game proof | no global `-force-d3d12` based on Unity alone | Schedule I and Subnautica BZ remain M11 unless explicitly configured otherwise |
+
+## Control Game Acceptance Matrix
+
+These are hard gates for any release candidate that includes Wine 11.9. The evidence must come from fresh launch logs and fresh `lsof` captures from the candidate build.
+
+Capture command:
+
+- `scripts/capture-steam-game-proof.sh 535520 Nidhogg_2 /tmp/metalsharp-proof-nidhogg2-candidate`
+- `scripts/capture-steam-game-proof.sh 3164500 'Schedule I' /tmp/metalsharp-proof-schedule-i-candidate`
+- `scripts/capture-steam-game-proof.sh 848450 SubnauticaZero /tmp/metalsharp-proof-subnautica-bz-candidate`
+
+The proof script writes:
+
+- `summary.txt`
+- `all-processes.txt`
+- `matching-processes.txt`
+- `game-pids.txt`
+- latest copied `launch-*.log`
+- `metalsharp-compatdata.json`
+- `bottle.json`
+- shader/pipeline cache listings
+- `lsof-<pid>.txt` for each matching live game PID
+
+If `game-pids.txt` is empty, the proof is log-only and does not satisfy a release gate. Candidate parity requires a live game PID plus `lsof` loaded-module evidence.
+
+| Game | Route | Must prove | Must not happen |
+| --- | --- | --- | --- |
+| Nidhogg 2 `535520` | M9 / `d3d9_metal` | process `Nidhogg_2.exe`; `pipeline=M9`; `dxmt.conf` visible; i386 `d3d11.dll`, `dxgi.dll`, `winemetal.dll` loaded where the 0.33.27 control loaded them; Unix `winemetal.so`; shader cache under `~/.metalsharp/shader-cache/m9/535520` | black/no-window-with-music; missing real game pid; Steam relaunch; M9 config stripped; native-only override narrowing without proof |
+| Schedule I `3164500` | M11 / `dxmt_metal` | process `Schedule I.exe`; `pipeline=M11`; `d3d11`/`dxgi` route active; Unix `winemetal.so`; `libMoltenVK.1.dylib`; shader cache under `~/.metalsharp/shader-cache/m11/3164500`; Unity crash handler can exist without counting as launch failure by itself | crash-to-dust after handoff; M12 forced by Unity; Steam relaunch; game pid replaced by Steam URL helper |
+| Subnautica BZ `848450` | M11 / `dxmt_metal` | process `SubnauticaZero.exe`; `pipeline=M11`; `d3d11.dll`, `dxgi.dll`, `winemetal.dll`, Unix `winemetal.so`, `libMoltenVK.1.dylib`; shader cache under `~/.metalsharp/shader-cache/m11/848450` | ambiguous fallback rendering; split process with no loaded DXMT proof; M12 inference from Unity; missing cache activity |
+
+Current log-only control captures from the 0.33.27 runtime:
+
+- `/tmp/metalsharp-proof-nidhogg2-control/summary.txt`
+- `/tmp/metalsharp-proof-schedule-i-control/summary.txt`
+- `/tmp/metalsharp-proof-subnautica-bz-control/summary.txt`
+
+These confirm the latest launch contracts from logs, but because the games were no longer running when captured, they correctly report `none; live lsof proof still required`. The earlier live `lsof` snapshots remain the stronger control evidence for this investigation.
+
+## Runtime Manifest Requirements
+
+Every Wine 11.9 build candidate should emit or archive a manifest with:
+
+- command:
+  - `scripts/runtime-manifest.sh ~/.metalsharp/runtime/wine /tmp/metalsharp-runtime-11.5-current`
+  - `scripts/runtime-manifest.sh <candidate-runtime-root>/wine /tmp/metalsharp-runtime-11.9-candidate`
+- normalized file list for final runtime root
+- SHA256 for route-critical binaries:
+  - `bin/wine`
+  - `bin/wineserver`
+  - `bin/metalsharp-wine`
+  - `share/wine/wine.inf`
+  - `etc/dxmt.conf`
+  - `etc/mscompatdb_rules.toml`
+  - `etc/vulkan/icd.d/MoltenVK_icd.json`
+  - `etc/vulkan/icd.d/MoltenVK_x86_64_icd.json`
+  - `lib/dxmt/x86_64-windows/{d3d10core.dll,d3d11.dll,d3d12.dll,dxgi.dll,winemetal.dll}`
+  - `lib/dxmt/x86_64-unix/winemetal.so`
+  - `lib/wine/x86_64-unix/{winemetal.so,mscompatdb.so,mscompatdb.dylib,libMoltenVK.1.dylib}`
+  - `lib/wine/x86_64-windows/{d3d11.dll,dxgi.dll,winemetal.dll}`
+  - `lib/wine/i386-windows/{d3d11.dll,dxgi.dll,winemetal.dll}`
+- `file` output for Wine executables and Mach-O dylibs
+- `otool -L` output for `winemetal.so`, `mscompatdb.so`, `mscompatdb.dylib`, and `libMoltenVK.1.dylib`
+- `nm -gU` hook probe output for `ntdll.so`, `mscompatdb.so`, and `mscompatdb.dylib`
+- final installer source URL or artifact digest
+
+The manifest script is `scripts/runtime-manifest.sh`. It is read-only against the runtime root and writes:
+
+- `versions.txt`
+- `files.txt`
+- `file-count.txt`
+- `critical-sha256.txt`
+- `file.txt`
+- `otool-L.txt`
+- `nm-gU.txt`
+- `manifest.json`
+
+Manifest comparison is handled by `scripts/compare-runtime-manifests.sh`:
+
+- command:
+  - `scripts/compare-runtime-manifests.sh /tmp/metalsharp-runtime-11.5-current /tmp/metalsharp-runtime-11.9-candidate /tmp/metalsharp-runtime-11.9-candidate/classified-diff.md`
+- behavior:
+  - classifies route-critical deltas instead of requiring byte-for-byte identity
+  - allows expected Wine version changes
+  - allows expected DXMT D3D12/DXGI/WineMetal bridge changes
+  - allows expected anti-cheat hook-surface changes
+  - requires wrapper/config/Vulkan/MoltenVK/shared DXMT files to match
+  - marks unknown or route-critical missing files as release blockers
+
+Candidate orchestration is handled by `scripts/prepare-wine119-parity-candidates.sh`:
+
+- command:
+  - `scripts/prepare-wine119-parity-candidates.sh /tmp/metalsharp-wine-assets-IjmErR/metalsharp_bundle.tar.zst /tmp/metalsharp-wine119-parity`
+- behavior:
+  - creates a fresh 11.5 baseline manifest
+  - prepares `clean`, `dxmt32`, and `borrowed` Wine 11.9 runtime candidates under `/tmp/metalsharp-wine119-parity/candidates`
+  - writes manifests under `/tmp/metalsharp-wine119-parity/manifests`
+  - compares each candidate against the 11.5 baseline contract
+  - writes `/tmp/metalsharp-wine119-parity/summary.md`
+- default explicit i386 DXMT source:
+  - `/Volumes/AverySSD/metalsharp/dxmt-src/build32/src/winemetal/winemetal.dll`
+- override:
+  - `METALSHARP_I386_WINEMETAL_SOURCE=/path/to/winemetal.dll`
+
+Latest orchestration result:
+
+| Candidate | Root | Manifest gate | Meaning |
+| --- | --- | --- | --- |
+| `clean` | `/tmp/metalsharp-wine119-parity/candidates/clean/wine` | fail | release 11.9 bundle lacks i386 `winemetal.dll` |
+| `dxmt32` | `/tmp/metalsharp-wine119-parity/candidates/dxmt32/wine` | fail | i386 WineMetal exists but differs from 11.5 control; requires live M9 proof |
+| `borrowed` | `/tmp/metalsharp-wine119-parity/candidates/borrowed/wine` | pass | manifest-complete by borrowing 11.5 i386 WineMetal; still requires live M9 proof before any release blessing |
+
+Manifest pass is not a release gate. The orchestrator only proves runtime-shape readiness. Live control games remain mandatory.
+
+Isolated parity-home installation is handled by `scripts/install-wine119-parity-home.sh`:
+
+- command:
+  - `scripts/install-wine119-parity-home.sh /tmp/metalsharp-wine119-parity/candidates/dxmt32/wine /tmp/metalsharp-home-wine119-dxmt32`
+- behavior:
+  - copies the selected candidate runtime into `<parity-home>/.metalsharp/runtime/wine`
+  - writes `<parity-home>/activate-parity-env.sh`
+  - writes `<parity-home>/proof-commands.sh`
+  - writes `<parity-home>/runtime-manifest`
+  - does not modify the working `~/.metalsharp`
+- default state behavior:
+  - runtime only; no Steam prefix, compatdata, bottles, games, or caches are copied
+- optional state clone:
+  - `METALSHARP_CLONE_USER_STATE=1 scripts/install-wine119-parity-home.sh ...`
+  - copies `prefix-steam`, `compatdata`, `bottles`, `games`, `configs`, `shader-cache`, and `pipeline-cache` from the source MetalSharp home into the isolated parity home
+  - rewrites active cloned bottle/compatdata/config manifests from the source MetalSharp home path to the parity MetalSharp home path
+  - fails if any active cloned manifest still points back at the source MetalSharp home
+- copy mode:
+  - `METALSHARP_COPY_MODE=auto` prefers APFS clone-copy on macOS and falls back to ordinary copy
+  - `METALSHARP_COPY_MODE=clone` requires APFS clone-copy and fails instead of silently making a full copy
+  - this matters because the current `prefix-steam` source is about `20G` while the internal disk has about `8.4Gi` free
+- size/copy evidence:
+  - writes `<parity-home>/state-sizes.txt`
+  - writes `<parity-home>/copy.log`
+  - writes `<parity-home>/state-path-rewrite.log`
+- safety rails:
+  - the installer refuses to target the real `HOME` or the source MetalSharp home
+  - parity homes must live under `/tmp` or `/private/tmp` unless `METALSHARP_ALLOW_NON_TMP_PARITY_HOME=1` is explicitly set
+  - copied `compatdata/*/logs` directories are pruned so old 11.5 launch logs cannot contaminate Wine 11.9 proof summaries
+
+Latest isolated install result:
+
+- parity home: `/private/tmp/metalsharp-home-wine119-dxmt32`
+- runtime: `/private/tmp/metalsharp-home-wine119-dxmt32/.metalsharp/runtime/wine`
+- `wine --version`: `wine-11.9`
+- `wineserver --version`: `Wine 11.9`
+- cloned user state: `0`
+- activation file: `/private/tmp/metalsharp-home-wine119-dxmt32/activate-parity-env.sh`
+- proof commands: `/private/tmp/metalsharp-home-wine119-dxmt32/proof-commands.sh`
+
+Latest cloned-state install result:
+
+- command:
+  - `METALSHARP_CLONE_USER_STATE=1 METALSHARP_COPY_MODE=clone scripts/install-wine119-parity-home.sh /tmp/metalsharp-wine119-parity/candidates/dxmt32/wine /tmp/metalsharp-home-wine119-dxmt32-state`
+- parity home: `/private/tmp/metalsharp-home-wine119-dxmt32-state`
+- runtime: `/private/tmp/metalsharp-home-wine119-dxmt32-state/.metalsharp/runtime/wine`
+- cloned user state: `1`
+- copy method: `clone`
+- `wine --version`: `wine-11.9`
+- `wineserver --version`: `Wine 11.9`
+- active state path rewrite:
+  - source MetalSharp home: `/Users/alexmondello/.metalsharp`
+  - parity MetalSharp home: `/private/tmp/metalsharp-home-wine119-dxmt32-state/.metalsharp`
+  - active stale manifest count before rewrite: `8`
+  - active stale manifest count after rewrite: `0`
+  - verified by `state-path-rewrite.log`
+  - copied launch log directories after hardening: `0`
+- source state sizes:
+  - `prefix-steam`: `20G`
+  - `compatdata`: `96K`
+  - `bottles`: `64K`
+  - `games`: `0B`
+  - `shader-cache`: `12M`
+- destination state sizes are recorded in `/private/tmp/metalsharp-home-wine119-dxmt32-state/state-sizes.txt`
+- copy log: `/private/tmp/metalsharp-home-wine119-dxmt32-state/copy.log`
+
+To test a candidate live without mutating the working runtime, launch the backend/app from a shell that has sourced the activation file. The current app code resolves most MetalSharp paths through `dirs::home_dir()/.metalsharp`, so the isolated run depends on `HOME=<parity-home>`.
+
+Backend parity preflight is handled by `scripts/probe-wine119-parity-backend.sh`:
+
+- command:
+  - `scripts/probe-wine119-parity-backend.sh /private/tmp/metalsharp-home-wine119-dxmt32 /private/tmp/metalsharp-home-wine119-dxmt32/backend-probe-main03327`
+- behavior:
+  - starts `metalsharp-backend` with `HOME=<parity-home>`
+  - uses a non-default port, default `9374`
+  - probes `/status`, `/setup/dependencies`, `/runtime/host-abi`, and `/bottles/profiles`
+  - records direct `wine --version` and `wineserver --version` from the parity runtime
+  - stops the backend before exiting
+- safety rails:
+  - refuses the real `HOME` or source MetalSharp home as a parity target
+  - refuses non-tmp parity homes unless `METALSHARP_ALLOW_NON_TMP_PARITY_HOME=1` is set
+- latest verified result after rebuilding the Rust backend from current `main`:
+  - backend binary: `/Users/alexmondello/Dev/metalsharp/app/src-rust/target/release/metalsharp-backend`
+  - backend `/status` version: `0.33.27`
+  - parity runtime: `/private/tmp/metalsharp-home-wine119-dxmt32/.metalsharp/runtime/wine`
+  - parity `wine --version`: `wine-11.9`
+  - parity `wineserver --version`: `Wine 11.9`
+  - probe summary: `/private/tmp/metalsharp-home-wine119-dxmt32/backend-probe-main03327/summary.txt`
+- stale-binary warning:
+  - before rebuilding, the existing release backend binary reported `0.33.30`
+  - backend preflight evidence must therefore include `/status` version and should rebuild `app/src-rust` from current `main` before any release decision
+- expected setup text caveat:
+  - current `main` setup copy still describes Wine 11.5 even when the isolated runtime is Wine 11.9
+  - this is not a runtime identity failure; setup text should only be updated after 11.9 parity passes
+- latest cloned-state backend preflight:
+  - probe summary: `/private/tmp/metalsharp-home-wine119-dxmt32-state/backend-probe-main03327-hardened/summary.txt`
+  - backend `/status` version: `0.33.27`
+  - parity `wine --version`: `wine-11.9`
+  - parity `wineserver --version`: `Wine 11.9`
+  - `/bottles/profiles` returns M9, M10, M11, and M12 profiles from the cloned-state parity home
+
+Live control suite orchestration is handled by `scripts/run-wine119-live-control-suite.sh`:
+
+- guarded command:
+  - `METALSHARP_RUN_LIVE_GAMES=1 scripts/run-wine119-live-control-suite.sh /tmp/metalsharp-home-wine119-dxmt32 /tmp/metalsharp-live-controls-dxmt32`
+- hard guard:
+  - the script refuses to launch anything unless `METALSHARP_RUN_LIVE_GAMES=1` is set
+- active-state guard:
+  - before launching, the script reads the parity install report or `METALSHARP_PARITY_SOURCE_HOME`
+  - source-home metadata is mandatory for cloned-state live runs
+  - it refuses to continue if active cloned JSON/TOML/CONF/ENV manifests under bottles, compatdata, or configs still reference the source MetalSharp home
+  - it requires the three control-game bottle and compatdata manifests to reference the parity MetalSharp home
+  - it refuses to run if copied historical `compatdata/*/logs` directories are present
+  - it refuses the real `HOME` or source MetalSharp home as a parity target
+  - it refuses non-tmp parity homes unless `METALSHARP_ALLOW_NON_TMP_PARITY_HOME=1` is set
+- required parity-home state:
+  - prepare the parity home with `METALSHARP_CLONE_USER_STATE=1 scripts/install-wine119-parity-home.sh ...`
+  - the script refuses to run if `prefix-steam`, `compatdata`, `bottles`, or `games` are missing from the parity home
+- launch sequence:
+  - `535520` Nidhogg 2 with `launchMethod: "m9"`
+  - `3164500` Schedule I with `launchMethod: "m11"`
+  - `848450` Subnautica Below Zero with `launchMethod: "m11"`
+- proof sequence:
+  - waits after each launch, default `METALSHARP_WAIT_SECS=20`
+  - runs `scripts/capture-steam-game-proof.sh` against the same isolated `METALSHARP_HOME` with `METALSHARP_REQUIRE_PARITY_HOME=1`
+  - writes `summary.md`, launch JSON responses, backend logs, and per-game proof directories
+- latest guard validation:
+  - running without `METALSHARP_RUN_LIVE_GAMES=1` exits with code `2` and launches nothing
+  - a fake stale parity home with active manifests pointing at `/Users/alexmondello/.metalsharp` is refused before backend/game launch
+  - a fake parity home with no source metadata is refused before backend/game launch
+  - `scripts/install-wine119-parity-home.sh ... /Users/alexmondello` is refused before runtime copy
+  - `METALSHARP_REQUIRE_PARITY_HOME=1 scripts/capture-steam-game-proof.sh ...` without explicit `METALSHARP_HOME` is refused
+
+This script is the release-candidate gate runner. It should be run first against the `dxmt32` parity home. The borrowed candidate should only be tested if `dxmt32` fails in a way that points specifically at the explicit DXMT i386 WineMetal artifact.
+
+Live control verification is handled by `scripts/verify-wine119-live-control-suite.sh`:
+
+- command:
+  - `scripts/verify-wine119-live-control-suite.sh /tmp/metalsharp-live-controls-dxmt32`
+- behavior:
+  - requires parity runtime identity to report Wine 11.9
+  - requires backend `/status` to report current-main version `0.33.27`
+  - requires every launch JSON to report `ok: true` and the expected pipeline
+  - requires each proof directory to contain a live game PID
+  - requires loaded-module/cache evidence for each control game from `summary.txt`
+- expected gate:
+  - `pass` only when all three control games satisfy the acceptance matrix
+  - `fail` for log-only captures, wrong route, missing DXMT/WineMetal/MoltenVK evidence, missing cache evidence, or failed launch JSON
+
+This verifier is the final local release gate before any Wine 11.9 tag bump. A green manifest or backend preflight is not enough.
+
+Non-live readiness auditing is handled by `scripts/audit-wine119-readiness.sh`:
+
+- command:
+  - `scripts/audit-wine119-readiness.sh /private/tmp/metalsharp-home-wine119-dxmt32-state /tmp/metalsharp-wine119-readiness-current`
+- behavior:
+  - checks that current source is still on the v0.33.27 rollback commit
+  - verifies the installed 11.5 baseline still reports `wine-11.5` and still has i386 WineMetal
+  - verifies the prepared `clean`, `dxmt32`, and `borrowed` Wine 11.9 candidates still report `wine-11.9`
+  - checks the parity home for Wine 11.9 identity, source-home metadata, no active source-home references, no copied historical logs, and control manifests bound to the parity home
+  - checks the latest guarded backend preflight status for backend version `0.33.27`
+  - fails until a passing live control suite is supplied through `METALSHARP_LIVE_SUITE_DIR`
+- latest result:
+  - report: `/tmp/metalsharp-wine119-readiness-current/readiness.md`
+  - failures: `1`
+  - warning: `1`
+  - only failure: no passing live control suite has been supplied
+  - warning: HEAD is not exactly tagged `v0.33.27`, because `main` is on the rollback commit even though it is the intended v0.33.27 tree line
+
+This audit is intentionally non-live. It proves the staged 11.9 testbed is clean enough to run controlled live tests, but it cannot bless a release candidate.
+
+Candidate preparation for Pass B is handled by `scripts/prepare-wine119-candidate.sh`:
+
+- command:
+  - `scripts/prepare-wine119-candidate.sh /tmp/metalsharp-wine-assets-IjmErR/metalsharp_bundle.tar.zst /tmp/metalsharp-wine119-candidate/wine`
+- behavior:
+  - normalizes archive root `wine-11.9` into final runtime root shape
+  - carries the current `bin/metalsharp-wine` wrapper when the bundle lacks one
+  - binds x86_64 `winemetal.so` into `lib/wine/x86_64-unix/winemetal.so`
+  - binds x86_64 `winemetal.dll` into `lib/wine/x86_64-windows/winemetal.dll`
+  - writes `prepare-report.txt` and `missing-critical.txt` beside the candidate runtime root
+
+Current Pass B dry run result:
+
+- candidate root: `/tmp/metalsharp-wine119-candidate/wine`
+- source bundle: `/tmp/metalsharp-wine-assets-IjmErR/metalsharp_bundle.tar.zst`
+- `metalsharp-wine --version`: `wine-11.9`
+- `wine --version`: `wine-11.9`
+- `wineserver --version`: `Wine 11.9`
+- candidate manifest: `/tmp/metalsharp-runtime-11.9-candidate`
+- candidate file count after normalization: `3922`
+- remaining critical missing file: `lib/wine/i386-windows/winemetal.dll`
+- classified diff: `/tmp/metalsharp-runtime-11.9-candidate/classified-diff.md`
+- classified diff gate: `fail`
+- classified release blockers: `1`
+- 11.9 `ntdll.so` hook symbols found:
+  - `_MetalSharpGetMscompatdbHookContract`
+  - `_MetalSharpGetMscompatdbHookContractVersion`
+
+That means the recovered 11.9 bundle can be shaped into a runnable candidate root, but it is not release-ready for Nidhogg 2/M9 parity until the 32-bit `winemetal.dll` gap is resolved or proven unnecessary with a live control launch.
+
+Current i386 WineMetal investigation:
+
+- The release bundle contains no `wine-11.9` i386 `winemetal.dll` under either `lib/wine/i386-windows` or `lib/dxmt/i386-windows`.
+- The 11.5 control file is `~/.metalsharp/runtime/wine/lib/wine/i386-windows/winemetal.dll`.
+- `file` identifies it as `PE32 executable (DLL) (console) Intel 80386`.
+- SHA256: `20a6865facebdaac92b6c06fadf37d2efb5a242b22ca1c349bb57d7ad43df8e3`.
+- Size: `68K`.
+- `i686-w64-mingw32-objdump -p` shows imports from:
+  - `KERNEL32.dll`
+  - CRT API-set DLLs
+  - `ntdll.dll`
+- The export table has `0x83` entries.
+
+Build-surface audit:
+
+- The checkout contains MetalSharp D3D9 shim sources and build scripts:
+  - `scripts/build-d3d9-metal.sh`
+  - `src/d3d9/d3d9_pe.cpp`
+  - `src/d3d9/d3d9_unix.mm`
+  - `src/wine/d3d9_pe.cpp`
+  - `src/wine/d3d9_unix.mm`
+- Those scripts build or deploy `d3d9.dll`/`d3d9.so`; they do not build DXMT's `winemetal.dll`.
+- No DXMT source tree for rebuilding `winemetal.dll` is present in this checkout. Only DXMT license files and packaged runtime DLLs are present.
+- The only local i386 `winemetal.dll` found by path scan is the 11.5 control artifact at `~/.metalsharp/runtime/wine/lib/wine/i386-windows/winemetal.dll`.
+- The 11.9 x86_64 DXMT `winemetal.dll` is `PE32+ x86-64`, SHA256 `d357ed7a83df000f98f7e4fe5e2da99f0e36561457d2dfc30e90f09504880fc8`, and has `0x84` exports.
+- The 11.5 i386 WineMetal file is `PE32 Intel 80386`, SHA256 `20a6865facebdaac92b6c06fadf37d2efb5a242b22ca1c349bb57d7ad43df8e3`, and has `0x83` exports.
+- Both WineMetal PE files import the same high-level dependency family: `KERNEL32.dll`, CRT API-set DLLs, and `ntdll.dll`.
+
+This means the clean 11.9 candidate cannot be completed from checked-in MetalSharp source alone. A release-quality fix must either recover/build a true 11.9 i386 `winemetal.dll` from the DXMT build source that produced the x86_64 payload, or explicitly promote the 11.5 i386 bridge as a compatibility artifact after it passes live Nidhogg 2/M9 proof under Wine 11.9.
+
+External DXMT source/build provenance found on AverySSD:
+
+- Source checkout: `/Volumes/AverySSD/metalsharp/dxmt-src`
+- Current branch: `codex/d3d12-ordinal-compat`
+- HEAD: `f520cb8 Stabilize Elden Ring D3D12 startup probes`
+- Dirty files exist in D3D12, DXGI, and WineMetal sources, so the checkout must be treated as a local build workspace, not a clean upstream tag.
+- Remotes:
+  - fork: `https://github.com/aaf2tbz/dxmt.git`
+  - origin: `https://github.com/3Shain/dxmt.git`
+- `build32/meson-logs/meson-setup.txt` says the i386 build used:
+  - cross file: `/Volumes/AverySSD/metalsharp/dxmt-src/build-win32.txt`
+  - compiler: `i686-w64-mingw32-gcc/g++` `15.2.0`
+  - build type: `release`
+  - `wine_install_path`: `/Volumes/AverySSD/metalsharp/runtime/wine-11.5`
+- `build64/meson-logs/meson-setup.txt` says the x86_64 build used:
+  - cross file: `build-win64.txt`
+  - compiler: `x86_64-w64-mingw32-gcc/g++` `15.2.0`
+  - `wine_builtin_dll`: `true`
+  - `wine_install_path`: `/Users/alexmondello/.metalsharp/runtime/wine`
+
+DXMT build outputs found:
+
+| Path | Type | SHA256 | Notes |
+| --- | --- | --- | --- |
+| `/Volumes/AverySSD/metalsharp/dxmt-src/build32/src/winemetal/winemetal.dll` | PE32 i386 | `30dc23b57f6498df50217f71ee68029c2ff8ed1abdefa178574a07d9095c077e` | true i386 DXMT WineMetal candidate; built against Wine 11.5 path |
+| `/Volumes/AverySSD/metalsharp/dxmt-src/build32/src/d3d11/d3d11.dll` | PE32 i386 | `565d442115a3bddd869c950f75a620b0eef6014459a93e1e8131cf2eaa5878dd` | i386 DXMT D3D11 build output |
+| `/Volumes/AverySSD/metalsharp/dxmt-src/build32/src/dxgi/dxgi.dll` | PE32 i386 | `93bdab58be082fdf31caf2becd7b2caec5ccf526cdc7ce348cb0ac98935fef71` | i386 DXMT DXGI build output |
+| `/Volumes/AverySSD/metalsharp/dxmt-src/build64/src/winemetal/winemetal.dll` | PE32+ x86_64 | `ab235e49844dc3ee2b0313d7812f3c90128d698e4aa20803f66f846c1fd7da70` | local build output, does not match release bundle x86_64 WineMetal |
+| `/Volumes/AverySSD/metalsharp/dxmt-src/build64/src/winemetal/unix/winemetal.so` | Mach-O x86_64 | `cdb05c6737c4b1dc1792f162d098d35357d60ef1f0229cb35c7c09c4de5d048b` | local build output, does not match release bundle Unix WineMetal |
+
+The AverySSD i386 WineMetal artifact is a better first 11.9/M9 candidate than borrowing the 11.5 installed `winemetal.dll`, because it is a true DXMT i386 build output. It is still not release-proven: it was built against a Wine 11.5 path, from a dirty DXMT workspace, and its x86_64 siblings do not match the released 11.9 bundle payload.
+
+A third disposable candidate was prepared from the 11.9 bundle plus that explicit i386 artifact:
+
+- command:
+  - `METALSHARP_I386_WINEMETAL_SOURCE=/Volumes/AverySSD/metalsharp/dxmt-src/build32/src/winemetal/winemetal.dll scripts/prepare-wine119-candidate.sh /tmp/metalsharp-wine-assets-IjmErR/metalsharp_bundle.tar.zst /tmp/metalsharp-wine119-candidate-dxmt32/wine`
+- prepare report: `/tmp/metalsharp-wine119-candidate-dxmt32/prepare-report.txt`
+- candidate manifest: `/tmp/metalsharp-runtime-11.9-candidate-dxmt32`
+- classified diff: `/tmp/metalsharp-runtime-11.9-candidate-dxmt32/classified-diff.md`
+- missing critical files: `0`
+- classified diff gate: `fail`
+- gate reason: i386 `winemetal.dll` exists, but it differs from the 11.5 control and therefore remains `release_blocker_until_live_m9_proves_unneeded`
+
+This is the current best M9 test candidate, not a release candidate.
+
+Borrowed-i386 experiment:
+
+- command:
+  - `METALSHARP_BORROW_BASELINE_I386_WINEMETAL=1 scripts/prepare-wine119-candidate.sh /tmp/metalsharp-wine-assets-IjmErR/metalsharp_bundle.tar.zst /tmp/metalsharp-wine119-candidate-borrow/wine`
+- candidate root: `/tmp/metalsharp-wine119-candidate-borrow/wine`
+- prepare report: `/tmp/metalsharp-wine119-candidate-borrow/prepare-report.txt`
+- candidate manifest: `/tmp/metalsharp-runtime-11.9-candidate-borrow`
+- classified diff: `/tmp/metalsharp-runtime-11.9-candidate-borrow/classified-diff.md`
+- `borrowed_baseline_i386_winemetal=1`
+- missing critical files: `0`
+- classified diff gate: `pass`
+- i386 `winemetal.dll` gate: `ok_manifest_only_still_requires_live_m9`
+
+This borrowed-i386 candidate is only an experiment. It may be useful for the first Nidhogg 2/M9 Wine 11.9 parity attempt, but it is not a final release answer unless live M9 proves the 11.5 i386 bridge is compatible with the 11.9 runtime or a true 11.9-built i386 `winemetal.dll` is produced.
+
+The manifest should be compared against the 11.5 control manifest. Differences are allowed only when classified as:
+
+- expected Wine version delta
+- expected DXMT/DXGI/D3D12 delta
+- expected anti-cheat hook delta
+- packaging defect
+- unknown and release-blocking
+
+## Why the Previous 11.9 Attempt Failed
+
+The failure pattern is now specific enough to explain without guessing:
+
+1. Wine changed from 11.5 to 11.9.
+2. The runtime package shape changed at the same time, including missing `bin/metalsharp-wine` and missing pre-bound `lib/wine/.../winemetal.*` paths unless later code repaired them.
+3. Migration/schema behavior changed at the same time, so users were not just switching binaries; their runtime/prefix state was being forced through a new repair/migration path.
+4. Steam launch semantics changed for protected handoff, first relaunching Wine Steam and later still splitting route env from an already-running Steam client.
+5. DXMT config/cache handling improved in some ways, but M9/M10 config visibility was narrowed even though the live Nidhogg 2 M9 control proves `dxmt.conf` is part of the working path.
+6. Winemetal moved from game-local deployment to prefix/runtime binding at the same time as the Wine bump.
+7. DirectX overrides narrowed from `=n,b` to native-only `=n`, altering loader fallback semantics.
+8. Unity launch args churned while Schedule I and Subnautica BZ needed route authority to stay M11 unless explicitly configured.
+
+The core mistake was not choosing Wine 11.9 for anti-cheat. The mistake was coupling the anti-cheat Wine bump with loader model changes, Steam handoff changes, migration changes, override changes, and Unity argument changes. The rebuild should prove Wine 11.9 as a layout-compatible substrate first, then add anti-cheat behavior as a separately gated layer.
+
+## Completion Audit For This Investigation
+
+Current investigation status:
+
+- Done: rollback source-of-truth identified (`main` tree-equivalent to `v0.33.27`).
+- Done: three live 11.5 control samples captured and documented.
+- Done: release asset source for current Wine 11.9 identified (`bundles/metalsharp_bundle.tar.zst`, also embedded in the recovered `v0.33.30` Actions DMG artifact).
+- Done: release/upload evidence checked; the Wine 11.9 release asset does not contain an i386 `winemetal.dll`.
+- Done: external AverySSD DXMT source/build workspace found, including a true PE32 i386 WineMetal candidate at `/Volumes/AverySSD/metalsharp/dxmt-src/build32/src/winemetal/winemetal.dll`.
+- Done: Wine 11.5 vs Wine 11.9 internal runtime map added.
+- Done: WineMetal build-surface audit completed; this checkout can build the MetalSharp D3D9 shim but does not contain the DXMT source/build path needed to produce a fresh i386 `winemetal.dll`.
+- Done: code yin/yang map added against `backup/main-before-v0.33.28-reset-20260521T223249Z`.
+- Done: rebuild passes, hard gates, and acceptance matrix defined.
+- Done: strict commit replay ledger added; the post-0.33.27 branch is source material only, not a linear replay plan.
+- Done: branch execution runbook added at `docs/wine-119-implementation-runbook.md`.
+- Done: non-live readiness audit added and currently fails only because no passing live control suite has been supplied.
+- Not done: no Wine 11.9 parity branch has been implemented yet.
+- Not done: no candidate Wine 11.9 runtime has passed the three control games.
+- Not done: no release-proven 11.9-built i386 `winemetal.dll` has been recovered or produced; the AverySSD DXMT i386 artifact and borrowed 11.5 i386 bridge both remain experiments until live M9 proof says otherwise.
+- Not done: anti-cheat hook readiness has not been proven beyond file presence.
+
+Therefore the investigation/design artifact is ready to guide implementation, but the overall Wine 11.9 rebuild goal is not complete until a candidate build passes the matrix above.

--- a/docs/wine-119-rebuild-forensics.md
+++ b/docs/wine-119-rebuild-forensics.md
@@ -183,6 +183,14 @@ Additional recovered asset from the deleted/working investigation path:
 - Release/upload tar listing contains `wine-11.9/lib/dxmt/x86_64-windows/winemetal.dll` and `wine-11.9/lib/dxmt/x86_64-unix/winemetal.so`.
 - Release/upload tar listing does not contain `wine-11.9/lib/wine/i386-windows/winemetal.dll`.
 
+Reproducible fetch path:
+
+- `scripts/fetch-wine119-release-assets.sh /tmp/metalsharp-wine-assets metalsharp_bundle.tar.zst`
+- output asset: `/tmp/metalsharp-wine-assets/metalsharp_bundle.tar.zst`
+- fetch report: `/tmp/metalsharp-wine-assets/fetch-report.txt`
+- digest source: GitHub release metadata for the `bundles` release
+- required SHA256: `833f63566b0c1b98fa917337716f57d689c42d0c2878204b4716ba29637d7372`
+
 The same `bundles` release also has `metalsharp_bundle2.tar.zst`:
 
 - Local download: `/tmp/metalsharp-bundle2-aSicSS/metalsharp_bundle2.tar.zst`
@@ -1060,6 +1068,7 @@ Current investigation status:
 - Done: rollback source-of-truth identified (`main` tree-equivalent to `v0.33.27`).
 - Done: three live 11.5 control samples captured and documented.
 - Done: release asset source for current Wine 11.9 identified (`bundles/metalsharp_bundle.tar.zst`, also embedded in the recovered `v0.33.30` Actions DMG artifact).
+- Done: reproducible GitHub release asset fetch/verify script added for `bundles/metalsharp_bundle.tar.zst`.
 - Done: release/upload evidence checked; the Wine 11.9 release asset does not contain an i386 `winemetal.dll`.
 - Done: external AverySSD DXMT source/build workspace found, including a true PE32 i386 WineMetal candidate at `/Volumes/AverySSD/metalsharp/dxmt-src/build32/src/winemetal/winemetal.dll`.
 - Done: Wine 11.5 vs Wine 11.9 internal runtime map added.

--- a/docs/wine-119-rebuild-forensics.md
+++ b/docs/wine-119-rebuild-forensics.md
@@ -783,7 +783,7 @@ Isolated parity-home installation is handled by `scripts/install-wine119-parity-
 - safety rails:
   - the installer refuses to target the real `HOME` or the source MetalSharp home
   - parity homes must live under `/tmp` or `/private/tmp` unless `METALSHARP_ALLOW_NON_TMP_PARITY_HOME=1` is explicitly set
-  - copied `compatdata/*/logs` directories are pruned so old 11.5 launch logs cannot contaminate Wine 11.9 proof summaries
+  - copied `compatdata/*/logs` files are pruned so old 11.5 launch logs cannot contaminate Wine 11.9 proof summaries; empty log directories created by backend scans are harmless
 
 Latest isolated install result:
 
@@ -908,7 +908,17 @@ Live control verification is handled by `scripts/verify-wine119-live-control-sui
 
 This verifier is the final local release gate before any Wine 11.9 tag bump. A green manifest or backend preflight is not enough.
 
-Current verifier limitation: the live suite exercises the backend `/steam/launch-game` route directly. The Electron path is `LibraryView.vue` -> `window.metalsharpAPI.backendRequest` -> `RustBridge.request` -> backend HTTP, and `auto` can still fall through to `/game/launch-auto` when Steam route metadata is missing or stale. Before a Wine 11.9 release candidate is marked app-ready, add an app-facing proof pass that launches the same controls through the renderer-selected route or proves the renderer will call `/steam/launch-game` for each configured M9/M11 control.
+App-facing route verification is handled by `scripts/audit-electron-launch-routes.mjs`. The Electron path is `LibraryView.vue` -> `window.metalsharpAPI.backendRequest` -> `RustBridge.request` -> backend HTTP. The audit mirrors the Library view routing decision and proves the control games resolve to `/steam/launch-game` from the renderer-facing model, including `auto` fallback behavior when library route metadata is missing.
+
+- command:
+  - `node scripts/audit-electron-launch-routes.mjs --base-url http://127.0.0.1:<port> --out-dir <probe>/electron-launch-routes`
+- behavior:
+  - reads `/steam/library`
+  - probes `/mtsp/pipelines?appid=<control>` for backend recommended route context
+  - checks Nidhogg 2, Schedule I, and Subnautica BZ
+  - requires both renderer `auto` and explicit M9/M11 selections to resolve to `/steam/launch-game`
+
+This plugs the previous proof gap where backend direct launches were covered but Electron's route selection could still fall through to `/game/launch-auto`.
 
 Current M12 limitation: the first live gate intentionally targets the reported regressions: Nidhogg 2 M9, Schedule I M11, and Subnautica Below Zero M11. M12 remains a mapped rebuild surface, not a passed live surface. Add a dedicated M12 control before enabling D3D12/M12 behavior changes beyond this parity plan.
 

--- a/docs/wine-119-rebuild-forensics.md
+++ b/docs/wine-119-rebuild-forensics.md
@@ -615,9 +615,10 @@ Release gates:
 1. Create a Wine 11.9 parity branch from `main`/`v0.33.27`.
 2. Add diagnostics/manifests first, without changing runtime behavior.
 3. Package Wine 11.9 into the 11.5-compatible runtime layout.
-4. Prepare two M9 candidate variants:
-   - 11.9 bundle plus `/Volumes/AverySSD/metalsharp/dxmt-src/build32/src/winemetal/winemetal.dll`
-   - 11.9 bundle plus borrowed 11.5 i386 `winemetal.dll` as a compatibility fallback experiment
+4. Prepare M9 candidate variants:
+   - 11.9 bundle plus the clean 11.9-linked i386 `winemetal.dll` at `/tmp/metalsharp-dxmt-clean-build32-wine119/src/winemetal/winemetal.dll`
+   - dirty AverySSD `build32` i386 `winemetal.dll` only as a diagnostic fallback
+   - 11.9 bundle plus borrowed 11.5 i386 `winemetal.dll` only as a compatibility fallback experiment
 5. Install candidates only into a disposable `~/.metalsharp-119-parity` or alternate runtime root first.
 6. Run the three control games with the exact 0.33.27 route semantics.
 7. Only after parity, cherry-pick or reimplement anti-cheat hook commits in isolation.
@@ -631,7 +632,7 @@ The next Wine 11.9 attempt should be built as multiple small passes. Each pass h
 | --- | --- | --- | --- |
 | A: Baseline diagnostics on 11.5 | add manifest generation, launch contract logging, route/cache/env introspection, and `lsof` capture helpers | no Wine version change, no route behavior change, no migration bump | 11.5 controls still launch; logs include pipeline, runtime root, `WINEDLLOVERRIDES`, config/cache paths, winemetal binding model, and Steam identity mode |
 | B: Wine 11.9 asset packaging | install from `bundles/metalsharp_bundle.tar.zst`; normalize archive root `wine-11.9` into final runtime root `~/.metalsharp/runtime/wine`; regenerate/carry `bin/metalsharp-wine` | no protected Steam handoff, no winemetal relocation, no native-only DirectX overrides, no Unity arg changes | runtime manifest shows complete 11.9 file tree plus 11.5-compatible final paths; `wine --version` and `wineserver --version` return 11.9; `bin/metalsharp-wine` exists or all callers are updated |
-| C1: 11.9 parity with explicit DXMT i386 WineMetal | run M9/M11/M12 routes using 0.33.27 overrides, config visibility, game-local deployment, and Steam attach semantics; source i386 WineMetal from `/Volumes/AverySSD/metalsharp/dxmt-src/build32/src/winemetal/winemetal.dll` | no mscompatdb hook mutation, no schema-forced prefix migration, no Steam handoff changes | Nidhogg 2, Schedule I, and Subnautica BZ match the control matrix below under Wine 11.9; i386 artifact provenance is logged |
+| C1: 11.9 parity with explicit DXMT i386 WineMetal | run M9/M11/M12 routes using 0.33.27 overrides, config visibility, game-local deployment, and Steam attach semantics; source i386 WineMetal from the clean 11.9-linked artifact at `/tmp/metalsharp-dxmt-clean-build32-wine119/src/winemetal/winemetal.dll`, falling back to the dirty AverySSD `build32` artifact only for diagnosis | no mscompatdb hook mutation, no schema-forced prefix migration, no Steam handoff changes | Nidhogg 2, Schedule I, and Subnautica BZ match the control matrix below under Wine 11.9; i386 artifact provenance is logged |
 | C2: 11.9 parity with borrowed 11.5 i386 fallback | only if C1 fails specifically on i386 WineMetal compatibility, test the borrowed 11.5 i386 `winemetal.dll` as a compatibility artifact | no release blessing without live M9 proof and an explicit compatibility rationale | Nidhogg 2 proves whether the 11.5 i386 bridge can safely pair with Wine 11.9, or the path is rejected |
 | D: Anti-cheat hook surface | add hook headers/exports/probes and mscompatdb readiness reporting | no route behavior changes; no Steam relaunch for normal routes | symbol probe proves hook contract; runtime endpoint reports hook readiness; non-anti-cheat control games still match pass C |
 | E: Protected Steam handoff | enable protected handoff only for explicit anti-cheat recipes | no global Steam launch path replacement | logs prove protected handoff is used only for opted-in games; already-running Wine Steam is not killed for normal routes |
@@ -755,22 +756,26 @@ Candidate orchestration is handled by `scripts/prepare-wine119-parity-candidates
   - `scripts/prepare-wine119-parity-candidates.sh /tmp/metalsharp-wine-assets-IjmErR/metalsharp_bundle.tar.zst /tmp/metalsharp-wine119-parity`
 - behavior:
   - creates a fresh 11.5 baseline manifest
-  - prepares `clean`, `dxmt32`, and `borrowed` Wine 11.9 runtime candidates under `/tmp/metalsharp-wine119-parity/candidates`
-  - writes manifests under `/tmp/metalsharp-wine119-parity/manifests`
+  - prepares `clean`, `dxmt32`, and `borrowed` Wine 11.9 runtime candidates under the requested work directory
+  - writes manifests under the requested work directory
   - compares each candidate against the 11.5 baseline contract
-  - writes `/tmp/metalsharp-wine119-parity/summary.md`
+  - writes `<work-dir>/summary.md`
 - default explicit i386 DXMT source:
-  - `/Volumes/AverySSD/metalsharp/dxmt-src/build32/src/winemetal/winemetal.dll`
+  - preferred when present:
+    `/tmp/metalsharp-dxmt-clean-build32-wine119/src/winemetal/winemetal.dll`
+  - fallback:
+    `/Volumes/AverySSD/metalsharp/dxmt-src/build32/src/winemetal/winemetal.dll`
 - override:
   - `METALSHARP_I386_WINEMETAL_SOURCE=/path/to/winemetal.dll`
+  - `METALSHARP_I386_WINEMETAL_CLEAN_SOURCE=/path/to/clean/winemetal.dll`
 
 Latest orchestration result:
 
 | Candidate | Root | Manifest gate | Meaning |
 | --- | --- | --- | --- |
-| `clean` | `/tmp/metalsharp-wine119-parity/candidates/clean/wine` | fail | release 11.9 bundle lacks i386 `winemetal.dll` |
-| `dxmt32` | `/tmp/metalsharp-wine119-parity/candidates/dxmt32/wine` | fail | i386 WineMetal exists but differs from 11.5 control; requires live M9 proof |
-| `borrowed` | `/tmp/metalsharp-wine119-parity/candidates/borrowed/wine` | pass | manifest-complete by borrowing 11.5 i386 WineMetal; still requires live M9 proof before any release blessing |
+| `clean` | `<work-dir>/candidates/clean/wine` | fail | release 11.9 bundle lacks i386 `winemetal.dll` |
+| `dxmt32` | `<work-dir>/candidates/dxmt32/wine` | fail | i386 WineMetal exists but differs from 11.5 control; now defaults to the clean 11.9-linked artifact when present; requires live M9 proof |
+| `borrowed` | `<work-dir>/candidates/borrowed/wine` | pass | manifest-complete by borrowing 11.5 i386 WineMetal; still requires live M9 proof before any release blessing |
 
 Manifest pass is not a release gate. The orchestrator only proves runtime-shape readiness. Live control games remain mandatory.
 
@@ -1143,7 +1148,9 @@ A third disposable candidate was prepared from the 11.9 bundle plus that explici
 - classified diff gate: `fail`
 - gate reason: i386 `winemetal.dll` exists, but it differs from the 11.5 control and therefore remains `release_blocker_until_live_m9_proves_unneeded`
 
-This is the current best M9 test candidate, not a release candidate.
+That older dirty-source candidate is no longer the preferred M9 test candidate
+when the clean 11.9-linked artifact is available. It remains useful only as a
+diagnostic fallback if the clean artifact cannot be staged.
 
 Borrowed-i386 experiment:
 

--- a/docs/wine-119-rebuild-forensics.md
+++ b/docs/wine-119-rebuild-forensics.md
@@ -953,6 +953,17 @@ Non-live readiness auditing is handled by `scripts/audit-wine119-readiness.sh`:
 
 This audit is intentionally non-live. It proves the staged 11.9 testbed is clean enough to run controlled live tests, but it cannot bless a release candidate.
 
+Objective-level completion auditing is handled by `scripts/audit-wine119-objective-completion.sh`:
+
+- command:
+  - `scripts/audit-wine119-objective-completion.sh /tmp/metalsharp-wine119-objective-audit`
+- behavior:
+  - maps the original Wine 11.9 investigation/rebuild objective to concrete evidence rows
+  - fails while any requirement is missing, incomplete, or unverified
+  - records the remaining proof needed for live controls, i386 WineMetal provenance, and protected anti-cheat hook readiness
+
+This audit is the guard against redefining the goal around the evidence branch. It should not pass until the real Wine 11.9 candidate has passed live controls and all release-grade provenance gaps are closed.
+
 Candidate preparation for Pass B is handled by `scripts/prepare-wine119-candidate.sh`:
 
 - command:
@@ -1113,9 +1124,9 @@ Current investigation status:
 - Done: strict commit replay ledger added; the post-0.33.27 branch is source material only, not a linear replay plan.
 - Done: branch execution runbook added at `docs/wine-119-implementation-runbook.md`.
 - Done: non-live readiness audit added and currently fails only because no passing live control suite has been supplied.
-- Not done: no Wine 11.9 parity branch has been implemented yet.
+- Not done: no Wine 11.9 parity release candidate has passed the release gates yet.
 - Not done: no candidate Wine 11.9 runtime has passed the three control games.
 - Not done: no release-proven 11.9-built i386 `winemetal.dll` has been recovered or produced; the AverySSD DXMT i386 artifact and borrowed 11.5 i386 bridge both remain experiments until live M9 proof says otherwise.
-- Not done: anti-cheat hook readiness has not been proven beyond file presence.
+- Not done: anti-cheat hook readiness has not been proven beyond non-live symbol-surface evidence.
 
 Therefore the investigation/design artifact is ready to guide implementation, but the overall Wine 11.9 rebuild goal is not complete until a candidate build passes the matrix above.

--- a/docs/wine-119-rebuild-forensics.md
+++ b/docs/wine-119-rebuild-forensics.md
@@ -406,8 +406,8 @@ Commit replay guidance:
 - Do not replay merge commit `797db720c852b7f46356fa2541fb4dac81afcc69` as a unit.
 - Do not cherry-pick `e2dff524f35604164ca5ab7f99bcd7b31a8f732e` as-is. It mixed WineMetal deployment model changes into the same regression cluster.
 - Do not cherry-pick the mscompatdb/protected-handoff cluster as-is. Commits `c95fd904812190809748feae0dacd8fcd8584c79`, `6e235de`, `8e83923`, `ef3377b`, and `10aeada` must be rebuilt as separately gated behavior.
-- Replay only the clean observability subset directly: `65032f7`, `168d235`, `ce2c008`, `1148f57`, `cfade4e`, `f654c10`, `1c0b788`, `38fed0a`, `d269d74`, `e796968`, `1e54117`, `ddba26f`, `e3c2a63`, `557cb14`, `05d7fd9`, `a514813`, `5e9a23c`, and `1683b79`.
-- Reimplement mixed evidence/behavior commits manually instead of replaying them: `df728e3`, `d86fd03`, `2644948`, `63867b1`, `ab719e3`, `b5e4e28`, `f9aa3bd`, and `610411d`.
+- Replay only the clean observability subset directly: `65032f7`, `168d235`, `ce2c008`, `1148f57`, `cfade4e`, `f654c10`, `38fed0a`, `d269d74`, `e796968`, `1e54117`, `ddba26f`, `05d7fd9`, `a514813`, and `5e9a23c`.
+- Reimplement mixed evidence/behavior commits manually instead of replaying them: `df728e3`, `d86fd03`, `2644948`, `63867b1`, `ab719e3`, `1c0b788`, `557cb14`, `b5e4e28`, `f9aa3bd`, `610411d`, and `1683b79`.
 - Rebuild route parsing and custom launch args next, but preserve configured route authority.
 - Rebuild DXMT file deployment for direct/non-Steam launches before touching Steam handoff.
 - Rebuild cache/config next, and keep the live-proven M9 config visibility intact.
@@ -421,7 +421,8 @@ This ledger is intentionally stricter than normal cherry-pick guidance. The next
 
 Classification meanings:
 
-- `safe-diagnostic`: may be replayed early if it does not change route, runtime, migration, or Steam handoff behavior.
+- `safe-diagnostic`: may be replayed early only if it does not change route, runtime, launch environment, migration, cache behavior, native runtime behavior, or Steam handoff behavior.
+- `diagnostic-source-only`: useful diagnostic/test intent, but do not replay directly because the original patch changes launch/runtime behavior or depends on quarantined runtime work.
 - `rebuild-manually`: useful intent, but must be reimplemented in a narrower patch because the original commit couples too many behaviors.
 - `quarantine-until-parity`: do not apply until the three Wine 11.9 control games pass with 0.33.27 semantics.
 - `never-as-is`: known regression cluster; only salvage small pieces after new tests and proof exist.
@@ -465,16 +466,16 @@ Classification meanings:
 | `82e46e0` | Stabilize M12 runtime contract | `quarantine-until-parity` | M12 contract work belongs after M9/M11 parity. |
 | `fe3164a` | Make D3D12 descriptor copies overlap-safe | `quarantine-until-parity` | Likely valid fix, but still D3D12 runtime mutation. |
 | `7ae7ce7` | Report D3D12 capabilities conservatively | `quarantine-until-parity` | Capability reporting can affect game decisions; prove later. |
-| `1c0b788` | Log direct MTSP runtime contracts | `safe-diagnostic` | Logging-only; useful for future rebuild verification. |
+| `1c0b788` | Log direct MTSP runtime contracts | `rebuild-manually` | Useful launch-log intent, but it threads new log context through launcher behavior; extract only minimal logging after parity. |
 | `38fed0a` | Format D3D12 feature checks | `safe-diagnostic` | Test formatting only. |
 | `d269d74` | Log D3D12 compute pipeline evidence | `safe-diagnostic` | Logging-only in D3D12 path; acceptable as diagnostics. |
 | `e796968` | Log D3D12 compute dispatch evidence | `safe-diagnostic` | Logging-only. |
 | `1e54117` | Log D3D12 draw execution evidence | `safe-diagnostic` | Logging-only. |
 | `194c66f` | Preserve swapchain drawable presentation | `quarantine-until-parity` | Presentation behavior change; validate in M12 pass. |
 | `ddba26f` | Log D3D12 feature query decisions | `safe-diagnostic` | Logging-only. |
-| `e3c2a63` | Track DXGI present count | `safe-diagnostic` | Counter/test evidence; useful for live proof. |
+| `e3c2a63` | Track DXGI present count | `quarantine-until-parity` | Changes DXGI runtime behavior; useful compatibility work only after base Wine/DXMT parity passes. |
 | `4e3afde` | Make explicit M12 Unity launches force D3D12 | `quarantine-until-parity` | Route-forcing must wait until base M11/M12 split is proven. |
-| `557cb14` | Route DXMT D3D12 traces per launch | `safe-diagnostic` | Trace file routing is good observability if non-invasive. |
+| `557cb14` | Route DXMT D3D12 traces per launch | `rebuild-manually` | Adds launch environment variables and a DXMT patch file; reintroduce only after route/env parity. |
 | `05d7fd9` | Harden DXMT patch preflight | `safe-diagnostic` | Patch preflight/docs are useful before applying anything. |
 | `c01180f` | Harden DXMT launch cache contract | `never-as-is` | Cache contract changes are implicated in shader-cache regression; rebuild in a smaller route-cache pass. |
 | `b5e4e28` | Capture launcher installer evidence | `rebuild-manually` | Evidence is useful, but original touches launcher/install surfaces too broadly. |
@@ -486,7 +487,7 @@ Classification meanings:
 | `230c2ec` | Scope DXMT config contract to M11 M12 | `never-as-is` | Explicitly narrows DXMT config away from M9, conflicting with working Nidhogg 2 evidence. |
 | `51e1417` | Preserve D3D12 device ABI method order | `quarantine-until-parity` | ABI fix may be valid, but belongs in later D3D12 pass. |
 | `c95024d` | Scope DXMT config recipe asset to M11 M12 | `never-as-is` | Same M9 exclusion risk as `230c2ec`; likely breaks M9 DXMT-family path. |
-| `1683b79` | Cover DXGI factory implementation surface | `safe-diagnostic` | Test/coverage around DXGI surface; safe as evidence. |
+| `1683b79` | Cover DXGI factory implementation surface | `diagnostic-source-only` | Test source material only; may depend on quarantined DXGI implementation changes. |
 | `79cc6fb` | Bump version to 0.33.30 | `version-only` | Release metadata only. |
 | `797db72` | Bind DXMT winemetal through Wine runtime | `never-as-is` | PR merge/rollup with mixed runtime, launcher, D3D12, patch, and version changes. |
 
@@ -695,15 +696,18 @@ Every Wine 11.9 build candidate should emit or archive a manifest with:
   - `etc/vulkan/icd.d/MoltenVK_x86_64_icd.json`
   - `lib/libMoltenVK.dylib`
   - `lib/dxmt/x86_64-windows/{d3d10core.dll,d3d11.dll,d3d12.dll,dxgi.dll,winemetal.dll}`
+  - optional `lib/dxmt/i386-windows/{d3d11.dll,dxgi.dll,winemetal.dll}` source-surface evidence when a build produces it
   - `lib/dxmt/x86_64-unix/winemetal.so`
   - `lib/wine/x86_64-unix/{winemetal.so,mscompatdb.so,mscompatdb.dylib,libMoltenVK.1.dylib}`
   - `lib/wine/x86_64-windows/{d3d11.dll,dxgi.dll,winemetal.dll}`
   - `lib/wine/i386-windows/{d3d11.dll,dxgi.dll,winemetal.dll}`
-- `file` output for Wine executables and Mach-O dylibs
+- `file` output for every route-critical path, including PE DLL architecture for `i386-windows` and `x86_64-windows`
 - `otool -L` output for `winemetal.so`, `mscompatdb.so`, `mscompatdb.dylib`, and `libMoltenVK.1.dylib`
 - `otool -l` load-command output for Unix-side probes, so install names, `LC_RPATH`, and `@rpath` loader contracts are captured instead of inferred
+- `objdump -p` PE import/export summary for every route-critical Windows DLL
+- `bin/metalsharp-wine` wrapper contract evidence: executable mode, shebang, wrapper exports, SHA256, and `--version` probe
 - `nm -gU` hook probe output for `ntdll.so`, `mscompatdb.so`, and `mscompatdb.dylib`
-- final installer source URL or artifact digest
+- final installer source URL, GitHub release identity, and artifact digest
 
 mscompatdb hook surface auditing is handled by `scripts/audit-mscompatdb-hook-surface.sh`:
 
@@ -722,8 +726,13 @@ The manifest script is `scripts/runtime-manifest.sh`. It is read-only against th
 - `file-count.txt`
 - `critical-sha256.txt`
 - `file.txt`
+- `critical-file.txt`
 - `otool-L.txt`
+- `critical-otool-L.txt`
 - `otool-l.txt`
+- `critical-linkage-summary.txt`
+- `metalsharp-wine-wrapper.txt`
+- `critical-pe-objdump.txt`
 - `nm-gU.txt`
 - `manifest.json`
 

--- a/docs/wine-119-rebuild-forensics.md
+++ b/docs/wine-119-rebuild-forensics.md
@@ -900,6 +900,7 @@ Live control verification is handled by `scripts/verify-wine119-live-control-sui
   - requires every launch JSON to report `ok: true` and the expected pipeline
   - requires each proof directory to contain a live game PID
   - requires Wine Steam PID snapshots before/after each launch and fails if a pre-existing `Steam.exe` PID disappears
+  - when `METALSHARP_REQUIRE_PREEXISTING_WINE_STEAM=1` is used, starts Wine Steam before the controls and fails verification unless each control had a pre-existing Wine Steam PID to attach to
   - requires loaded-module/cache evidence for each control game from `summary.txt`
 - expected gate:
   - `pass` only when all three control games satisfy the acceptance matrix

--- a/docs/wine-119-rebuild-forensics.md
+++ b/docs/wine-119-rebuild-forensics.md
@@ -1079,6 +1079,22 @@ Current provenance auditing is handled by `scripts/audit-i386-winemetal-provenan
 
 This makes the current `dxmt32` candidate explicitly non-release-proven. It can still be used as the first live M9 experiment because it is a real i386 DXMT WineMetal build, but a final Wine 11.9 release needs either a clean 11.9-built i386 artifact or a documented compatibility exception backed by live Nidhogg 2 proof.
 
+The release-grade i386 build input preflight is handled by `scripts/preflight-i386-winemetal-build.sh`:
+
+- command:
+  - `scripts/preflight-i386-winemetal-build.sh /Volumes/AverySSD/metalsharp/dxmt-src /tmp/metalsharp-wine119-parity/candidates/dxmt32/wine /tmp/metalsharp-i386-winemetal-build-preflight-current`
+- current result:
+  - fail only on `source-clean`
+  - Wine root reports `wine-11.9`
+  - 11.9 runtime has executable `bin/winebuild`
+  - 11.9 runtime has `lib/wine/i386-windows/libwinecrt0.a`, `libntdll.a`, and `dbghelp.dll`
+  - local tools exist: Meson, Ninja, `i686-w64-mingw32-gcc`, `g++`, `ar`, `strip`, and `windres`
+- proposed build shape:
+  - `meson setup <tmp-build-dir> /Volumes/AverySSD/metalsharp/dxmt-src --cross-file /Volumes/AverySSD/metalsharp/dxmt-src/build-win32.txt --buildtype release -Dwine_install_path=/tmp/metalsharp-wine119-parity/candidates/dxmt32/wine -Dwine_builtin_dll=true -Denable_tests=false`
+  - `ninja -C <tmp-build-dir> src/winemetal/winemetal.dll`
+
+That narrows the i386 blocker: the machine has the 11.9 Wine inputs needed to attempt a correct build, but the DXMT source must be made clean or forked before the output can be treated as release-grade.
+
 A third disposable candidate was prepared from the 11.9 bundle plus that explicit i386 artifact:
 
 - command:

--- a/docs/wine-119-rebuild-forensics.md
+++ b/docs/wine-119-rebuild-forensics.md
@@ -937,6 +937,10 @@ Live control verification is handled by `scripts/verify-wine119-live-control-sui
   - `pass` only when all three control games satisfy the acceptance matrix
   - `fail` for log-only captures, wrong route, missing DXMT/WineMetal/MoltenVK evidence, missing cache evidence, or failed launch JSON
   - `fail` if an already-running Wine Steam process is killed/relaunched during a control-game launch
+- fixture:
+  - `scripts/test-wine119-live-verifier-fixtures.sh`
+  - proves the verifier accepts complete synthetic proof and rejects both
+    disappeared pre-existing Wine Steam PIDs and log-only game captures
 
 This verifier is the final local release gate before any Wine 11.9 tag bump. A green manifest or backend preflight is not enough.
 

--- a/docs/wine-119-rebuild-forensics.md
+++ b/docs/wine-119-rebuild-forensics.md
@@ -1065,6 +1065,20 @@ DXMT build outputs found:
 
 The AverySSD i386 WineMetal artifact is a better first 11.9/M9 candidate than borrowing the 11.5 installed `winemetal.dll`, because it is a true DXMT i386 build output. It is still not release-proven: it was built against a Wine 11.5 path, from a dirty DXMT workspace, and its x86_64 siblings do not match the released 11.9 bundle payload.
 
+Current provenance auditing is handled by `scripts/audit-i386-winemetal-provenance.sh`:
+
+- command:
+  - `scripts/audit-i386-winemetal-provenance.sh /Volumes/AverySSD/metalsharp/dxmt-src /Volumes/AverySSD/metalsharp/dxmt-src/build32/src/winemetal/winemetal.dll /tmp/metalsharp-i386-winemetal-provenance-current`
+- current result:
+  - fail
+  - artifact SHA256 `30dc23b57f6498df50217f71ee68029c2ff8ed1abdefa178574a07d9095c077e`
+  - branch `codex/d3d12-ordinal-compat`
+  - HEAD `f520cb84159ef7db1cdbd364d51738ef7effb0a6`
+  - source checkout is dirty
+  - linker metadata references `/Volumes/AverySSD/metalsharp/runtime/wine-11.5/lib/wine/i386-windows/libwinecrt0.a`, `libntdll.a`, and `dbghelp.dll`
+
+This makes the current `dxmt32` candidate explicitly non-release-proven. It can still be used as the first live M9 experiment because it is a real i386 DXMT WineMetal build, but a final Wine 11.9 release needs either a clean 11.9-built i386 artifact or a documented compatibility exception backed by live Nidhogg 2 proof.
+
 A third disposable candidate was prepared from the 11.9 bundle plus that explicit i386 artifact:
 
 - command:

--- a/docs/wine-119-rebuild-forensics.md
+++ b/docs/wine-119-rebuild-forensics.md
@@ -983,6 +983,14 @@ Objective-level completion auditing is handled by `scripts/audit-wine119-objecti
   - fails while any requirement is missing, incomplete, or unverified
   - records the remaining proof needed for live controls, i386 WineMetal provenance, and protected anti-cheat hook readiness
 
+Objective-audit fixture coverage is handled by `scripts/test-wine119-objective-audit-guards.sh`:
+
+- proves stale readiness cannot satisfy non-live completion unless the readiness
+  report also proves clean `dxmt32` i386 WineMetal SHA provenance and parity
+  install source alignment
+- proves the objective audit still fails without live controls even when
+  non-live clean-candidate readiness is complete
+
 This audit is the guard against redefining the goal around the evidence branch. It should not pass until the real Wine 11.9 candidate has passed live controls and all release-grade provenance gaps are closed.
 
 Candidate preparation for Pass B is handled by `scripts/prepare-wine119-candidate.sh`:

--- a/docs/wine-119-rebuild-forensics.md
+++ b/docs/wine-119-rebuild-forensics.md
@@ -891,10 +891,12 @@ Live control verification is handled by `scripts/verify-wine119-live-control-sui
   - requires backend `/status` to report current-main version `0.33.27`
   - requires every launch JSON to report `ok: true` and the expected pipeline
   - requires each proof directory to contain a live game PID
+  - requires Wine Steam PID snapshots before/after each launch and fails if a pre-existing `Steam.exe` PID disappears
   - requires loaded-module/cache evidence for each control game from `summary.txt`
 - expected gate:
   - `pass` only when all three control games satisfy the acceptance matrix
   - `fail` for log-only captures, wrong route, missing DXMT/WineMetal/MoltenVK evidence, missing cache evidence, or failed launch JSON
+  - `fail` if an already-running Wine Steam process is killed/relaunched during a control-game launch
 
 This verifier is the final local release gate before any Wine 11.9 tag bump. A green manifest or backend preflight is not enough.
 

--- a/docs/wine-119-rebuild-forensics.md
+++ b/docs/wine-119-rebuild-forensics.md
@@ -705,6 +705,16 @@ Every Wine 11.9 build candidate should emit or archive a manifest with:
 - `nm -gU` hook probe output for `ntdll.so`, `mscompatdb.so`, and `mscompatdb.dylib`
 - final installer source URL or artifact digest
 
+mscompatdb hook surface auditing is handled by `scripts/audit-mscompatdb-hook-surface.sh`:
+
+- command:
+  - `scripts/audit-mscompatdb-hook-surface.sh <candidate-runtime-root>/wine <out-dir>`
+- behavior:
+  - probes `lib/wine/x86_64-unix/ntdll.so`, `mscompatdb.so`, and `mscompatdb.dylib`
+  - requires `_MetalSharpGetMscompatdbHookContract` and `_MetalSharpGetMscompatdbHookContractVersion` in Unix `ntdll.so`
+  - records whether `mscompatdb.so` and `mscompatdb.dylib` exist and expose public symbols
+  - always keeps `hookReady=false` until a protected runtime launch proves load and behavior
+
 The manifest script is `scripts/runtime-manifest.sh`. It is read-only against the runtime root and writes:
 
 - `versions.txt`

--- a/docs/wine-119-rebuild-forensics.md
+++ b/docs/wine-119-rebuild-forensics.md
@@ -1095,6 +1095,43 @@ The release-grade i386 build input preflight is handled by `scripts/preflight-i3
 
 That narrows the i386 blocker: the machine has the 11.9 Wine inputs needed to attempt a correct build, but the DXMT source must be made clean or forked before the output can be treated as release-grade.
 
+Clean 11.9-linked i386 WineMetal build:
+
+- A detached clean DXMT worktree was created at `/tmp/metalsharp-dxmt-clean-f520cb8`
+  from commit `f520cb84159ef7db1cdbd364d51738ef7effb0a6`.
+- `git submodule update --init --recursive` could not fetch
+  `include/native/directx` commit `53ce4bef9ee777ab896f2adf56417fcf67a07579`
+  from the remote, so that submodule tree was copied from the existing
+  AverySSD DXMT checkout and the copied source commit was recorded in
+  `/tmp/metalsharp-clean-i386-build-evidence/directx-submodule-copied.txt`.
+- Build command:
+  - `meson setup /tmp/metalsharp-dxmt-clean-build32-wine119 /tmp/metalsharp-dxmt-clean-f520cb8 --cross-file /tmp/metalsharp-dxmt-clean-f520cb8/build-win32.txt --buildtype release -Dwine_install_path=/tmp/metalsharp-wine119-parity/candidates/dxmt32/wine -Dwine_builtin_dll=true -Denable_tests=false`
+  - `ninja -C /tmp/metalsharp-dxmt-clean-build32-wine119 src/winemetal/winemetal.dll`
+- Built artifact:
+  - `/tmp/metalsharp-dxmt-clean-build32-wine119/src/winemetal/winemetal.dll`
+  - type: `PE32 executable (DLL) (console) Intel 80386, for MS Windows`
+  - SHA256: `12b9343459d28dfe1d7668a31a58a0c3506948d7c533507fdaec65d59c6697ab`
+- Clean build preflight:
+  - `/tmp/metalsharp-i386-winemetal-build-preflight-clean-f520cb8/preflight.md`
+  - result: `gate: pass`
+  - proves clean source, Wine 11.9 runtime identity, Wine 11.9 i386 build
+    inputs, and local Meson/Ninja/i686 mingw tools.
+- Clean artifact provenance:
+  - `/tmp/metalsharp-clean-i386-winemetal-provenance-119/provenance.md`
+  - result: `review`
+  - reason: source tree is clean and linker metadata references the shaped Wine
+    11.9 runtime, but live M9 proof is still required before release.
+- AverySSD candidate staging:
+  - `/Volumes/AverySSD/metalsharp/wine119-parity-clean-i386/summary.md`
+  - uses the clean artifact as `dxmt32_source`
+  - still reports a release blocker because any i386 WineMetal delta must pass
+    live Nidhogg 2/M9 process, module, and cache proof.
+
+This changes the i386 status from "no true 11.9-linked build exists" to
+"a clean 11.9-linked candidate exists, but it is not release-proven until the
+live M9 gate passes." The older dirty AverySSD `build32` output should remain
+available only as a diagnostic fallback.
+
 A third disposable candidate was prepared from the 11.9 bundle plus that explicit i386 artifact:
 
 - command:
@@ -1156,6 +1193,7 @@ Current investigation status:
 - Done: reproducible GitHub release asset fetch/verify script added for `bundles/metalsharp_bundle.tar.zst`.
 - Done: release/upload evidence checked; the Wine 11.9 release asset does not contain an i386 `winemetal.dll`.
 - Done: external AverySSD DXMT source/build workspace found, including a true PE32 i386 WineMetal candidate at `/Volumes/AverySSD/metalsharp/dxmt-src/build32/src/winemetal/winemetal.dll`.
+- Done: clean detached DXMT worktree build produced a Wine 11.9-linked PE32 i386 WineMetal candidate at `/tmp/metalsharp-dxmt-clean-build32-wine119/src/winemetal/winemetal.dll`.
 - Done: Wine 11.5 vs Wine 11.9 internal runtime map added.
 - Done: WineMetal build-surface audit completed; this checkout can build the MetalSharp D3D9 shim but does not contain the DXMT source/build path needed to produce a fresh i386 `winemetal.dll`.
 - Done: code yin/yang map added against `backup/main-before-v0.33.28-reset-20260521T223249Z`.
@@ -1165,7 +1203,7 @@ Current investigation status:
 - Done: non-live readiness audit added and currently fails only because no passing live control suite has been supplied.
 - Not done: no Wine 11.9 parity release candidate has passed the release gates yet.
 - Not done: no candidate Wine 11.9 runtime has passed the three control games.
-- Not done: no release-proven 11.9-built i386 `winemetal.dll` has been recovered or produced; the AverySSD DXMT i386 artifact and borrowed 11.5 i386 bridge both remain experiments until live M9 proof says otherwise.
+- Not done: a clean 11.9-linked i386 `winemetal.dll` has been produced, but it is not release-proven until packaged into the active 11.9 candidate and backed by live Nidhogg 2/M9 proof. The dirty AverySSD DXMT i386 artifact and borrowed 11.5 i386 bridge remain diagnostic fallbacks only.
 - Not done: anti-cheat hook readiness has not been proven beyond non-live symbol-surface evidence.
 
 Therefore the investigation/design artifact is ready to guide implementation, but the overall Wine 11.9 rebuild goal is not complete until a candidate build passes the matrix above.

--- a/docs/wine-119-rebuild-forensics.md
+++ b/docs/wine-119-rebuild-forensics.md
@@ -911,6 +911,9 @@ Live control suite orchestration is handled by `scripts/run-wine119-live-control
   - writes `summary.md`, launch JSON responses, backend logs, and per-game proof directories
 - latest guard validation:
   - running without `METALSHARP_RUN_LIVE_GAMES=1` exits with code `2` and launches nothing
+  - `scripts/test-wine119-live-suite-guards.sh` proves the live runner accepts
+    clean `dxmt32` preflight and refuses stale/dirty candidate summary or
+    mismatched parity install source before backend/game launch
   - a fake stale parity home with active manifests pointing at `/Users/alexmondello/.metalsharp` is refused before backend/game launch
   - a fake parity home with no source metadata is refused before backend/game launch
   - `scripts/install-wine119-parity-home.sh ... /Users/alexmondello` is refused before runtime copy

--- a/docs/wine-119-rebuild-forensics.md
+++ b/docs/wine-119-rebuild-forensics.md
@@ -244,8 +244,9 @@ Top-level/runtime-shape comparison:
 | `bin/metalsharp-wine` | present shell wrapper, SHA256 `6873d7f19ff16c707b76806732f531f06cd2b5305231f7142d12b3ebc8ad9cd0` | missing | must be regenerated or carried forward; launcher prefers this wrapper when present |
 | `etc/dxmt.conf` | present, SHA256 `166e2fe829de03d64b225c65fa1682162e198852df51e9520adc3f3b37244621` | present, same SHA256 | preserve path and visibility for M9/M11/M12 |
 | `etc/mscompatdb_rules.toml` | present, SHA256 `7b17e2feafa3453e79a43ab0cfe246faecc70ec8c3427a1128eb8bd1fd375e87` | present, same SHA256 | not a differentiator by itself |
-| `etc/vulkan/icd.d/MoltenVK_icd.json` | present, SHA256 `61d212ba97b02155cd8a16ef3e1be0ef7bf7a8c93e9f20c30506550f69a673ae` | present, same SHA256 | preserve |
-| `etc/vulkan/icd.d/MoltenVK_x86_64_icd.json` | present, SHA256 `7ce881b47fd3adbc29855703c147566e7ffebf514bf7191e6f7903b4eb433af8` | present, same SHA256 | preserve |
+| `etc/vulkan/icd.d/MoltenVK_icd.json` | present, SHA256 `61d212ba97b02155cd8a16ef3e1be0ef7bf7a8c93e9f20c30506550f69a673ae` | raw bundle is same SHA256 | candidate preparation must rewrite `library_path` to the candidate runtime so isolated proof does not load MoltenVK from the installed 11.5 home |
+| `etc/vulkan/icd.d/MoltenVK_x86_64_icd.json` | present, SHA256 `7ce881b47fd3adbc29855703c147566e7ffebf514bf7191e6f7903b4eb433af8` | raw bundle is same SHA256 | candidate preparation must rewrite `library_path` to the candidate runtime so isolated proof does not load MoltenVK from the installed 11.5 home |
+| `lib/libMoltenVK.dylib` | missing, while ICD JSON points at this absolute path under the installed home | missing in raw bundle | candidate preparation must create a candidate-local binding to `lib/wine/x86_64-unix/libMoltenVK.1.dylib` and rewrite ICD JSON to that candidate-local path |
 | Wine version marker | `share/wine/wine.inf` says Wine 11.5, SHA256 `14f55c9a641549b253445ffabc2fccf4ede4852f2ffc5aaea780f2c5da19c763` | says Wine 11.9, SHA256 `a4db2eb9c9746ec670dd982e306e419dda2fcb5625de577fddc109d8e6e888b6` | expected version change |
 
 DXMT/WineMetal internal comparison:
@@ -282,6 +283,7 @@ Critical internal mismatches found by file-list comparison:
 - Wine 11.9 asset is missing `wine/lib/wine/i386-windows/winemetal.dll`.
 - Wine 11.9 asset is missing the working install's `.dxvk` and `.wine-builtin` backup filenames under `lib/wine`, including `d3d11.dll.dxvk`, `d3d11.dll.wine-builtin`, and `winevulkan.dll.115`.
 - Wine 11.9 asset adds `wine/lib/wine/x86_64-unix/mscompatdb.dylib`.
+- Both the working 11.5 install and raw 11.9 asset carry Vulkan ICD JSON that points at `/Users/alexmondello/.metalsharp/runtime/wine/lib/libMoltenVK.dylib`, but that file is absent in the inspected roots; isolated 11.9 candidates must localize the ICD path before live proof, otherwise Subnautica/Schedule evidence can accidentally borrow the installed runtime.
 - Wine 11.9 asset adds headers under `include/wine/...`, which are useful for building but do not prove runtime parity.
 
 Internal rebuild contract:
@@ -373,6 +375,8 @@ This is likely related to Schedule I and Subnautica BZ ambiguity. Wine 11.9 rebu
 
 - Yin: current `main`, tree-equivalent to `v0.33.27`
 - Yang: `backup/main-before-v0.33.28-reset-20260521T223249Z` at `797db720c852b7f46356fa2541fb4dac81afcc69`
+
+There is a second backup ref, `backup/main-before-v0.33.27-reset-20260521T225540Z`, at `e16b754eb770fdabc4810b371839d1d42c11cf70`. That ref is not the full regression tip. Its tree is identical to `c2eb975907cc5e285463ce08989a36d8b55f9412` (`Bump version to 0.33.28`), which is already after the Wine 11.9 promotion commit `6e235de53e717f106d4b61e2f2e29f00e21bcba3`. Treat `e16b754` as an intermediate rollback checkpoint, not as "pre-Wine-11.9" evidence.
 
 Code surfaces that changed between yin and yang:
 
@@ -689,6 +693,7 @@ Every Wine 11.9 build candidate should emit or archive a manifest with:
   - `etc/mscompatdb_rules.toml`
   - `etc/vulkan/icd.d/MoltenVK_icd.json`
   - `etc/vulkan/icd.d/MoltenVK_x86_64_icd.json`
+  - `lib/libMoltenVK.dylib`
   - `lib/dxmt/x86_64-windows/{d3d10core.dll,d3d11.dll,d3d12.dll,dxgi.dll,winemetal.dll}`
   - `lib/dxmt/x86_64-unix/winemetal.so`
   - `lib/wine/x86_64-unix/{winemetal.so,mscompatdb.so,mscompatdb.dylib,libMoltenVK.1.dylib}`
@@ -696,6 +701,7 @@ Every Wine 11.9 build candidate should emit or archive a manifest with:
   - `lib/wine/i386-windows/{d3d11.dll,dxgi.dll,winemetal.dll}`
 - `file` output for Wine executables and Mach-O dylibs
 - `otool -L` output for `winemetal.so`, `mscompatdb.so`, `mscompatdb.dylib`, and `libMoltenVK.1.dylib`
+- `otool -l` load-command output for Unix-side probes, so install names, `LC_RPATH`, and `@rpath` loader contracts are captured instead of inferred
 - `nm -gU` hook probe output for `ntdll.so`, `mscompatdb.so`, and `mscompatdb.dylib`
 - final installer source URL or artifact digest
 
@@ -707,6 +713,7 @@ The manifest script is `scripts/runtime-manifest.sh`. It is read-only against th
 - `critical-sha256.txt`
 - `file.txt`
 - `otool-L.txt`
+- `otool-l.txt`
 - `nm-gU.txt`
 - `manifest.json`
 
@@ -719,7 +726,8 @@ Manifest comparison is handled by `scripts/compare-runtime-manifests.sh`:
   - allows expected Wine version changes
   - allows expected DXMT D3D12/DXGI/WineMetal bridge changes
   - allows expected anti-cheat hook-surface changes
-  - requires wrapper/config/Vulkan/MoltenVK/shared DXMT files to match
+  - requires wrapper/config/MoltenVK/shared DXMT files to match
+  - allows Vulkan ICD JSON and `lib/libMoltenVK.dylib` to differ only as candidate-local binding repairs
   - marks unknown or route-critical missing files as release blockers
 
 Candidate orchestration is handled by `scripts/prepare-wine119-parity-candidates.sh`:
@@ -899,6 +907,10 @@ Live control verification is handled by `scripts/verify-wine119-live-control-sui
   - `fail` if an already-running Wine Steam process is killed/relaunched during a control-game launch
 
 This verifier is the final local release gate before any Wine 11.9 tag bump. A green manifest or backend preflight is not enough.
+
+Current verifier limitation: the live suite exercises the backend `/steam/launch-game` route directly. The Electron path is `LibraryView.vue` -> `window.metalsharpAPI.backendRequest` -> `RustBridge.request` -> backend HTTP, and `auto` can still fall through to `/game/launch-auto` when Steam route metadata is missing or stale. Before a Wine 11.9 release candidate is marked app-ready, add an app-facing proof pass that launches the same controls through the renderer-selected route or proves the renderer will call `/steam/launch-game` for each configured M9/M11 control.
+
+Current M12 limitation: the first live gate intentionally targets the reported regressions: Nidhogg 2 M9, Schedule I M11, and Subnautica Below Zero M11. M12 remains a mapped rebuild surface, not a passed live surface. Add a dedicated M12 control before enabling D3D12/M12 behavior changes beyond this parity plan.
 
 Non-live readiness auditing is handled by `scripts/audit-wine119-readiness.sh`:
 

--- a/scripts/audit-electron-launch-routes.mjs
+++ b/scripts/audit-electron-launch-routes.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import http from "node:http";
+import path from "node:path";
+
+const controls = [
+  { label: "nidhogg2", appid: 535520, expectedLaunchMethod: "m9" },
+  { label: "schedule-i", appid: 3164500, expectedLaunchMethod: "m11" },
+  { label: "subnautica-bz", appid: 848450, expectedLaunchMethod: "m11" },
+];
+
+const wineRouteIds = new Set([
+  "steam",
+  "wine_steam",
+  "m9",
+  "m10",
+  "m11",
+  "m12",
+  "m32",
+  "dx9",
+  "dx10",
+  "dx11",
+  "dx12",
+  "d3d9",
+  "d3d10",
+  "d3d11",
+  "d3d12",
+  "d3d9_metal",
+  "dxmt_metal",
+  "dxmt_metal12",
+  "wined3d_32",
+]);
+
+function usage() {
+  console.error(`Usage:
+  node scripts/audit-electron-launch-routes.mjs --base-url http://127.0.0.1:9274 --out-dir /tmp/route-audit
+  node scripts/audit-electron-launch-routes.mjs --library-json /tmp/steam-library.json --out-dir /tmp/route-audit
+
+Audits the Electron LibraryView launch routing decision for the Wine 11.9
+control games. This is non-live: it does not launch games.`);
+}
+
+function argValue(args, name) {
+  const index = args.indexOf(name);
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+function getJson(url) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, (res) => {
+      const chunks = [];
+      res.on("data", (chunk) => chunks.push(chunk));
+      res.on("end", () => {
+        const text = Buffer.concat(chunks).toString("utf8");
+        if (res.statusCode < 200 || res.statusCode >= 300) {
+          reject(new Error(`${url} returned HTTP ${res.statusCode}: ${text}`));
+          return;
+        }
+        try {
+          resolve(JSON.parse(text));
+        } catch (error) {
+          reject(new Error(`${url} did not return JSON: ${error.message}`));
+        }
+      });
+    });
+    req.on("error", reject);
+    req.setTimeout(5000, () => {
+      req.destroy(new Error(`${url} timed out`));
+    });
+  });
+}
+
+function isMacSteamLaunch(launchMethod) {
+  return launchMethod === "mac_steam" || launchMethod === "macos_steam" || launchMethod === "native_steam";
+}
+
+function isWineSteamRouteId(launchMethod) {
+  return wineRouteIds.has(String(launchMethod ?? "").toLowerCase());
+}
+
+function recommendedLaunchMethod(game) {
+  return game.launch_method ?? game.available_pipelines?.find((pipeline) => pipeline.recommended)?.id;
+}
+
+function isWineSteamRouteLaunch(game, launchMethod) {
+  const method = String(launchMethod).toLowerCase();
+  if (method === "auto") {
+    const recommended = recommendedLaunchMethod(game);
+    if (!recommended) return true;
+    if (isMacSteamLaunch(recommended)) return false;
+    return isWineSteamRouteId(recommended);
+  }
+  return isWineSteamRouteId(method);
+}
+
+function endpointFor(game, launchMethod) {
+  return isWineSteamRouteLaunch(game, launchMethod) ? "/steam/launch-game" : "/game/launch-auto";
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const baseUrl = argValue(args, "--base-url");
+  const libraryJson = argValue(args, "--library-json");
+  const outDir = argValue(args, "--out-dir") ?? `/tmp/metalsharp-electron-route-audit-${Date.now()}`;
+
+  if ((!baseUrl && !libraryJson) || args.includes("-h") || args.includes("--help")) {
+    usage();
+    process.exit(args.includes("-h") || args.includes("--help") ? 0 : 1);
+  }
+
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const library = libraryJson
+    ? JSON.parse(fs.readFileSync(libraryJson, "utf8"))
+    : await getJson(`${baseUrl.replace(/\/$/, "")}/steam/library`);
+
+  fs.writeFileSync(path.join(outDir, "steam-library.json"), `${JSON.stringify(library, null, 2)}\n`);
+
+  const games = Array.isArray(library.games) ? library.games : [];
+  const rows = [];
+  let failures = 0;
+
+  for (const control of controls) {
+    const game = games.find((candidate) => Number(candidate.appid) === control.appid);
+    const backendPipelines = baseUrl
+      ? await getJson(`${baseUrl.replace(/\/$/, "")}/mtsp/pipelines?appid=${control.appid}`).catch((error) => ({
+          ok: false,
+          error: error.message,
+        }))
+      : null;
+
+    if (!game) {
+      failures += 1;
+      rows.push({
+        ...control,
+        ok: false,
+        error: "control game missing from /steam/library",
+      });
+      continue;
+    }
+
+    const autoEndpoint = endpointFor(game, "auto");
+    const explicitEndpoint = endpointFor(game, control.expectedLaunchMethod);
+    const recommended = recommendedLaunchMethod(game) ?? null;
+    const ok = autoEndpoint === "/steam/launch-game" && explicitEndpoint === "/steam/launch-game";
+    if (!ok) failures += 1;
+
+    rows.push({
+      ...control,
+      ok,
+      name: game.name,
+      installed: game.installed,
+      gameLaunchMethod: game.launch_method ?? null,
+      recommendedFromLibrary: recommended,
+      backendRecommended: backendPipelines?.recommended ?? null,
+      autoEndpoint,
+      explicitEndpoint,
+      note:
+        autoEndpoint === "/steam/launch-game"
+          ? "Electron auto route stays on Wine Steam attach path"
+          : "Electron auto route falls back to /game/launch-auto",
+    });
+  }
+
+  const result = {
+    ok: failures === 0,
+    failures,
+    controls: rows,
+  };
+  fs.writeFileSync(path.join(outDir, "electron-launch-route-audit.json"), `${JSON.stringify(result, null, 2)}\n`);
+
+  const lines = [
+    "# MetalSharp Electron Launch Route Audit",
+    "",
+    `- failures: ${failures}`,
+    `- gate: ${failures === 0 ? "pass" : "fail"}`,
+    "",
+    "| Game | AppID | Expected Method | Library Recommended | Backend Recommended | Auto Endpoint | Explicit Endpoint | Gate |",
+    "| --- | --- | --- | --- | --- | --- | --- | --- |",
+  ];
+  for (const row of rows) {
+    lines.push(
+      `| ${row.name ?? row.label} | ${row.appid} | ${row.expectedLaunchMethod} | ${row.recommendedFromLibrary ?? "none"} | ${row.backendRecommended ?? "not-probed"} | ${row.autoEndpoint ?? "missing"} | ${row.explicitEndpoint ?? "missing"} | ${row.ok ? "pass" : "fail"} |`,
+    );
+  }
+  lines.push("");
+  lines.push("This audit mirrors `LibraryView.vue` routing: `auto` uses `/steam/launch-game` unless the library metadata explicitly selects macOS/native Steam.");
+  fs.writeFileSync(path.join(outDir, "electron-launch-route-audit.md"), `${lines.join("\n")}\n`);
+
+  console.log(`electron launch route audit written: ${outDir}`);
+  if (failures > 0) process.exit(2);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/scripts/audit-i386-winemetal-provenance.sh
+++ b/scripts/audit-i386-winemetal-provenance.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  scripts/audit-i386-winemetal-provenance.sh <dxmt-source-root> <winemetal.dll> [output-dir]
+
+Example:
+  scripts/audit-i386-winemetal-provenance.sh \
+    /Volumes/AverySSD/metalsharp/dxmt-src \
+    /Volumes/AverySSD/metalsharp/dxmt-src/build32/src/winemetal/winemetal.dll \
+    /tmp/metalsharp-i386-winemetal-provenance
+
+Captures read-only provenance for a candidate i386 winemetal.dll. This does not
+bless the artifact for release; it records whether the source tree is clean, the
+exact git/build identity, PE architecture/import/export evidence, and whether
+the build metadata links against Wine 11.5 or Wine 11.9 inputs.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+src_root="${1:-}"
+artifact="${2:-}"
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+out_dir="${3:-/tmp/metalsharp-i386-winemetal-provenance-$timestamp}"
+
+if [[ -z "$src_root" || -z "$artifact" ]]; then
+    usage >&2
+    exit 1
+fi
+if [[ ! -d "$src_root/.git" ]]; then
+    echo "DXMT source root is not a git checkout: $src_root" >&2
+    exit 1
+fi
+if [[ ! -f "$artifact" ]]; then
+    echo "artifact not found: $artifact" >&2
+    exit 1
+fi
+
+mkdir -p "$out_dir"
+report="$out_dir/provenance.md"
+
+src_abs="$(cd "$src_root" && pwd -P)"
+artifact_dir="$(cd "$(dirname "$artifact")" && pwd -P)"
+artifact_abs="$artifact_dir/$(basename "$artifact")"
+build_root="$src_abs/build32"
+target_info="$build_root/meson-info/intro-targets.json"
+machines_info="$build_root/meson-info/intro-machines.json"
+compilers_info="$build_root/meson-info/intro-compilers.json"
+buildoptions_info="$build_root/meson-info/intro-buildoptions.json"
+
+git_head="$(git -C "$src_abs" rev-parse HEAD)"
+git_branch="$(git -C "$src_abs" branch --show-current 2>/dev/null || true)"
+git_dirty="no"
+if [[ -n "$(git -C "$src_abs" status --porcelain)" ]]; then
+    git_dirty="yes"
+fi
+artifact_sha="$(shasum -a 256 "$artifact_abs" | awk '{ print $1 }')"
+artifact_file="$(file "$artifact_abs")"
+
+git -C "$src_abs" status --short --branch > "$out_dir/git-status.txt"
+git -C "$src_abs" diff --stat > "$out_dir/git-diff-stat.txt"
+git -C "$src_abs" diff -- src/winemetal/main.c src/winemetal/unix/winemetal_unix.c src/winemetal/wineunixlib.h > "$out_dir/winemetal-source-diff.patch" || true
+objdump -p "$artifact_abs" > "$out_dir/objdump-p.txt" 2>&1 || true
+file "$artifact_abs" > "$out_dir/file.txt"
+shasum -a 256 "$artifact_abs" > "$out_dir/sha256.txt"
+
+if [[ -f "$target_info" ]] && command -v jq >/dev/null 2>&1; then
+    jq '.[] | select(.filename[]? | test("winemetal[.]dll$"))' "$target_info" > "$out_dir/meson-winemetal-target.json"
+else
+    : > "$out_dir/meson-winemetal-target.json"
+fi
+
+if [[ -f "$machines_info" ]]; then
+    cp "$machines_info" "$out_dir/intro-machines.json"
+fi
+if [[ -f "$compilers_info" ]]; then
+    cp "$compilers_info" "$out_dir/intro-compilers.json"
+fi
+if [[ -f "$buildoptions_info" ]]; then
+    cp "$buildoptions_info" "$out_dir/intro-buildoptions.json"
+fi
+
+linker_wine_refs="$out_dir/linker-wine-refs.txt"
+if [[ -s "$out_dir/meson-winemetal-target.json" ]]; then
+    rg -o '/[^" ]*wine-[0-9][^" ]*' "$out_dir/meson-winemetal-target.json" > "$linker_wine_refs" || true
+else
+    : > "$linker_wine_refs"
+fi
+
+{
+    echo "# i386 WineMetal Provenance Audit"
+    echo
+    echo "- captured_at_utc: \`$timestamp\`"
+    echo "- dxmt_source_root: \`$src_abs\`"
+    echo "- artifact: \`$artifact_abs\`"
+    echo "- artifact_sha256: \`$artifact_sha\`"
+    echo "- artifact_file: \`$artifact_file\`"
+    echo "- git_branch: \`${git_branch:-unknown}\`"
+    echo "- git_head: \`$git_head\`"
+    echo "- git_dirty: \`$git_dirty\`"
+    echo
+    echo "## Gate"
+    echo
+    if [[ "$git_dirty" == "yes" ]]; then
+        echo "- result: fail"
+        echo "- reason: source checkout has uncommitted changes, so this artifact is not release-proven."
+    elif rg -q 'wine-11[.]5' "$linker_wine_refs"; then
+        echo "- result: fail"
+        echo "- reason: linker/build metadata references Wine 11.5 inputs, so this is not a 11.9-built i386 WineMetal."
+    else
+        echo "- result: review"
+        echo "- reason: source tree is clean and no Wine 11.5 linker refs were detected; still requires live M9 proof before release."
+    fi
+    echo
+    echo "## Evidence Files"
+    echo
+    echo "- git status: \`$out_dir/git-status.txt\`"
+    echo "- git diff stat: \`$out_dir/git-diff-stat.txt\`"
+    echo "- winemetal source diff: \`$out_dir/winemetal-source-diff.patch\`"
+    echo "- file: \`$out_dir/file.txt\`"
+    echo "- objdump: \`$out_dir/objdump-p.txt\`"
+    echo "- meson target: \`$out_dir/meson-winemetal-target.json\`"
+    echo "- linker Wine refs: \`$linker_wine_refs\`"
+    echo
+    echo "## Linker Wine References"
+    echo
+    if [[ -s "$linker_wine_refs" ]]; then
+        sed 's/^/- `/' "$linker_wine_refs" | sed 's/$/`/'
+    else
+        echo "- none detected"
+    fi
+} > "$report"
+
+echo "i386 WineMetal provenance audit written: $report"
+if rg -q '^- result: fail$' "$report"; then
+    exit 2
+fi

--- a/scripts/audit-i386-winemetal-provenance.sh
+++ b/scripts/audit-i386-winemetal-provenance.sh
@@ -33,7 +33,7 @@ if [[ -z "$src_root" || -z "$artifact" ]]; then
     usage >&2
     exit 1
 fi
-if [[ ! -d "$src_root/.git" ]]; then
+if ! git -C "$src_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     echo "DXMT source root is not a git checkout: $src_root" >&2
     exit 1
 fi
@@ -49,6 +49,14 @@ src_abs="$(cd "$src_root" && pwd -P)"
 artifact_dir="$(cd "$(dirname "$artifact")" && pwd -P)"
 artifact_abs="$artifact_dir/$(basename "$artifact")"
 build_root="$src_abs/build32"
+search_dir="$artifact_dir"
+while [[ "$search_dir" != "/" ]]; do
+    if [[ -d "$search_dir/meson-info" ]]; then
+        build_root="$search_dir"
+        break
+    fi
+    search_dir="$(dirname "$search_dir")"
+done
 target_info="$build_root/meson-info/intro-targets.json"
 machines_info="$build_root/meson-info/intro-machines.json"
 compilers_info="$build_root/meson-info/intro-compilers.json"
@@ -71,7 +79,7 @@ file "$artifact_abs" > "$out_dir/file.txt"
 shasum -a 256 "$artifact_abs" > "$out_dir/sha256.txt"
 
 if [[ -f "$target_info" ]] && command -v jq >/dev/null 2>&1; then
-    jq '.[] | select(.filename[]? | test("winemetal[.]dll$"))' "$target_info" > "$out_dir/meson-winemetal-target.json"
+    jq '.[] | select(.filename[]? | contains("winemetal.dll"))' "$target_info" > "$out_dir/meson-winemetal-target.json"
 else
     : > "$out_dir/meson-winemetal-target.json"
 fi
@@ -88,7 +96,7 @@ fi
 
 linker_wine_refs="$out_dir/linker-wine-refs.txt"
 if [[ -s "$out_dir/meson-winemetal-target.json" ]]; then
-    rg -o '/[^" ]*wine-[0-9][^" ]*' "$out_dir/meson-winemetal-target.json" > "$linker_wine_refs" || true
+    rg -o '/[^" ]*(wine-[0-9][^" ]*|metalsharp-wine119-parity[^" ]*)' "$out_dir/meson-winemetal-target.json" > "$linker_wine_refs" || true
 else
     : > "$linker_wine_refs"
 fi
@@ -113,9 +121,12 @@ fi
     elif rg -q 'wine-11[.]5' "$linker_wine_refs"; then
         echo "- result: fail"
         echo "- reason: linker/build metadata references Wine 11.5 inputs, so this is not a 11.9-built i386 WineMetal."
+    elif rg -q 'metalsharp-wine119-parity|wine-11[.]9' "$linker_wine_refs"; then
+        echo "- result: review"
+        echo "- reason: source tree is clean and linker metadata references the shaped Wine 11.9 runtime; still requires live M9 proof before release."
     else
         echo "- result: review"
-        echo "- reason: source tree is clean and no Wine 11.5 linker refs were detected; still requires live M9 proof before release."
+        echo "- reason: source tree is clean and no Wine 11.5 linker refs were detected, but Wine 11.9 linker refs were not explicit; still requires build log review and live M9 proof before release."
     fi
     echo
     echo "## Evidence Files"

--- a/scripts/audit-mscompatdb-hook-surface.sh
+++ b/scripts/audit-mscompatdb-hook-surface.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  scripts/audit-mscompatdb-hook-surface.sh <wine-root> [output-dir]
+
+Example:
+  scripts/audit-mscompatdb-hook-surface.sh \
+    /tmp/metalsharp-home-wine119-dxmt32-state/.metalsharp/runtime/wine \
+    /tmp/metalsharp-mscompatdb-hook-audit
+
+Audits the Wine runtime mscompatdb hook surface without mutating the runtime.
+This is deliberately conservative: exported symbols prove only symbol presence,
+not that the hook is loaded or ready inside a protected game process.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+wine_root="${1:-}"
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+out_dir="${2:-/tmp/metalsharp-mscompatdb-hook-audit-$timestamp}"
+
+if [[ -z "$wine_root" ]]; then
+    usage >&2
+    exit 1
+fi
+
+if [[ ! -d "$wine_root" ]]; then
+    echo "wine root not found: $wine_root" >&2
+    exit 1
+fi
+
+wine_root="$(cd "$wine_root" && pwd -P)"
+mkdir -p "$out_dir"
+
+ntdll="$wine_root/lib/wine/x86_64-unix/ntdll.so"
+mscompatdb_so="$wine_root/lib/wine/x86_64-unix/mscompatdb.so"
+mscompatdb_dylib="$wine_root/lib/wine/x86_64-unix/mscompatdb.dylib"
+
+json_bool() {
+    if [[ "$1" == "1" ]]; then
+        printf 'true'
+    else
+        printf 'false'
+    fi
+}
+
+path_exists() {
+    [[ -f "$1" ]] && printf '1' || printf '0'
+}
+
+has_symbol() {
+    local file="$1"
+    local symbol="$2"
+    [[ -f "$file" ]] && nm -gU "$file" 2>/dev/null | grep -Fq "$symbol"
+}
+
+capture_probe() {
+    local rel="$1"
+    local file="$wine_root/$rel"
+    {
+        echo "== $rel =="
+        if [[ -f "$file" ]]; then
+            file "$file" || true
+            echo
+            echo "-- nm -gU --"
+            nm -gU "$file" 2>&1 || true
+            echo
+            echo "-- otool -L --"
+            otool -L "$file" 2>&1 || true
+            echo
+            echo "-- otool -l --"
+            otool -l "$file" 2>&1 || true
+        else
+            echo "missing"
+        fi
+    } >> "$out_dir/probes.txt"
+}
+
+: > "$out_dir/probes.txt"
+capture_probe "lib/wine/x86_64-unix/ntdll.so"
+capture_probe "lib/wine/x86_64-unix/mscompatdb.so"
+capture_probe "lib/wine/x86_64-unix/mscompatdb.dylib"
+
+ntdll_exists="$(path_exists "$ntdll")"
+mscompatdb_so_exists="$(path_exists "$mscompatdb_so")"
+mscompatdb_dylib_exists="$(path_exists "$mscompatdb_dylib")"
+
+contract_symbol=0
+contract_version_symbol=0
+if has_symbol "$ntdll" "_MetalSharpGetMscompatdbHookContract"; then
+    contract_symbol=1
+fi
+if has_symbol "$ntdll" "_MetalSharpGetMscompatdbHookContractVersion"; then
+    contract_version_symbol=1
+fi
+
+mscompatdb_so_public_symbols=0
+if [[ -f "$mscompatdb_so" ]] && nm -gU "$mscompatdb_so" 2>/dev/null | grep -q ' _'; then
+    mscompatdb_so_public_symbols=1
+fi
+
+mscompatdb_dylib_public_symbols=0
+if [[ -f "$mscompatdb_dylib" ]] && nm -gU "$mscompatdb_dylib" 2>/dev/null | grep -q ' _'; then
+    mscompatdb_dylib_public_symbols=1
+fi
+
+symbol_surface_ready=0
+if [[ "$ntdll_exists" == "1" && "$contract_symbol" == "1" && "$contract_version_symbol" == "1" ]]; then
+    symbol_surface_ready=1
+fi
+
+runtime_loaded=0
+hook_ready=0
+status="missing_hook_symbols"
+if [[ "$ntdll_exists" != "1" ]]; then
+    status="missing_ntdll_unix"
+elif [[ "$symbol_surface_ready" != "1" ]]; then
+    status="missing_hook_symbols"
+elif [[ "$mscompatdb_so_exists" != "1" && "$mscompatdb_dylib_exists" != "1" ]]; then
+    status="missing_mscompatdb_runtime"
+else
+    status="symbol_surface_present_runtime_unproven"
+fi
+
+cat > "$out_dir/hook-surface.json" <<EOF
+{
+  "ok": true,
+  "wineRoot": "$wine_root",
+  "status": "$status",
+  "symbolSurfaceReady": $(json_bool "$symbol_surface_ready"),
+  "runtimeLoaded": $(json_bool "$runtime_loaded"),
+  "hookReady": $(json_bool "$hook_ready"),
+  "files": {
+    "ntdllUnix": {"path": "$ntdll", "exists": $(json_bool "$ntdll_exists")},
+    "mscompatdbSo": {"path": "$mscompatdb_so", "exists": $(json_bool "$mscompatdb_so_exists")},
+    "mscompatdbDylib": {"path": "$mscompatdb_dylib", "exists": $(json_bool "$mscompatdb_dylib_exists")}
+  },
+  "symbols": {
+    "MetalSharpGetMscompatdbHookContract": $(json_bool "$contract_symbol"),
+    "MetalSharpGetMscompatdbHookContractVersion": $(json_bool "$contract_version_symbol"),
+    "mscompatdbSoPublicSymbols": $(json_bool "$mscompatdb_so_public_symbols"),
+    "mscompatdbDylibPublicSymbols": $(json_bool "$mscompatdb_dylib_public_symbols")
+  },
+  "evidence": {
+    "probes": "$out_dir/probes.txt"
+  }
+}
+EOF
+
+{
+    echo "# MetalSharp mscompatdb Hook Surface Audit"
+    echo
+    echo "- wine_root: \`$wine_root\`"
+    echo "- status: \`$status\`"
+    echo "- symbol_surface_ready: \`$(json_bool "$symbol_surface_ready")\`"
+    echo "- runtime_loaded: \`false\`"
+    echo "- hook_ready: \`false\`"
+    echo
+    echo "| Check | Result |"
+    echo "| --- | --- |"
+    echo "| ntdll.so exists | $(json_bool "$ntdll_exists") |"
+    echo "| mscompatdb.so exists | $(json_bool "$mscompatdb_so_exists") |"
+    echo "| mscompatdb.dylib exists | $(json_bool "$mscompatdb_dylib_exists") |"
+    echo "| _MetalSharpGetMscompatdbHookContract | $(json_bool "$contract_symbol") |"
+    echo "| _MetalSharpGetMscompatdbHookContractVersion | $(json_bool "$contract_version_symbol") |"
+    echo "| mscompatdb.so public symbols | $(json_bool "$mscompatdb_so_public_symbols") |"
+    echo "| mscompatdb.dylib public symbols | $(json_bool "$mscompatdb_dylib_public_symbols") |"
+    echo
+    echo "Symbols alone do not prove hook readiness. This audit stays false for \`hook_ready\` until a protected runtime launch proves load and behavior."
+} > "$out_dir/hook-surface.md"
+
+echo "mscompatdb hook surface audit written: $out_dir"
+if [[ "$symbol_surface_ready" != "1" ]]; then
+    exit 2
+fi

--- a/scripts/audit-wine119-objective-completion.sh
+++ b/scripts/audit-wine119-objective-completion.sh
@@ -17,6 +17,7 @@ Environment:
   METALSHARP_CANDIDATE_SUMMARY     parity candidate summary.md path
   METALSHARP_FETCH_REPORT          release fetch-report.txt path
   METALSHARP_PARITY_PROBE_DIR      backend probe dir for route/hook evidence
+  METALSHARP_I386_WINEMETAL_PROVENANCE provenance.md path
   METALSHARP_LIVE_SUITE_DIR        optional live suite dir to prove live gate
 USAGE
 }
@@ -62,6 +63,7 @@ readiness="${METALSHARP_READINESS_REPORT:-/tmp/metalsharp-wine119-readiness-curr
 candidate_summary="${METALSHARP_CANDIDATE_SUMMARY:-/tmp/metalsharp-wine119-parity/summary.md}"
 fetch_report="${METALSHARP_FETCH_REPORT:-/tmp/metalsharp-wine-assets/fetch-report.txt}"
 parity_probe="${METALSHARP_PARITY_PROBE_DIR:-/private/tmp/metalsharp-home-wine119-dxmt32-state/backend-probe-main03327-guard-v2}"
+i386_provenance="${METALSHARP_I386_WINEMETAL_PROVENANCE:-/tmp/metalsharp-i386-winemetal-provenance-current/provenance.md}"
 live_suite="${METALSHARP_LIVE_SUITE_DIR:-}"
 
 main_head="$(git -C "$repo_root" rev-parse --short HEAD)"
@@ -143,8 +145,10 @@ else
     requirement_row "Pass Nidhogg 2, Schedule I, and Subnautica BZ under Wine 11.9" "unverified" "$readiness does not clearly prove live controls" "inspect METALSHARP_LIVE_SUITE_DIR and verification.md"
 fi
 
-if contains_file "$candidate_summary" 'dxmt32' && contains_file "$candidate_summary" 'release_blockers: 1' && contains_file "$forensics" 'no release-proven 11[.]9-built i386 `winemetal[.]dll`'; then
-    requirement_row "Recover or produce release-proven 11.9 i386 WineMetal" "missing" "candidate summary and forensics mark i386 WineMetal as unresolved" "build/recover true 11.9 i386 winemetal.dll or bless fallback only after live proof"
+if contains_file "$i386_provenance" '^- result: fail$'; then
+    requirement_row "Recover or produce release-proven 11.9 i386 WineMetal" "missing" "$i386_provenance reports the current i386 bridge is not release-proven" "build/recover true 11.9 i386 winemetal.dll or bless fallback only after live proof"
+elif contains_file "$candidate_summary" 'dxmt32' && contains_file "$candidate_summary" 'release_blockers: 1' && contains_file "$forensics" 'no release-proven 11[.]9-built i386 `winemetal[.]dll`'; then
+    requirement_row "Recover or produce release-proven 11.9 i386 WineMetal" "missing" "candidate summary and forensics mark i386 WineMetal as unresolved" "run scripts/audit-i386-winemetal-provenance.sh, then build/recover true 11.9 i386 winemetal.dll or bless fallback only after live proof"
 else
     requirement_row "Recover or produce release-proven 11.9 i386 WineMetal" "unverified" "i386 WineMetal status is not explicit" "audit candidate provenance and live M9 result"
 fi

--- a/scripts/audit-wine119-objective-completion.sh
+++ b/scripts/audit-wine119-objective-completion.sh
@@ -145,10 +145,14 @@ else
     requirement_row "Prepare 11.9 candidates in 11.5-compatible runtime shape" "missing" "$candidate_summary missing" "run scripts/prepare-wine119-parity-candidates.sh"
 fi
 
-if contains_file "$readiness" 'PASS \[electron-route\]' && contains_file "$readiness" 'PASS \[mscompatdb-hook\]' && contains_file "$readiness" 'PASS \[parity-home\] active state has no source-home references'; then
-    requirement_row "Prove non-live parity home/backend/app route readiness" "proven" "$readiness passes backend, Electron route, mscompatdb symbol, and isolated state checks" "live suite still required"
+if contains_file "$readiness" 'PASS \[electron-route\]' &&
+    contains_file "$readiness" 'PASS \[mscompatdb-hook\]' &&
+    contains_file "$readiness" 'PASS \[parity-home\] active state has no source-home references' &&
+    contains_file "$readiness" 'PASS \[candidate-dxmt32-source\] provenance records clean i386 WineMetal source/destination SHA256' &&
+    contains_file "$readiness" 'PASS \[parity-home\] install report source matches the audited clean dxmt32 candidate'; then
+    requirement_row "Prove non-live parity home/backend/app route readiness" "proven" "$readiness passes backend, Electron route, mscompatdb symbol, clean dxmt32 source, and isolated state checks" "live suite still required"
 else
-    requirement_row "Prove non-live parity home/backend/app route readiness" "incomplete" "$readiness lacks expected non-live passes" "rerun probe/readiness scripts"
+    requirement_row "Prove non-live parity home/backend/app route readiness" "incomplete" "$readiness lacks expected non-live clean-candidate/backend/app passes" "rerun probe/readiness scripts against the clean dxmt32 candidate work dir and parity home"
 fi
 
 live_verification=""

--- a/scripts/audit-wine119-objective-completion.sh
+++ b/scripts/audit-wine119-objective-completion.sh
@@ -11,6 +11,13 @@ Example:
 
 Builds a requirement-by-requirement completion audit for the Wine 11.9 rebuild
 objective. This script does not launch games and does not mutate runtimes.
+
+Environment:
+  METALSHARP_READINESS_REPORT       readiness.md path
+  METALSHARP_CANDIDATE_SUMMARY     parity candidate summary.md path
+  METALSHARP_FETCH_REPORT          release fetch-report.txt path
+  METALSHARP_PARITY_PROBE_DIR      backend probe dir for route/hook evidence
+  METALSHARP_LIVE_SUITE_DIR        optional live suite dir to prove live gate
 USAGE
 }
 
@@ -51,10 +58,11 @@ requirement_row() {
 
 forensics="$repo_root/docs/wine-119-rebuild-forensics.md"
 runbook="$repo_root/docs/wine-119-implementation-runbook.md"
-readiness="/tmp/metalsharp-wine119-readiness-current/readiness.md"
-candidate_summary="/tmp/metalsharp-wine119-parity/summary.md"
-fetch_report="/tmp/metalsharp-wine-assets/fetch-report.txt"
-parity_probe="/private/tmp/metalsharp-home-wine119-dxmt32-state/backend-probe-main03327-guard-v2"
+readiness="${METALSHARP_READINESS_REPORT:-/tmp/metalsharp-wine119-readiness-current/readiness.md}"
+candidate_summary="${METALSHARP_CANDIDATE_SUMMARY:-/tmp/metalsharp-wine119-parity/summary.md}"
+fetch_report="${METALSHARP_FETCH_REPORT:-/tmp/metalsharp-wine-assets/fetch-report.txt}"
+parity_probe="${METALSHARP_PARITY_PROBE_DIR:-/private/tmp/metalsharp-home-wine119-dxmt32-state/backend-probe-main03327-guard-v2}"
+live_suite="${METALSHARP_LIVE_SUITE_DIR:-}"
 
 main_head="$(git -C "$repo_root" rev-parse --short HEAD)"
 main_descends="no"
@@ -92,10 +100,15 @@ else
     requirement_row "Map Wine 11.9 internals against working Wine 11.5" "incomplete" "internal map is missing expected route-critical surfaces" "expand 11.5/11.9 runtime map"
 fi
 
-if contains_file "$fetch_report" 'asset=metalsharp_bundle[.]tar[.]zst' && contains_file "$fetch_report" 'verified=1'; then
+if contains_file "$fetch_report" 'repo=aaf2tbz/metalsharp' &&
+    contains_file "$fetch_report" 'tag=bundles' &&
+    contains_file "$fetch_report" 'release_tag_name=bundles' &&
+    contains_file "$fetch_report" 'asset=metalsharp_bundle[.]tar[.]zst' &&
+    contains_file "$fetch_report" 'sha256=833f63566b0c1b98fa917337716f57d689c42d0c2878204b4716ba29637d7372' &&
+    contains_file "$fetch_report" 'verified=1'; then
     requirement_row "Use GitHub release asset as Wine 11.9 source" "proven" "$fetch_report verifies bundles/metalsharp_bundle.tar.zst" "none"
 else
-    requirement_row "Use GitHub release asset as Wine 11.9 source" "missing" "$fetch_report not present or not verified" "run scripts/fetch-wine119-release-assets.sh"
+    requirement_row "Use GitHub release asset as Wine 11.9 source" "missing" "$fetch_report not present or missing repo/tag/sha verification" "run scripts/fetch-wine119-release-assets.sh"
 fi
 
 if contains_file "$candidate_summary" '## dxmt32' && contains_file "$candidate_summary" '## borrowed' && contains_file "$candidate_summary" 'Manifest pass alone is not a release gate'; then
@@ -110,7 +123,21 @@ else
     requirement_row "Prove non-live parity home/backend/app route readiness" "incomplete" "$readiness lacks expected non-live passes" "rerun probe/readiness scripts"
 fi
 
-if contains_file "$readiness" 'FAIL \[live-gate\] no passing live control suite supplied'; then
+live_verification=""
+if [[ -n "$live_suite" ]]; then
+    live_verification="$live_suite/verification.md"
+fi
+
+if contains_file "$readiness" 'PASS \[live-gate\]' &&
+    contains_file "$live_verification" '## nidhogg2' &&
+    contains_file "$live_verification" '## schedule-i' &&
+    contains_file "$live_verification" '## subnautica-bz' &&
+    contains_file "$live_verification" 'PASS \[nidhogg2\].*pipeline=m9' &&
+    contains_file "$live_verification" 'PASS \[schedule-i\].*pipeline=m11' &&
+    contains_file "$live_verification" 'PASS \[subnautica-bz\].*pipeline=m11' &&
+    contains_file "$live_verification" 'gate: pass'; then
+    requirement_row "Pass Nidhogg 2, Schedule I, and Subnautica BZ under Wine 11.9" "proven" "$live_verification proves all three live controls and readiness reports PASS [live-gate]" "none"
+elif contains_file "$readiness" 'FAIL \[live-gate\] no passing live control suite supplied'; then
     requirement_row "Pass Nidhogg 2, Schedule I, and Subnautica BZ under Wine 11.9" "missing" "$readiness explicitly reports no passing live suite" "run guarded live suite with METALSHARP_RUN_LIVE_GAMES=1 and METALSHARP_REQUIRE_PREEXISTING_WINE_STEAM=1"
 else
     requirement_row "Pass Nidhogg 2, Schedule I, and Subnautica BZ under Wine 11.9" "unverified" "$readiness does not clearly prove live controls" "inspect METALSHARP_LIVE_SUITE_DIR and verification.md"
@@ -129,7 +156,12 @@ else
     requirement_row "Separate anti-cheat hook surface from runtime hook readiness" "incomplete" "mscompatdb hook surface audit missing or ambiguous" "run scripts/audit-mscompatdb-hook-surface.sh"
 fi
 
-if contains_file "$runbook" '^## Pass 0:' && contains_file "$runbook" '^## Pass 6:' && contains_file "$runbook" '^## Final Release Checklist$'; then
+if contains_file "$runbook" '^## Pass 0:' &&
+    contains_file "$runbook" '^## Pass 6:' &&
+    contains_file "$runbook" '^## Final Release Checklist$' &&
+    contains_file "$runbook" 'Required pass conditions:' &&
+    contains_file "$runbook" 'Required proof before live launch:' &&
+    contains_file "$runbook" 'Do not bump version or tag until all live gates pass'; then
     requirement_row "Plan complete multi-pass Wine 11.9 rebuild" "proven" "docs/wine-119-implementation-runbook.md defines passes 0-6 and release checklist" "execute live/release gates before tag"
 else
     requirement_row "Plan complete multi-pass Wine 11.9 rebuild" "incomplete" "runbook does not contain expected pass matrix" "finish pass-by-pass rebuild design"

--- a/scripts/audit-wine119-objective-completion.sh
+++ b/scripts/audit-wine119-objective-completion.sh
@@ -62,10 +62,26 @@ requirement_row() {
 
 forensics="$repo_root/docs/wine-119-rebuild-forensics.md"
 runbook="$repo_root/docs/wine-119-implementation-runbook.md"
-readiness="${METALSHARP_READINESS_REPORT:-/tmp/metalsharp-wine119-readiness-current/readiness.md}"
-candidate_summary="${METALSHARP_CANDIDATE_SUMMARY:-/tmp/metalsharp-wine119-parity/summary.md}"
+clean_readiness="/tmp/metalsharp-wine119-readiness-clean-current/readiness.md"
+if [[ -z "${METALSHARP_READINESS_REPORT:-}" && -f "$clean_readiness" ]]; then
+    readiness="$clean_readiness"
+else
+    readiness="${METALSHARP_READINESS_REPORT:-/tmp/metalsharp-wine119-readiness-current/readiness.md}"
+fi
+default_candidate_summary="/tmp/metalsharp-wine119-parity/summary.md"
+clean_candidate_summary="/Volumes/AverySSD/metalsharp/wine119-parity-clean-i386/summary.md"
+if [[ -z "${METALSHARP_CANDIDATE_SUMMARY:-}" && -f "$clean_candidate_summary" ]]; then
+    candidate_summary="$clean_candidate_summary"
+else
+    candidate_summary="${METALSHARP_CANDIDATE_SUMMARY:-$default_candidate_summary}"
+fi
 fetch_report="${METALSHARP_FETCH_REPORT:-/tmp/metalsharp-wine-assets/fetch-report.txt}"
-parity_probe="${METALSHARP_PARITY_PROBE_DIR:-/private/tmp/metalsharp-home-wine119-dxmt32-state/backend-probe-main03327-guard-v2}"
+clean_parity_probe="/Volumes/AverySSD/metalsharp/home-wine119-dxmt32-clean-state/backend-probe-main03327-guard-v2"
+if [[ -z "${METALSHARP_PARITY_PROBE_DIR:-}" && -d "$clean_parity_probe" ]]; then
+    parity_probe="$clean_parity_probe"
+else
+    parity_probe="${METALSHARP_PARITY_PROBE_DIR:-/private/tmp/metalsharp-home-wine119-dxmt32-state/backend-probe-main03327-guard-v2}"
+fi
 i386_provenance="${METALSHARP_I386_WINEMETAL_PROVENANCE:-/tmp/metalsharp-i386-winemetal-provenance-current/provenance.md}"
 i386_build_preflight="${METALSHARP_I386_WINEMETAL_BUILD_PREFLIGHT:-/tmp/metalsharp-i386-winemetal-build-preflight-current/preflight.md}"
 i386_clean_provenance="${METALSHARP_I386_WINEMETAL_CLEAN_PROVENANCE:-/tmp/metalsharp-clean-i386-winemetal-provenance-119/provenance.md}"
@@ -120,7 +136,11 @@ else
 fi
 
 if contains_file "$candidate_summary" '## dxmt32' && contains_file "$candidate_summary" '## borrowed' && contains_file "$candidate_summary" 'Manifest pass alone is not a release gate'; then
-    requirement_row "Prepare 11.9 candidates in 11.5-compatible runtime shape" "proven" "$candidate_summary records clean, dxmt32, and borrowed candidates" "live M9 proof still required before release"
+    candidate_evidence="$candidate_summary records clean, dxmt32, and borrowed candidates"
+    if contains_file "$candidate_summary" 'dxmt32_source_kind: `clean-11[.]9-linked-default`'; then
+        candidate_evidence="$candidate_evidence; dxmt32 uses the clean 11.9-linked i386 WineMetal artifact by default"
+    fi
+    requirement_row "Prepare 11.9 candidates in 11.5-compatible runtime shape" "proven" "$candidate_evidence" "live M9 proof still required before release"
 else
     requirement_row "Prepare 11.9 candidates in 11.5-compatible runtime shape" "missing" "$candidate_summary missing" "run scripts/prepare-wine119-parity-candidates.sh"
 fi
@@ -155,7 +175,15 @@ if contains_file "$i386_clean_provenance" '^- result: review$' &&
     contains_file "$i386_clean_provenance" 'linker metadata references the shaped Wine 11[.]9 runtime' &&
     contains_file "$i386_clean_preflight" 'PASS \[source-clean\]' &&
     contains_file "$i386_clean_preflight" 'PASS \[wine-version\] wine reports wine-11[.]9'; then
-    requirement_row "Recover or produce release-proven 11.9 i386 WineMetal" "unverified" "$i386_clean_provenance records a clean 11.9-linked PE32 i386 WineMetal candidate; $i386_clean_preflight proves clean source and 11.9 build inputs" "package this clean artifact into the active candidate and pass live Nidhogg 2/M9 proof before release"
+    evidence="$i386_clean_provenance records a clean 11.9-linked PE32 i386 WineMetal candidate; $i386_clean_preflight proves clean source and 11.9 build inputs"
+    remaining="package this clean artifact into the active candidate and pass live Nidhogg 2/M9 proof before release"
+    if contains_file "$candidate_summary" 'dxmt32_source_kind: `clean-11[.]9-linked-default`' &&
+        contains_file "$readiness" 'PASS \[candidate-dxmt32-source\] provenance records clean i386 WineMetal source/destination SHA256' &&
+        contains_file "$readiness" 'PASS \[parity-home\] install report source matches the audited clean dxmt32 candidate'; then
+        evidence="$evidence; $candidate_summary and $readiness prove the active dxmt32 candidate/parity home use the clean artifact"
+        remaining="pass live Nidhogg 2/M9 process, module, and cache proof before release"
+    fi
+    requirement_row "Recover or produce release-proven 11.9 i386 WineMetal" "unverified" "$evidence" "$remaining"
 elif contains_file "$i386_provenance" '^- result: fail$'; then
     evidence="$i386_provenance reports the current i386 bridge is not release-proven"
     if contains_file "$i386_build_preflight" 'PASS \[wine-version\] wine reports wine-11[.]9' &&

--- a/scripts/audit-wine119-objective-completion.sh
+++ b/scripts/audit-wine119-objective-completion.sh
@@ -18,6 +18,7 @@ Environment:
   METALSHARP_FETCH_REPORT          release fetch-report.txt path
   METALSHARP_PARITY_PROBE_DIR      backend probe dir for route/hook evidence
   METALSHARP_I386_WINEMETAL_PROVENANCE provenance.md path
+  METALSHARP_I386_WINEMETAL_BUILD_PREFLIGHT preflight.md path
   METALSHARP_LIVE_SUITE_DIR        optional live suite dir to prove live gate
 USAGE
 }
@@ -64,6 +65,7 @@ candidate_summary="${METALSHARP_CANDIDATE_SUMMARY:-/tmp/metalsharp-wine119-parit
 fetch_report="${METALSHARP_FETCH_REPORT:-/tmp/metalsharp-wine-assets/fetch-report.txt}"
 parity_probe="${METALSHARP_PARITY_PROBE_DIR:-/private/tmp/metalsharp-home-wine119-dxmt32-state/backend-probe-main03327-guard-v2}"
 i386_provenance="${METALSHARP_I386_WINEMETAL_PROVENANCE:-/tmp/metalsharp-i386-winemetal-provenance-current/provenance.md}"
+i386_build_preflight="${METALSHARP_I386_WINEMETAL_BUILD_PREFLIGHT:-/tmp/metalsharp-i386-winemetal-build-preflight-current/preflight.md}"
 live_suite="${METALSHARP_LIVE_SUITE_DIR:-}"
 
 main_head="$(git -C "$repo_root" rev-parse --short HEAD)"
@@ -146,9 +148,14 @@ else
 fi
 
 if contains_file "$i386_provenance" '^- result: fail$'; then
-    requirement_row "Recover or produce release-proven 11.9 i386 WineMetal" "missing" "$i386_provenance reports the current i386 bridge is not release-proven" "build/recover true 11.9 i386 winemetal.dll or bless fallback only after live proof"
+    evidence="$i386_provenance reports the current i386 bridge is not release-proven"
+    if contains_file "$i386_build_preflight" 'PASS \[wine-version\] wine reports wine-11[.]9' &&
+        contains_file "$i386_build_preflight" 'FAIL \[source-clean\]'; then
+        evidence="$evidence; $i386_build_preflight proves 11.9 build inputs exist but the DXMT source tree is dirty"
+    fi
+    requirement_row "Recover or produce release-proven 11.9 i386 WineMetal" "missing" "$evidence" "build/recover true 11.9 i386 winemetal.dll from a clean source tree or bless fallback only after live proof"
 elif contains_file "$candidate_summary" 'dxmt32' && contains_file "$candidate_summary" 'release_blockers: 1' && contains_file "$forensics" 'no release-proven 11[.]9-built i386 `winemetal[.]dll`'; then
-    requirement_row "Recover or produce release-proven 11.9 i386 WineMetal" "missing" "candidate summary and forensics mark i386 WineMetal as unresolved" "run scripts/audit-i386-winemetal-provenance.sh, then build/recover true 11.9 i386 winemetal.dll or bless fallback only after live proof"
+    requirement_row "Recover or produce release-proven 11.9 i386 WineMetal" "missing" "candidate summary and forensics mark i386 WineMetal as unresolved" "run scripts/audit-i386-winemetal-provenance.sh and scripts/preflight-i386-winemetal-build.sh, then build/recover true 11.9 i386 winemetal.dll or bless fallback only after live proof"
 else
     requirement_row "Recover or produce release-proven 11.9 i386 WineMetal" "unverified" "i386 WineMetal status is not explicit" "audit candidate provenance and live M9 result"
 fi

--- a/scripts/audit-wine119-objective-completion.sh
+++ b/scripts/audit-wine119-objective-completion.sh
@@ -19,6 +19,8 @@ Environment:
   METALSHARP_PARITY_PROBE_DIR      backend probe dir for route/hook evidence
   METALSHARP_I386_WINEMETAL_PROVENANCE provenance.md path
   METALSHARP_I386_WINEMETAL_BUILD_PREFLIGHT preflight.md path
+  METALSHARP_I386_WINEMETAL_CLEAN_PROVENANCE clean 11.9-linked provenance.md path
+  METALSHARP_I386_WINEMETAL_CLEAN_PREFLIGHT clean 11.9-linked preflight.md path
   METALSHARP_LIVE_SUITE_DIR        optional live suite dir to prove live gate
 USAGE
 }
@@ -66,6 +68,8 @@ fetch_report="${METALSHARP_FETCH_REPORT:-/tmp/metalsharp-wine-assets/fetch-repor
 parity_probe="${METALSHARP_PARITY_PROBE_DIR:-/private/tmp/metalsharp-home-wine119-dxmt32-state/backend-probe-main03327-guard-v2}"
 i386_provenance="${METALSHARP_I386_WINEMETAL_PROVENANCE:-/tmp/metalsharp-i386-winemetal-provenance-current/provenance.md}"
 i386_build_preflight="${METALSHARP_I386_WINEMETAL_BUILD_PREFLIGHT:-/tmp/metalsharp-i386-winemetal-build-preflight-current/preflight.md}"
+i386_clean_provenance="${METALSHARP_I386_WINEMETAL_CLEAN_PROVENANCE:-/tmp/metalsharp-clean-i386-winemetal-provenance-119/provenance.md}"
+i386_clean_preflight="${METALSHARP_I386_WINEMETAL_CLEAN_PREFLIGHT:-/tmp/metalsharp-i386-winemetal-build-preflight-clean-f520cb8/preflight.md}"
 live_suite="${METALSHARP_LIVE_SUITE_DIR:-}"
 
 main_head="$(git -C "$repo_root" rev-parse --short HEAD)"
@@ -147,7 +151,12 @@ else
     requirement_row "Pass Nidhogg 2, Schedule I, and Subnautica BZ under Wine 11.9" "unverified" "$readiness does not clearly prove live controls" "inspect METALSHARP_LIVE_SUITE_DIR and verification.md"
 fi
 
-if contains_file "$i386_provenance" '^- result: fail$'; then
+if contains_file "$i386_clean_provenance" '^- result: review$' &&
+    contains_file "$i386_clean_provenance" 'linker metadata references the shaped Wine 11[.]9 runtime' &&
+    contains_file "$i386_clean_preflight" 'PASS \[source-clean\]' &&
+    contains_file "$i386_clean_preflight" 'PASS \[wine-version\] wine reports wine-11[.]9'; then
+    requirement_row "Recover or produce release-proven 11.9 i386 WineMetal" "unverified" "$i386_clean_provenance records a clean 11.9-linked PE32 i386 WineMetal candidate; $i386_clean_preflight proves clean source and 11.9 build inputs" "package this clean artifact into the active candidate and pass live Nidhogg 2/M9 proof before release"
+elif contains_file "$i386_provenance" '^- result: fail$'; then
     evidence="$i386_provenance reports the current i386 bridge is not release-proven"
     if contains_file "$i386_build_preflight" 'PASS \[wine-version\] wine reports wine-11[.]9' &&
         contains_file "$i386_build_preflight" 'FAIL \[source-clean\]'; then

--- a/scripts/audit-wine119-objective-completion.sh
+++ b/scripts/audit-wine119-objective-completion.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  scripts/audit-wine119-objective-completion.sh [output-dir]
+
+Example:
+  scripts/audit-wine119-objective-completion.sh /tmp/metalsharp-wine119-objective-audit
+
+Builds a requirement-by-requirement completion audit for the Wine 11.9 rebuild
+objective. This script does not launch games and does not mutate runtimes.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(cd "$script_dir/.." && pwd -P)"
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+out_dir="${1:-/tmp/metalsharp-wine119-objective-audit-$timestamp}"
+report="$out_dir/objective-completion-audit.md"
+
+mkdir -p "$out_dir"
+
+status_for_file() {
+    [[ -f "$repo_root/$1" ]] && printf 'proven' || printf 'missing'
+}
+
+status_for_path() {
+    [[ -e "$1" ]] && printf 'proven' || printf 'missing'
+}
+
+contains_file() {
+    local file="$1"
+    local pattern="$2"
+    [[ -f "$file" ]] && rg -q "$pattern" "$file"
+}
+
+requirement_row() {
+    local requirement="$1"
+    local status="$2"
+    local evidence="$3"
+    local remaining="$4"
+    printf '| %s | %s | %s | %s |\n' "$requirement" "$status" "$evidence" "$remaining" >> "$report"
+}
+
+forensics="$repo_root/docs/wine-119-rebuild-forensics.md"
+runbook="$repo_root/docs/wine-119-implementation-runbook.md"
+readiness="/tmp/metalsharp-wine119-readiness-current/readiness.md"
+candidate_summary="/tmp/metalsharp-wine119-parity/summary.md"
+fetch_report="/tmp/metalsharp-wine-assets/fetch-report.txt"
+parity_probe="/private/tmp/metalsharp-home-wine119-dxmt32-state/backend-probe-main03327-guard-v2"
+
+main_head="$(git -C "$repo_root" rev-parse --short HEAD)"
+main_descends="no"
+if git -C "$repo_root" merge-base --is-ancestor cebf936 HEAD 2>/dev/null; then
+    main_descends="yes"
+fi
+
+{
+    echo "# Wine 11.9 Objective Completion Audit"
+    echo
+    echo "- captured_at_utc: \`$timestamp\`"
+    echo "- repo: \`$repo_root\`"
+    echo "- head: \`$main_head\`"
+    echo "- descends_from_rollback_cebf936: \`$main_descends\`"
+    echo
+    echo "| Requirement | Status | Evidence | Remaining proof |"
+    echo "| --- | --- | --- | --- |"
+} > "$report"
+
+if [[ "$main_descends" == "yes" ]] && contains_file "$forensics" 'v0[.]33[.]27' && contains_file "$forensics" '797db720c852b7f46356fa2541fb4dac81afcc69'; then
+    requirement_row "Identify yin/yang source of truth" "proven" "rollback base and full regression tip are documented in docs/wine-119-rebuild-forensics.md" "none"
+else
+    requirement_row "Identify yin/yang source of truth" "missing" "expected rollback/regression refs not found in forensics doc" "document and verify main/v0.33.27 versus 797db72"
+fi
+
+if contains_file "$forensics" '^## Commit Replay Ledger$' && contains_file "$forensics" 'Do not replay merge commit' && contains_file "$forensics" '\| `797db72`'; then
+    requirement_row "Compare post-0.33.27 changes commit by commit" "proven" "commit replay ledger covers the regression branch and marks rollup commits unsafe" "none"
+else
+    requirement_row "Compare post-0.33.27 changes commit by commit" "incomplete" "commit ledger evidence is missing or weak" "complete ledger for v0.33.27..797db72"
+fi
+
+if contains_file "$forensics" '^## Wine 11[.]9 Internal Map Against Working Wine 11[.]5$' && contains_file "$forensics" 'lib/wine/i386-windows/winemetal[.]dll' && contains_file "$forensics" 'lib/libMoltenVK[.]dylib'; then
+    requirement_row "Map Wine 11.9 internals against working Wine 11.5" "proven" "forensics map covers runtime shape, WineMetal, Vulkan/MoltenVK, DXMT, and mscompatdb surfaces" "none"
+else
+    requirement_row "Map Wine 11.9 internals against working Wine 11.5" "incomplete" "internal map is missing expected route-critical surfaces" "expand 11.5/11.9 runtime map"
+fi
+
+if contains_file "$fetch_report" 'asset=metalsharp_bundle[.]tar[.]zst' && contains_file "$fetch_report" 'verified=1'; then
+    requirement_row "Use GitHub release asset as Wine 11.9 source" "proven" "$fetch_report verifies bundles/metalsharp_bundle.tar.zst" "none"
+else
+    requirement_row "Use GitHub release asset as Wine 11.9 source" "missing" "$fetch_report not present or not verified" "run scripts/fetch-wine119-release-assets.sh"
+fi
+
+if contains_file "$candidate_summary" '## dxmt32' && contains_file "$candidate_summary" '## borrowed' && contains_file "$candidate_summary" 'Manifest pass alone is not a release gate'; then
+    requirement_row "Prepare 11.9 candidates in 11.5-compatible runtime shape" "proven" "$candidate_summary records clean, dxmt32, and borrowed candidates" "live M9 proof still required before release"
+else
+    requirement_row "Prepare 11.9 candidates in 11.5-compatible runtime shape" "missing" "$candidate_summary missing" "run scripts/prepare-wine119-parity-candidates.sh"
+fi
+
+if contains_file "$readiness" 'PASS \[electron-route\]' && contains_file "$readiness" 'PASS \[mscompatdb-hook\]' && contains_file "$readiness" 'PASS \[parity-home\] active state has no source-home references'; then
+    requirement_row "Prove non-live parity home/backend/app route readiness" "proven" "$readiness passes backend, Electron route, mscompatdb symbol, and isolated state checks" "live suite still required"
+else
+    requirement_row "Prove non-live parity home/backend/app route readiness" "incomplete" "$readiness lacks expected non-live passes" "rerun probe/readiness scripts"
+fi
+
+if contains_file "$readiness" 'FAIL \[live-gate\] no passing live control suite supplied'; then
+    requirement_row "Pass Nidhogg 2, Schedule I, and Subnautica BZ under Wine 11.9" "missing" "$readiness explicitly reports no passing live suite" "run guarded live suite with METALSHARP_RUN_LIVE_GAMES=1 and METALSHARP_REQUIRE_PREEXISTING_WINE_STEAM=1"
+else
+    requirement_row "Pass Nidhogg 2, Schedule I, and Subnautica BZ under Wine 11.9" "unverified" "$readiness does not clearly prove live controls" "inspect METALSHARP_LIVE_SUITE_DIR and verification.md"
+fi
+
+if contains_file "$candidate_summary" 'dxmt32' && contains_file "$candidate_summary" 'release_blockers: 1' && contains_file "$forensics" 'no release-proven 11[.]9-built i386 `winemetal[.]dll`'; then
+    requirement_row "Recover or produce release-proven 11.9 i386 WineMetal" "missing" "candidate summary and forensics mark i386 WineMetal as unresolved" "build/recover true 11.9 i386 winemetal.dll or bless fallback only after live proof"
+else
+    requirement_row "Recover or produce release-proven 11.9 i386 WineMetal" "unverified" "i386 WineMetal status is not explicit" "audit candidate provenance and live M9 result"
+fi
+
+if contains_file "$parity_probe/mscompatdb-hook-surface/hook-surface.json" '"symbolSurfaceReady"[[:space:]]*:[[:space:]]*true' &&
+    contains_file "$parity_probe/mscompatdb-hook-surface/hook-surface.json" '"hookReady"[[:space:]]*:[[:space:]]*false'; then
+    requirement_row "Separate anti-cheat hook surface from runtime hook readiness" "proven-nonlive" "$parity_probe/mscompatdb-hook-surface/hook-surface.json proves symbols and refuses hookReady" "protected runtime launch proof required before hookReady can be true"
+else
+    requirement_row "Separate anti-cheat hook surface from runtime hook readiness" "incomplete" "mscompatdb hook surface audit missing or ambiguous" "run scripts/audit-mscompatdb-hook-surface.sh"
+fi
+
+if contains_file "$runbook" '^## Pass 0:' && contains_file "$runbook" '^## Pass 6:' && contains_file "$runbook" '^## Final Release Checklist$'; then
+    requirement_row "Plan complete multi-pass Wine 11.9 rebuild" "proven" "docs/wine-119-implementation-runbook.md defines passes 0-6 and release checklist" "execute live/release gates before tag"
+else
+    requirement_row "Plan complete multi-pass Wine 11.9 rebuild" "incomplete" "runbook does not contain expected pass matrix" "finish pass-by-pass rebuild design"
+fi
+
+{
+    echo
+    echo "## Summary"
+    echo
+    if rg -q '\| [^|]+ \| (missing|incomplete|unverified)' "$report"; then
+        echo "- gate: fail"
+        echo "- reason: the objective is not complete until missing/incomplete rows are proven."
+    else
+        echo "- gate: pass"
+    fi
+} >> "$report"
+
+cp "$report" "$out_dir/latest.md"
+echo "objective completion audit written: $report"
+if rg -q '\| [^|]+ \| (missing|incomplete|unverified)' "$report"; then
+    exit 2
+fi

--- a/scripts/audit-wine119-readiness.sh
+++ b/scripts/audit-wine119-readiness.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  scripts/audit-wine119-readiness.sh [parity-home] [output-dir]
+
+Example:
+  scripts/audit-wine119-readiness.sh \
+    /private/tmp/metalsharp-home-wine119-dxmt32-state \
+    /tmp/metalsharp-wine119-readiness
+
+Runs a non-live Wine 11.9 readiness audit. This script does not launch games.
+It checks whether the repo, installed 11.5 baseline, prepared 11.9 candidates,
+isolated parity home, and existing live-suite proof satisfy the rebuild gates.
+
+The final release gate still requires a passing live control suite.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(cd "$script_dir/.." && pwd -P)"
+parity_home="${1:-/private/tmp/metalsharp-home-wine119-dxmt32-state}"
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+out_dir="${2:-/tmp/metalsharp-wine119-readiness-$timestamp}"
+report="$out_dir/readiness.md"
+failures=0
+warnings=0
+
+mkdir -p "$out_dir"
+: > "$report"
+
+append() {
+    printf '%s\n' "$*" >> "$report"
+}
+
+pass() {
+    append "- PASS [$1] $2"
+}
+
+fail() {
+    failures=$((failures + 1))
+    append "- FAIL [$1] $2"
+}
+
+warn() {
+    warnings=$((warnings + 1))
+    append "- WARN [$1] $2"
+}
+
+contains() {
+    local file="$1"
+    local pattern="$2"
+    [[ -f "$file" ]] && rg -q "$pattern" "$file"
+}
+
+canonical_dir() {
+    local path="$1"
+    if [[ -d "$path" ]]; then
+        cd "$path" && pwd -P
+    else
+        printf '%s\n' "$path"
+    fi
+}
+
+check_wine_version() {
+    local label="$1"
+    local wine_root="$2"
+    local expected="$3"
+    if [[ ! -x "$wine_root/bin/wine" ]]; then
+        fail "$label" "missing executable wine at $wine_root/bin/wine"
+        return
+    fi
+    local version
+    version="$("$wine_root/bin/wine" --version 2>&1 || true)"
+    if [[ "$version" == "$expected" ]]; then
+        pass "$label" "wine version is $expected"
+    else
+        fail "$label" "wine version is '$version', expected '$expected'"
+    fi
+}
+
+candidate_gate() {
+    local candidate="$1"
+    local summary="$2"
+    awk -v candidate="$candidate" '
+        $0 == "## " candidate { in_section=1; next }
+        in_section && /^## (clean|dxmt32|borrowed|Required Live Gates)$/ { in_section=0 }
+        in_section && /^- gate: / {
+            print $3
+            exit
+        }
+    ' "$summary"
+}
+
+append "# MetalSharp Wine 11.9 Readiness Audit"
+append
+append "- captured_at_utc: \`$timestamp\`"
+append "- repo: \`$repo_root\`"
+append "- parity_home: \`$parity_home\`"
+append
+
+append "## Source State"
+append
+main_head="$(git -C "$repo_root" rev-parse --short HEAD)"
+main_tag="$(git -C "$repo_root" describe --tags --exact-match HEAD 2>/dev/null || true)"
+if [[ "$main_head" == "cebf936" ]]; then
+    pass "repo" "main HEAD is rollback commit cebf936"
+else
+    warn "repo" "main HEAD is $main_head; expected rollback commit cebf936 for this audit"
+fi
+if [[ "$main_tag" == "v0.33.27" ]]; then
+    pass "repo" "HEAD is exactly tag v0.33.27"
+else
+    warn "repo" "HEAD exact tag is '${main_tag:-none}', but rollback commit may still be tree-equivalent"
+fi
+
+check_wine_version "installed-11.5" "$HOME/.metalsharp/runtime/wine" "wine-11.5"
+if [[ -f "$HOME/.metalsharp/runtime/wine/lib/wine/i386-windows/winemetal.dll" ]]; then
+    pass "installed-11.5" "i386 WineMetal baseline exists"
+else
+    fail "installed-11.5" "missing i386 WineMetal baseline"
+fi
+append
+
+append "## Candidate Runtime Shape"
+for candidate in clean dxmt32 borrowed; do
+    root="/tmp/metalsharp-wine119-parity/candidates/$candidate/wine"
+    check_wine_version "candidate-$candidate" "$root" "wine-11.9"
+done
+
+if [[ -f /tmp/metalsharp-wine119-parity/summary.md ]]; then
+    pass "candidates" "candidate summary exists"
+    [[ "$(candidate_gate clean /tmp/metalsharp-wine119-parity/summary.md)" == "fail" ]] \
+        && pass "candidate-clean" "clean candidate is documented as fail" \
+        || warn "candidate-clean" "clean candidate failure not found in summary"
+    [[ "$(candidate_gate dxmt32 /tmp/metalsharp-wine119-parity/summary.md)" == "fail" ]] \
+        && pass "candidate-dxmt32" "dxmt32 candidate is documented as needing live proof" \
+        || warn "candidate-dxmt32" "dxmt32 live-proof blocker not found in summary"
+    [[ "$(candidate_gate borrowed /tmp/metalsharp-wine119-parity/summary.md)" == "pass" ]] \
+        && pass "candidate-borrowed" "borrowed candidate is manifest-complete" \
+        || warn "candidate-borrowed" "borrowed manifest pass not found in summary"
+else
+    fail "candidates" "missing /tmp/metalsharp-wine119-parity/summary.md"
+fi
+append
+
+append "## Isolated Parity Home"
+if [[ ! -d "$parity_home/.metalsharp/runtime/wine" ]]; then
+    fail "parity-home" "missing parity runtime"
+else
+    parity_home="$(canonical_dir "$parity_home")"
+    check_wine_version "parity-home" "$parity_home/.metalsharp/runtime/wine" "wine-11.9"
+fi
+
+install_report="$parity_home/parity-install-report.txt"
+if [[ -f "$install_report" ]]; then
+    pass "parity-home" "install report exists"
+    source_ms_home="$(awk -F= '$1 == "source_metalsharp_home" { print substr($0, index($0, "=") + 1); exit }' "$install_report")"
+else
+    fail "parity-home" "missing install report"
+    source_ms_home=""
+fi
+
+if [[ -n "$source_ms_home" ]]; then
+    stale_refs="$out_dir/stale-active-state-refs.txt"
+    : > "$stale_refs"
+    if find "$parity_home/.metalsharp/bottles" "$parity_home/.metalsharp/compatdata" "$parity_home/.metalsharp/configs" \
+        -type f \( -name '*.json' -o -name '*.toml' -o -name '*.conf' -o -name '*.env' \) -print0 2>/dev/null \
+        | xargs -0 rg -n --fixed-strings "$source_ms_home" -S > "$stale_refs" 2>/dev/null; then
+        fail "parity-home" "active state still references source MetalSharp home; see $stale_refs"
+    else
+        pass "parity-home" "active state has no source-home references"
+    fi
+else
+    fail "parity-home" "cannot check stale state refs without source_metalsharp_home"
+fi
+
+if find "$parity_home/.metalsharp/compatdata" -type d -name logs -print -quit 2>/dev/null | grep -q .; then
+    fail "parity-home" "copied compatdata logs are present and can contaminate proof"
+else
+    pass "parity-home" "copied compatdata logs are pruned"
+fi
+
+for appid in 535520 3164500 848450; do
+    bottle="$parity_home/.metalsharp/bottles/steam_$appid/bottle.json"
+    compat="$parity_home/.metalsharp/compatdata/$appid/metalsharp-compatdata.json"
+    if [[ -f "$bottle" ]] && grep -Fq "$parity_home/.metalsharp" "$bottle"; then
+        pass "control-$appid" "bottle manifest references parity home"
+    else
+        fail "control-$appid" "bottle manifest missing or not bound to parity home"
+    fi
+    if [[ -f "$compat" ]] && grep -Fq "$parity_home/.metalsharp" "$compat"; then
+        pass "control-$appid" "compatdata manifest references parity home"
+    else
+        fail "control-$appid" "compatdata manifest missing or not bound to parity home"
+    fi
+done
+append
+
+append "## Backend Preflight"
+probe="$parity_home/backend-probe-main03327-guard-v2"
+if [[ -f "$probe/status.json" ]]; then
+    contains "$probe/status.json" '"version"[[:space:]]*:[[:space:]]*"0\.33\.27"' \
+        && pass "backend" "preflight status reports version 0.33.27" \
+        || fail "backend" "preflight status does not report version 0.33.27"
+else
+    warn "backend" "latest guard-v2 backend preflight not found"
+fi
+append
+
+append "## Live Gate"
+live_suite="${METALSHARP_LIVE_SUITE_DIR:-}"
+if [[ -n "$live_suite" && -d "$live_suite" ]]; then
+    if "$repo_root/scripts/verify-wine119-live-control-suite.sh" "$live_suite" >/dev/null 2>&1; then
+        pass "live-gate" "live control suite verifier passes: $live_suite"
+    else
+        fail "live-gate" "live control suite verifier fails: $live_suite"
+    fi
+else
+    fail "live-gate" "no passing live control suite supplied; set METALSHARP_LIVE_SUITE_DIR after running guarded live controls"
+fi
+append
+
+append "## Summary"
+append
+append "- failures: $failures"
+append "- warnings: $warnings"
+if [[ "$failures" -eq 0 ]]; then
+    append "- gate: pass"
+    echo "Wine 11.9 readiness audit passed: $report"
+else
+    append "- gate: fail"
+    echo "Wine 11.9 readiness audit failed: $report"
+    exit 2
+fi

--- a/scripts/audit-wine119-readiness.sh
+++ b/scripts/audit-wine119-readiness.sh
@@ -216,10 +216,10 @@ else
     fail "parity-home" "cannot check stale state refs without source_metalsharp_home"
 fi
 
-if find "$parity_home/.metalsharp/compatdata" -type d -name logs -print -quit 2>/dev/null | grep -q .; then
-    fail "parity-home" "copied compatdata logs are present and can contaminate proof"
+if find "$parity_home/.metalsharp/compatdata" -path '*/logs/*' -type f -print -quit 2>/dev/null | grep -q .; then
+    fail "parity-home" "copied compatdata log files are present and can contaminate proof"
 else
-    pass "parity-home" "copied compatdata logs are pruned"
+    pass "parity-home" "copied compatdata log files are pruned"
 fi
 
 for appid in 535520 3164500 848450; do
@@ -246,6 +246,15 @@ if [[ -f "$probe/status.json" ]]; then
         || fail "backend" "preflight status does not report version 0.33.27"
 else
     warn "backend" "latest guard-v2 backend preflight not found"
+fi
+
+route_audit="$probe/electron-launch-routes/electron-launch-route-audit.json"
+if [[ -f "$route_audit" ]]; then
+    contains "$route_audit" '"ok"[[:space:]]*:[[:space:]]*true' \
+        && pass "electron-route" "app-facing route audit keeps controls on /steam/launch-game" \
+        || fail "electron-route" "app-facing route audit did not pass"
+else
+    warn "electron-route" "app-facing route audit not found at $route_audit"
 fi
 append
 

--- a/scripts/audit-wine119-readiness.sh
+++ b/scripts/audit-wine119-readiness.sh
@@ -86,6 +86,27 @@ check_wine_version() {
     fi
 }
 
+check_local_moltenvk_icd() {
+    local label="$1"
+    local wine_root="$2"
+    local icd="$wine_root/etc/vulkan/icd.d/MoltenVK_x86_64_icd.json"
+    local expected="$wine_root/lib/libMoltenVK.dylib"
+
+    if [[ ! -f "$expected" ]]; then
+        fail "$label" "missing candidate-local MoltenVK ICD target: $expected"
+        return
+    fi
+    if [[ ! -f "$icd" ]]; then
+        fail "$label" "missing MoltenVK_x86_64_icd.json"
+        return
+    fi
+    if grep -Fq "\"library_path\": \"$expected\"" "$icd"; then
+        pass "$label" "MoltenVK ICD points at candidate-local runtime"
+    else
+        fail "$label" "MoltenVK ICD does not point at candidate-local runtime"
+    fi
+}
+
 candidate_gate() {
     local candidate="$1"
     local summary="$2"
@@ -145,6 +166,7 @@ fi
 for candidate in clean dxmt32 borrowed; do
     root="/tmp/metalsharp-wine119-parity/candidates/$candidate/wine"
     check_wine_version "candidate-$candidate" "$root" "wine-11.9"
+    check_local_moltenvk_icd "candidate-$candidate" "$root"
 done
 
 if [[ -f /tmp/metalsharp-wine119-parity/summary.md ]]; then

--- a/scripts/audit-wine119-readiness.sh
+++ b/scripts/audit-wine119-readiness.sh
@@ -112,8 +112,10 @@ main_head="$(git -C "$repo_root" rev-parse --short HEAD)"
 main_tag="$(git -C "$repo_root" describe --tags --exact-match HEAD 2>/dev/null || true)"
 if [[ "$main_head" == "cebf936" ]]; then
     pass "repo" "main HEAD is rollback commit cebf936"
+elif git -C "$repo_root" merge-base --is-ancestor cebf936 HEAD 2>/dev/null; then
+    pass "repo" "current branch descends from rollback commit cebf936"
 else
-    warn "repo" "main HEAD is $main_head; expected rollback commit cebf936 for this audit"
+    warn "repo" "current HEAD is $main_head and does not descend from rollback commit cebf936"
 fi
 if [[ "$main_tag" == "v0.33.27" ]]; then
     pass "repo" "HEAD is exactly tag v0.33.27"
@@ -130,6 +132,16 @@ fi
 append
 
 append "## Candidate Runtime Shape"
+fetch_report="/tmp/metalsharp-wine-assets/fetch-report.txt"
+if [[ -f "$fetch_report" ]] &&
+    contains "$fetch_report" 'asset=metalsharp_bundle\.tar\.zst' &&
+    contains "$fetch_report" 'sha256=833f63566b0c1b98fa917337716f57d689c42d0c2878204b4716ba29637d7372' &&
+    contains "$fetch_report" 'verified=1'; then
+    pass "release-asset" "GitHub bundles/metalsharp_bundle.tar.zst was fetched and SHA256 verified"
+else
+    warn "release-asset" "verified fetch report not found at $fetch_report"
+fi
+
 for candidate in clean dxmt32 borrowed; do
     root="/tmp/metalsharp-wine119-parity/candidates/$candidate/wine"
     check_wine_version "candidate-$candidate" "$root" "wine-11.9"

--- a/scripts/audit-wine119-readiness.sh
+++ b/scripts/audit-wine119-readiness.sh
@@ -256,6 +256,18 @@ if [[ -f "$route_audit" ]]; then
 else
     warn "electron-route" "app-facing route audit not found at $route_audit"
 fi
+
+hook_audit="$probe/mscompatdb-hook-surface/hook-surface.json"
+if [[ -f "$hook_audit" ]]; then
+    contains "$hook_audit" '"symbolSurfaceReady"[[:space:]]*:[[:space:]]*true' \
+        && pass "mscompatdb-hook" "ntdll hook symbols are present in the parity runtime" \
+        || fail "mscompatdb-hook" "ntdll hook symbols are not ready in the parity runtime"
+    contains "$hook_audit" '"hookReady"[[:space:]]*:[[:space:]]*false' \
+        && pass "mscompatdb-hook" "hook readiness is explicitly not claimed without runtime proof" \
+        || fail "mscompatdb-hook" "hook readiness state is ambiguous"
+else
+    warn "mscompatdb-hook" "hook surface audit not found at $hook_audit"
+fi
 append
 
 append "## Live Gate"

--- a/scripts/audit-wine119-readiness.sh
+++ b/scripts/audit-wine119-readiness.sh
@@ -16,6 +16,10 @@ It checks whether the repo, installed 11.5 baseline, prepared 11.9 candidates,
 isolated parity home, and existing live-suite proof satisfy the rebuild gates.
 
 The final release gate still requires a passing live control suite.
+
+Environment:
+  METALSHARP_WINE119_CANDIDATE_WORK_DIR  candidate work dir, default prefers
+                                         AverySSD clean-i386 output when present
 USAGE
 }
 
@@ -27,6 +31,14 @@ fi
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 repo_root="$(cd "$script_dir/.." && pwd -P)"
 parity_home="${1:-/private/tmp/metalsharp-home-wine119-dxmt32-state}"
+default_candidate_work_dir="/tmp/metalsharp-wine119-parity"
+clean_candidate_work_dir="/Volumes/AverySSD/metalsharp/wine119-parity-clean-i386"
+if [[ -z "${METALSHARP_WINE119_CANDIDATE_WORK_DIR:-}" && -f "$clean_candidate_work_dir/summary.md" ]]; then
+    candidate_work_dir="$clean_candidate_work_dir"
+else
+    candidate_work_dir="${METALSHARP_WINE119_CANDIDATE_WORK_DIR:-$default_candidate_work_dir}"
+fi
+candidate_summary="$candidate_work_dir/summary.md"
 timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
 out_dir="${2:-/tmp/metalsharp-wine119-readiness-$timestamp}"
 report="$out_dir/readiness.md"
@@ -125,6 +137,7 @@ append
 append "- captured_at_utc: \`$timestamp\`"
 append "- repo: \`$repo_root\`"
 append "- parity_home: \`$parity_home\`"
+append "- candidate_work_dir: \`$candidate_work_dir\`"
 append
 
 append "## Source State"
@@ -164,24 +177,44 @@ else
 fi
 
 for candidate in clean dxmt32 borrowed; do
-    root="/tmp/metalsharp-wine119-parity/candidates/$candidate/wine"
+    root="$candidate_work_dir/candidates/$candidate/wine"
     check_wine_version "candidate-$candidate" "$root" "wine-11.9"
     check_local_moltenvk_icd "candidate-$candidate" "$root"
 done
 
-if [[ -f /tmp/metalsharp-wine119-parity/summary.md ]]; then
+if [[ -f "$candidate_summary" ]]; then
     pass "candidates" "candidate summary exists"
-    [[ "$(candidate_gate clean /tmp/metalsharp-wine119-parity/summary.md)" == "fail" ]] \
+    [[ "$(candidate_gate clean "$candidate_summary")" == "fail" ]] \
         && pass "candidate-clean" "clean candidate is documented as fail" \
         || warn "candidate-clean" "clean candidate failure not found in summary"
-    [[ "$(candidate_gate dxmt32 /tmp/metalsharp-wine119-parity/summary.md)" == "fail" ]] \
+    [[ "$(candidate_gate dxmt32 "$candidate_summary")" == "fail" ]] \
         && pass "candidate-dxmt32" "dxmt32 candidate is documented as needing live proof" \
         || warn "candidate-dxmt32" "dxmt32 live-proof blocker not found in summary"
-    [[ "$(candidate_gate borrowed /tmp/metalsharp-wine119-parity/summary.md)" == "pass" ]] \
+    [[ "$(candidate_gate borrowed "$candidate_summary")" == "pass" ]] \
         && pass "candidate-borrowed" "borrowed candidate is manifest-complete" \
         || warn "candidate-borrowed" "borrowed manifest pass not found in summary"
+    if contains "$candidate_summary" 'dxmt32_source_kind: `clean-11[.]9-linked-default`'; then
+        pass "candidate-dxmt32-source" "dxmt32 defaults to clean 11.9-linked i386 WineMetal"
+    else
+        warn "candidate-dxmt32-source" "dxmt32 summary does not prove clean 11.9-linked source selection"
+    fi
 else
-    fail "candidates" "missing /tmp/metalsharp-wine119-parity/summary.md"
+    fail "candidates" "missing $candidate_summary"
+fi
+
+dxmt32_prepare="$candidate_work_dir/candidates/dxmt32/prepare-report.txt"
+dxmt32_provenance="$candidate_work_dir/candidates/dxmt32/provenance-report.txt"
+if [[ -f "$dxmt32_prepare" ]] && contains "$dxmt32_prepare" 'i386_winemetal_source=/tmp/metalsharp-dxmt-clean-build32-wine119/src/winemetal/winemetal[.]dll'; then
+    pass "candidate-dxmt32-source" "prepare report records the clean i386 WineMetal source"
+else
+    fail "candidate-dxmt32-source" "prepare report does not record the clean i386 WineMetal source: $dxmt32_prepare"
+fi
+if [[ -f "$dxmt32_provenance" ]] &&
+    contains "$dxmt32_provenance" 'source_sha256=12b9343459d28dfe1d7668a31a58a0c3506948d7c533507fdaec65d59c6697ab' &&
+    contains "$dxmt32_provenance" 'destination_sha256=12b9343459d28dfe1d7668a31a58a0c3506948d7c533507fdaec65d59c6697ab'; then
+    pass "candidate-dxmt32-source" "provenance records clean i386 WineMetal source/destination SHA256"
+else
+    fail "candidate-dxmt32-source" "provenance does not prove clean i386 WineMetal SHA256 copy: $dxmt32_provenance"
 fi
 append
 
@@ -197,6 +230,13 @@ install_report="$parity_home/parity-install-report.txt"
 if [[ -f "$install_report" ]]; then
     pass "parity-home" "install report exists"
     source_ms_home="$(awk -F= '$1 == "source_metalsharp_home" { print substr($0, index($0, "=") + 1); exit }' "$install_report")"
+    installed_candidate_root="$(awk -F= '$1 == "candidate_root" { print substr($0, index($0, "=") + 1); exit }' "$install_report")"
+    expected_candidate_root="$candidate_work_dir/candidates/dxmt32/wine"
+    if [[ "$(canonical_dir "$installed_candidate_root")" == "$(canonical_dir "$expected_candidate_root")" ]]; then
+        pass "parity-home" "install report source matches the audited clean dxmt32 candidate"
+    else
+        fail "parity-home" "install report candidate_root '$installed_candidate_root' does not match audited dxmt32 '$expected_candidate_root'"
+    fi
 else
     fail "parity-home" "missing install report"
     source_ms_home=""

--- a/scripts/capture-steam-game-proof.sh
+++ b/scripts/capture-steam-game-proof.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  scripts/capture-steam-game-proof.sh <appid> <exe-match> [output-dir]
+
+Examples:
+  scripts/capture-steam-game-proof.sh 535520 Nidhogg_2 /tmp/metalsharp-proof-nidhogg2
+  scripts/capture-steam-game-proof.sh 3164500 'Schedule I' /tmp/metalsharp-proof-schedule-i
+  scripts/capture-steam-game-proof.sh 848450 SubnauticaZero /tmp/metalsharp-proof-subnautica-bz
+
+Captures live and recent-launch proof for a Steam game: matching processes,
+latest launch log, compatdata/bottle manifests, route cache listings, and lsof
+for matching live PIDs. The script is read-only against METALSHARP_HOME, or
+~/.metalsharp when METALSHARP_HOME is unset.
+
+For Wine 11.9 parity proof, set METALSHARP_REQUIRE_PARITY_HOME=1. In that mode
+METALSHARP_HOME must be explicit and must not be the caller's real ~/.metalsharp.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+appid="${1:-}"
+exe_match="${2:-}"
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+out_dir="${3:-/tmp/metalsharp-steam-proof-${appid:-unknown}-$timestamp}"
+
+if [[ -z "$appid" || -z "$exe_match" ]]; then
+    usage >&2
+    exit 1
+fi
+
+metalsharp_home="${METALSHARP_HOME:-$HOME/.metalsharp}"
+if [[ -d "$metalsharp_home" ]]; then
+    metalsharp_home="$(cd "$metalsharp_home" && pwd -P)"
+fi
+
+if [[ "${METALSHARP_REQUIRE_PARITY_HOME:-0}" == "1" ]]; then
+    if [[ -z "${METALSHARP_HOME:-}" ]]; then
+        echo "METALSHARP_REQUIRE_PARITY_HOME=1 requires explicit METALSHARP_HOME" >&2
+        exit 1
+    fi
+    real_home_abs="$(cd "$HOME" && pwd -P)"
+    real_ms_home="$real_home_abs/.metalsharp"
+    if [[ "$metalsharp_home" == "$real_ms_home" ]]; then
+        echo "refusing parity proof against real MetalSharp home: $metalsharp_home" >&2
+        exit 1
+    fi
+fi
+compat_dir="$metalsharp_home/compatdata/$appid"
+bottle_dir="$metalsharp_home/bottles/steam_$appid"
+
+mkdir -p "$out_dir"
+
+copy_if_present() {
+    local src="$1"
+    local dst="$2"
+    if [[ -e "$src" ]]; then
+        cp "$src" "$dst"
+    fi
+}
+
+ps -axo pid,ppid,etime,command > "$out_dir/all-processes.txt"
+grep -iE "$exe_match|$appid|UnityCrash|Steam.exe|steam.exe|metalsharp-backend|wine" \
+    "$out_dir/all-processes.txt" > "$out_dir/matching-processes.txt" || true
+
+latest_log=""
+if [[ -d "$compat_dir/logs" ]]; then
+    latest_log="$(find "$compat_dir/logs" -name 'launch-*.log' -type f -print0 2>/dev/null \
+        | xargs -0 ls -t 2>/dev/null \
+        | head -1 || true)"
+fi
+
+if [[ -n "$latest_log" ]]; then
+    copy_if_present "$latest_log" "$out_dir/$(basename "$latest_log")"
+fi
+
+copy_if_present "$compat_dir/metalsharp-compatdata.json" "$out_dir/metalsharp-compatdata.json"
+copy_if_present "$bottle_dir/bottle.json" "$out_dir/bottle.json"
+
+if [[ -d "$metalsharp_home/shader-cache" ]]; then
+    find "$metalsharp_home/shader-cache" -path "*/$appid/*" -maxdepth 5 -print -exec ls -ld {} \; \
+        > "$out_dir/shader-cache-files.txt" 2>/dev/null || true
+fi
+
+if [[ -d "$metalsharp_home/pipeline-cache" ]]; then
+    find "$metalsharp_home/pipeline-cache" -path "*/$appid/*" -maxdepth 5 -print -exec ls -ld {} \; \
+        > "$out_dir/pipeline-cache-files.txt" 2>/dev/null || true
+fi
+
+awk -v pat="$(printf '%s' "$exe_match" | tr '[:upper:]' '[:lower:]')" '
+    {
+        line = tolower($0)
+        if (index(line, pat) > 0 &&
+            index(line, "capture-steam-game-proof.sh") == 0 &&
+            index(line, "/bin/zsh -lc") == 0 &&
+            index(line, "/bin/bash") == 0 &&
+            index(line, " rg ") == 0 &&
+            index(line, " grep ") == 0) print $1
+    }
+' "$out_dir/all-processes.txt" > "$out_dir/game-pids.txt"
+
+while read -r pid; do
+    if [[ "$pid" =~ ^[0-9]+$ ]]; then
+        lsof -p "$pid" > "$out_dir/lsof-$pid.txt" 2>&1 || true
+    fi
+done < "$out_dir/game-pids.txt"
+
+{
+    echo "appid=$appid"
+    echo "exe_match=$exe_match"
+    echo "captured_at_utc=$timestamp"
+    echo "metalsharp_home=$metalsharp_home"
+    echo "compat_dir=$compat_dir"
+    echo "bottle_dir=$bottle_dir"
+    echo "latest_launch_log=$latest_log"
+    echo
+    echo "[matching_processes]"
+    cat "$out_dir/matching-processes.txt"
+    echo
+    echo "[game_pids]"
+    if [[ -s "$out_dir/game-pids.txt" ]]; then
+        cat "$out_dir/game-pids.txt"
+    else
+        echo "none; live lsof proof still required"
+    fi
+    echo
+    echo "[launch_contract]"
+    if [[ -n "$latest_log" ]]; then
+        rg -n '^(appid|pipeline|prefix|metalsharp_home|host_runtime|wine_runtime|steam_identity_mode|cwd|exe|args|compatdata|compatdata_manifest)=' "$latest_log" || true
+        rg -n 'DXMT|dxmt|winemetal|MoltenVK|feature level|DirectX|shader|swap|mscompatdb|KeService|Steam' "$latest_log" || true
+    else
+        echo "no launch log found"
+    fi
+    echo
+    echo "[loaded_route_files]"
+    for lsof_file in "$out_dir"/lsof-*.txt; do
+        [[ -f "$lsof_file" ]] || continue
+        echo "== $(basename "$lsof_file") =="
+        rg -n 'd3d|dxgi|winemetal|MoltenVK|shader-cache|pipeline-cache|com\.apple\.metal|Player\.log|Steam|Subnautica|Nidhogg|Schedule' "$lsof_file" || true
+    done
+    echo
+    echo "[shader_cache_files]"
+    if [[ -f "$out_dir/shader-cache-files.txt" ]]; then
+        cat "$out_dir/shader-cache-files.txt"
+    else
+        echo "no shader cache listing found"
+    fi
+    echo
+    echo "[pipeline_cache_files]"
+    if [[ -f "$out_dir/pipeline-cache-files.txt" ]]; then
+        cat "$out_dir/pipeline-cache-files.txt"
+    else
+        echo "no pipeline cache listing found"
+    fi
+} > "$out_dir/summary.txt"
+
+echo "steam game proof written: $out_dir"
+echo "summary: $out_dir/summary.txt"

--- a/scripts/compare-runtime-manifests.sh
+++ b/scripts/compare-runtime-manifests.sh
@@ -14,7 +14,9 @@ Example:
 
 Classifies route-critical Wine/DXMT runtime manifest deltas into expected
 version changes, expected DXMT/anti-cheat changes, packaging defects, and
-release blockers. Inputs are directories produced by scripts/runtime-manifest.sh.
+release blockers. It also reports critical-path file(1) type changes when the
+input manifests include critical-file.txt. Inputs are directories produced by
+scripts/runtime-manifest.sh.
 USAGE
 }
 
@@ -59,6 +61,22 @@ extract_value() {
     awk -v rel="$rel" '$2 == rel { print $1; found=1 } END { if (!found) exit 1 }' "$file" 2>/dev/null || true
 }
 
+extract_block_line() {
+    local file="$1"
+    local rel="$2"
+    [[ -f "$file" ]] || return 0
+    awk -v header="== $rel ==" '
+        $0 == header {
+            getline
+            sub(/^[^:]+: /, "")
+            print
+            found=1
+            exit
+        }
+        END { if (!found) exit 1 }
+    ' "$file" 2>/dev/null || true
+}
+
 classify_path() {
     local rel="$1"
     case "$rel" in
@@ -67,6 +85,9 @@ classify_path() {
             ;;
         lib/dxmt/x86_64-windows/d3d12.dll|lib/dxmt/x86_64-windows/dxgi.dll|lib/dxmt/x86_64-unix/winemetal.so)
             echo "expected_dxmt_delta"
+            ;;
+        lib/dxmt/i386-windows/d3d11.dll|lib/dxmt/i386-windows/dxgi.dll|lib/dxmt/i386-windows/winemetal.dll)
+            echo "optional_i386_dxmt_source_surface"
             ;;
         lib/wine/x86_64-unix/mscompatdb.so|lib/wine/x86_64-unix/mscompatdb.dylib)
             echo "expected_anticheat_delta"
@@ -134,10 +155,13 @@ unknowns=0
         class="$(classify_path "$rel")"
         gate="ok"
 
-        if [[ "$cand_hash" == "MISSING" || "$cand_hash" == "ABSENT" ]]; then
+        if [[ ("$base_hash" == "MISSING" || "$base_hash" == "ABSENT") && ("$cand_hash" == "MISSING" || "$cand_hash" == "ABSENT") ]]; then
+            gate="ok_absent_in_both"
+        elif [[ "$cand_hash" == "MISSING" || "$cand_hash" == "ABSENT" ]]; then
             case "$class" in
                 expected_anticheat_delta)
-                    gate="ok_if_intentional_new_surface_absent"
+                    gate="release_blocker_missing_11_9_anticheat_surface"
+                    release_blockers=$((release_blockers + 1))
                     ;;
                 expected_vulkan_icd_local_binding)
                     gate="packaging_defect"
@@ -168,6 +192,34 @@ unknowns=0
 
         printf '| `%s` | `%s` | `%s` | `%s` | `%s` |\n' "$rel" "$base_hash" "$cand_hash" "$class" "$gate"
     done < "$all_paths"
+
+    if [[ -f "$baseline/critical-file.txt" || -f "$candidate/critical-file.txt" ]]; then
+        echo
+        echo "## Critical File Type Changes"
+        echo
+        echo "| Path | Baseline file(1) | Candidate file(1) | Gate |"
+        echo "| --- | --- | --- | --- |"
+
+        while IFS= read -r rel; do
+            [[ -z "$rel" ]] && continue
+            base_type="$(extract_block_line "$baseline/critical-file.txt" "$rel")"
+            cand_type="$(extract_block_line "$candidate/critical-file.txt" "$rel")"
+            [[ -z "$base_type" ]] && base_type="missing manifest evidence"
+            [[ -z "$cand_type" ]] && cand_type="missing manifest evidence"
+            if [[ "$base_type" != "$cand_type" || "$base_type" == *"missing"* || "$cand_type" == *"missing"* ]]; then
+                gate="review"
+                class="$(classify_path "$rel")"
+                if [[ "$class" == "optional_i386_dxmt_source_surface" && "$base_type" == "missing" && "$cand_type" == "missing" ]]; then
+                    gate="ok_absent_optional"
+                elif [[ "$cand_type" == "missing"* || "$cand_type" == "missing manifest evidence" ]]; then
+                    gate="release_blocker_if_route_critical"
+                fi
+                base_type="${base_type//|/\\|}"
+                cand_type="${cand_type//|/\\|}"
+                printf '| `%s` | `%s` | `%s` | `%s` |\n' "$rel" "$base_type" "$cand_type" "$gate"
+            fi
+        done < "$all_paths"
+    fi
 
     echo
     echo "## Summary"

--- a/scripts/compare-runtime-manifests.sh
+++ b/scripts/compare-runtime-manifests.sh
@@ -74,7 +74,10 @@ classify_path() {
         lib/wine/x86_64-unix/winemetal.so|lib/wine/x86_64-windows/winemetal.dll)
             echo "expected_rebound_from_dxmt"
             ;;
-        bin/metalsharp-wine|etc/dxmt.conf|etc/mscompatdb_rules.toml|etc/vulkan/icd.d/MoltenVK_icd.json|etc/vulkan/icd.d/MoltenVK_x86_64_icd.json|lib/dxmt/x86_64-windows/d3d10core.dll|lib/dxmt/x86_64-windows/d3d11.dll|lib/dxmt/x86_64-windows/winemetal.dll|lib/wine/x86_64-unix/libMoltenVK.1.dylib)
+        etc/vulkan/icd.d/MoltenVK_icd.json|etc/vulkan/icd.d/MoltenVK_x86_64_icd.json|lib/libMoltenVK.dylib)
+            echo "expected_vulkan_icd_local_binding"
+            ;;
+        bin/metalsharp-wine|etc/dxmt.conf|etc/mscompatdb_rules.toml|lib/dxmt/x86_64-windows/d3d10core.dll|lib/dxmt/x86_64-windows/d3d11.dll|lib/dxmt/x86_64-windows/winemetal.dll|lib/wine/x86_64-unix/libMoltenVK.1.dylib)
             echo "must_match"
             ;;
         lib/wine/x86_64-windows/d3d11.dll|lib/wine/x86_64-windows/dxgi.dll|lib/wine/i386-windows/d3d11.dll|lib/wine/i386-windows/dxgi.dll)
@@ -135,6 +138,10 @@ unknowns=0
             case "$class" in
                 expected_anticheat_delta)
                     gate="ok_if_intentional_new_surface_absent"
+                    ;;
+                expected_vulkan_icd_local_binding)
+                    gate="packaging_defect"
+                    packaging_defects=$((packaging_defects + 1))
                     ;;
                 must_exist_for_m9_or_live_prove_unneeded)
                     gate="release_blocker"

--- a/scripts/compare-runtime-manifests.sh
+++ b/scripts/compare-runtime-manifests.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  scripts/compare-runtime-manifests.sh <baseline-manifest-dir> <candidate-manifest-dir> [report-file]
+
+Example:
+  scripts/compare-runtime-manifests.sh \
+    /tmp/metalsharp-runtime-11.5-current \
+    /tmp/metalsharp-runtime-11.9-candidate \
+    /tmp/metalsharp-runtime-11.9-candidate/classified-diff.md
+
+Classifies route-critical Wine/DXMT runtime manifest deltas into expected
+version changes, expected DXMT/anti-cheat changes, packaging defects, and
+release blockers. Inputs are directories produced by scripts/runtime-manifest.sh.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+baseline="${1:-}"
+candidate="${2:-}"
+report="${3:-}"
+
+if [[ -z "$baseline" || -z "$candidate" ]]; then
+    usage >&2
+    exit 1
+fi
+
+for dir in "$baseline" "$candidate"; do
+    if [[ ! -d "$dir" ]]; then
+        echo "manifest directory not found: $dir" >&2
+        exit 1
+    fi
+    if [[ ! -f "$dir/critical-sha256.txt" ]]; then
+        echo "missing critical-sha256.txt in $dir" >&2
+        exit 1
+    fi
+done
+
+if [[ -z "$report" ]]; then
+    report="$candidate/classified-diff.md"
+fi
+
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/metalsharp-manifest-compare.XXXXXX")"
+cleanup() {
+    rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+extract_value() {
+    local file="$1"
+    local rel="$2"
+    awk -v rel="$rel" '$2 == rel { print $1; found=1 } END { if (!found) exit 1 }' "$file" 2>/dev/null || true
+}
+
+classify_path() {
+    local rel="$1"
+    case "$rel" in
+        bin/wine|bin/wineserver|share/wine/wine.inf|lib/wine/x86_64-unix/ntdll.so|lib/wine/x86_64-unix/win32u.so)
+            echo "expected_wine_version_delta"
+            ;;
+        lib/dxmt/x86_64-windows/d3d12.dll|lib/dxmt/x86_64-windows/dxgi.dll|lib/dxmt/x86_64-unix/winemetal.so)
+            echo "expected_dxmt_delta"
+            ;;
+        lib/wine/x86_64-unix/mscompatdb.so|lib/wine/x86_64-unix/mscompatdb.dylib)
+            echo "expected_anticheat_delta"
+            ;;
+        lib/wine/x86_64-unix/winemetal.so|lib/wine/x86_64-windows/winemetal.dll)
+            echo "expected_rebound_from_dxmt"
+            ;;
+        bin/metalsharp-wine|etc/dxmt.conf|etc/mscompatdb_rules.toml|etc/vulkan/icd.d/MoltenVK_icd.json|etc/vulkan/icd.d/MoltenVK_x86_64_icd.json|lib/dxmt/x86_64-windows/d3d10core.dll|lib/dxmt/x86_64-windows/d3d11.dll|lib/dxmt/x86_64-windows/winemetal.dll|lib/wine/x86_64-unix/libMoltenVK.1.dylib)
+            echo "must_match"
+            ;;
+        lib/wine/x86_64-windows/d3d11.dll|lib/wine/x86_64-windows/dxgi.dll|lib/wine/i386-windows/d3d11.dll|lib/wine/i386-windows/dxgi.dll)
+            echo "expected_wine_builtin_delta"
+            ;;
+        lib/wine/i386-windows/winemetal.dll)
+            echo "must_exist_for_m9_or_live_prove_unneeded"
+            ;;
+        *)
+            echo "unknown_release_blocking"
+            ;;
+    esac
+}
+
+all_paths="$tmp/all-paths.txt"
+{
+    awk '{ print $2 }' "$baseline/critical-sha256.txt"
+    awk '{ print $2 }' "$candidate/critical-sha256.txt"
+} | LC_ALL=C sort -u > "$all_paths"
+
+release_blockers=0
+packaging_defects=0
+unknowns=0
+
+{
+    echo "# MetalSharp Runtime Manifest Classified Diff"
+    echo
+    echo "- Baseline: $baseline"
+    echo "- Candidate: $candidate"
+    echo
+
+    if [[ -f "$baseline/versions.txt" || -f "$candidate/versions.txt" ]]; then
+        echo "## Versions"
+        echo
+        echo '```text'
+        [[ -f "$baseline/versions.txt" ]] && sed 's/^/baseline: /' "$baseline/versions.txt"
+        [[ -f "$candidate/versions.txt" ]] && sed 's/^/candidate: /' "$candidate/versions.txt"
+        echo '```'
+        echo
+    fi
+
+    echo "## Critical Path Classification"
+    echo
+    echo "| Path | Baseline | Candidate | Classification | Gate |"
+    echo "| --- | --- | --- | --- | --- |"
+
+    while IFS= read -r rel; do
+        [[ -z "$rel" ]] && continue
+        base_hash="$(extract_value "$baseline/critical-sha256.txt" "$rel")"
+        cand_hash="$(extract_value "$candidate/critical-sha256.txt" "$rel")"
+        [[ -z "$base_hash" ]] && base_hash="ABSENT"
+        [[ -z "$cand_hash" ]] && cand_hash="ABSENT"
+
+        class="$(classify_path "$rel")"
+        gate="ok"
+
+        if [[ "$cand_hash" == "MISSING" || "$cand_hash" == "ABSENT" ]]; then
+            case "$class" in
+                expected_anticheat_delta)
+                    gate="ok_if_intentional_new_surface_absent"
+                    ;;
+                must_exist_for_m9_or_live_prove_unneeded)
+                    gate="release_blocker"
+                    release_blockers=$((release_blockers + 1))
+                    ;;
+                *)
+                    gate="packaging_defect"
+                    packaging_defects=$((packaging_defects + 1))
+                    ;;
+            esac
+        elif [[ "$class" == "must_match" && "$base_hash" != "$cand_hash" ]]; then
+            gate="release_blocker_unexpected_change"
+            release_blockers=$((release_blockers + 1))
+        elif [[ "$class" == "unknown_release_blocking" && "$base_hash" != "$cand_hash" ]]; then
+            gate="release_blocker_unknown_delta"
+            release_blockers=$((release_blockers + 1))
+            unknowns=$((unknowns + 1))
+        elif [[ "$class" == "must_exist_for_m9_or_live_prove_unneeded" && "$base_hash" != "$cand_hash" ]]; then
+            gate="release_blocker_until_live_m9_proves_unneeded"
+            release_blockers=$((release_blockers + 1))
+        elif [[ "$class" == "must_exist_for_m9_or_live_prove_unneeded" && "$base_hash" == "$cand_hash" ]]; then
+            gate="ok_manifest_only_still_requires_live_m9"
+        fi
+
+        printf '| `%s` | `%s` | `%s` | `%s` | `%s` |\n' "$rel" "$base_hash" "$cand_hash" "$class" "$gate"
+    done < "$all_paths"
+
+    echo
+    echo "## Summary"
+    echo
+    echo "- release_blockers: $release_blockers"
+    echo "- packaging_defects: $packaging_defects"
+    echo "- unknown_release_blocking: $unknowns"
+    if [[ "$release_blockers" -eq 0 && "$packaging_defects" -eq 0 && "$unknowns" -eq 0 ]]; then
+        echo "- gate: pass"
+    else
+        echo "- gate: fail"
+    fi
+} > "$report"
+
+echo "classified diff written: $report"
+if [[ "$release_blockers" -ne 0 || "$packaging_defects" -ne 0 || "$unknowns" -ne 0 ]]; then
+    echo "gate: fail"
+    exit 2
+fi
+
+echo "gate: pass"

--- a/scripts/fetch-wine119-release-assets.sh
+++ b/scripts/fetch-wine119-release-assets.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  scripts/fetch-wine119-release-assets.sh [output-dir] [asset ...]
+
+Examples:
+  scripts/fetch-wine119-release-assets.sh /tmp/metalsharp-wine-assets
+  scripts/fetch-wine119-release-assets.sh /tmp/metalsharp-wine-assets metalsharp_bundle.tar.zst metalsharp_bundle2.tar.zst
+
+Downloads Wine 11.9 release assets from the GitHub "bundles" release and
+verifies each downloaded file against the asset digest reported by GitHub.
+
+Defaults:
+  repo: aaf2tbz/metalsharp
+  tag:  bundles
+  asset: metalsharp_bundle.tar.zst
+
+Environment:
+  METALSHARP_RELEASE_REPO  Override repo, default aaf2tbz/metalsharp
+  METALSHARP_RELEASE_TAG   Override release tag, default bundles
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+repo="${METALSHARP_RELEASE_REPO:-aaf2tbz/metalsharp}"
+tag="${METALSHARP_RELEASE_TAG:-bundles}"
+out_dir="${1:-/tmp/metalsharp-wine-assets}"
+shift || true
+
+assets=("$@")
+if (( ${#assets[@]} == 0 )); then
+    assets=("metalsharp_bundle.tar.zst")
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "gh is required to fetch release assets" >&2
+    exit 1
+fi
+
+mkdir -p "$out_dir"
+out_dir_abs="$(cd "$out_dir" && pwd -P)"
+assets_json="$out_dir_abs/release-assets.json"
+report="$out_dir_abs/fetch-report.txt"
+
+gh release view "$tag" --repo "$repo" --json tagName,name,isDraft,isPrerelease,assets > "$assets_json"
+
+: > "$report"
+{
+    echo "repo=$repo"
+    echo "tag=$tag"
+    echo "output_dir=$out_dir_abs"
+    echo "release_assets_json=$assets_json"
+} >> "$report"
+
+for asset in "${assets[@]}"; do
+    expected_digest="$(
+        ASSET="$asset" gh release view "$tag" --repo "$repo" --json assets \
+            --jq '.assets[] | select(.name == env.ASSET) | .digest' 2>/dev/null || true
+    )"
+    expected_sha="${expected_digest#sha256:}"
+
+    if [[ -z "$expected_digest" || "$expected_digest" == "$expected_sha" ]]; then
+        echo "asset digest not found in release metadata: $asset" >&2
+        exit 1
+    fi
+
+    gh release download "$tag" \
+        --repo "$repo" \
+        --pattern "$asset" \
+        --dir "$out_dir_abs" \
+        --clobber
+
+    local_path="$out_dir_abs/$asset"
+    if [[ ! -f "$local_path" ]]; then
+        echo "downloaded asset missing: $local_path" >&2
+        exit 1
+    fi
+
+    actual_sha="$(shasum -a 256 "$local_path" | awk '{ print $1 }')"
+    if [[ "$actual_sha" != "$expected_sha" ]]; then
+        echo "sha256 mismatch for $asset" >&2
+        echo "expected: $expected_sha" >&2
+        echo "actual:   $actual_sha" >&2
+        exit 1
+    fi
+
+    {
+        echo
+        echo "asset=$asset"
+        echo "path=$local_path"
+        echo "sha256=$actual_sha"
+        echo "verified=1"
+    } >> "$report"
+done
+
+echo "release assets fetched and verified: $out_dir_abs"
+echo "report: $report"

--- a/scripts/fetch-wine119-release-assets.sh
+++ b/scripts/fetch-wine119-release-assets.sh
@@ -55,6 +55,8 @@ gh release view "$tag" --repo "$repo" --json tagName,name,isDraft,isPrerelease,a
 {
     echo "repo=$repo"
     echo "tag=$tag"
+    gh release view "$tag" --repo "$repo" --json tagName,name,isDraft,isPrerelease \
+        --jq '"release_tag_name=\(.tagName)\nrelease_name=\(.name)\nrelease_is_draft=\(.isDraft)\nrelease_is_prerelease=\(.isPrerelease)"'
     echo "output_dir=$out_dir_abs"
     echo "release_assets_json=$assets_json"
 } >> "$report"

--- a/scripts/install-wine119-parity-home.sh
+++ b/scripts/install-wine119-parity-home.sh
@@ -261,6 +261,15 @@ set -euo pipefail
 export HOME="$parity_home_abs"
 export METALSHARP_HOME="$parity_ms_home"
 export METALSHARP_REQUIRE_PARITY_HOME=1
+export METALSHARP_ALLOW_NON_TMP_PARITY_HOME=1
+export METALSHARP_WINE119_CANDIDATE_WORK_DIR="$(cd "$(dirname "$(dirname "$(dirname "$candidate_root")")")" && pwd -P)"
+
+# Full release-gate capture. Intentionally guarded: this launches real games.
+# METALSHARP_RUN_LIVE_GAMES=1 \\
+# METALSHARP_REQUIRE_PREEXISTING_WINE_STEAM=1 \\
+# "$repo_root/scripts/run-wine119-live-control-suite.sh" \\
+#   "$parity_home_abs" \\
+#   "$parity_home_abs/live-controls-clean-dxmt32"
 
 "$repo_root/scripts/capture-steam-game-proof.sh" 535520 Nidhogg_2 "$parity_home_abs/proof-nidhogg2"
 "$repo_root/scripts/capture-steam-game-proof.sh" 3164500 "Schedule I" "$parity_home_abs/proof-schedule-i"

--- a/scripts/install-wine119-parity-home.sh
+++ b/scripts/install-wine119-parity-home.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  scripts/install-wine119-parity-home.sh <candidate-runtime-root> [parity-home]
+
+Example:
+  scripts/install-wine119-parity-home.sh \
+    /tmp/metalsharp-wine119-parity/candidates/dxmt32/wine \
+    /tmp/metalsharp-home-wine119-dxmt32
+
+Installs a prepared Wine 11.9 candidate into an isolated HOME:
+
+  <parity-home>/.metalsharp/runtime/wine
+
+By default this only installs the runtime and writes launch/proof helper files.
+It does not modify ~/.metalsharp and does not clone Steam prefixes or game state.
+
+Optional:
+  METALSHARP_CLONE_USER_STATE=1
+
+Copies selected user state from ~/.metalsharp into the parity home so live Steam
+game launches can be tested without mutating the working runtime. Copied dirs:
+prefix-steam, compatdata, bottles, games, configs, shader-cache, pipeline-cache.
+Active cloned manifests are rewritten from the source MetalSharp home path to
+the parity MetalSharp home path before any live-control run should use them.
+
+Copy mode:
+  METALSHARP_COPY_MODE=auto   Prefer APFS clone-copy on macOS, fallback to copy
+  METALSHARP_COPY_MODE=clone  Require APFS clone-copy with cp -cR
+  METALSHARP_COPY_MODE=copy   Force ordinary recursive copy
+
+Safety:
+  Parity homes must live under /tmp or /private/tmp by default. Set
+  METALSHARP_ALLOW_NON_TMP_PARITY_HOME=1 only for an intentional alternate
+  scratch location. The installer refuses to target the real HOME/.metalsharp.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+candidate_root="${1:-}"
+parity_home="${2:-/tmp/metalsharp-home-wine119-parity}"
+
+if [[ -z "$candidate_root" ]]; then
+    usage >&2
+    exit 1
+fi
+
+if [[ ! -d "$candidate_root" ]]; then
+    echo "candidate runtime root not found: $candidate_root" >&2
+    exit 1
+fi
+
+if [[ ! -x "$candidate_root/bin/wine" ]]; then
+    echo "candidate runtime missing executable bin/wine: $candidate_root" >&2
+    exit 1
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(cd "$script_dir/.." && pwd -P)"
+source_ms_home="${METALSHARP_SOURCE_HOME:-$HOME/.metalsharp}"
+if [[ -d "$source_ms_home" ]]; then
+    source_ms_home="$(cd "$source_ms_home" && pwd -P)"
+fi
+parity_home_abs="$(mkdir -p "$parity_home" && cd "$parity_home" && pwd -P)"
+parity_ms_home="$parity_home_abs/.metalsharp"
+real_home_abs="$(cd "$HOME" && pwd -P)"
+runtime_dest="$parity_ms_home/runtime/wine"
+report="$parity_home_abs/parity-install-report.txt"
+state_sizes="$parity_home_abs/state-sizes.txt"
+copy_log="$parity_home_abs/copy.log"
+rewrite_log="$parity_home_abs/state-path-rewrite.log"
+copy_mode="${METALSHARP_COPY_MODE:-auto}"
+
+if [[ "$parity_home_abs" == "$real_home_abs" ]]; then
+    echo "refusing parity install into real HOME: $parity_home_abs" >&2
+    exit 1
+fi
+
+if [[ "$parity_ms_home" == "$source_ms_home" ]]; then
+    echo "refusing parity install into source MetalSharp home: $parity_ms_home" >&2
+    exit 1
+fi
+
+if [[ "${METALSHARP_ALLOW_NON_TMP_PARITY_HOME:-0}" != "1" ]]; then
+    case "$parity_home_abs" in
+        /tmp/*|/private/tmp/*) ;;
+        *)
+            echo "refusing non-tmp parity home: $parity_home_abs" >&2
+            echo "set METALSHARP_ALLOW_NON_TMP_PARITY_HOME=1 for an intentional scratch location" >&2
+            exit 1
+            ;;
+    esac
+fi
+
+copy_method="copy"
+if [[ "$copy_mode" == "clone" ]]; then
+    if ! [[ "$(uname -s)" == "Darwin" ]]; then
+        echo "METALSHARP_COPY_MODE=clone requires macOS cp -cR" >&2
+        exit 1
+    fi
+    copy_method="clone"
+elif [[ "$copy_mode" == "auto" && "$(uname -s)" == "Darwin" ]]; then
+    copy_method="clone"
+elif [[ "$copy_mode" == "copy" ]]; then
+    copy_method="copy"
+else
+    echo "unsupported METALSHARP_COPY_MODE: $copy_mode" >&2
+    exit 1
+fi
+
+copy_dir() {
+    local src="$1"
+    local dst="$2"
+    if [[ ! -e "$src" ]]; then
+        return 0
+    fi
+
+    rm -rf "$dst"
+    mkdir -p "$(dirname "$dst")"
+    echo "copy $src -> $dst via $copy_method" >> "$copy_log"
+    if [[ "$copy_method" == "clone" ]]; then
+        if cp -cR "$src" "$dst" >> "$copy_log" 2>&1; then
+            return 0
+        fi
+        if [[ "$copy_mode" == "clone" ]]; then
+            echo "clone-copy failed for $src -> $dst; see $copy_log" >&2
+            exit 1
+        fi
+        echo "clone-copy failed; falling back to ordinary copy for $src" >> "$copy_log"
+    fi
+
+    if command -v ditto >/dev/null 2>&1; then
+        ditto "$src" "$dst"
+    else
+        cp -R "$src" "$dst"
+    fi
+}
+
+write_size_line() {
+    local label="$1"
+    local path="$2"
+    if [[ -e "$path" ]]; then
+        printf '%s\t%s\t%s\n' "$label" "$(du -sh "$path" | awk '{ print $1 }')" "$path" >> "$state_sizes"
+    else
+        printf '%s\tmissing\t%s\n' "$label" "$path" >> "$state_sizes"
+    fi
+}
+
+prune_copied_launch_logs() {
+    if [[ -d "$parity_ms_home/compatdata" ]]; then
+        find "$parity_ms_home/compatdata" -type d -name logs -prune -print -exec rm -rf {} + >> "$copy_log" 2>&1 || true
+    fi
+}
+
+active_state_files() {
+    local roots=()
+    local rel
+    for rel in bottles compatdata configs; do
+        if [[ -d "$parity_ms_home/$rel" ]]; then
+            roots+=("$parity_ms_home/$rel")
+        fi
+    done
+
+    if (( ${#roots[@]} == 0 )); then
+        return 0
+    fi
+
+    find "${roots[@]}" -type f \( \
+        -name '*.json' -o \
+        -name '*.toml' -o \
+        -name '*.conf' -o \
+        -name '*.env' \
+    \) -print0
+}
+
+count_stale_active_state_refs() {
+    local count=0
+    local file
+    while IFS= read -r -d '' file; do
+        if grep -Fq -- "$source_ms_home" "$file"; then
+            printf '%s\n' "$file" >> "$rewrite_log"
+            count=$((count + 1))
+        fi
+    done < <(active_state_files)
+    printf '%s\n' "$count"
+}
+
+rewrite_cloned_state_paths() {
+    if [[ "$source_ms_home" == "$parity_ms_home" ]]; then
+        echo "source and parity MetalSharp homes are identical; no rewrite needed" >> "$rewrite_log"
+        return 0
+    fi
+
+    local before
+    local after
+    local file
+
+    echo "source_metalsharp_home=$source_ms_home" >> "$rewrite_log"
+    echo "parity_metalsharp_home=$parity_ms_home" >> "$rewrite_log"
+    echo "[stale_active_files_before]" >> "$rewrite_log"
+    before="$(count_stale_active_state_refs)"
+
+    if [[ "$before" != "0" ]]; then
+        while IFS= read -r -d '' file; do
+            SOURCE_METALSHARP_HOME="$source_ms_home" \
+            PARITY_METALSHARP_HOME="$parity_ms_home" \
+            perl -0pi -e 's/\Q$ENV{SOURCE_METALSHARP_HOME}\E/$ENV{PARITY_METALSHARP_HOME}/g' "$file"
+        done < <(active_state_files)
+    fi
+
+    echo "[stale_active_files_after]" >> "$rewrite_log"
+    after="$(count_stale_active_state_refs)"
+    echo "stale_active_file_count_before=$before" >> "$rewrite_log"
+    echo "stale_active_file_count_after=$after" >> "$rewrite_log"
+
+    if [[ "$after" != "0" ]]; then
+        echo "active cloned state still references $source_ms_home; see $rewrite_log" >&2
+        exit 1
+    fi
+}
+
+mkdir -p "$parity_ms_home/runtime"
+: > "$copy_log"
+: > "$state_sizes"
+: > "$rewrite_log"
+write_size_line "source.runtime_candidate" "$candidate_root"
+copy_dir "$candidate_root" "$runtime_dest"
+write_size_line "dest.runtime" "$runtime_dest"
+
+if [[ "${METALSHARP_CLONE_USER_STATE:-0}" == "1" ]]; then
+    for rel in prefix-steam compatdata bottles games configs shader-cache pipeline-cache; do
+        write_size_line "source.$rel" "$source_ms_home/$rel"
+        copy_dir "$source_ms_home/$rel" "$parity_ms_home/$rel"
+        write_size_line "dest.$rel" "$parity_ms_home/$rel"
+    done
+    prune_copied_launch_logs
+    rewrite_cloned_state_paths
+fi
+
+"$repo_root/scripts/runtime-manifest.sh" "$runtime_dest" "$parity_home_abs/runtime-manifest"
+
+cat > "$parity_home_abs/activate-parity-env.sh" <<EOF
+#!/usr/bin/env bash
+export HOME="$parity_home_abs"
+export METALSHARP_HOME="$parity_ms_home"
+export METALSHARP_PARITY_RUNTIME="$runtime_dest"
+export METALSHARP_PARITY_SOURCE_HOME="$source_ms_home"
+EOF
+chmod +x "$parity_home_abs/activate-parity-env.sh"
+
+cat > "$parity_home_abs/proof-commands.sh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+export HOME="$parity_home_abs"
+export METALSHARP_HOME="$parity_ms_home"
+export METALSHARP_REQUIRE_PARITY_HOME=1
+
+"$repo_root/scripts/capture-steam-game-proof.sh" 535520 Nidhogg_2 "$parity_home_abs/proof-nidhogg2"
+"$repo_root/scripts/capture-steam-game-proof.sh" 3164500 "Schedule I" "$parity_home_abs/proof-schedule-i"
+"$repo_root/scripts/capture-steam-game-proof.sh" 848450 SubnauticaZero "$parity_home_abs/proof-subnautica-bz"
+EOF
+chmod +x "$parity_home_abs/proof-commands.sh"
+
+{
+    echo "candidate_root=$candidate_root"
+    echo "parity_home=$parity_home_abs"
+    echo "parity_metalsharp_home=$parity_ms_home"
+    echo "runtime_dest=$runtime_dest"
+    echo "source_metalsharp_home=$source_ms_home"
+    echo "cloned_user_state=${METALSHARP_CLONE_USER_STATE:-0}"
+    echo "copy_mode=$copy_mode"
+    echo "copy_method=$copy_method"
+    echo "copy_log=$copy_log"
+    echo "state_sizes=$state_sizes"
+    echo "state_path_rewrite_log=$rewrite_log"
+    echo "activate_env=$parity_home_abs/activate-parity-env.sh"
+    echo "proof_commands=$parity_home_abs/proof-commands.sh"
+    echo "runtime_manifest=$parity_home_abs/runtime-manifest"
+    if [[ -x "$runtime_dest/bin/wine" ]]; then
+        printf "wine_version="
+        "$runtime_dest/bin/wine" --version 2>&1 || true
+    fi
+    if [[ -x "$runtime_dest/bin/wineserver" ]]; then
+        printf "wineserver_version="
+        "$runtime_dest/bin/wineserver" --version 2>&1 || true
+    fi
+} > "$report"
+
+echo "parity home installed: $parity_home_abs"
+echo "report: $report"
+echo "activate: source $parity_home_abs/activate-parity-env.sh"
+echo "proof commands: $parity_home_abs/proof-commands.sh"

--- a/scripts/preflight-i386-winemetal-build.sh
+++ b/scripts/preflight-i386-winemetal-build.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  scripts/preflight-i386-winemetal-build.sh <dxmt-source-root> <wine-11.9-runtime-root> [output-dir]
+
+Example:
+  scripts/preflight-i386-winemetal-build.sh \
+    /Volumes/AverySSD/metalsharp/dxmt-src \
+    /tmp/metalsharp-wine119-parity/candidates/dxmt32/wine \
+    /tmp/metalsharp-i386-winemetal-build-preflight
+
+Checks whether this machine has the inputs required to build a release-grade
+i386 winemetal.dll from DXMT source against the shaped Wine 11.9 runtime. This
+script is read-only. It does not run Meson setup, build, or mutate the DXMT tree.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+src_root="${1:-}"
+wine_root="${2:-}"
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+out_dir="${3:-/tmp/metalsharp-i386-winemetal-build-preflight-$timestamp}"
+
+if [[ -z "$src_root" || -z "$wine_root" ]]; then
+    usage >&2
+    exit 1
+fi
+
+mkdir -p "$out_dir"
+report="$out_dir/preflight.md"
+failures=0
+warnings=0
+
+append() {
+    printf '%s\n' "$*" >> "$report"
+}
+
+pass() {
+    append "- PASS [$1] $2"
+}
+
+fail() {
+    failures=$((failures + 1))
+    append "- FAIL [$1] $2"
+}
+
+warn() {
+    warnings=$((warnings + 1))
+    append "- WARN [$1] $2"
+}
+
+check_tool() {
+    local tool="$1"
+    if command -v "$tool" >/dev/null 2>&1; then
+        pass "tool-$tool" "$(command -v "$tool")"
+    else
+        fail "tool-$tool" "$tool is not on PATH"
+    fi
+}
+
+check_file() {
+    local label="$1"
+    local path="$2"
+    if [[ -f "$path" ]]; then
+        pass "$label" "$path exists; sha256=$(shasum -a 256 "$path" | awk '{ print $1 }')"
+    else
+        fail "$label" "missing $path"
+    fi
+}
+
+check_executable() {
+    local label="$1"
+    local path="$2"
+    if [[ -x "$path" ]]; then
+        pass "$label" "$path is executable; sha256=$(shasum -a 256 "$path" | awk '{ print $1 }')"
+    else
+        fail "$label" "missing executable $path"
+    fi
+}
+
+: > "$report"
+append "# i386 WineMetal 11.9 Build Preflight"
+append
+append "- captured_at_utc: \`$timestamp\`"
+append "- dxmt_source_root: \`$src_root\`"
+append "- wine_119_runtime_root: \`$wine_root\`"
+append
+
+if [[ ! -d "$src_root/.git" ]]; then
+    fail "source" "$src_root is not a git checkout"
+else
+    src_abs="$(cd "$src_root" && pwd -P)"
+    append "- source_abs: \`$src_abs\`"
+    append "- source_head: \`$(git -C "$src_abs" rev-parse HEAD)\`"
+    append "- source_branch: \`$(git -C "$src_abs" branch --show-current 2>/dev/null || true)\`"
+    git -C "$src_abs" status --short --branch > "$out_dir/git-status.txt"
+    if [[ -n "$(git -C "$src_abs" status --porcelain)" ]]; then
+        fail "source-clean" "DXMT source has uncommitted changes; see $out_dir/git-status.txt"
+    else
+        pass "source-clean" "DXMT source tree is clean"
+    fi
+    if [[ -f "$src_abs/build-win32.txt" ]]; then
+        pass "cross-file" "$src_abs/build-win32.txt exists"
+    else
+        fail "cross-file" "missing $src_abs/build-win32.txt"
+    fi
+fi
+
+if [[ ! -d "$wine_root" ]]; then
+    fail "wine-root" "$wine_root does not exist"
+else
+    wine_abs="$(cd "$wine_root" && pwd -P)"
+    append "- wine_abs: \`$wine_abs\`"
+    if [[ -x "$wine_abs/bin/wine" ]]; then
+        version="$("$wine_abs/bin/wine" --version 2>&1 || true)"
+        if [[ "$version" == "wine-11.9" ]]; then
+            pass "wine-version" "wine reports wine-11.9"
+        else
+            fail "wine-version" "wine reports '$version', expected wine-11.9"
+        fi
+    else
+        fail "wine-version" "missing executable $wine_abs/bin/wine"
+    fi
+    check_executable "winebuild" "$wine_abs/bin/winebuild"
+    check_file "libwinecrt0-i386" "$wine_abs/lib/wine/i386-windows/libwinecrt0.a"
+    check_file "libntdll-i386" "$wine_abs/lib/wine/i386-windows/libntdll.a"
+    check_file "dbghelp-i386" "$wine_abs/lib/wine/i386-windows/dbghelp.dll"
+fi
+
+check_tool "meson"
+check_tool "ninja"
+check_tool "i686-w64-mingw32-gcc"
+check_tool "i686-w64-mingw32-g++"
+check_tool "i686-w64-mingw32-ar"
+check_tool "i686-w64-mingw32-strip"
+check_tool "i686-w64-mingw32-windres"
+
+if [[ -d "$src_root" && -d "$wine_root" ]]; then
+    build_dir="$out_dir/build32-wine119"
+    append
+    append "## Proposed Build Commands"
+    append
+    append '```bash'
+    append "meson setup '$build_dir' '$src_root' \\"
+    append "  --cross-file '$src_root/build-win32.txt' \\"
+    append "  --buildtype release \\"
+    append "  -Dwine_install_path='$wine_root' \\"
+    append "  -Dwine_builtin_dll=true \\"
+    append "  -Denable_tests=false"
+    append "ninja -C '$build_dir' src/winemetal/winemetal.dll"
+    append '```'
+fi
+
+append
+append "## Summary"
+append
+append "- failures: $failures"
+append "- warnings: $warnings"
+if [[ "$failures" -eq 0 ]]; then
+    append "- gate: pass"
+    echo "i386 WineMetal build preflight passed: $report"
+else
+    append "- gate: fail"
+    echo "i386 WineMetal build preflight failed: $report"
+    exit 2
+fi

--- a/scripts/preflight-i386-winemetal-build.sh
+++ b/scripts/preflight-i386-winemetal-build.sh
@@ -93,7 +93,7 @@ append "- dxmt_source_root: \`$src_root\`"
 append "- wine_119_runtime_root: \`$wine_root\`"
 append
 
-if [[ ! -d "$src_root/.git" ]]; then
+if ! git -C "$src_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     fail "source" "$src_root is not a git checkout"
 else
     src_abs="$(cd "$src_root" && pwd -P)"

--- a/scripts/prepare-wine119-candidate.sh
+++ b/scripts/prepare-wine119-candidate.sh
@@ -86,30 +86,85 @@ mkdir -p "$candidate_root/bin" \
     "$candidate_root/lib/wine/x86_64-windows" \
     "$candidate_root/lib/wine/i386-windows"
 
+report_dir="$(dirname "$candidate_root")"
+provenance_report="$report_dir/provenance-report.txt"
+: > "$provenance_report"
+
+sha256_or_missing() {
+    local path="$1"
+    if [[ -f "$path" ]]; then
+        shasum -a 256 "$path" | awk '{ print $1 }'
+    else
+        printf 'missing'
+    fi
+}
+
+record_provenance() {
+    local label="$1"
+    local src="$2"
+    local dst="$3"
+    local action="$4"
+    {
+        echo "[$label]"
+        echo "action=$action"
+        echo "source=$src"
+        echo "source_sha256=$(sha256_or_missing "$src")"
+        echo "destination=$dst"
+        echo "destination_sha256=$(sha256_or_missing "$dst")"
+        echo
+    } >> "$provenance_report"
+}
+
+{
+    echo "[bundle]"
+    echo "path=$bundle"
+    echo "sha256=$(sha256_or_missing "$bundle")"
+    echo "fetch_report=${METALSHARP_FETCH_REPORT:-/tmp/metalsharp-wine-assets/fetch-report.txt}"
+    echo "release_repo=${METALSHARP_RELEASE_REPO:-aaf2tbz/metalsharp}"
+    echo "release_tag=${METALSHARP_RELEASE_TAG:-bundles}"
+    echo "asset_name=$(basename "$bundle")"
+    echo
+    echo "[source-root]"
+    echo "path=$source_root"
+    echo "name=$(basename "$source_root")"
+    echo
+} >> "$provenance_report"
+
 if [[ ! -f "$candidate_root/bin/metalsharp-wine" ]]; then
     wrapper_source="${METALSHARP_WINE_WRAPPER:-$baseline_root/bin/metalsharp-wine}"
     if [[ -f "$wrapper_source" ]]; then
         cp "$wrapper_source" "$candidate_root/bin/metalsharp-wine"
         chmod +x "$candidate_root/bin/metalsharp-wine"
+        record_provenance "bin/metalsharp-wine" "$wrapper_source" "$candidate_root/bin/metalsharp-wine" "copied_wrapper"
     fi
+else
+    record_provenance "bin/metalsharp-wine" "$candidate_root/bin/metalsharp-wine" "$candidate_root/bin/metalsharp-wine" "original_bundle_file"
 fi
 
 bind_if_missing() {
     local src="$1"
     local dst="$2"
+    local label="${3:-$dst}"
     if [[ ! -f "$dst" && -f "$src" ]]; then
         mkdir -p "$(dirname "$dst")"
         cp "$src" "$dst"
+        record_provenance "$label" "$src" "$dst" "copied_if_missing"
+    elif [[ -f "$dst" ]]; then
+        record_provenance "$label" "$dst" "$dst" "kept_existing_destination"
+    else
+        record_provenance "$label" "$src" "$dst" "missing_source_and_destination"
     fi
 }
 
 bind_if_missing \
     "$candidate_root/lib/dxmt/x86_64-unix/winemetal.so" \
-    "$candidate_root/lib/wine/x86_64-unix/winemetal.so"
+    "$candidate_root/lib/wine/x86_64-unix/winemetal.so" \
+    "lib/wine/x86_64-unix/winemetal.so"
 
 bind_if_missing \
     "$candidate_root/lib/dxmt/x86_64-windows/winemetal.dll" \
-    "$candidate_root/lib/wine/x86_64-windows/winemetal.dll"
+    "$candidate_root/lib/wine/x86_64-windows/winemetal.dll" \
+    "lib/wine/x86_64-windows/winemetal.dll"
 
 localize_vulkan_icd() {
     local molten_src="$candidate_root/lib/wine/x86_64-unix/libMoltenVK.1.dylib"
@@ -125,11 +180,23 @@ localize_vulkan_icd() {
 
     for icd in "$candidate_root/etc/vulkan/icd.d/"*.json; do
         [[ -f "$icd" ]] || continue
+        before_path="$(awk -F\" '/"library_path"/ { print $4; exit }' "$icd")"
         if grep -Fq '"library_path"' "$icd"; then
             tmp_icd="$icd.tmp.$$"
             sed -E 's#"library_path"[[:space:]]*:[[:space:]]*"[^"]*"#"library_path": "'"$molten_dst"'"#' "$icd" > "$tmp_icd"
             mv "$tmp_icd" "$icd"
         fi
+        after_path="$(awk -F\" '/"library_path"/ { print $4; exit }' "$icd")"
+        {
+            echo "[vulkan-icd $(basename "$icd")]"
+            echo "before_library_path=$before_path"
+            echo "after_library_path=$after_path"
+            echo "target=$molten_dst"
+            echo "target_exists=$([[ -e "$molten_dst" ]] && echo 1 || echo 0)"
+            echo "target_realpath=$(cd "$(dirname "$molten_dst")" && pwd -P)/$(basename "$molten_dst")"
+            echo "target_readlink=$(readlink "$molten_dst" 2>/dev/null || true)"
+            echo
+        } >> "$provenance_report"
     done
 }
 
@@ -142,11 +209,19 @@ if [[ -n "${METALSHARP_I386_WINEMETAL_SOURCE:-}" ]]; then
     fi
     bind_if_missing \
         "$METALSHARP_I386_WINEMETAL_SOURCE" \
-        "$candidate_root/lib/wine/i386-windows/winemetal.dll"
+        "$candidate_root/lib/wine/i386-windows/winemetal.dll" \
+        "lib/wine/i386-windows/winemetal.dll"
 elif [[ "${METALSHARP_BORROW_BASELINE_I386_WINEMETAL:-0}" == "1" ]]; then
     bind_if_missing \
         "$baseline_root/lib/wine/i386-windows/winemetal.dll" \
-        "$candidate_root/lib/wine/i386-windows/winemetal.dll"
+        "$candidate_root/lib/wine/i386-windows/winemetal.dll" \
+        "lib/wine/i386-windows/winemetal.dll"
+else
+    record_provenance \
+        "lib/wine/i386-windows/winemetal.dll" \
+        "${METALSHARP_I386_WINEMETAL_SOURCE:-}" \
+        "$candidate_root/lib/wine/i386-windows/winemetal.dll" \
+        "not_supplied"
 fi
 
 critical=(
@@ -177,7 +252,6 @@ critical=(
     "lib/wine/i386-windows/winemetal.dll"
 )
 
-report_dir="$(dirname "$candidate_root")"
 missing_report="$report_dir/missing-critical.txt"
 : > "$missing_report"
 for rel in "${critical[@]}"; do
@@ -200,6 +274,7 @@ done
     fi
     echo "i386_winemetal_source=${METALSHARP_I386_WINEMETAL_SOURCE:-}"
     echo "borrowed_baseline_i386_winemetal=${METALSHARP_BORROW_BASELINE_I386_WINEMETAL:-0}"
+    echo "provenance_report=$provenance_report"
     echo "missing_count=$(wc -l < "$missing_report" | tr -d ' ')"
 } > "$report_dir/prepare-report.txt"
 

--- a/scripts/prepare-wine119-candidate.sh
+++ b/scripts/prepare-wine119-candidate.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  scripts/prepare-wine119-candidate.sh <metalsharp_bundle.tar.zst> <candidate-runtime-root>
+
+Example:
+  scripts/prepare-wine119-candidate.sh \
+    /tmp/metalsharp-wine-assets-IjmErR/metalsharp_bundle.tar.zst \
+    /tmp/metalsharp-wine119-candidate/wine
+
+Creates a disposable Wine 11.9 candidate runtime with the final MetalSharp
+runtime shape expected by the app: <candidate-runtime-root>/bin, lib, etc, share.
+It does not modify ~/.metalsharp.
+
+The script normalizes the archive root (wine-11.9 -> runtime/wine), carries the
+current metalsharp-wine wrapper when the bundle lacks one, binds x86_64
+WineMetal into lib/wine fallback paths, then writes reports beside the runtime
+root. Set METALSHARP_I386_WINEMETAL_SOURCE=/path/to/winemetal.dll to bind an
+explicit i386 WineMetal candidate. Set
+METALSHARP_BORROW_BASELINE_I386_WINEMETAL=1 to intentionally borrow the 11.5
+i386 winemetal.dll for an experiment; the default is to report it missing.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+bundle="${1:-}"
+candidate_root="${2:-}"
+
+if [[ -z "$bundle" || -z "$candidate_root" ]]; then
+    usage >&2
+    exit 1
+fi
+
+if [[ ! -f "$bundle" ]]; then
+    echo "bundle not found: $bundle" >&2
+    exit 1
+fi
+
+if ! command -v zstd >/dev/null 2>&1; then
+    echo "zstd is required to extract $bundle" >&2
+    exit 1
+fi
+
+baseline_root="${METALSHARP_BASELINE_WINE:-$HOME/.metalsharp/runtime/wine}"
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/metalsharp-wine119.XXXXXX")"
+cleanup() {
+    rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+mkdir -p "$(dirname "$candidate_root")"
+rm -rf "$candidate_root"
+
+zstd -dc "$bundle" | tar -xf - -C "$tmp_dir"
+
+source_root=""
+for candidate in "$tmp_dir/wine-11.9" "$tmp_dir/wine"; do
+    if [[ -d "$candidate" ]]; then
+        source_root="$candidate"
+        break
+    fi
+done
+
+if [[ -z "$source_root" ]]; then
+    echo "bundle did not contain wine-11.9/ or wine/" >&2
+    exit 1
+fi
+
+mkdir -p "$candidate_root"
+if command -v ditto >/dev/null 2>&1; then
+    ditto "$source_root" "$candidate_root"
+else
+    cp -R "$source_root"/. "$candidate_root"/
+fi
+
+mkdir -p "$candidate_root/bin" \
+    "$candidate_root/lib/wine/x86_64-unix" \
+    "$candidate_root/lib/wine/x86_64-windows" \
+    "$candidate_root/lib/wine/i386-windows"
+
+if [[ ! -f "$candidate_root/bin/metalsharp-wine" ]]; then
+    wrapper_source="${METALSHARP_WINE_WRAPPER:-$baseline_root/bin/metalsharp-wine}"
+    if [[ -f "$wrapper_source" ]]; then
+        cp "$wrapper_source" "$candidate_root/bin/metalsharp-wine"
+        chmod +x "$candidate_root/bin/metalsharp-wine"
+    fi
+fi
+
+bind_if_missing() {
+    local src="$1"
+    local dst="$2"
+    if [[ ! -f "$dst" && -f "$src" ]]; then
+        mkdir -p "$(dirname "$dst")"
+        cp "$src" "$dst"
+    fi
+}
+
+bind_if_missing \
+    "$candidate_root/lib/dxmt/x86_64-unix/winemetal.so" \
+    "$candidate_root/lib/wine/x86_64-unix/winemetal.so"
+
+bind_if_missing \
+    "$candidate_root/lib/dxmt/x86_64-windows/winemetal.dll" \
+    "$candidate_root/lib/wine/x86_64-windows/winemetal.dll"
+
+if [[ -n "${METALSHARP_I386_WINEMETAL_SOURCE:-}" ]]; then
+    if [[ ! -f "$METALSHARP_I386_WINEMETAL_SOURCE" ]]; then
+        echo "METALSHARP_I386_WINEMETAL_SOURCE not found: $METALSHARP_I386_WINEMETAL_SOURCE" >&2
+        exit 1
+    fi
+    bind_if_missing \
+        "$METALSHARP_I386_WINEMETAL_SOURCE" \
+        "$candidate_root/lib/wine/i386-windows/winemetal.dll"
+elif [[ "${METALSHARP_BORROW_BASELINE_I386_WINEMETAL:-0}" == "1" ]]; then
+    bind_if_missing \
+        "$baseline_root/lib/wine/i386-windows/winemetal.dll" \
+        "$candidate_root/lib/wine/i386-windows/winemetal.dll"
+fi
+
+critical=(
+    "bin/wine"
+    "bin/wineserver"
+    "bin/metalsharp-wine"
+    "share/wine/wine.inf"
+    "etc/dxmt.conf"
+    "etc/mscompatdb_rules.toml"
+    "etc/vulkan/icd.d/MoltenVK_icd.json"
+    "etc/vulkan/icd.d/MoltenVK_x86_64_icd.json"
+    "lib/dxmt/x86_64-windows/d3d10core.dll"
+    "lib/dxmt/x86_64-windows/d3d11.dll"
+    "lib/dxmt/x86_64-windows/d3d12.dll"
+    "lib/dxmt/x86_64-windows/dxgi.dll"
+    "lib/dxmt/x86_64-windows/winemetal.dll"
+    "lib/dxmt/x86_64-unix/winemetal.so"
+    "lib/wine/x86_64-unix/winemetal.so"
+    "lib/wine/x86_64-unix/mscompatdb.so"
+    "lib/wine/x86_64-unix/mscompatdb.dylib"
+    "lib/wine/x86_64-unix/libMoltenVK.1.dylib"
+    "lib/wine/x86_64-windows/d3d11.dll"
+    "lib/wine/x86_64-windows/dxgi.dll"
+    "lib/wine/x86_64-windows/winemetal.dll"
+    "lib/wine/i386-windows/d3d11.dll"
+    "lib/wine/i386-windows/dxgi.dll"
+    "lib/wine/i386-windows/winemetal.dll"
+)
+
+report_dir="$(dirname "$candidate_root")"
+missing_report="$report_dir/missing-critical.txt"
+: > "$missing_report"
+for rel in "${critical[@]}"; do
+    if [[ ! -f "$candidate_root/$rel" ]]; then
+        echo "$rel" >> "$missing_report"
+    fi
+done
+
+{
+    echo "bundle=$bundle"
+    echo "source_root=$(basename "$source_root")"
+    echo "candidate_root=$candidate_root"
+    if [[ -x "$candidate_root/bin/wine" ]]; then
+        printf "wine_version="
+        "$candidate_root/bin/wine" --version 2>&1 || true
+    fi
+    if [[ -x "$candidate_root/bin/wineserver" ]]; then
+        printf "wineserver_version="
+        "$candidate_root/bin/wineserver" --version 2>&1 || true
+    fi
+    echo "i386_winemetal_source=${METALSHARP_I386_WINEMETAL_SOURCE:-}"
+    echo "borrowed_baseline_i386_winemetal=${METALSHARP_BORROW_BASELINE_I386_WINEMETAL:-0}"
+    echo "missing_count=$(wc -l < "$missing_report" | tr -d ' ')"
+} > "$report_dir/prepare-report.txt"
+
+echo "candidate runtime written: $candidate_root"
+echo "prepare report: $report_dir/prepare-report.txt"
+if [[ -s "$missing_report" ]]; then
+    echo "missing critical files:"
+    sed 's/^/  - /' "$missing_report"
+fi

--- a/scripts/prepare-wine119-candidate.sh
+++ b/scripts/prepare-wine119-candidate.sh
@@ -17,8 +17,9 @@ It does not modify ~/.metalsharp.
 
 The script normalizes the archive root (wine-11.9 -> runtime/wine), carries the
 current metalsharp-wine wrapper when the bundle lacks one, binds x86_64
-WineMetal into lib/wine fallback paths, then writes reports beside the runtime
-root. Set METALSHARP_I386_WINEMETAL_SOURCE=/path/to/winemetal.dll to bind an
+WineMetal into lib/wine fallback paths, localizes Vulkan ICD bindings so proof
+does not load MoltenVK from the installed runtime, then writes reports beside
+the runtime root. Set METALSHARP_I386_WINEMETAL_SOURCE=/path/to/winemetal.dll to bind an
 explicit i386 WineMetal candidate. Set
 METALSHARP_BORROW_BASELINE_I386_WINEMETAL=1 to intentionally borrow the 11.5
 i386 winemetal.dll for an experiment; the default is to report it missing.
@@ -110,6 +111,30 @@ bind_if_missing \
     "$candidate_root/lib/dxmt/x86_64-windows/winemetal.dll" \
     "$candidate_root/lib/wine/x86_64-windows/winemetal.dll"
 
+localize_vulkan_icd() {
+    local molten_src="$candidate_root/lib/wine/x86_64-unix/libMoltenVK.1.dylib"
+    local molten_dst="$candidate_root/lib/libMoltenVK.dylib"
+    local icd
+
+    if [[ -f "$molten_src" ]]; then
+        mkdir -p "$candidate_root/lib"
+        if [[ ! -e "$molten_dst" ]]; then
+            ln -s "wine/x86_64-unix/libMoltenVK.1.dylib" "$molten_dst"
+        fi
+    fi
+
+    for icd in "$candidate_root/etc/vulkan/icd.d/"*.json; do
+        [[ -f "$icd" ]] || continue
+        if grep -Fq '"library_path"' "$icd"; then
+            tmp_icd="$icd.tmp.$$"
+            sed -E 's#"library_path"[[:space:]]*:[[:space:]]*"[^"]*"#"library_path": "'"$molten_dst"'"#' "$icd" > "$tmp_icd"
+            mv "$tmp_icd" "$icd"
+        fi
+    done
+}
+
+localize_vulkan_icd
+
 if [[ -n "${METALSHARP_I386_WINEMETAL_SOURCE:-}" ]]; then
     if [[ ! -f "$METALSHARP_I386_WINEMETAL_SOURCE" ]]; then
         echo "METALSHARP_I386_WINEMETAL_SOURCE not found: $METALSHARP_I386_WINEMETAL_SOURCE" >&2
@@ -133,6 +158,7 @@ critical=(
     "etc/mscompatdb_rules.toml"
     "etc/vulkan/icd.d/MoltenVK_icd.json"
     "etc/vulkan/icd.d/MoltenVK_x86_64_icd.json"
+    "lib/libMoltenVK.dylib"
     "lib/dxmt/x86_64-windows/d3d10core.dll"
     "lib/dxmt/x86_64-windows/d3d11.dll"
     "lib/dxmt/x86_64-windows/d3d12.dll"

--- a/scripts/prepare-wine119-parity-candidates.sh
+++ b/scripts/prepare-wine119-parity-candidates.sh
@@ -14,11 +14,15 @@ Example:
 Builds disposable Wine 11.9 parity candidates and manifest comparisons:
 
   clean    - release bundle only, with x86_64 WineMetal rebound into lib/wine
-  dxmt32   - clean + explicit i386 WineMetal from METALSHARP_I386_WINEMETAL_SOURCE
+  dxmt32   - clean + preferred explicit i386 WineMetal candidate
   borrowed - clean + 11.5 baseline i386 WineMetal compatibility experiment
 
 The script does not modify ~/.metalsharp. It reads the installed 11.5 runtime as
 the baseline unless METALSHARP_BASELINE_WINE is set.
+
+Environment:
+  METALSHARP_I386_WINEMETAL_SOURCE        explicit i386 WineMetal candidate
+  METALSHARP_I386_WINEMETAL_CLEAN_SOURCE  clean 11.9-linked i386 candidate
 USAGE
 }
 
@@ -43,7 +47,19 @@ fi
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 repo_root="$(cd "$script_dir/.." && pwd -P)"
 baseline_wine="${METALSHARP_BASELINE_WINE:-$HOME/.metalsharp/runtime/wine}"
-dxmt32_source="${METALSHARP_I386_WINEMETAL_SOURCE:-/Volumes/AverySSD/metalsharp/dxmt-src/build32/src/winemetal/winemetal.dll}"
+clean_i386_source="${METALSHARP_I386_WINEMETAL_CLEAN_SOURCE:-/tmp/metalsharp-dxmt-clean-build32-wine119/src/winemetal/winemetal.dll}"
+legacy_i386_source="/Volumes/AverySSD/metalsharp/dxmt-src/build32/src/winemetal/winemetal.dll"
+dxmt32_source="${METALSHARP_I386_WINEMETAL_SOURCE:-}"
+dxmt32_source_kind="explicit"
+if [[ -z "$dxmt32_source" ]]; then
+    if [[ -f "$clean_i386_source" ]]; then
+        dxmt32_source="$clean_i386_source"
+        dxmt32_source_kind="clean-11.9-linked-default"
+    else
+        dxmt32_source="$legacy_i386_source"
+        dxmt32_source_kind="legacy-dirty-dxmt-build32-fallback"
+    fi
+fi
 
 if [[ ! -d "$baseline_wine" ]]; then
     echo "baseline Wine runtime not found: $baseline_wine" >&2
@@ -112,6 +128,9 @@ append_summary "- bundle_sha256: \`$(shasum -a 256 "$bundle" | awk '{ print $1 }
 append_summary "- baseline_wine: \`$baseline_wine\`"
 append_summary "- work_dir: \`$work_dir\`"
 append_summary "- dxmt32_source: \`$dxmt32_source\`"
+append_summary "- dxmt32_source_kind: \`$dxmt32_source_kind\`"
+append_summary "- clean_i386_source: \`$clean_i386_source\`"
+append_summary "- legacy_i386_source: \`$legacy_i386_source\`"
 append_summary
 
 "$repo_root/scripts/runtime-manifest.sh" "$baseline_wine" "$work_dir/manifests/11.5-baseline"

--- a/scripts/prepare-wine119-parity-candidates.sh
+++ b/scripts/prepare-wine119-parity-candidates.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  scripts/prepare-wine119-parity-candidates.sh <metalsharp_bundle.tar.zst> [work-dir]
+
+Example:
+  scripts/prepare-wine119-parity-candidates.sh \
+    /tmp/metalsharp-wine-assets-IjmErR/metalsharp_bundle.tar.zst \
+    /tmp/metalsharp-wine119-parity
+
+Builds disposable Wine 11.9 parity candidates and manifest comparisons:
+
+  clean    - release bundle only, with x86_64 WineMetal rebound into lib/wine
+  dxmt32   - clean + explicit i386 WineMetal from METALSHARP_I386_WINEMETAL_SOURCE
+  borrowed - clean + 11.5 baseline i386 WineMetal compatibility experiment
+
+The script does not modify ~/.metalsharp. It reads the installed 11.5 runtime as
+the baseline unless METALSHARP_BASELINE_WINE is set.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+bundle="${1:-}"
+work_dir="${2:-/tmp/metalsharp-wine119-parity}"
+
+if [[ -z "$bundle" ]]; then
+    usage >&2
+    exit 1
+fi
+
+if [[ ! -f "$bundle" ]]; then
+    echo "bundle not found: $bundle" >&2
+    exit 1
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(cd "$script_dir/.." && pwd -P)"
+baseline_wine="${METALSHARP_BASELINE_WINE:-$HOME/.metalsharp/runtime/wine}"
+dxmt32_source="${METALSHARP_I386_WINEMETAL_SOURCE:-/Volumes/AverySSD/metalsharp/dxmt-src/build32/src/winemetal/winemetal.dll}"
+
+if [[ ! -d "$baseline_wine" ]]; then
+    echo "baseline Wine runtime not found: $baseline_wine" >&2
+    exit 1
+fi
+
+rm -rf "$work_dir"
+mkdir -p "$work_dir"
+
+summary="$work_dir/summary.md"
+: > "$summary"
+
+append_summary() {
+    printf '%s\n' "$*" >> "$summary"
+}
+
+run_compare() {
+    local candidate_name="$1"
+    local prepare_env="$2"
+    local candidate_root="$work_dir/candidates/$candidate_name/wine"
+    local manifest_dir="$work_dir/manifests/11.9-$candidate_name"
+    local report="$manifest_dir/classified-diff.md"
+    local status_file="$work_dir/$candidate_name.status"
+
+    mkdir -p "$(dirname "$candidate_root")" "$(dirname "$manifest_dir")"
+
+    echo "== preparing $candidate_name =="
+    if [[ -n "$prepare_env" ]]; then
+        env METALSHARP_BASELINE_WINE="$baseline_wine" $prepare_env \
+            "$repo_root/scripts/prepare-wine119-candidate.sh" "$bundle" "$candidate_root"
+    else
+        env METALSHARP_BASELINE_WINE="$baseline_wine" \
+            "$repo_root/scripts/prepare-wine119-candidate.sh" "$bundle" "$candidate_root"
+    fi
+
+    "$repo_root/scripts/runtime-manifest.sh" "$candidate_root" "$manifest_dir"
+
+    set +e
+    "$repo_root/scripts/compare-runtime-manifests.sh" \
+        "$work_dir/manifests/11.5-baseline" \
+        "$manifest_dir" \
+        "$report"
+    local code=$?
+    set -e
+
+    printf '%s\n' "$code" > "$status_file"
+    append_summary "## $candidate_name"
+    append_summary
+    append_summary "- candidate_root: \`$candidate_root\`"
+    append_summary "- manifest: \`$manifest_dir\`"
+    append_summary "- classified_diff: \`$report\`"
+    append_summary "- compare_exit_code: \`$code\`"
+    append_summary "- prepare_report: \`$work_dir/candidates/$candidate_name/prepare-report.txt\`"
+    append_summary
+
+    if [[ -f "$report" ]]; then
+        sed -n '/## Summary/,$p' "$report" >> "$summary"
+        append_summary
+    fi
+}
+
+append_summary "# MetalSharp Wine 11.9 Parity Candidates"
+append_summary
+append_summary "- bundle: \`$bundle\`"
+append_summary "- bundle_sha256: \`$(shasum -a 256 "$bundle" | awk '{ print $1 }')\`"
+append_summary "- baseline_wine: \`$baseline_wine\`"
+append_summary "- work_dir: \`$work_dir\`"
+append_summary "- dxmt32_source: \`$dxmt32_source\`"
+append_summary
+
+"$repo_root/scripts/runtime-manifest.sh" "$baseline_wine" "$work_dir/manifests/11.5-baseline"
+
+run_compare "clean" ""
+
+if [[ -f "$dxmt32_source" ]]; then
+    run_compare "dxmt32" "METALSHARP_I386_WINEMETAL_SOURCE=$dxmt32_source"
+else
+    append_summary "## dxmt32"
+    append_summary
+    append_summary "- skipped: i386 WineMetal source not found at \`$dxmt32_source\`"
+    append_summary
+fi
+
+run_compare "borrowed" "METALSHARP_BORROW_BASELINE_I386_WINEMETAL=1"
+
+append_summary "## Required Live Gates"
+append_summary
+append_summary "- Nidhogg 2 must pass M9 live process/module/cache proof."
+append_summary "- Schedule I must pass M11 live process/module/cache proof."
+append_summary "- Subnautica Below Zero must pass M11 live process/module/cache proof."
+append_summary "- Manifest pass alone is not a release gate for any candidate."
+
+echo "parity candidate summary: $summary"
+cat "$summary"

--- a/scripts/probe-wine119-parity-backend.sh
+++ b/scripts/probe-wine119-parity-backend.sh
@@ -145,6 +145,11 @@ if command -v node >/dev/null 2>&1 && [[ -s "$out_dir/steam-library.json" ]]; th
         > "$out_dir/electron-launch-routes.log" 2>&1 || true
 fi
 
+"$repo_root/scripts/audit-mscompatdb-hook-surface.sh" \
+    "$parity_home/.metalsharp/runtime/wine" \
+    "$out_dir/mscompatdb-hook-surface" \
+    > "$out_dir/mscompatdb-hook-surface.log" 2>&1 || true
+
 {
     echo "# MetalSharp Parity Backend Probe"
     echo
@@ -156,6 +161,7 @@ fi
     echo "bottles_profiles_json=$out_dir/bottles-profiles.json"
     echo "steam_library_json=$out_dir/steam-library.json"
     echo "electron_launch_route_audit=$out_dir/electron-launch-routes/electron-launch-route-audit.md"
+    echo "mscompatdb_hook_surface=$out_dir/mscompatdb-hook-surface/hook-surface.md"
     echo "backend_stdout=$out_dir/backend.stdout.log"
     echo "backend_stderr=$out_dir/backend.stderr.log"
 } > "$out_dir/summary.txt"

--- a/scripts/probe-wine119-parity-backend.sh
+++ b/scripts/probe-wine119-parity-backend.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  scripts/probe-wine119-parity-backend.sh <parity-home> [output-dir]
+
+Example:
+  scripts/probe-wine119-parity-backend.sh \
+    /tmp/metalsharp-home-wine119-dxmt32 \
+    /tmp/metalsharp-home-wine119-dxmt32/backend-probe
+
+Starts metalsharp-backend with HOME=<parity-home> and a non-default port, probes
+basic backend/runtime endpoints, records the parity Wine identity, then stops
+the backend. This is a preflight for live game proof; it does not launch games.
+
+Environment:
+  METALSHARP_PORT       Port to use, default 9374
+  METALSHARP_BACKEND    Backend binary override
+  METALSHARP_ALLOW_NON_TMP_PARITY_HOME=1
+                       Allow a parity home outside /tmp or /private/tmp
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+parity_home="${1:-}"
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+out_dir="${2:-/tmp/metalsharp-parity-backend-probe-$timestamp}"
+
+if [[ -z "$parity_home" ]]; then
+    usage >&2
+    exit 1
+fi
+
+if [[ ! -d "$parity_home/.metalsharp/runtime/wine" ]]; then
+    echo "parity runtime not found: $parity_home/.metalsharp/runtime/wine" >&2
+    exit 1
+fi
+
+parity_home="$(cd "$parity_home" && pwd -P)"
+source_ms_home="${METALSHARP_PARITY_SOURCE_HOME:-${METALSHARP_SOURCE_HOME:-}}"
+if [[ -z "$source_ms_home" && -f "$parity_home/parity-install-report.txt" ]]; then
+    source_ms_home="$(awk -F= '$1 == "source_metalsharp_home" { print substr($0, index($0, "=") + 1); exit }' "$parity_home/parity-install-report.txt")"
+fi
+source_ms_home="${source_ms_home:-$HOME/.metalsharp}"
+if [[ -d "$source_ms_home" ]]; then
+    source_ms_home="$(cd "$source_ms_home" && pwd -P)"
+fi
+source_home_parent="$(cd "$(dirname "$source_ms_home")" && pwd -P 2>/dev/null || dirname "$source_ms_home")"
+
+if [[ "$parity_home" == "$source_home_parent" || "$parity_home/.metalsharp" == "$source_ms_home" ]]; then
+    echo "refusing to probe real MetalSharp home as parity home: $parity_home" >&2
+    exit 1
+fi
+
+if [[ "${METALSHARP_ALLOW_NON_TMP_PARITY_HOME:-0}" != "1" ]]; then
+    case "$parity_home" in
+        /tmp/*|/private/tmp/*) ;;
+        *)
+            echo "refusing non-tmp parity home: $parity_home" >&2
+            echo "set METALSHARP_ALLOW_NON_TMP_PARITY_HOME=1 for an intentional scratch location" >&2
+            exit 1
+            ;;
+    esac
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(cd "$script_dir/.." && pwd -P)"
+port="${METALSHARP_PORT:-9374}"
+backend="${METALSHARP_BACKEND:-$repo_root/app/src-rust/target/release/metalsharp-backend}"
+
+if [[ ! -x "$backend" ]]; then
+    backend="$repo_root/app/src-rust/target/debug/metalsharp-backend"
+fi
+
+if [[ ! -x "$backend" ]]; then
+    echo "backend binary not found; run npm run rust:build or npm run rust:dev in app first" >&2
+    exit 1
+fi
+
+mkdir -p "$out_dir"
+
+backend_pid=""
+cleanup() {
+    if [[ -n "$backend_pid" ]] && kill -0 "$backend_pid" 2>/dev/null; then
+        kill "$backend_pid" 2>/dev/null || true
+        wait "$backend_pid" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+{
+    echo "parity_home=$parity_home"
+    echo "metalsharp_home=$parity_home/.metalsharp"
+    echo "runtime=$parity_home/.metalsharp/runtime/wine"
+    echo "backend=$backend"
+    echo "port=$port"
+    echo "captured_at_utc=$timestamp"
+    if [[ -x "$parity_home/.metalsharp/runtime/wine/bin/wine" ]]; then
+        printf "wine_version="
+        "$parity_home/.metalsharp/runtime/wine/bin/wine" --version 2>&1 || true
+    fi
+    if [[ -x "$parity_home/.metalsharp/runtime/wine/bin/wineserver" ]]; then
+        printf "wineserver_version="
+        "$parity_home/.metalsharp/runtime/wine/bin/wineserver" --version 2>&1 || true
+    fi
+} > "$out_dir/runtime-identity.txt"
+
+HOME="$parity_home" \
+METALSHARP_HOME="$parity_home/.metalsharp" \
+METALSHARP_PORT="$port" \
+    "$backend" > "$out_dir/backend.stdout.log" 2> "$out_dir/backend.stderr.log" &
+backend_pid=$!
+echo "$backend_pid" > "$out_dir/backend.pid"
+
+base_url="http://127.0.0.1:$port"
+ready=0
+for _ in $(seq 1 50); do
+    if curl -fsS "$base_url/status" > "$out_dir/status.json" 2> "$out_dir/status.curl.log"; then
+        ready=1
+        break
+    fi
+    sleep 0.1
+done
+
+if [[ "$ready" != "1" ]]; then
+    echo "backend did not become ready on $base_url" >&2
+    exit 1
+fi
+
+curl -fsS "$base_url/setup/dependencies" > "$out_dir/setup-dependencies.json" 2> "$out_dir/setup-dependencies.curl.log" || true
+curl -fsS "$base_url/runtime/host-abi" > "$out_dir/runtime-host-abi.json" 2> "$out_dir/runtime-host-abi.curl.log" || true
+curl -fsS "$base_url/bottles/profiles" > "$out_dir/bottles-profiles.json" 2> "$out_dir/bottles-profiles.curl.log" || true
+
+{
+    echo "# MetalSharp Parity Backend Probe"
+    echo
+    cat "$out_dir/runtime-identity.txt"
+    echo
+    echo "status_json=$out_dir/status.json"
+    echo "setup_dependencies_json=$out_dir/setup-dependencies.json"
+    echo "runtime_host_abi_json=$out_dir/runtime-host-abi.json"
+    echo "bottles_profiles_json=$out_dir/bottles-profiles.json"
+    echo "backend_stdout=$out_dir/backend.stdout.log"
+    echo "backend_stderr=$out_dir/backend.stderr.log"
+} > "$out_dir/summary.txt"
+
+echo "parity backend probe written: $out_dir"
+echo "summary: $out_dir/summary.txt"

--- a/scripts/probe-wine119-parity-backend.sh
+++ b/scripts/probe-wine119-parity-backend.sh
@@ -136,6 +136,14 @@ fi
 curl -fsS "$base_url/setup/dependencies" > "$out_dir/setup-dependencies.json" 2> "$out_dir/setup-dependencies.curl.log" || true
 curl -fsS "$base_url/runtime/host-abi" > "$out_dir/runtime-host-abi.json" 2> "$out_dir/runtime-host-abi.curl.log" || true
 curl -fsS "$base_url/bottles/profiles" > "$out_dir/bottles-profiles.json" 2> "$out_dir/bottles-profiles.curl.log" || true
+curl -fsS "$base_url/steam/library" > "$out_dir/steam-library.json" 2> "$out_dir/steam-library.curl.log" || true
+
+if command -v node >/dev/null 2>&1 && [[ -s "$out_dir/steam-library.json" ]]; then
+    node "$repo_root/scripts/audit-electron-launch-routes.mjs" \
+        --base-url "$base_url" \
+        --out-dir "$out_dir/electron-launch-routes" \
+        > "$out_dir/electron-launch-routes.log" 2>&1 || true
+fi
 
 {
     echo "# MetalSharp Parity Backend Probe"
@@ -146,6 +154,8 @@ curl -fsS "$base_url/bottles/profiles" > "$out_dir/bottles-profiles.json" 2> "$o
     echo "setup_dependencies_json=$out_dir/setup-dependencies.json"
     echo "runtime_host_abi_json=$out_dir/runtime-host-abi.json"
     echo "bottles_profiles_json=$out_dir/bottles-profiles.json"
+    echo "steam_library_json=$out_dir/steam-library.json"
+    echo "electron_launch_route_audit=$out_dir/electron-launch-routes/electron-launch-route-audit.md"
     echo "backend_stdout=$out_dir/backend.stdout.log"
     echo "backend_stderr=$out_dir/backend.stderr.log"
 } > "$out_dir/summary.txt"

--- a/scripts/run-wine119-live-control-suite.sh
+++ b/scripts/run-wine119-live-control-suite.sh
@@ -166,6 +166,32 @@ if find "$parity_home/.metalsharp/compatdata" -type d -name logs -print -quit 2>
     exit 1
 fi
 
+mkdir -p "$out_dir/steam"
+
+capture_steam_snapshot() {
+    local label="$1"
+    local all_processes="$out_dir/steam/$label-processes.txt"
+    local matching="$out_dir/steam/$label-matching-steam.txt"
+    local pids="$out_dir/steam/$label-wine-steam-pids.txt"
+
+    ps -axo pid,ppid,etime,command > "$all_processes"
+    grep -iE 'Steam\.exe|steam\.exe|steamwebhelper|steam://|metalsharp-backend|wine' \
+        "$all_processes" > "$matching" || true
+    awk '
+        {
+            line = tolower($0)
+            if (index(line, "steam.exe") > 0 &&
+                index(line, "run-wine119-live-control-suite.sh") == 0 &&
+                index(line, "/bin/zsh -lc") == 0 &&
+                index(line, "/bin/bash") == 0 &&
+                index(line, " grep ") == 0 &&
+                index(line, " rg ") == 0) print $1
+        }
+    ' "$all_processes" | sort -n > "$pids"
+}
+
+capture_steam_snapshot "before-backend"
+
 backend_pid=""
 cleanup() {
     if [[ -n "$backend_pid" ]] && kill -0 "$backend_pid" 2>/dev/null; then
@@ -211,6 +237,8 @@ if [[ "$ready" != "1" ]]; then
     exit 1
 fi
 
+capture_steam_snapshot "backend-ready"
+
 launch_game() {
     local label="$1"
     local appid="$2"
@@ -220,6 +248,8 @@ launch_game() {
     local launch_curl="$out_dir/launches/$label-launch.curl.log"
     local proof_dir="$out_dir/proof/$label"
 
+    capture_steam_snapshot "before-$label"
+
     printf '{"appid":%s,"launchMethod":"%s"}' "$appid" "$method" \
         | curl -fsS -X POST "$base_url/steam/launch-game" \
             -H 'Content-Type: application/json' \
@@ -227,6 +257,8 @@ launch_game() {
             > "$launch_json" 2> "$launch_curl" || true
 
     sleep "$wait_secs"
+
+    capture_steam_snapshot "after-$label"
 
     HOME="$parity_home" \
     METALSHARP_HOME="$parity_home/.metalsharp" \
@@ -246,6 +278,7 @@ launch_game "subnautica-bz" 848450 "m11" "SubnauticaZero"
     echo "status_json=$out_dir/status.json"
     echo "backend_stdout=$out_dir/backend.stdout.log"
     echo "backend_stderr=$out_dir/backend.stderr.log"
+    echo "steam_snapshots=$out_dir/steam"
     echo
     for label in nidhogg2 schedule-i subnautica-bz; do
         echo "## $label"
@@ -256,6 +289,12 @@ launch_game "subnautica-bz" 848450 "m11" "SubnauticaZero"
             echo "- live_game_pids: $(tr '\n' ' ' < "$out_dir/proof/$label/game-pids.txt" | sed 's/[[:space:]]*$//')"
         else
             echo "- live_game_pids: none"
+        fi
+        if [[ -f "$out_dir/steam/before-$label-wine-steam-pids.txt" ]]; then
+            echo "- wine_steam_pids_before: $(tr '\n' ' ' < "$out_dir/steam/before-$label-wine-steam-pids.txt" | sed 's/[[:space:]]*$//')"
+        fi
+        if [[ -f "$out_dir/steam/after-$label-wine-steam-pids.txt" ]]; then
+            echo "- wine_steam_pids_after: $(tr '\n' ' ' < "$out_dir/steam/after-$label-wine-steam-pids.txt" | sed 's/[[:space:]]*$//')"
         fi
         echo
     done

--- a/scripts/run-wine119-live-control-suite.sh
+++ b/scripts/run-wine119-live-control-suite.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  METALSHARP_RUN_LIVE_GAMES=1 scripts/run-wine119-live-control-suite.sh <parity-home> [output-dir]
+
+Example:
+  METALSHARP_RUN_LIVE_GAMES=1 scripts/run-wine119-live-control-suite.sh \
+    /tmp/metalsharp-home-wine119-dxmt32 \
+    /tmp/metalsharp-live-controls-dxmt32
+
+Starts metalsharp-backend with HOME=<parity-home>, launches the three Wine 11.9
+control games through /steam/launch-game, waits briefly, captures live process
+proof, then stops the backend.
+
+Hard safety guard:
+  METALSHARP_RUN_LIVE_GAMES must be set to 1.
+
+The parity home should be prepared with copied user state:
+  METALSHARP_CLONE_USER_STATE=1 scripts/install-wine119-parity-home.sh ...
+The runner refuses to continue if active cloned manifests still point at the
+source ~/.metalsharp path instead of the parity home.
+
+Controls:
+  Nidhogg 2          appid 535520   launchMethod m9
+  Schedule I         appid 3164500  launchMethod m11
+  Subnautica BZ      appid 848450   launchMethod m11
+
+Environment:
+  METALSHARP_PORT       Port to use, default 9375
+  METALSHARP_BACKEND    Backend binary override
+  METALSHARP_WAIT_SECS  Seconds to wait after each launch before proof, default 20
+  METALSHARP_ALLOW_NON_TMP_PARITY_HOME=1
+                       Allow a parity home outside /tmp or /private/tmp
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+if [[ "${METALSHARP_RUN_LIVE_GAMES:-0}" != "1" ]]; then
+    usage >&2
+    echo >&2
+    echo "refusing to launch games: set METALSHARP_RUN_LIVE_GAMES=1 to proceed" >&2
+    exit 2
+fi
+
+parity_home="${1:-}"
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+out_dir="${2:-/tmp/metalsharp-live-controls-$timestamp}"
+
+if [[ -z "$parity_home" ]]; then
+    usage >&2
+    exit 1
+fi
+
+if [[ ! -d "$parity_home/.metalsharp/runtime/wine" ]]; then
+    echo "parity runtime not found: $parity_home/.metalsharp/runtime/wine" >&2
+    exit 1
+fi
+
+parity_home="$(cd "$parity_home" && pwd -P)"
+
+for rel in prefix-steam compatdata bottles games; do
+    if [[ ! -e "$parity_home/.metalsharp/$rel" ]]; then
+        echo "parity home missing copied user state: $parity_home/.metalsharp/$rel" >&2
+        echo "prepare it with METALSHARP_CLONE_USER_STATE=1 scripts/install-wine119-parity-home.sh ..." >&2
+        exit 1
+    fi
+done
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(cd "$script_dir/.." && pwd -P)"
+port="${METALSHARP_PORT:-9375}"
+backend="${METALSHARP_BACKEND:-$repo_root/app/src-rust/target/release/metalsharp-backend}"
+wait_secs="${METALSHARP_WAIT_SECS:-20}"
+
+if [[ ! -x "$backend" ]]; then
+    backend="$repo_root/app/src-rust/target/debug/metalsharp-backend"
+fi
+
+if [[ ! -x "$backend" ]]; then
+    echo "backend binary not found; run cargo build --release in app/src-rust first" >&2
+    exit 1
+fi
+
+mkdir -p "$out_dir/launches" "$out_dir/proof"
+
+source_ms_home="${METALSHARP_PARITY_SOURCE_HOME:-}"
+if [[ -z "$source_ms_home" && -f "$parity_home/parity-install-report.txt" ]]; then
+    source_ms_home="$(awk -F= '$1 == "source_metalsharp_home" { print substr($0, index($0, "=") + 1); exit }' "$parity_home/parity-install-report.txt")"
+fi
+if [[ -z "$source_ms_home" ]]; then
+    echo "refusing to launch games: parity source MetalSharp home is unknown" >&2
+    echo "prepare the parity home with scripts/install-wine119-parity-home.sh or set METALSHARP_PARITY_SOURCE_HOME" >&2
+    exit 1
+fi
+if [[ -n "$source_ms_home" && -d "$source_ms_home" ]]; then
+    source_ms_home="$(cd "$source_ms_home" && pwd -P)"
+fi
+source_home_parent="$(cd "$(dirname "$source_ms_home")" && pwd -P 2>/dev/null || dirname "$source_ms_home")"
+
+if [[ "$parity_home" == "$source_home_parent" || "$parity_home/.metalsharp" == "$source_ms_home" ]]; then
+    echo "refusing to launch games against real MetalSharp home: $parity_home" >&2
+    exit 1
+fi
+
+if [[ "${METALSHARP_ALLOW_NON_TMP_PARITY_HOME:-0}" != "1" ]]; then
+    case "$parity_home" in
+        /tmp/*|/private/tmp/*) ;;
+        *)
+            echo "refusing non-tmp parity home: $parity_home" >&2
+            echo "set METALSHARP_ALLOW_NON_TMP_PARITY_HOME=1 for an intentional scratch location" >&2
+            exit 1
+            ;;
+    esac
+fi
+
+if [[ "$source_ms_home" != "$parity_home/.metalsharp" ]]; then
+    stale_refs="$out_dir/stale-active-state-refs.txt"
+    : > "$stale_refs"
+    if find "$parity_home/.metalsharp/bottles" "$parity_home/.metalsharp/compatdata" "$parity_home/.metalsharp/configs" \
+        -type f \( -name '*.json' -o -name '*.toml' -o -name '*.conf' -o -name '*.env' \) -print0 2>/dev/null \
+        | xargs -0 rg -n --fixed-strings "$source_ms_home" -S > "$stale_refs" 2>/dev/null; then
+        echo "refusing to launch games: active parity manifests still reference source MetalSharp home: $source_ms_home" >&2
+        echo "stale refs: $stale_refs" >&2
+        exit 1
+    fi
+fi
+
+validate_control_state_paths() {
+    local label="$1"
+    local appid="$2"
+    local bottle="$parity_home/.metalsharp/bottles/steam_$appid/bottle.json"
+    local compat="$parity_home/.metalsharp/compatdata/$appid/metalsharp-compatdata.json"
+
+    if [[ ! -f "$bottle" ]]; then
+        echo "refusing to launch games: missing bottle manifest for $label: $bottle" >&2
+        exit 1
+    fi
+    if [[ ! -f "$compat" ]]; then
+        echo "refusing to launch games: missing compatdata manifest for $label: $compat" >&2
+        exit 1
+    fi
+    if ! grep -Fq -- "$parity_home/.metalsharp" "$bottle"; then
+        echo "refusing to launch games: bottle manifest for $label does not reference parity MetalSharp home" >&2
+        exit 1
+    fi
+    if ! grep -Fq -- "$parity_home/.metalsharp" "$compat"; then
+        echo "refusing to launch games: compatdata manifest for $label does not reference parity MetalSharp home" >&2
+        exit 1
+    fi
+}
+
+validate_control_state_paths "Nidhogg 2" 535520
+validate_control_state_paths "Schedule I" 3164500
+validate_control_state_paths "Subnautica Below Zero" 848450
+
+if find "$parity_home/.metalsharp/compatdata" -type d -name logs -print -quit 2>/dev/null | grep -q .; then
+    echo "refusing to launch games: copied compatdata logs are present and could contaminate proof" >&2
+    echo "reinstall parity state with scripts/install-wine119-parity-home.sh to prune historical logs" >&2
+    exit 1
+fi
+
+backend_pid=""
+cleanup() {
+    if [[ -n "$backend_pid" ]] && kill -0 "$backend_pid" 2>/dev/null; then
+        kill "$backend_pid" 2>/dev/null || true
+        wait "$backend_pid" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+{
+    echo "parity_home=$parity_home"
+    echo "metalsharp_home=$parity_home/.metalsharp"
+    echo "runtime=$parity_home/.metalsharp/runtime/wine"
+    echo "backend=$backend"
+    echo "port=$port"
+    echo "wait_secs=$wait_secs"
+    echo "captured_at_utc=$timestamp"
+    printf "wine_version="
+    "$parity_home/.metalsharp/runtime/wine/bin/wine" --version 2>&1 || true
+    printf "wineserver_version="
+    "$parity_home/.metalsharp/runtime/wine/bin/wineserver" --version 2>&1 || true
+} > "$out_dir/runtime-identity.txt"
+
+HOME="$parity_home" \
+METALSHARP_HOME="$parity_home/.metalsharp" \
+METALSHARP_PORT="$port" \
+    "$backend" > "$out_dir/backend.stdout.log" 2> "$out_dir/backend.stderr.log" &
+backend_pid=$!
+echo "$backend_pid" > "$out_dir/backend.pid"
+
+base_url="http://127.0.0.1:$port"
+ready=0
+for _ in $(seq 1 80); do
+    if curl -fsS "$base_url/status" > "$out_dir/status.json" 2> "$out_dir/status.curl.log"; then
+        ready=1
+        break
+    fi
+    sleep 0.1
+done
+
+if [[ "$ready" != "1" ]]; then
+    echo "backend did not become ready on $base_url" >&2
+    exit 1
+fi
+
+launch_game() {
+    local label="$1"
+    local appid="$2"
+    local method="$3"
+    local exe_match="$4"
+    local launch_json="$out_dir/launches/$label-launch.json"
+    local launch_curl="$out_dir/launches/$label-launch.curl.log"
+    local proof_dir="$out_dir/proof/$label"
+
+    printf '{"appid":%s,"launchMethod":"%s"}' "$appid" "$method" \
+        | curl -fsS -X POST "$base_url/steam/launch-game" \
+            -H 'Content-Type: application/json' \
+            --data-binary @- \
+            > "$launch_json" 2> "$launch_curl" || true
+
+    sleep "$wait_secs"
+
+    HOME="$parity_home" \
+    METALSHARP_HOME="$parity_home/.metalsharp" \
+    METALSHARP_REQUIRE_PARITY_HOME=1 \
+        "$repo_root/scripts/capture-steam-game-proof.sh" "$appid" "$exe_match" "$proof_dir"
+}
+
+launch_game "nidhogg2" 535520 "m9" "Nidhogg_2"
+launch_game "schedule-i" 3164500 "m11" "Schedule I"
+launch_game "subnautica-bz" 848450 "m11" "SubnauticaZero"
+
+{
+    echo "# MetalSharp Wine 11.9 Live Control Suite"
+    echo
+    cat "$out_dir/runtime-identity.txt"
+    echo
+    echo "status_json=$out_dir/status.json"
+    echo "backend_stdout=$out_dir/backend.stdout.log"
+    echo "backend_stderr=$out_dir/backend.stderr.log"
+    echo
+    for label in nidhogg2 schedule-i subnautica-bz; do
+        echo "## $label"
+        echo
+        echo "- launch_json: $out_dir/launches/$label-launch.json"
+        echo "- proof_summary: $out_dir/proof/$label/summary.txt"
+        if [[ -f "$out_dir/proof/$label/game-pids.txt" && -s "$out_dir/proof/$label/game-pids.txt" ]]; then
+            echo "- live_game_pids: $(tr '\n' ' ' < "$out_dir/proof/$label/game-pids.txt" | sed 's/[[:space:]]*$//')"
+        else
+            echo "- live_game_pids: none"
+        fi
+        echo
+    done
+} > "$out_dir/summary.md"
+
+echo "live control suite written: $out_dir"
+echo "summary: $out_dir/summary.md"

--- a/scripts/run-wine119-live-control-suite.sh
+++ b/scripts/run-wine119-live-control-suite.sh
@@ -37,6 +37,11 @@ Environment:
                        launch to attach to that pre-existing Steam process.
   METALSHARP_ALLOW_NON_TMP_PARITY_HOME=1
                        Allow a parity home outside /tmp or /private/tmp
+  METALSHARP_WINE119_CANDIDATE_WORK_DIR
+                       Candidate work dir, default prefers AverySSD clean-i386
+                       output when present. The live runner refuses to launch
+                       if the parity home was not installed from this dxmt32
+                       candidate or if i386 WineMetal provenance is stale.
 USAGE
 }
 
@@ -82,6 +87,13 @@ port="${METALSHARP_PORT:-9375}"
 backend="${METALSHARP_BACKEND:-$repo_root/app/src-rust/target/release/metalsharp-backend}"
 wait_secs="${METALSHARP_WAIT_SECS:-20}"
 require_preexisting_steam="${METALSHARP_REQUIRE_PREEXISTING_WINE_STEAM:-0}"
+default_candidate_work_dir="/tmp/metalsharp-wine119-parity"
+clean_candidate_work_dir="/Volumes/AverySSD/metalsharp/wine119-parity-clean-i386"
+if [[ -z "${METALSHARP_WINE119_CANDIDATE_WORK_DIR:-}" && -f "$clean_candidate_work_dir/summary.md" ]]; then
+    candidate_work_dir="$clean_candidate_work_dir"
+else
+    candidate_work_dir="${METALSHARP_WINE119_CANDIDATE_WORK_DIR:-$default_candidate_work_dir}"
+fi
 
 if [[ ! -x "$backend" ]]; then
     backend="$repo_root/app/src-rust/target/debug/metalsharp-backend"
@@ -170,6 +182,38 @@ if find "$parity_home/.metalsharp/compatdata" -path '*/logs/*' -type f -print -q
     exit 1
 fi
 
+install_report="$parity_home/parity-install-report.txt"
+if [[ ! -f "$install_report" ]]; then
+    echo "refusing to launch games: missing parity install report: $install_report" >&2
+    exit 1
+fi
+installed_candidate_root="$(awk -F= '$1 == "candidate_root" { print substr($0, index($0, "=") + 1); exit }' "$install_report")"
+expected_candidate_root="$candidate_work_dir/candidates/dxmt32/wine"
+installed_candidate_abs="$(cd "$installed_candidate_root" && pwd -P 2>/dev/null || printf '%s\n' "$installed_candidate_root")"
+expected_candidate_abs="$(cd "$expected_candidate_root" && pwd -P 2>/dev/null || printf '%s\n' "$expected_candidate_root")"
+if [[ "$installed_candidate_abs" != "$expected_candidate_abs" ]]; then
+    echo "refusing to launch games: parity home was installed from '$installed_candidate_root', expected clean dxmt32 '$expected_candidate_root'" >&2
+    exit 1
+fi
+
+candidate_summary="$candidate_work_dir/summary.md"
+dxmt32_prepare="$candidate_work_dir/candidates/dxmt32/prepare-report.txt"
+dxmt32_provenance="$candidate_work_dir/candidates/dxmt32/provenance-report.txt"
+if [[ ! -f "$candidate_summary" ]] || ! rg -q 'dxmt32_source_kind: `clean-11[.]9-linked-default`' "$candidate_summary"; then
+    echo "refusing to launch games: dxmt32 summary does not prove clean 11.9-linked i386 source: $candidate_summary" >&2
+    exit 1
+fi
+if [[ ! -f "$dxmt32_prepare" ]] || ! rg -q 'i386_winemetal_source=/tmp/metalsharp-dxmt-clean-build32-wine119/src/winemetal/winemetal[.]dll' "$dxmt32_prepare"; then
+    echo "refusing to launch games: dxmt32 prepare report does not record the clean i386 source: $dxmt32_prepare" >&2
+    exit 1
+fi
+if [[ ! -f "$dxmt32_provenance" ]] ||
+    ! rg -q 'source_sha256=12b9343459d28dfe1d7668a31a58a0c3506948d7c533507fdaec65d59c6697ab' "$dxmt32_provenance" ||
+    ! rg -q 'destination_sha256=12b9343459d28dfe1d7668a31a58a0c3506948d7c533507fdaec65d59c6697ab' "$dxmt32_provenance"; then
+    echo "refusing to launch games: dxmt32 provenance does not prove clean i386 WineMetal SHA256 copy: $dxmt32_provenance" >&2
+    exit 1
+fi
+
 mkdir -p "$out_dir/steam"
 
 capture_steam_snapshot() {
@@ -212,6 +256,8 @@ trap cleanup EXIT
     echo "backend=$backend"
     echo "port=$port"
     echo "wait_secs=$wait_secs"
+    echo "candidate_work_dir=$candidate_work_dir"
+    echo "candidate_root=$installed_candidate_abs"
     echo "captured_at_utc=$timestamp"
     printf "wine_version="
     "$parity_home/.metalsharp/runtime/wine/bin/wine" --version 2>&1 || true

--- a/scripts/run-wine119-live-control-suite.sh
+++ b/scripts/run-wine119-live-control-suite.sh
@@ -98,15 +98,6 @@ else
     candidate_work_dir="${METALSHARP_WINE119_CANDIDATE_WORK_DIR:-$default_candidate_work_dir}"
 fi
 
-if [[ ! -x "$backend" ]]; then
-    backend="$repo_root/app/src-rust/target/debug/metalsharp-backend"
-fi
-
-if [[ ! -x "$backend" ]]; then
-    echo "backend binary not found; run cargo build --release in app/src-rust first" >&2
-    exit 1
-fi
-
 mkdir -p "$out_dir/launches" "$out_dir/proof"
 
 source_ms_home="${METALSHARP_PARITY_SOURCE_HOME:-}"
@@ -226,6 +217,15 @@ if [[ "${METALSHARP_LIVE_PREFLIGHT_ONLY:-0}" == "1" ]]; then
     } > "$out_dir/preflight-only.txt"
     echo "live control preflight passed without launching games: $out_dir/preflight-only.txt"
     exit 0
+fi
+
+if [[ ! -x "$backend" ]]; then
+    backend="$repo_root/app/src-rust/target/debug/metalsharp-backend"
+fi
+
+if [[ ! -x "$backend" ]]; then
+    echo "backend binary not found; run cargo build --release in app/src-rust first" >&2
+    exit 1
 fi
 
 mkdir -p "$out_dir/steam"

--- a/scripts/run-wine119-live-control-suite.sh
+++ b/scripts/run-wine119-live-control-suite.sh
@@ -160,8 +160,8 @@ validate_control_state_paths "Nidhogg 2" 535520
 validate_control_state_paths "Schedule I" 3164500
 validate_control_state_paths "Subnautica Below Zero" 848450
 
-if find "$parity_home/.metalsharp/compatdata" -type d -name logs -print -quit 2>/dev/null | grep -q .; then
-    echo "refusing to launch games: copied compatdata logs are present and could contaminate proof" >&2
+if find "$parity_home/.metalsharp/compatdata" -path '*/logs/*' -type f -print -quit 2>/dev/null | grep -q .; then
+    echo "refusing to launch games: copied compatdata log files are present and could contaminate proof" >&2
     echo "reinstall parity state with scripts/install-wine119-parity-home.sh to prune historical logs" >&2
     exit 1
 fi

--- a/scripts/run-wine119-live-control-suite.sh
+++ b/scripts/run-wine119-live-control-suite.sh
@@ -37,6 +37,9 @@ Environment:
                        launch to attach to that pre-existing Steam process.
   METALSHARP_ALLOW_NON_TMP_PARITY_HOME=1
                        Allow a parity home outside /tmp or /private/tmp
+  METALSHARP_LIVE_PREFLIGHT_ONLY=1
+                       Run all non-destructive preflight guards, then exit
+                       before backend, Steam, or game launch.
   METALSHARP_WINE119_CANDIDATE_WORK_DIR
                        Candidate work dir, default prefers AverySSD clean-i386
                        output when present. The live runner refuses to launch
@@ -212,6 +215,17 @@ if [[ ! -f "$dxmt32_provenance" ]] ||
     ! rg -q 'destination_sha256=12b9343459d28dfe1d7668a31a58a0c3506948d7c533507fdaec65d59c6697ab' "$dxmt32_provenance"; then
     echo "refusing to launch games: dxmt32 provenance does not prove clean i386 WineMetal SHA256 copy: $dxmt32_provenance" >&2
     exit 1
+fi
+
+if [[ "${METALSHARP_LIVE_PREFLIGHT_ONLY:-0}" == "1" ]]; then
+    {
+        echo "parity_home=$parity_home"
+        echo "candidate_work_dir=$candidate_work_dir"
+        echo "candidate_root=$installed_candidate_abs"
+        echo "preflight_only=1"
+    } > "$out_dir/preflight-only.txt"
+    echo "live control preflight passed without launching games: $out_dir/preflight-only.txt"
+    exit 0
 fi
 
 mkdir -p "$out_dir/steam"

--- a/scripts/run-wine119-live-control-suite.sh
+++ b/scripts/run-wine119-live-control-suite.sh
@@ -32,6 +32,9 @@ Environment:
   METALSHARP_PORT       Port to use, default 9375
   METALSHARP_BACKEND    Backend binary override
   METALSHARP_WAIT_SECS  Seconds to wait after each launch before proof, default 20
+  METALSHARP_REQUIRE_PREEXISTING_WINE_STEAM=1
+                       Start Wine Steam before the controls and require every
+                       launch to attach to that pre-existing Steam process.
   METALSHARP_ALLOW_NON_TMP_PARITY_HOME=1
                        Allow a parity home outside /tmp or /private/tmp
 USAGE
@@ -78,6 +81,7 @@ repo_root="$(cd "$script_dir/.." && pwd -P)"
 port="${METALSHARP_PORT:-9375}"
 backend="${METALSHARP_BACKEND:-$repo_root/app/src-rust/target/release/metalsharp-backend}"
 wait_secs="${METALSHARP_WAIT_SECS:-20}"
+require_preexisting_steam="${METALSHARP_REQUIRE_PREEXISTING_WINE_STEAM:-0}"
 
 if [[ ! -x "$backend" ]]; then
     backend="$repo_root/app/src-rust/target/debug/metalsharp-backend"
@@ -239,6 +243,28 @@ fi
 
 capture_steam_snapshot "backend-ready"
 
+if [[ "$require_preexisting_steam" == "1" ]]; then
+    curl -fsS -X POST "$base_url/steam/launch" \
+        -H 'Content-Type: application/json' \
+        --data-binary '{}' \
+        > "$out_dir/steam/prestart-launch.json" \
+        2> "$out_dir/steam/prestart-launch.curl.log" || true
+
+    prestarted=0
+    for _ in $(seq 1 120); do
+        capture_steam_snapshot "prestarted"
+        if [[ -s "$out_dir/steam/prestarted-wine-steam-pids.txt" ]]; then
+            prestarted=1
+            break
+        fi
+        sleep 0.5
+    done
+    if [[ "$prestarted" != "1" ]]; then
+        echo "refusing to launch games: Wine Steam did not become visible before controls" >&2
+        exit 1
+    fi
+fi
+
 launch_game() {
     local label="$1"
     local appid="$2"
@@ -279,6 +305,10 @@ launch_game "subnautica-bz" 848450 "m11" "SubnauticaZero"
     echo "backend_stdout=$out_dir/backend.stdout.log"
     echo "backend_stderr=$out_dir/backend.stderr.log"
     echo "steam_snapshots=$out_dir/steam"
+    echo "require_preexisting_wine_steam=$require_preexisting_steam"
+    if [[ -f "$out_dir/steam/prestarted-wine-steam-pids.txt" ]]; then
+        echo "prestarted_wine_steam_pids=$(tr '\n' ' ' < "$out_dir/steam/prestarted-wine-steam-pids.txt" | sed 's/[[:space:]]*$//')"
+    fi
     echo
     for label in nidhogg2 schedule-i subnautica-bz; do
         echo "## $label"

--- a/scripts/runtime-manifest.sh
+++ b/scripts/runtime-manifest.sh
@@ -12,8 +12,8 @@ Examples:
 
 Captures a reproducible Wine/DXMT runtime manifest for MetalSharp route parity:
 versions, normalized file list, route-critical hashes, file(1), otool -L,
-Mach-O load commands/rpaths, and nm -gU hook probes. The script is read-only
-against the runtime root.
+Mach-O load commands/rpaths, critical-path type/linkage probes, and nm -gU hook
+probes. The script is read-only against the runtime root.
 USAGE
 }
 
@@ -50,6 +50,9 @@ critical_paths=(
     "lib/dxmt/x86_64-windows/d3d12.dll"
     "lib/dxmt/x86_64-windows/dxgi.dll"
     "lib/dxmt/x86_64-windows/winemetal.dll"
+    "lib/dxmt/i386-windows/d3d11.dll"
+    "lib/dxmt/i386-windows/dxgi.dll"
+    "lib/dxmt/i386-windows/winemetal.dll"
     "lib/dxmt/x86_64-unix/winemetal.so"
     "lib/wine/x86_64-unix/winemetal.so"
     "lib/wine/x86_64-unix/mscompatdb.so"
@@ -125,6 +128,18 @@ find "$real_root" -type f | wc -l | tr -d ' ' > "$out_dir/file-count.txt"
 } > "$out_dir/file.txt"
 
 {
+    for rel in "${critical_paths[@]}"; do
+        abs="$real_root/$rel"
+        echo "== $rel =="
+        if [[ -e "$abs" ]]; then
+            file "$abs" || true
+        else
+            echo "missing"
+        fi
+    done
+} > "$out_dir/critical-file.txt"
+
+{
     for rel in "${probe_paths[@]}"; do
         abs="$real_root/$rel"
         echo "== $rel =="
@@ -137,6 +152,18 @@ find "$real_root" -type f | wc -l | tr -d ' ' > "$out_dir/file-count.txt"
 } > "$out_dir/otool-L.txt"
 
 {
+    for rel in "${critical_paths[@]}"; do
+        abs="$real_root/$rel"
+        echo "== $rel =="
+        if [[ -f "$abs" ]]; then
+            otool -L "$abs" 2>&1 || true
+        else
+            echo "missing"
+        fi
+    done
+} > "$out_dir/critical-otool-L.txt"
+
+{
     for rel in "${probe_paths[@]}"; do
         abs="$real_root/$rel"
         echo "== $rel =="
@@ -147,6 +174,70 @@ find "$real_root" -type f | wc -l | tr -d ' ' > "$out_dir/file-count.txt"
         fi
     done
 } > "$out_dir/otool-l.txt"
+
+{
+    for rel in "${critical_paths[@]}"; do
+        abs="$real_root/$rel"
+        echo "== $rel =="
+        if [[ -f "$abs" ]]; then
+            otool -l "$abs" 2>/dev/null |
+                awk '
+                    /cmd LC_ID_DYLIB/ { want=1; next }
+                    /cmd LC_LOAD_DYLIB/ { want=1; next }
+                    /cmd LC_LOAD_WEAK_DYLIB/ { want=1; next }
+                    /cmd LC_RPATH/ { want=1; next }
+                    want && /^[[:space:]]+(name|path) / {
+                        sub(/^[[:space:]]+/, "")
+                        print
+                        want=0
+                    }
+                    /^[[:space:]]*cmd / && !/LC_(ID_DYLIB|LOAD_DYLIB|LOAD_WEAK_DYLIB|RPATH)/ {
+                        want=0
+                    }
+                ' || true
+        else
+            echo "missing"
+        fi
+    done
+} > "$out_dir/critical-linkage-summary.txt"
+
+{
+    wrapper="$real_root/bin/metalsharp-wine"
+    echo "path=$wrapper"
+    if [[ -e "$wrapper" ]]; then
+        stat -f 'mode=%Sp' "$wrapper" 2>/dev/null || stat -c 'mode=%A' "$wrapper" 2>/dev/null || true
+        shasum -a 256 "$wrapper" | sed "s#  $real_root/#  #"
+        echo "first_line=$(sed -n '1p' "$wrapper")"
+        echo "exports:"
+        rg -n '^export ' "$wrapper" || true
+        echo "version_probe:"
+        "$wrapper" --version 2>&1 || true
+    else
+        echo "missing"
+    fi
+} > "$out_dir/metalsharp-wine-wrapper.txt"
+
+{
+    for rel in "${critical_paths[@]}"; do
+        case "$rel" in
+            *-windows/*.dll)
+                abs="$real_root/$rel"
+                echo "== $rel =="
+                if [[ -f "$abs" ]]; then
+                    objdump -p "$abs" 2>&1 | awk '
+                        /DLL Name:/ { print }
+                        /^The Export Tables / { in_exports=1; print; next }
+                        /^The Import Tables / { in_imports=1; print; next }
+                        in_exports && /Ordinal Base|Number in:|Name Pointer|Export Address Table|Export Flags|Time\/Date|Major\/Minor/ { print }
+                        in_imports && /DLL Name:/ { print }
+                    ' || true
+                else
+                    echo "missing"
+                fi
+                ;;
+        esac
+    done
+} > "$out_dir/critical-pe-objdump.txt"
 
 {
     for rel in \
@@ -173,8 +264,13 @@ find "$real_root" -type f | wc -l | tr -d ' ' > "$out_dir/file-count.txt"
     echo '    "files": "files.txt",'
     echo '    "critical_sha256": "critical-sha256.txt",'
     echo '    "file": "file.txt",'
+    echo '    "critical_file": "critical-file.txt",'
     echo '    "otool_L": "otool-L.txt",'
+    echo '    "critical_otool_L": "critical-otool-L.txt",'
     echo '    "otool_l": "otool-l.txt",'
+    echo '    "critical_linkage_summary": "critical-linkage-summary.txt",'
+    echo '    "metalsharp_wine_wrapper": "metalsharp-wine-wrapper.txt",'
+    echo '    "critical_pe_objdump": "critical-pe-objdump.txt",'
     echo '    "nm_gU": "nm-gU.txt"'
     echo "  }"
     echo "}"

--- a/scripts/runtime-manifest.sh
+++ b/scripts/runtime-manifest.sh
@@ -11,8 +11,9 @@ Examples:
   scripts/runtime-manifest.sh /tmp/wine-11.9-candidate/runtime/wine /tmp/metalsharp-runtime-11.9
 
 Captures a reproducible Wine/DXMT runtime manifest for MetalSharp route parity:
-versions, normalized file list, route-critical hashes, file(1), otool -L, and
-nm -gU hook probes. The script is read-only against the runtime root.
+versions, normalized file list, route-critical hashes, file(1), otool -L,
+Mach-O load commands/rpaths, and nm -gU hook probes. The script is read-only
+against the runtime root.
 USAGE
 }
 
@@ -43,6 +44,7 @@ critical_paths=(
     "etc/mscompatdb_rules.toml"
     "etc/vulkan/icd.d/MoltenVK_icd.json"
     "etc/vulkan/icd.d/MoltenVK_x86_64_icd.json"
+    "lib/libMoltenVK.dylib"
     "lib/dxmt/x86_64-windows/d3d10core.dll"
     "lib/dxmt/x86_64-windows/d3d11.dll"
     "lib/dxmt/x86_64-windows/d3d12.dll"
@@ -71,6 +73,7 @@ probe_paths=(
     "lib/wine/x86_64-unix/winemetal.so"
     "lib/wine/x86_64-unix/mscompatdb.so"
     "lib/wine/x86_64-unix/mscompatdb.dylib"
+    "lib/libMoltenVK.dylib"
     "lib/wine/x86_64-unix/libMoltenVK.1.dylib"
     "lib/wine/x86_64-unix/ntdll.so"
     "lib/wine/x86_64-unix/win32u.so"
@@ -134,6 +137,18 @@ find "$real_root" -type f | wc -l | tr -d ' ' > "$out_dir/file-count.txt"
 } > "$out_dir/otool-L.txt"
 
 {
+    for rel in "${probe_paths[@]}"; do
+        abs="$real_root/$rel"
+        echo "== $rel =="
+        if [[ -f "$abs" ]]; then
+            otool -l "$abs" 2>&1 || true
+        else
+            echo "missing"
+        fi
+    done
+} > "$out_dir/otool-l.txt"
+
+{
     for rel in \
         "lib/wine/x86_64-unix/ntdll.so" \
         "lib/wine/x86_64-unix/mscompatdb.so" \
@@ -159,6 +174,7 @@ find "$real_root" -type f | wc -l | tr -d ' ' > "$out_dir/file-count.txt"
     echo '    "critical_sha256": "critical-sha256.txt",'
     echo '    "file": "file.txt",'
     echo '    "otool_L": "otool-L.txt",'
+    echo '    "otool_l": "otool-l.txt",'
     echo '    "nm_gU": "nm-gU.txt"'
     echo "  }"
     echo "}"

--- a/scripts/runtime-manifest.sh
+++ b/scripts/runtime-manifest.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  scripts/runtime-manifest.sh [runtime-root] [output-dir]
+
+Examples:
+  scripts/runtime-manifest.sh ~/.metalsharp/runtime/wine /tmp/metalsharp-runtime-11.5
+  scripts/runtime-manifest.sh /tmp/wine-11.9-candidate/runtime/wine /tmp/metalsharp-runtime-11.9
+
+Captures a reproducible Wine/DXMT runtime manifest for MetalSharp route parity:
+versions, normalized file list, route-critical hashes, file(1), otool -L, and
+nm -gU hook probes. The script is read-only against the runtime root.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+runtime_root="${1:-${METALSHARP_HOME:-$HOME/.metalsharp}/runtime/wine}"
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+out_dir="${2:-/tmp/metalsharp-runtime-manifest-$timestamp}"
+
+if [[ ! -d "$runtime_root" ]]; then
+    echo "runtime root not found: $runtime_root" >&2
+    exit 1
+fi
+
+mkdir -p "$out_dir"
+
+real_root="$(cd "$runtime_root" && pwd -P)"
+
+critical_paths=(
+    "bin/wine"
+    "bin/wineserver"
+    "bin/metalsharp-wine"
+    "share/wine/wine.inf"
+    "etc/dxmt.conf"
+    "etc/mscompatdb_rules.toml"
+    "etc/vulkan/icd.d/MoltenVK_icd.json"
+    "etc/vulkan/icd.d/MoltenVK_x86_64_icd.json"
+    "lib/dxmt/x86_64-windows/d3d10core.dll"
+    "lib/dxmt/x86_64-windows/d3d11.dll"
+    "lib/dxmt/x86_64-windows/d3d12.dll"
+    "lib/dxmt/x86_64-windows/dxgi.dll"
+    "lib/dxmt/x86_64-windows/winemetal.dll"
+    "lib/dxmt/x86_64-unix/winemetal.so"
+    "lib/wine/x86_64-unix/winemetal.so"
+    "lib/wine/x86_64-unix/mscompatdb.so"
+    "lib/wine/x86_64-unix/mscompatdb.dylib"
+    "lib/wine/x86_64-unix/libMoltenVK.1.dylib"
+    "lib/wine/x86_64-windows/d3d11.dll"
+    "lib/wine/x86_64-windows/dxgi.dll"
+    "lib/wine/x86_64-windows/winemetal.dll"
+    "lib/wine/i386-windows/d3d11.dll"
+    "lib/wine/i386-windows/dxgi.dll"
+    "lib/wine/i386-windows/winemetal.dll"
+    "lib/wine/x86_64-unix/ntdll.so"
+    "lib/wine/x86_64-unix/win32u.so"
+)
+
+probe_paths=(
+    "bin/wine"
+    "bin/wineserver"
+    "bin/metalsharp-wine"
+    "lib/dxmt/x86_64-unix/winemetal.so"
+    "lib/wine/x86_64-unix/winemetal.so"
+    "lib/wine/x86_64-unix/mscompatdb.so"
+    "lib/wine/x86_64-unix/mscompatdb.dylib"
+    "lib/wine/x86_64-unix/libMoltenVK.1.dylib"
+    "lib/wine/x86_64-unix/ntdll.so"
+    "lib/wine/x86_64-unix/win32u.so"
+)
+
+{
+    echo "runtime_root=$real_root"
+    echo "captured_at_utc=$timestamp"
+    echo "host=$(uname -a)"
+    echo
+    if [[ -x "$real_root/bin/wine" ]]; then
+        printf "wine_version="
+        "$real_root/bin/wine" --version 2>&1 || true
+    else
+        echo "wine_version=missing bin/wine"
+    fi
+    if [[ -x "$real_root/bin/wineserver" ]]; then
+        printf "wineserver_version="
+        "$real_root/bin/wineserver" --version 2>&1 || true
+    else
+        echo "wineserver_version=missing bin/wineserver"
+    fi
+} > "$out_dir/versions.txt"
+
+find "$real_root" -type f | sed "s#^$real_root/##" | LC_ALL=C sort > "$out_dir/files.txt"
+find "$real_root" -type f | wc -l | tr -d ' ' > "$out_dir/file-count.txt"
+
+{
+    for rel in "${critical_paths[@]}"; do
+        abs="$real_root/$rel"
+        if [[ -f "$abs" ]]; then
+            shasum -a 256 "$abs" | sed "s#  $real_root/#  #"
+        else
+            echo "MISSING  $rel"
+        fi
+    done
+} > "$out_dir/critical-sha256.txt"
+
+{
+    for rel in "${probe_paths[@]}"; do
+        abs="$real_root/$rel"
+        echo "== $rel =="
+        if [[ -e "$abs" ]]; then
+            file "$abs" || true
+        else
+            echo "missing"
+        fi
+    done
+} > "$out_dir/file.txt"
+
+{
+    for rel in "${probe_paths[@]}"; do
+        abs="$real_root/$rel"
+        echo "== $rel =="
+        if [[ -f "$abs" ]]; then
+            otool -L "$abs" 2>&1 || true
+        else
+            echo "missing"
+        fi
+    done
+} > "$out_dir/otool-L.txt"
+
+{
+    for rel in \
+        "lib/wine/x86_64-unix/ntdll.so" \
+        "lib/wine/x86_64-unix/mscompatdb.so" \
+        "lib/wine/x86_64-unix/mscompatdb.dylib"; do
+        abs="$real_root/$rel"
+        echo "== $rel =="
+        if [[ -f "$abs" ]]; then
+            nm -gU "$abs" 2>&1 || true
+        else
+            echo "missing"
+        fi
+    done
+} > "$out_dir/nm-gU.txt"
+
+{
+    echo "{"
+    printf '  "runtime_root": "%s",\n' "$real_root"
+    printf '  "captured_at_utc": "%s",\n' "$timestamp"
+    printf '  "file_count": %s,\n' "$(cat "$out_dir/file-count.txt")"
+    echo '  "artifacts": {'
+    echo '    "versions": "versions.txt",'
+    echo '    "files": "files.txt",'
+    echo '    "critical_sha256": "critical-sha256.txt",'
+    echo '    "file": "file.txt",'
+    echo '    "otool_L": "otool-L.txt",'
+    echo '    "nm_gU": "nm-gU.txt"'
+    echo "  }"
+    echo "}"
+} > "$out_dir/manifest.json"
+
+echo "runtime manifest written: $out_dir"

--- a/scripts/test-wine119-live-suite-guards.sh
+++ b/scripts/test-wine119-live-suite-guards.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(cd "$script_dir/.." && pwd -P)"
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/metalsharp-live-guard-test.XXXXXX")"
+work_dir="$(cd "$work_dir" && pwd -P)"
+trap 'rm -rf "$work_dir"' EXIT
+
+sha="12b9343459d28dfe1d7668a31a58a0c3506948d7c533507fdaec65d59c6697ab"
+candidate_work="$work_dir/candidates-work"
+candidate_root="$candidate_work/candidates/dxmt32/wine"
+parity_home="$work_dir/parity-home"
+parity_ms_home="$parity_home/.metalsharp"
+
+mkdir -p "$candidate_root" \
+    "$candidate_work/candidates/dxmt32" \
+    "$parity_ms_home/runtime" \
+    "$parity_ms_home/prefix-steam" \
+    "$parity_ms_home/compatdata" \
+    "$parity_ms_home/bottles" \
+    "$parity_ms_home/games" \
+    "$parity_ms_home/configs" \
+    "$work_dir/source-home/.metalsharp"
+
+ln -s "$candidate_root" "$parity_ms_home/runtime/wine"
+
+cat > "$candidate_work/summary.md" <<EOF
+# MetalSharp Wine 11.9 Parity Candidates
+
+- dxmt32_source_kind: \`clean-11.9-linked-default\`
+
+## clean
+
+- gate: fail
+
+## dxmt32
+
+- gate: fail
+
+## borrowed
+
+- gate: pass
+
+## Required Live Gates
+EOF
+
+cat > "$candidate_work/candidates/dxmt32/prepare-report.txt" <<'EOF'
+i386_winemetal_source=/tmp/metalsharp-dxmt-clean-build32-wine119/src/winemetal/winemetal.dll
+EOF
+
+cat > "$candidate_work/candidates/dxmt32/provenance-report.txt" <<EOF
+[lib/wine/i386-windows/winemetal.dll]
+source_sha256=$sha
+destination_sha256=$sha
+EOF
+
+cat > "$parity_home/parity-install-report.txt" <<EOF
+candidate_root=$candidate_root
+source_metalsharp_home=$work_dir/source-home/.metalsharp
+EOF
+
+for appid in 535520 3164500 848450; do
+    mkdir -p "$parity_ms_home/bottles/steam_$appid" "$parity_ms_home/compatdata/$appid"
+    printf '{"metalsharp_home":"%s"}\n' "$parity_ms_home" > "$parity_ms_home/bottles/steam_$appid/bottle.json"
+    printf '{"metalsharp_home":"%s"}\n' "$parity_ms_home" > "$parity_ms_home/compatdata/$appid/metalsharp-compatdata.json"
+done
+
+run_preflight() {
+    local out="$1"
+    METALSHARP_RUN_LIVE_GAMES=1 \
+    METALSHARP_LIVE_PREFLIGHT_ONLY=1 \
+    METALSHARP_ALLOW_NON_TMP_PARITY_HOME=1 \
+    METALSHARP_WINE119_CANDIDATE_WORK_DIR="$candidate_work" \
+        "$repo_root/scripts/run-wine119-live-control-suite.sh" "$parity_home" "$out"
+}
+
+run_preflight "$work_dir/pass"
+test -f "$work_dir/pass/preflight-only.txt"
+
+cp "$candidate_work/summary.md" "$candidate_work/summary.md.good"
+perl -0pi -e 's/dxmt32_source_kind: `clean-11\.9-linked-default`/dxmt32_source_kind: `legacy-dirty-dxmt-build32-fallback`/' "$candidate_work/summary.md"
+if run_preflight "$work_dir/fail-dirty-summary" >/dev/null 2>"$work_dir/fail-dirty-summary.err"; then
+    echo "expected dirty dxmt32 summary to fail live preflight" >&2
+    exit 1
+fi
+grep -q 'dxmt32 summary does not prove clean 11.9-linked i386 source' "$work_dir/fail-dirty-summary.err"
+mv "$candidate_work/summary.md.good" "$candidate_work/summary.md"
+
+perl -0pi -e 's#^candidate_root=.*#candidate_root=/tmp/wrong-dxmt32#m' "$parity_home/parity-install-report.txt"
+if run_preflight "$work_dir/fail-wrong-root" >/dev/null 2>"$work_dir/fail-wrong-root.err"; then
+    echo "expected mismatched candidate_root to fail live preflight" >&2
+    exit 1
+fi
+grep -q 'parity home was installed from' "$work_dir/fail-wrong-root.err"
+
+echo "wine119 live-suite guard fixtures passed"

--- a/scripts/test-wine119-live-verifier-fixtures.sh
+++ b/scripts/test-wine119-live-verifier-fixtures.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(cd "$script_dir/.." && pwd -P)"
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/metalsharp-live-verifier-test.XXXXXX")"
+work_dir="$(cd "$work_dir" && pwd -P)"
+trap 'rm -rf "$work_dir"' EXIT
+
+suite="$work_dir/suite"
+mkdir -p "$suite/launches" "$suite/proof" "$suite/steam"
+
+cat > "$suite/runtime-identity.txt" <<'EOF'
+wine_version=wine-11.9
+wineserver_version=Wine 11.9
+EOF
+
+cat > "$suite/status.json" <<'EOF'
+{"ok":true,"version":"0.33.27"}
+EOF
+
+cat > "$suite/summary.md" <<'EOF'
+# MetalSharp Wine 11.9 Live Control Suite
+
+require_preexisting_wine_steam=1
+EOF
+
+write_control() {
+    local label="$1"
+    local appid="$2"
+    local pipeline="$3"
+    local pid="$4"
+    shift 4
+    local patterns=("$@")
+    local proof_dir="$suite/proof/$label"
+
+    mkdir -p "$proof_dir"
+    printf '{"ok":true,"pipeline":"%s"}\n' "$pipeline" > "$suite/launches/$label-launch.json"
+    printf '%s\n' "$pid" > "$proof_dir/game-pids.txt"
+    {
+        echo "appid=$appid"
+        echo "pipeline=$pipeline"
+        echo
+        for pattern in "${patterns[@]}"; do
+            echo "$pattern"
+        done
+    } > "$proof_dir/summary.txt"
+    printf '700\n701\n' > "$suite/steam/before-$label-wine-steam-pids.txt"
+    printf '700\n701\n' > "$suite/steam/after-$label-wine-steam-pids.txt"
+}
+
+write_control \
+    nidhogg2 \
+    535520 \
+    m9 \
+    12345 \
+    'lib/wine/i386-windows/winemetal.dll' \
+    'lib/wine/i386-windows/dxgi.dll' \
+    'lib/wine/i386-windows/d3d11.dll' \
+    'lib/wine/x86_64-unix/winemetal.so' \
+    'etc/dxmt.conf' \
+    'shader-cache/m9/535520'
+
+write_control \
+    schedule-i \
+    3164500 \
+    m11 \
+    12346 \
+    'lib/wine/x86_64-windows/d3d11.dll' \
+    'lib/wine/x86_64-windows/dxgi.dll' \
+    'lib/wine/x86_64-windows/winemetal.dll' \
+    'lib/wine/x86_64-unix/winemetal.so' \
+    'libMoltenVK.1.dylib' \
+    'etc/dxmt.conf' \
+    'shader-cache/m11/3164500'
+
+write_control \
+    subnautica-bz \
+    848450 \
+    m11 \
+    12347 \
+    'lib/wine/x86_64-windows/d3d11.dll' \
+    'lib/wine/x86_64-windows/dxgi.dll' \
+    'lib/wine/x86_64-windows/winemetal.dll' \
+    'lib/wine/x86_64-unix/winemetal.so' \
+    'libMoltenVK.1.dylib' \
+    'etc/dxmt.conf' \
+    'shader-cache/m11/848450'
+
+"$repo_root/scripts/verify-wine119-live-control-suite.sh" "$suite" >/dev/null
+grep -q 'gate: pass' "$suite/verification.md"
+
+cp -R "$suite" "$work_dir/suite-missing-steam"
+printf '700\n' > "$work_dir/suite-missing-steam/steam/after-nidhogg2-wine-steam-pids.txt"
+if "$repo_root/scripts/verify-wine119-live-control-suite.sh" "$work_dir/suite-missing-steam" >/dev/null 2>&1; then
+    echo "expected verifier to fail when a pre-existing Wine Steam PID disappears" >&2
+    exit 1
+fi
+grep -q 'pre-existing Wine Steam PID(s) disappeared after launch' "$work_dir/suite-missing-steam/verification.md"
+
+cp -R "$suite" "$work_dir/suite-log-only"
+: > "$work_dir/suite-log-only/proof/schedule-i/game-pids.txt"
+if "$repo_root/scripts/verify-wine119-live-control-suite.sh" "$work_dir/suite-log-only" >/dev/null 2>&1; then
+    echo "expected verifier to fail log-only Schedule I proof" >&2
+    exit 1
+fi
+grep -q 'missing live game PID; log-only proof is not a release gate' "$work_dir/suite-log-only/verification.md"
+
+echo "wine119 live verifier fixtures passed"

--- a/scripts/test-wine119-objective-audit-guards.sh
+++ b/scripts/test-wine119-objective-audit-guards.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(cd "$script_dir/.." && pwd -P)"
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/metalsharp-objective-audit-test.XXXXXX")"
+work_dir="$(cd "$work_dir" && pwd -P)"
+trap 'rm -rf "$work_dir"' EXIT
+
+sha="12b9343459d28dfe1d7668a31a58a0c3506948d7c533507fdaec65d59c6697ab"
+candidate_summary="$work_dir/summary.md"
+readiness="$work_dir/readiness.md"
+fetch_report="$work_dir/fetch-report.txt"
+probe_dir="$work_dir/probe"
+clean_provenance="$work_dir/clean-provenance.md"
+clean_preflight="$work_dir/clean-preflight.md"
+dirty_provenance="$work_dir/dirty-provenance.md"
+dirty_preflight="$work_dir/dirty-preflight.md"
+
+mkdir -p "$probe_dir/mscompatdb-hook-surface"
+
+cat > "$candidate_summary" <<'EOF'
+# MetalSharp Wine 11.9 Parity Candidates
+
+- dxmt32_source_kind: `clean-11.9-linked-default`
+
+## clean
+
+- gate: fail
+
+## dxmt32
+
+- gate: fail
+
+## borrowed
+
+- gate: pass
+
+## Required Live Gates
+
+- Manifest pass alone is not a release gate for any candidate.
+EOF
+
+cat > "$fetch_report" <<'EOF'
+repo=aaf2tbz/metalsharp
+tag=bundles
+release_tag_name=bundles
+asset=metalsharp_bundle.tar.zst
+sha256=833f63566b0c1b98fa917337716f57d689c42d0c2878204b4716ba29637d7372
+verified=1
+EOF
+
+cat > "$clean_provenance" <<EOF
+- result: review
+- reason: source tree is clean and linker metadata references the shaped Wine 11.9 runtime; still requires live M9 proof before release.
+- artifact_sha256: \`$sha\`
+EOF
+
+cat > "$clean_preflight" <<'EOF'
+- PASS [source-clean] DXMT source tree is clean
+- PASS [wine-version] wine reports wine-11.9
+EOF
+
+cat > "$dirty_provenance" <<'EOF'
+- result: fail
+EOF
+
+cat > "$dirty_preflight" <<'EOF'
+- PASS [wine-version] wine reports wine-11.9
+- FAIL [source-clean] DXMT source tree is dirty
+EOF
+
+cat > "$probe_dir/mscompatdb-hook-surface/hook-surface.json" <<'EOF'
+{"symbolSurfaceReady":true,"hookReady":false}
+EOF
+
+write_readiness() {
+    local include_clean="$1"
+    cat > "$readiness" <<'EOF'
+# MetalSharp Wine 11.9 Readiness Audit
+
+- PASS [parity-home] active state has no source-home references
+- PASS [electron-route] app-facing route audit keeps controls on /steam/launch-game
+- PASS [mscompatdb-hook] ntdll hook symbols are present in the parity runtime
+- FAIL [live-gate] no passing live control suite supplied; set METALSHARP_LIVE_SUITE_DIR after running guarded live controls
+EOF
+    if [[ "$include_clean" == "1" ]]; then
+        cat >> "$readiness" <<'EOF'
+- PASS [candidate-dxmt32-source] provenance records clean i386 WineMetal source/destination SHA256
+- PASS [parity-home] install report source matches the audited clean dxmt32 candidate
+EOF
+    fi
+}
+
+run_audit() {
+    local out="$1"
+    METALSHARP_READINESS_REPORT="$readiness" \
+    METALSHARP_CANDIDATE_SUMMARY="$candidate_summary" \
+    METALSHARP_FETCH_REPORT="$fetch_report" \
+    METALSHARP_PARITY_PROBE_DIR="$probe_dir" \
+    METALSHARP_I386_WINEMETAL_PROVENANCE="$dirty_provenance" \
+    METALSHARP_I386_WINEMETAL_BUILD_PREFLIGHT="$dirty_preflight" \
+    METALSHARP_I386_WINEMETAL_CLEAN_PROVENANCE="$clean_provenance" \
+    METALSHARP_I386_WINEMETAL_CLEAN_PREFLIGHT="$clean_preflight" \
+        "$repo_root/scripts/audit-wine119-objective-completion.sh" "$out"
+}
+
+write_readiness 0
+if run_audit "$work_dir/stale" >/dev/null 2>&1; then
+    echo "expected stale readiness audit to keep objective incomplete" >&2
+    exit 1
+fi
+grep -q 'Prove non-live parity home/backend/app route readiness | incomplete' "$work_dir/stale/objective-completion-audit.md"
+
+write_readiness 1
+if run_audit "$work_dir/clean" >/dev/null 2>&1; then
+    echo "expected objective audit to remain failed without live proof" >&2
+    exit 1
+fi
+grep -q 'Prove non-live parity home/backend/app route readiness | proven' "$work_dir/clean/objective-completion-audit.md"
+grep -q 'Pass Nidhogg 2, Schedule I, and Subnautica BZ under Wine 11.9 | missing' "$work_dir/clean/objective-completion-audit.md"
+grep -q 'Recover or produce release-proven 11.9 i386 WineMetal | unverified' "$work_dir/clean/objective-completion-audit.md"
+grep -q 'active dxmt32 candidate/parity home use the clean artifact' "$work_dir/clean/objective-completion-audit.md"
+
+echo "wine119 objective-audit guard fixtures passed"

--- a/scripts/verify-wine119-live-control-suite.sh
+++ b/scripts/verify-wine119-live-control-suite.sh
@@ -71,6 +71,37 @@ require_contains() {
     fi
 }
 
+verify_steam_survives() {
+    local label="$1"
+    local before="$suite_dir/steam/before-$label-wine-steam-pids.txt"
+    local after="$suite_dir/steam/after-$label-wine-steam-pids.txt"
+
+    if [[ ! -f "$before" || ! -f "$after" ]]; then
+        fail "$label" "missing Wine Steam PID snapshots for attach/relaunch proof"
+        return
+    fi
+
+    if [[ ! -s "$before" ]]; then
+        pass "$label" "no pre-existing Wine Steam PID before launch; attach survival gate not applicable"
+        return
+    fi
+
+    local missing=()
+    local pid
+    while read -r pid; do
+        [[ -n "$pid" ]] || continue
+        if ! grep -qx "$pid" "$after"; then
+            missing+=("$pid")
+        fi
+    done < "$before"
+
+    if (( ${#missing[@]} == 0 )); then
+        pass "$label" "pre-existing Wine Steam PID(s) survived launch: $(tr '\n' ' ' < "$before" | sed 's/[[:space:]]*$//')"
+    else
+        fail "$label" "pre-existing Wine Steam PID(s) disappeared after launch: ${missing[*]}"
+    fi
+}
+
 verify_game() {
     local label="$1"
     local expected_pipeline="$2"
@@ -106,8 +137,11 @@ verify_game() {
         fail "$label" "missing live game PID; log-only proof is not a release gate"
     fi
 
-    require_contains "$label" "$summary" "pipeline[=:]${expected_pipeline}|pipeline[=:]${expected_pipeline^^}" "proof summary includes expected pipeline"
+    local expected_pipeline_upper
+    expected_pipeline_upper="$(printf '%s' "$expected_pipeline" | tr '[:lower:]' '[:upper:]')"
+    require_contains "$label" "$summary" "pipeline[=:]${expected_pipeline}|pipeline[=:]${expected_pipeline_upper}" "proof summary includes expected pipeline"
     require_contains "$label" "$summary" "$appid" "proof summary includes appid $appid"
+    verify_steam_survives "$label"
 
     for pattern in "${patterns[@]}"; do
         require_contains "$label" "$summary" "$pattern" "proof summary includes $pattern"
@@ -129,7 +163,7 @@ fi
 
 if [[ -f "$suite_dir/status.json" ]]; then
     require_contains "backend" "$suite_dir/status.json" '"ok"[[:space:]]*:[[:space:]]*true' "backend status ok=true"
-    require_contains "backend" "$suite_dir/status.json" '"version"[[:space:]]*:[[:space:]]*"0\\.33\\.27"' "backend status is current main version 0.33.27"
+    require_contains "backend" "$suite_dir/status.json" '"version"[[:space:]]*:[[:space:]]*"0[.]33[.]27"' "backend status is current main version 0.33.27"
 else
     fail "backend" "missing status.json"
 fi

--- a/scripts/verify-wine119-live-control-suite.sh
+++ b/scripts/verify-wine119-live-control-suite.sh
@@ -184,14 +184,19 @@ verify_game \
     "i386-windows.*/dxgi\\.dll|i386-windows/dxgi\\.dll" \
     "i386-windows.*/d3d11\\.dll|i386-windows/d3d11\\.dll" \
     "x86_64-unix.*/winemetal\\.so|x86_64-unix/winemetal\\.so" \
+    "dxmt\\.conf" \
     "shader-cache/m9/535520"
 
 verify_game \
     "schedule-i" \
     "m11" \
     "3164500" \
+    "x86_64-windows.*/d3d11\\.dll|x86_64-windows/d3d11\\.dll" \
+    "x86_64-windows.*/dxgi\\.dll|x86_64-windows/dxgi\\.dll" \
+    "x86_64-windows.*/winemetal\\.dll|x86_64-windows/winemetal\\.dll" \
     "x86_64-unix.*/winemetal\\.so|x86_64-unix/winemetal\\.so" \
     "libMoltenVK\\.1\\.dylib|MoltenVK" \
+    "dxmt\\.conf" \
     "shader-cache/m11/3164500"
 
 verify_game \
@@ -203,6 +208,7 @@ verify_game \
     "x86_64-windows.*/winemetal\\.dll|x86_64-windows/winemetal\\.dll" \
     "x86_64-unix.*/winemetal\\.so|x86_64-unix/winemetal\\.so" \
     "libMoltenVK\\.1\\.dylib|MoltenVK" \
+    "dxmt\\.conf" \
     "shader-cache/m11/848450"
 
 append

--- a/scripts/verify-wine119-live-control-suite.sh
+++ b/scripts/verify-wine119-live-control-suite.sh
@@ -47,6 +47,10 @@ fail() {
     append "- FAIL [$label] $message"
 }
 
+requires_preexisting_steam() {
+    [[ -f "$suite_dir/summary.md" ]] && rg -q '^require_preexisting_wine_steam=1$' "$suite_dir/summary.md"
+}
+
 pass() {
     local label="$1"
     local message="$2"
@@ -82,7 +86,11 @@ verify_steam_survives() {
     fi
 
     if [[ ! -s "$before" ]]; then
-        pass "$label" "no pre-existing Wine Steam PID before launch; attach survival gate not applicable"
+        if requires_preexisting_steam; then
+            fail "$label" "required pre-existing Wine Steam PID before launch, but snapshot is empty"
+        else
+            pass "$label" "no pre-existing Wine Steam PID before launch; attach survival gate not applicable"
+        fi
         return
     fi
 

--- a/scripts/verify-wine119-live-control-suite.sh
+++ b/scripts/verify-wine119-live-control-suite.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  scripts/verify-wine119-live-control-suite.sh <live-control-output-dir>
+
+Example:
+  scripts/verify-wine119-live-control-suite.sh /tmp/metalsharp-live-controls-dxmt32
+
+Verifies a directory produced by scripts/run-wine119-live-control-suite.sh.
+This is intentionally strict: log-only captures, missing live PIDs, failed
+launch JSON, wrong route, or missing loaded DXMT/WineMetal/cache evidence fail
+the gate.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+suite_dir="${1:-}"
+
+if [[ -z "$suite_dir" ]]; then
+    usage >&2
+    exit 1
+fi
+
+if [[ ! -d "$suite_dir" ]]; then
+    echo "live-control output dir not found: $suite_dir" >&2
+    exit 1
+fi
+
+report="$suite_dir/verification.md"
+failures=0
+
+append() {
+    printf '%s\n' "$*" >> "$report"
+}
+
+fail() {
+    local label="$1"
+    local message="$2"
+    failures=$((failures + 1))
+    append "- FAIL [$label] $message"
+}
+
+pass() {
+    local label="$1"
+    local message="$2"
+    append "- PASS [$label] $message"
+}
+
+contains() {
+    local file="$1"
+    local pattern="$2"
+    [[ -f "$file" ]] && rg -qi "$pattern" "$file"
+}
+
+require_contains() {
+    local label="$1"
+    local file="$2"
+    local pattern="$3"
+    local message="$4"
+    if contains "$file" "$pattern"; then
+        pass "$label" "$message"
+    else
+        fail "$label" "$message (pattern: $pattern)"
+    fi
+}
+
+verify_game() {
+    local label="$1"
+    local expected_pipeline="$2"
+    local appid="$3"
+    shift 3
+    local patterns=("$@")
+    local proof_dir="$suite_dir/proof/$label"
+    local summary="$proof_dir/summary.txt"
+    local pids="$proof_dir/game-pids.txt"
+    local launch_json="$suite_dir/launches/$label-launch.json"
+
+    append
+    append "## $label"
+    append
+
+    if [[ -f "$launch_json" ]]; then
+        require_contains "$label" "$launch_json" '"ok"[[:space:]]*:[[:space:]]*true' "launch JSON reports ok=true"
+        require_contains "$label" "$launch_json" "\"pipeline\"[[:space:]]*:[[:space:]]*\"$expected_pipeline\"" "launch JSON reports pipeline=$expected_pipeline"
+    else
+        fail "$label" "missing launch JSON: $launch_json"
+    fi
+
+    if [[ -f "$summary" ]]; then
+        pass "$label" "proof summary exists"
+    else
+        fail "$label" "missing proof summary: $summary"
+        return
+    fi
+
+    if [[ -s "$pids" ]]; then
+        pass "$label" "live game PID captured: $(tr '\n' ' ' < "$pids" | sed 's/[[:space:]]*$//')"
+    else
+        fail "$label" "missing live game PID; log-only proof is not a release gate"
+    fi
+
+    require_contains "$label" "$summary" "pipeline[=:]${expected_pipeline}|pipeline[=:]${expected_pipeline^^}" "proof summary includes expected pipeline"
+    require_contains "$label" "$summary" "$appid" "proof summary includes appid $appid"
+
+    for pattern in "${patterns[@]}"; do
+        require_contains "$label" "$summary" "$pattern" "proof summary includes $pattern"
+    done
+}
+
+: > "$report"
+append "# MetalSharp Wine 11.9 Live Control Verification"
+append
+append "- suite_dir: \`$suite_dir\`"
+append
+
+if [[ -f "$suite_dir/runtime-identity.txt" ]]; then
+    require_contains "runtime" "$suite_dir/runtime-identity.txt" "wine_version=wine-11\\.9" "runtime identity is Wine 11.9"
+    require_contains "runtime" "$suite_dir/runtime-identity.txt" "wineserver_version=Wine 11\\.9" "wineserver identity is Wine 11.9"
+else
+    fail "runtime" "missing runtime-identity.txt"
+fi
+
+if [[ -f "$suite_dir/status.json" ]]; then
+    require_contains "backend" "$suite_dir/status.json" '"ok"[[:space:]]*:[[:space:]]*true' "backend status ok=true"
+    require_contains "backend" "$suite_dir/status.json" '"version"[[:space:]]*:[[:space:]]*"0\\.33\\.27"' "backend status is current main version 0.33.27"
+else
+    fail "backend" "missing status.json"
+fi
+
+verify_game \
+    "nidhogg2" \
+    "m9" \
+    "535520" \
+    "i386-windows.*/winemetal\\.dll|i386-windows/winemetal\\.dll" \
+    "i386-windows.*/dxgi\\.dll|i386-windows/dxgi\\.dll" \
+    "i386-windows.*/d3d11\\.dll|i386-windows/d3d11\\.dll" \
+    "x86_64-unix.*/winemetal\\.so|x86_64-unix/winemetal\\.so" \
+    "shader-cache/m9/535520"
+
+verify_game \
+    "schedule-i" \
+    "m11" \
+    "3164500" \
+    "x86_64-unix.*/winemetal\\.so|x86_64-unix/winemetal\\.so" \
+    "libMoltenVK\\.1\\.dylib|MoltenVK" \
+    "shader-cache/m11/3164500"
+
+verify_game \
+    "subnautica-bz" \
+    "m11" \
+    "848450" \
+    "x86_64-windows.*/d3d11\\.dll|x86_64-windows/d3d11\\.dll" \
+    "x86_64-windows.*/dxgi\\.dll|x86_64-windows/dxgi\\.dll" \
+    "x86_64-windows.*/winemetal\\.dll|x86_64-windows/winemetal\\.dll" \
+    "x86_64-unix.*/winemetal\\.so|x86_64-unix/winemetal\\.so" \
+    "libMoltenVK\\.1\\.dylib|MoltenVK" \
+    "shader-cache/m11/848450"
+
+append
+append "## Summary"
+append
+append "- failures: $failures"
+if [[ "$failures" -eq 0 ]]; then
+    append "- gate: pass"
+    echo "live control verification passed: $report"
+else
+    append "- gate: fail"
+    echo "live control verification failed: $report"
+    exit 2
+fi


### PR DESCRIPTION
## Summary
- add Wine 11.9 rebuild forensics mapping the working Wine 11.5 runtime against the recovered Wine 11.9 release asset and route-critical internals
- add a pass-by-pass implementation runbook, commit replay policy, parity candidate tooling, live-proof verifier, readiness audit, and objective-completion audit
- harden provenance capture for Wine 11.9 candidates: wrapper contract, PE import/export probes, linkage summaries, release identity, Vulkan ICD rewrite proof, and bridge source/destination SHA256s
- promote the clean Wine 11.9-linked PE32 i386 WineMetal artifact to the default `dxmt32` candidate when present, with the dirty AverySSD `build32` artifact demoted to diagnostic fallback
- wire readiness/objective audits to the clean candidate work dir and clean parity home so non-live evidence cannot silently mix with stale dirty `/tmp` candidates
- gate the live-suite runner itself on the audited clean `dxmt32` candidate and clean i386 WineMetal SHA before any game launch can proceed
- add non-live guard fixtures for live-suite preflight, objective-audit evidence alignment, and live-verifier acceptance/rejection behavior
- add PR CI coverage for the Wine 11.9 evidence scripts and fixtures
- keep the objective gate intentionally failing until real Wine 11.9 live controls pass and protected hook readiness is proven

## Current Evidence
- branch descends from rollback commit `cebf936` / v0.33.27 tree line
- release asset source is verified: `bundles/metalsharp_bundle.tar.zst`, SHA256 `833f63566b0c1b98fa917337716f57d689c42d0c2878204b4716ba29637d7372`
- Wine 11.9 internals are mapped against working Wine 11.5: missing `bin/metalsharp-wine`, missing pre-bound `lib/wine/.../winemetal.*`, missing raw i386 `winemetal.dll`, changed DXGI/D3D12/Unix WineMetal, MoltenVK ICD localization, and new `mscompatdb.dylib` are all explicit gates
- clean detached DXMT worktree at `f520cb84159ef7db1cdbd364d51738ef7effb0a6` produced PE32 i386 `winemetal.dll` linked against the shaped Wine 11.9 runtime
- clean i386 artifact: `/tmp/metalsharp-dxmt-clean-build32-wine119/src/winemetal/winemetal.dll`, SHA256 `12b9343459d28dfe1d7668a31a58a0c3506948d7c533507fdaec65d59c6697ab`
- regenerated clean candidate summary: `/Volumes/AverySSD/metalsharp/wine119-parity-clean-i386/summary.md` records `dxmt32_source_kind: clean-11.9-linked-default`
- clean parity home: `/Volumes/AverySSD/metalsharp/home-wine119-dxmt32-clean-state` was installed from that clean `dxmt32` candidate and backend-probed successfully
- readiness audit proves clean candidate selection, clean i386 source/destination SHA, parity-home source match, Electron route, backend 0.33.27, and mscompatdb hook symbol surface; it fails only on missing live suite
- live runner refuses to proceed unless the parity install report points at the audited clean `dxmt32` candidate and `dxmt32` provenance proves source/destination SHA `12b9343459d28dfe1d7668a31a58a0c3506948d7c533507fdaec65d59c6697ab`
- `scripts/test-wine119-live-suite-guards.sh` exercises live preflight without launching games: clean wiring passes, dirty summary fails, mismatched install source fails
- `scripts/test-wine119-objective-audit-guards.sh` proves stale readiness cannot satisfy non-live completion unless it also proves clean `dxmt32` source and parity-home source alignment
- `scripts/test-wine119-live-verifier-fixtures.sh` proves the live verifier accepts complete synthetic proof and rejects disappeared pre-existing Wine Steam PIDs and log-only game captures
- `Wine 11.9 Evidence CI` now runs syntax checks plus all three non-live guard fixtures on PRs
- objective audit proves the active `dxmt32` candidate/parity home use the clean i386 artifact; the full objective still fails on missing live Nidhogg 2/Schedule I/Subnautica BZ proof and protected hook runtime proof

## Testing
- `scripts/prepare-wine119-parity-candidates.sh /tmp/metalsharp-wine-assets/metalsharp_bundle.tar.zst /Volumes/AverySSD/metalsharp/wine119-parity-clean-i386`
- `METALSHARP_ALLOW_NON_TMP_PARITY_HOME=1 METALSHARP_CLONE_USER_STATE=1 METALSHARP_COPY_MODE=clone scripts/install-wine119-parity-home.sh /Volumes/AverySSD/metalsharp/wine119-parity-clean-i386/candidates/dxmt32/wine /Volumes/AverySSD/metalsharp/home-wine119-dxmt32-clean-state`
- `METALSHARP_ALLOW_NON_TMP_PARITY_HOME=1 scripts/probe-wine119-parity-backend.sh /Volumes/AverySSD/metalsharp/home-wine119-dxmt32-clean-state /Volumes/AverySSD/metalsharp/home-wine119-dxmt32-clean-state/backend-probe-main03327-guard-v2`
- install smoke generated proof commands with clean candidate work dir: `METALSHARP_ALLOW_NON_TMP_PARITY_HOME=1 scripts/install-wine119-parity-home.sh /Volumes/AverySSD/metalsharp/wine119-parity-clean-i386/candidates/dxmt32/wine /Volumes/AverySSD/metalsharp/home-wine119-install-smoke`
- live runner guard check without `METALSHARP_RUN_LIVE_GAMES=1` exits `2` and launches nothing
- `scripts/test-wine119-live-suite-guards.sh`
- `scripts/test-wine119-objective-audit-guards.sh`
- `scripts/test-wine119-live-verifier-fixtures.sh`
- `METALSHARP_WINE119_CANDIDATE_WORK_DIR=/Volumes/AverySSD/metalsharp/wine119-parity-clean-i386 scripts/audit-wine119-readiness.sh /Volumes/AverySSD/metalsharp/home-wine119-dxmt32-clean-state /tmp/metalsharp-wine119-readiness-clean-current` fails intentionally only on missing live suite
- `scripts/audit-wine119-objective-completion.sh /tmp/metalsharp-wine119-objective-audit-clean-current` fails intentionally because live game proof is still missing and the clean i386 candidate remains live-gated
- `bash -n scripts/fetch-wine119-release-assets.sh scripts/runtime-manifest.sh scripts/compare-runtime-manifests.sh scripts/prepare-wine119-candidate.sh scripts/prepare-wine119-parity-candidates.sh scripts/install-wine119-parity-home.sh scripts/probe-wine119-parity-backend.sh scripts/capture-steam-game-proof.sh scripts/run-wine119-live-control-suite.sh scripts/verify-wine119-live-control-suite.sh scripts/audit-wine119-readiness.sh scripts/audit-mscompatdb-hook-surface.sh scripts/audit-i386-winemetal-provenance.sh scripts/preflight-i386-winemetal-build.sh scripts/audit-wine119-objective-completion.sh scripts/test-wine119-live-suite-guards.sh scripts/test-wine119-objective-audit-guards.sh scripts/test-wine119-live-verifier-fixtures.sh`
- `node --check scripts/audit-electron-launch-routes.mjs`
- `git diff --check`
- `(cd app && npm run build)`
- `(cd app/src-rust && cargo test launcher::tests::)`

## Not Done
- no Wine 11.9 parity runtime has passed Nidhogg 2 M9, Schedule I M11, and Subnautica BZ M11 live proof yet
- the clean i386 WineMetal artifact has not been live-proven or release-blessed
- protected anti-cheat hook runtime readiness is not proven beyond non-live symbol surface evidence
