### PR TITLE
Fix Steam route drift and GPTK install state handling

### DIFF
--- a/app/src-rust/src/bottles.rs
+++ b/app/src-rust/src/bottles.rs
@@ -550,6 +550,50 @@ pub fn steam_game_bottle_id_for_pipeline(appid: u32, pipeline: crate::mtsp::engi
     }
 }
 
+fn apply_steam_game_bottle_metadata(
+    manifest: &mut BottleManifest,
+    appid: u32,
+    name: &str,
+    game_dir: Option<&Path>,
+    pipeline: crate::mtsp::engine::PipelineId,
+) {
+    let runtime_profile = runtime_profile_for_pipeline(pipeline);
+    let launch_prefix = steam_launch_prefix_for_pipeline(pipeline);
+
+    manifest.name = name.to_string();
+    manifest.bottle_type = BottleType::Steam;
+    manifest.steam_app_id = Some(appid);
+    manifest.prefix_path = launch_prefix.to_string_lossy().to_string();
+    manifest.arch = runtime_profile_definition(runtime_profile).arch;
+    manifest.runtime_profile = runtime_profile;
+    manifest.installed_components =
+        merge_components(manifest.installed_components.clone(), default_components_for(runtime_profile));
+    manifest.game_install_path = game_dir.map(normalized_existing_path_string);
+    manifest.runtime_assets = game_dir.map(detect_game_runtime_assets).unwrap_or_default();
+    manifest.installed_components = merge_components(
+        manifest.installed_components.clone(),
+        infer_components_from_runtime_assets(&manifest.runtime_assets),
+    );
+    manifest.installed_app_detections = game_dir.map(detect_apps_in_game_dir).unwrap_or_default();
+    manifest.health =
+        if game_dir.map(|dir| dir.exists()).unwrap_or(false) { BottleHealth::Ready } else { BottleHealth::New };
+}
+
+fn refresh_existing_steam_game_bottle(
+    mut manifest: BottleManifest,
+    appid: u32,
+    name: &str,
+    game_dir: Option<&Path>,
+) -> Result<BottleManifest, Box<dyn std::error::Error>> {
+    let pipeline = runtime_profile_definition(manifest.runtime_profile).launch_pipeline;
+    let now = timestamp_secs();
+    apply_steam_game_bottle_metadata(&mut manifest, appid, name, game_dir, pipeline);
+    manifest.updated_at = now;
+    save_bottle(&manifest)?;
+    let _ = save_steam_compatdata(&manifest, pipeline);
+    Ok(manifest)
+}
+
 pub fn ensure_steam_game_bottle(
     appid: u32,
     name: &str,
@@ -583,20 +627,7 @@ pub fn ensure_steam_game_bottle(
         updated_at: now.clone(),
     });
 
-    manifest.name = name.to_string();
-    manifest.bottle_type = BottleType::Steam;
-    manifest.steam_app_id = Some(appid);
-    manifest.prefix_path = launch_prefix.to_string_lossy().to_string();
-    manifest.runtime_profile = runtime_profile;
-    manifest.installed_components =
-        merge_components(manifest.installed_components, default_components_for(runtime_profile));
-    manifest.game_install_path = game_dir.map(normalized_existing_path_string);
-    manifest.runtime_assets = game_dir.map(detect_game_runtime_assets).unwrap_or_default();
-    manifest.installed_components =
-        merge_components(manifest.installed_components, infer_components_from_runtime_assets(&manifest.runtime_assets));
-    manifest.installed_app_detections = game_dir.map(detect_apps_in_game_dir).unwrap_or_default();
-    manifest.health =
-        if game_dir.map(|dir| dir.exists()).unwrap_or(false) { BottleHealth::Ready } else { BottleHealth::New };
+    apply_steam_game_bottle_metadata(&mut manifest, appid, name, game_dir, pipeline);
     manifest.updated_at = now;
     save_bottle(&manifest)?;
     let _ = save_steam_compatdata(&manifest, pipeline);
@@ -634,7 +665,12 @@ pub fn sync_steam_game_bottles() -> Result<Vec<BottleManifest>, Box<dyn std::err
         let dual = crate::scan::resolve_dual_game_dir(appid);
         let name = crate::steam::get_game_name_from_manifest(appid).unwrap_or_else(|| format!("Game {}", appid));
         let pipeline = crate::mtsp::rules::resolve_pipeline(appid);
-        bottles.push(ensure_steam_game_bottle(appid, &name, dual.wine_dir.as_deref(), pipeline)?);
+        let id = steam_game_bottle_id_for_pipeline(appid, pipeline);
+        let bottle = match load_bottle(&id) {
+            Ok(manifest) => refresh_existing_steam_game_bottle(manifest, appid, &name, dual.wine_dir.as_deref())?,
+            Err(_) => ensure_steam_game_bottle(appid, &name, dual.wine_dir.as_deref(), pipeline)?,
+        };
+        bottles.push(bottle);
     }
     Ok(bottles)
 }

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -437,6 +437,19 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
                     ));
                     let launch_result = match route_pipeline {
                         Some(pipeline) => {
+                            if let Some(explicit_pipeline) = mtsp::engine::PipelineId::from_str_flexible(launch_method)
+                            {
+                                if explicit_pipeline == pipeline {
+                                    let node = mtsp::engine::get_pipeline(pipeline);
+                                    if let Err(e) = mtsp::recipe::validate_explicit_pipeline_selection(
+                                        id,
+                                        node,
+                                        source_game_dir.as_deref(),
+                                    ) {
+                                        return resp(400, json!({"ok": false, "error": e.to_string()}));
+                                    }
+                                }
+                            }
                             let bottle = match bottles::prepare_steam_game_launch_with_game_dir(
                                 id,
                                 pipeline,

--- a/app/src-rust/src/mtsp/recipe.rs
+++ b/app/src-rust/src/mtsp/recipe.rs
@@ -465,6 +465,62 @@ pub fn diagnose_recipe(recipe: LaunchRecipe) -> LaunchDoctorReport {
     LaunchDoctorReport { ready, summary, blockers, warnings: dedupe_strings(warnings), checks, recipe }
 }
 
+fn compatible_route_hint(api: super::pe::D3dApi) -> &'static str {
+    match api {
+        super::pe::D3dApi::D3D9 => "M9",
+        super::pe::D3dApi::D3D10 => "M10",
+        super::pe::D3dApi::D3D11 => "M11",
+        super::pe::D3dApi::D3D12 => "M12 or D3DMetal",
+        super::pe::D3dApi::Unknown => "Auto",
+    }
+}
+
+fn explicit_route_api_mismatch_message(
+    pipeline: PipelineId,
+    pipeline_name: &str,
+    api: super::pe::D3dApi,
+    exe_name: &str,
+) -> Option<String> {
+    if api == super::pe::D3dApi::Unknown || !route_api_mismatch(pipeline, api) {
+        return None;
+    }
+
+    Some(format!(
+        "Selected route {} is not compatible with {} because it imports {}. Try Auto or {} instead.",
+        pipeline_name,
+        exe_name,
+        d3d_api_label(api),
+        compatible_route_hint(api)
+    ))
+}
+
+pub fn explicit_route_mismatch_message(recipe: &LaunchRecipe) -> Option<String> {
+    let exe_path = recipe.exe_path.as_deref()?;
+    let data = std::fs::read(exe_path).ok()?;
+    let pe = super::pe::parse_pe_imports(&data)?;
+    let exe_name = recipe
+        .exe_name
+        .as_deref()
+        .or_else(|| exe_path.file_name().and_then(|name| name.to_str()))
+        .unwrap_or("this executable");
+    explicit_route_api_mismatch_message(recipe.pipeline, &recipe.pipeline_name, pe.detected_api, exe_name)
+}
+
+pub fn validate_explicit_pipeline_selection(
+    appid: u32,
+    node: &PipelineNode,
+    game_dir_override: Option<&Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let recipe = match game_dir_override {
+        Some(game_dir) => build_custom_launch_recipe(appid, node, game_dir, None)?,
+        None => build_launch_recipe(appid, node)?,
+    };
+    if let Some(message) = explicit_route_mismatch_message(&recipe) {
+        return Err(message.into());
+    }
+    Ok(())
+}
+
 fn inspect_exe_route_compatibility(
     recipe: &LaunchRecipe,
     checks: &mut Vec<LaunchDoctorCheck>,
@@ -1035,6 +1091,33 @@ mod tests {
         assert!(report.summary.contains("Blocked"));
         assert!(report.blockers.iter().any(|blocker| blocker.contains("Recipe build did not complete")));
         assert!(report.checks.iter().any(|check| check.id == "exe" && !check.ok));
+    }
+
+    #[test]
+    fn explicit_route_mismatch_message_flags_d3d12_on_m11() {
+        let message = explicit_route_api_mismatch_message(
+            PipelineId::M11,
+            "M11",
+            super::super::pe::D3dApi::D3D12,
+            "Subnautica2.exe",
+        )
+        .expect("expected mismatch");
+
+        assert!(message.contains("Selected route M11"));
+        assert!(message.contains("Subnautica2.exe"));
+        assert!(message.contains("D3D12"));
+        assert!(message.contains("M12 or D3DMetal"));
+    }
+
+    #[test]
+    fn explicit_route_mismatch_message_allows_matching_route() {
+        assert!(explicit_route_api_mismatch_message(
+            PipelineId::M11,
+            "M11",
+            super::super::pe::D3dApi::D3D11,
+            "Game.exe",
+        )
+        .is_none());
     }
 
     #[test]

--- a/app/src-rust/src/steam.rs
+++ b/app/src-rust/src/steam.rs
@@ -179,26 +179,54 @@ fn write_gptk_steam_install_progress(phase: &str, message: &str, error: Option<&
 
 fn read_gptk_steam_install_progress() -> Value {
     let path = gptk_steam_install_progress_path();
+    let installing = is_installing_gptk_setup();
+    let toolkit_installed = gptk_installed();
+    let steam_installed = gptk_steam_installed();
     if path.exists() {
         if let Ok(contents) = std::fs::read_to_string(path) {
-            if let Ok(value) = serde_json::from_str::<Value>(&contents) {
+            if let Ok(mut value) = serde_json::from_str::<Value>(&contents) {
+                let phase = value.get("phase").and_then(|v| v.as_str()).unwrap_or("idle");
+                let stale_in_progress = !installing
+                    && !steam_installed
+                    && matches!(
+                        phase,
+                        "starting"
+                            | "checking_toolkit"
+                            | "downloading_steam"
+                            | "preparing_prefix"
+                            | "running_installer"
+                            | "waiting_for_steam"
+                            | "deploying_wrapper"
+                    );
+                if stale_in_progress {
+                    value["phase"] = json!("idle");
+                    value["message"] = json!("GPTK Steam is not installed");
+                    value["error"] = Value::Null;
+                } else if steam_installed {
+                    value["phase"] = json!("ready");
+                    value["message"] = json!("GPTK Steam is installed");
+                    value["error"] = Value::Null;
+                }
+                value["installing"] = json!(installing);
+                value["toolkit_installed"] = json!(toolkit_installed);
+                value["steam_installed"] = json!(steam_installed);
                 return value;
             }
         }
     }
 
     json!({
-        "phase": if gptk_steam_installed() { "ready" } else { "idle" },
-        "message": if gptk_steam_installed() {
+        "phase": if steam_installed { "ready" } else { "idle" },
+        "message": if steam_installed {
             "GPTK Steam is installed"
         } else {
             "GPTK Steam is not installed"
         },
         "error": null,
         "warning": GPTK_UNSIGNED_CONTAINER_WARNING,
-        "installing": is_installing_gptk_setup(),
-        "toolkit_installed": gptk_installed(),
-        "steam_installed": gptk_steam_installed(),
+        "installing": installing,
+        "toolkit_installed": toolkit_installed,
+        "steam_installed": steam_installed,
     })
 }
 
@@ -1380,7 +1408,7 @@ fn run_install_gptk_steam() -> Result<String, Box<dyn std::error::Error>> {
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null());
     apply_gptk_env(&mut install_cmd);
-    let _child = install_cmd.spawn()?;
+    let mut child = install_cmd.spawn()?;
 
     write_gptk_steam_install_progress(
         "waiting_for_steam",
@@ -1393,6 +1421,15 @@ fn run_install_gptk_steam() -> Result<String, Box<dyn std::error::Error>> {
     for _ in 0..180 {
         if steam_exe.exists() && steam_ui_dll.exists() {
             break;
+        }
+        if let Some(status) = child.try_wait()? {
+            if !steam_exe.exists() || !steam_ui_dll.exists() {
+                return Err(format!(
+                    "SteamSetup.exe exited before GPTK Steam finished installing (status: {}).",
+                    status
+                )
+                .into());
+            }
         }
         std::thread::sleep(std::time::Duration::from_secs(1));
     }
@@ -2207,8 +2244,7 @@ pub fn library() -> Value {
             } else {
                 resolved
             };
-            let bottle =
-                crate::bottles::ensure_steam_game_bottle(*appid, name, dual.wine_dir.as_deref(), pipeline_id).ok();
+            let bottle = load_library_bottle(*appid, name, dual.wine_dir.as_deref(), pipeline_id);
             games.push(steam_library_card(SteamLibraryCardData {
                 appid: *appid,
                 name,
@@ -2226,13 +2262,8 @@ pub fn library() -> Value {
 
         if gptk_steam_appids.contains(appid) {
             let gptk_game_dir = resolve_game_dir_in_steamapps(*appid, crate::scan::gptk_steam_library_paths());
-            let bottle = crate::bottles::ensure_steam_game_bottle(
-                *appid,
-                name,
-                gptk_game_dir.as_deref(),
-                crate::mtsp::engine::PipelineId::M13,
-            )
-            .ok();
+            let bottle =
+                load_library_bottle(*appid, name, gptk_game_dir.as_deref(), crate::mtsp::engine::PipelineId::M13);
             games.push(steam_library_card(SteamLibraryCardData {
                 appid: *appid,
                 name,
@@ -2277,6 +2308,18 @@ pub fn library() -> Value {
         "installed_count": games.iter().filter(|g| g["installed"].as_bool().unwrap_or(false)).count(),
         "games": games,
     })
+}
+
+fn load_library_bottle(
+    appid: u32,
+    name: &str,
+    game_dir: Option<&Path>,
+    pipeline: crate::mtsp::engine::PipelineId,
+) -> Option<crate::bottles::BottleManifest> {
+    let bottle_id = crate::bottles::steam_game_bottle_id_for_pipeline(appid, pipeline);
+    crate::bottles::load_bottle(&bottle_id)
+        .ok()
+        .or_else(|| crate::bottles::ensure_steam_game_bottle(appid, name, game_dir, pipeline).ok())
 }
 
 struct SteamLibraryCardData<'a> {
@@ -2708,6 +2751,9 @@ pub fn watch_steamapps() -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{LazyLock, Mutex};
+
+    static HOME_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
     #[test]
     fn parses_acf_quoted_fields() {
@@ -2908,6 +2954,35 @@ mod tests {
         assert_eq!(card.get("library_source").and_then(Value::as_str), Some("gptk"));
         assert_eq!(card.get("can_uninstall").and_then(Value::as_bool), Some(false));
         assert_eq!(card.get("launch_method").and_then(Value::as_str), Some("d3dmetal"));
+    }
+
+    #[test]
+    fn stale_gptk_install_progress_reconciles_to_idle() {
+        let _guard = HOME_ENV_LOCK.lock().expect("home env lock");
+        let temp_home = unique_temp_dir("gptk-progress-home");
+        let _ = std::fs::remove_dir_all(&temp_home);
+        std::fs::create_dir_all(temp_home.join(".metalsharp")).expect("create temp home");
+        let progress_path = temp_home.join(".metalsharp").join("gptk_steam_install_progress.json");
+        std::fs::write(
+            &progress_path,
+            r#"{"phase":"waiting_for_steam","message":"Waiting for Steam installer...","error":"still waiting"}"#,
+        )
+        .expect("write progress");
+
+        let previous_home = std::env::var_os("HOME");
+        std::env::set_var("HOME", &temp_home);
+        let progress = read_gptk_steam_install_progress();
+        match previous_home {
+            Some(value) => std::env::set_var("HOME", value),
+            None => std::env::remove_var("HOME"),
+        }
+
+        assert_eq!(progress.get("phase").and_then(Value::as_str), Some("idle"));
+        assert_eq!(progress.get("message").and_then(Value::as_str), Some("GPTK Steam is not installed"));
+        assert_eq!(progress.get("error"), Some(&Value::Null));
+        assert_eq!(progress.get("installing").and_then(Value::as_bool), Some(false));
+
+        let _ = std::fs::remove_dir_all(temp_home);
     }
 
     #[test]

--- a/app/src/renderer/components/SetupWizard.vue
+++ b/app/src/renderer/components/SetupWizard.vue
@@ -185,6 +185,7 @@ async function installGptkSteam() {
       toast.show(s.gptk_install_progress.error ?? s.gptk_install_progress.message, "error");
     } else if (attempts > 180) {
       clearInterval(poll);
+      gptkSteamInstalling.value = false;
       toast.show("GPTK Steam setup is still running. Check the Steam installer window.", "error");
     }
   }, 2000);

--- a/app/src/renderer/views/LibraryView.vue
+++ b/app/src/renderer/views/LibraryView.vue
@@ -301,7 +301,9 @@ function pollGptkSteamInstall() {
       toast.show(status.gptk_install_progress.error ?? status.gptk_install_progress.message, "error");
     } else if (attempts > 180) {
       clearInterval(poll);
+      gptkSteamInstalling.value = false;
       toast.show("GPTK Steam setup is still running. Check the Steam installer window.", "error");
+      reloadLibrary();
     }
   }, 2000);
 }
@@ -579,21 +581,23 @@ watch([library, search, filter], applyFilter);
 }
 
 .library-controls {
-  display: grid;
-  grid-template-columns: minmax(260px, auto) minmax(280px, 1fr) auto;
+  display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 12px;
   min-width: 0;
 }
 .library-launch-actions {
   display: flex;
   align-items: center;
+  flex: 0 1 auto;
   gap: 10px;
   min-width: 0;
 }
 .library-controls-center {
+  flex: 1 1 420px;
   display: grid;
-  grid-template-columns: minmax(150px, 1fr) minmax(360px, auto);
+  grid-template-columns: minmax(150px, 1fr) minmax(170px, 220px);
   gap: 10px;
   min-width: 0;
 }
@@ -621,6 +625,9 @@ watch([library, search, filter], applyFilter);
   flex: 0 1 auto;
   min-width: 0;
 }
+.refresh-button {
+  margin-left: auto;
+}
 .control-icon {
   flex: 0 0 15px;
 }
@@ -630,11 +637,8 @@ watch([library, search, filter], applyFilter);
 }
 
 @media (max-width: 1040px) {
-  .library-controls {
-    grid-template-columns: 1fr;
-  }
   .refresh-button {
-    justify-self: start;
+    margin-left: 0;
   }
 }
 

--- a/app/src/renderer/views/SettingsView.vue
+++ b/app/src/renderer/views/SettingsView.vue
@@ -188,6 +188,7 @@ async function pollGptkSteamInstall() {
       toast.show(status.gptk_install_progress.error ?? status.gptk_install_progress.message, "error");
     } else if (attempts > 180) {
       clearInterval(poll);
+      gptkSteamInstalling.value = false;
       toast.show("GPTK Steam setup is still running. Check the Steam installer window.", "error");
     }
   }, 2000);


### PR DESCRIPTION
## Summary
- stop the Steam library read path from rewriting shared MetalSharp bottle/compatdata state back to the auto-resolved pipeline
- fail fast when GPTK Steam installer exits before writing Steam files, and reconcile stale GPTK install progress back to real backend state
- keep the library controls responsive by letting the source dropdown and refresh button share wrapped space cleanly

## Root causes addressed
- `GET /steam/library` was calling `ensure_steam_game_bottle(...)` for already-installed MetalSharp Steam games. Because non-GPTK Steam routes share the same `steam_<appid>` bottle id, that read-only code path rewrote Subnautica 2 back to its auto-resolved `m12` profile and compatdata on every refresh.
- GPTK Steam setup could look permanently "installing" when `SteamSetup.exe` exited immediately or when an old in-progress progress file no longer matched backend truth.
- The library header controls used a rigid grid layout that let the source dropdown crowd the refresh button off the screen.

## What changed
- library cards now load an existing Steam bottle without mutating it; first-time bottle creation still happens when needed
- Steam bottle sync preserves an existing bottle's runtime profile instead of resetting it to the rule-resolved lane
- explicit manual lane selection now validates the chosen executable's imported D3D API and returns a clear error if the user picks something incompatible like `M11` for a `D3D12` shipping binary
- GPTK Steam install now errors immediately if `SteamSetup.exe` exits before `Steam.exe` and `steamui.dll` exist, and stale progress snapshots reconcile to `idle`/`ready` based on real installation state
- all GPTK Steam pollers clear their local "installing" state on timeout, and the library controls wrap instead of shoving refresh off-canvas

## Verification
- `cargo fmt --all -- --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --release`
- `npm run build`
- `npx biome check src/`
