### PR TITLE
(fix) mono fna runtime repair

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -110,6 +110,14 @@
         ]
       },
       {
+        "from": "../src/fna/shims",
+        "to": "runtime/shim-sources/fna/shims",
+        "filter": [
+          "*.c",
+          "*.m"
+        ]
+      },
+      {
         "from": "updater",
         "to": "scripts/tools/updater"
       },

--- a/app/src-rust/src/bottles.rs
+++ b/app/src-rust/src/bottles.rs
@@ -2470,9 +2470,7 @@ fn inspect_component_state(prefix: &Path, id: &str, fallback: ComponentState) ->
             }
         },
         "xna" => {
-            if windows.join("Microsoft.NET").join("assembly").join("GAC_32").join("Microsoft.Xna.Framework").exists()
-                || drive_c.join("Program Files (x86)").join("Microsoft XNA").exists()
-            {
+            if xna_framework_installed(prefix) {
                 ComponentState::Installed
             } else {
                 ComponentState::Missing
@@ -2568,6 +2566,38 @@ fn core_fonts_installed(fonts_dir: &Path) -> bool {
 
     let installed = CORE_FONT_FILES.iter().filter(|name| fonts_dir.join(name).is_file()).count();
     installed >= 4
+}
+
+fn xna_framework_installed(prefix: &Path) -> bool {
+    let drive_c = prefix.join("drive_c");
+    let windows = drive_c.join("windows");
+    if drive_c.join("Program Files (x86)").join("Microsoft XNA").exists()
+        || drive_c.join("Program Files").join("Microsoft XNA").exists()
+    {
+        return true;
+    }
+
+    let framework_roots = [
+        windows.join("Microsoft.NET").join("assembly").join("GAC_32").join("Microsoft.Xna.Framework"),
+        windows.join("Microsoft.NET").join("assembly").join("GAC_MSIL").join("Microsoft.Xna.Framework"),
+        windows.join("assembly").join("GAC_32").join("Microsoft.Xna.Framework"),
+        windows.join("assembly").join("GAC_MSIL").join("Microsoft.Xna.Framework"),
+        windows.join("mono").join("mono-2.0").join("lib").join("mono").join("gac").join("Microsoft.Xna.Framework"),
+    ];
+    framework_roots.iter().any(|root| xna_framework_dll_exists(root))
+}
+
+fn xna_framework_dll_exists(root: &Path) -> bool {
+    if !root.exists() {
+        return false;
+    }
+    if root.join("Microsoft.Xna.Framework.dll").is_file() {
+        return true;
+    }
+    WalkDir::new(root).max_depth(3).into_iter().flatten().any(|entry| {
+        entry.file_type().is_file()
+            && entry.file_name().to_string_lossy().eq_ignore_ascii_case("Microsoft.Xna.Framework.dll")
+    })
 }
 
 fn host_core_font_sources() -> Vec<(String, PathBuf)> {
@@ -2691,6 +2721,7 @@ fn resolve_component_installer(component_id: &str, arch: BottleArch) -> Option<C
     let local_redist = crate::platform::metalsharp_home_dir_for(&home).join("runtime").join("redist");
 
     resolve_component_installer_from_roots(component_id, arch, &redist_root, &local_redist)
+        .or_else(|| resolve_sharp_library_component_installer(component_id))
 }
 
 fn resolve_component_installer_from_roots(
@@ -2784,7 +2815,12 @@ fn resolve_component_installer_from_roots(
         _ => None,
     }?;
 
-    let args = match component_id {
+    let args = component_installer_args(component_id, &executable);
+    Some(ComponentInstaller { path: executable, args })
+}
+
+fn component_installer_args(component_id: &str, executable: &Path) -> Vec<String> {
+    match component_id {
         "vcrun2019" | "vcrun2013" | "vcrun2010" => vec!["/quiet".to_string(), "/norestart".to_string()],
         "dotnet40" | "dotnet48" => vec!["/q".to_string(), "/norestart".to_string()],
         "webview2" => vec!["/silent".to_string(), "/install".to_string()],
@@ -2798,8 +2834,62 @@ fn resolve_component_installer_from_roots(
             }
         },
         _ => Vec::new(),
-    };
-    Some(ComponentInstaller { path: executable, args })
+    }
+}
+
+fn resolve_sharp_library_component_installer(component_id: &str) -> Option<ComponentInstaller> {
+    resolve_sharp_library_component_installer_from_root(component_id, &bottles_root())
+}
+
+fn resolve_sharp_library_component_installer_from_root(component_id: &str, root: &Path) -> Option<ComponentInstaller> {
+    if !root.exists() {
+        return None;
+    }
+    let mut bottle_dirs = fs::read_dir(root).ok()?.flatten().map(|entry| entry.path()).collect::<Vec<_>>();
+    bottle_dirs.sort();
+    for bottle_dir in bottle_dirs {
+        let manifest_path = bottle_dir.join(MANIFEST_FILE);
+        let Ok(data) = fs::read_to_string(&manifest_path) else {
+            continue;
+        };
+        let Ok(manifest) = serde_json::from_str::<BottleManifest>(&data) else {
+            continue;
+        };
+        if manifest.bottle_type != BottleType::Installer {
+            continue;
+        }
+
+        if let Some(path) = manifest.source_installer_path.as_deref().map(PathBuf::from) {
+            if let Some(installer) = component_installer_from_local_path(component_id, &path) {
+                return Some(installer);
+            }
+        }
+
+        let payload_dir = bottle_dir.join("installers");
+        let Ok(read_dir) = fs::read_dir(payload_dir) else {
+            continue;
+        };
+        let mut payloads = read_dir.flatten().map(|entry| entry.path()).collect::<Vec<_>>();
+        payloads.sort();
+        for path in payloads {
+            if let Some(installer) = component_installer_from_local_path(component_id, &path) {
+                return Some(installer);
+            }
+        }
+    }
+    None
+}
+
+fn component_installer_from_local_path(component_id: &str, path: &Path) -> Option<ComponentInstaller> {
+    if !path.is_file() || component_kind_from_local_installer(path).as_deref() != Some(component_id) {
+        return None;
+    }
+    Some(ComponentInstaller { path: path.to_path_buf(), args: component_installer_args(component_id, path) })
+}
+
+fn component_kind_from_local_installer(path: &Path) -> Option<String> {
+    let lower_name = path.file_name()?.to_string_lossy().to_ascii_lowercase();
+    classify_redist_asset(&lower_name)
 }
 
 fn resolve_game_runtime_asset_installer(manifest: &BottleManifest, component_id: &str) -> Option<ComponentInstaller> {
@@ -2826,7 +2916,8 @@ fn resolve_game_runtime_asset_installer(manifest: &BottleManifest, component_id:
             lower.ends_with(".bat") || lower.ends_with(".cmd")
         })
         .or_else(|| candidates.first())?;
-    Some(ComponentInstaller { path: PathBuf::from(&preferred.source_path), args: Vec::new() })
+    let path = PathBuf::from(&preferred.source_path);
+    Some(ComponentInstaller { args: component_installer_args(component_id, &path), path })
 }
 
 fn game_runtime_installer_candidates<'a>(
@@ -2842,6 +2933,7 @@ fn game_runtime_installer_candidates<'a>(
                 && match component_id {
                     "easyanticheat_eos" => matches!(asset.kind.as_str(), "easyanticheat" | "easyanticheat_eos"),
                     "battleye" => asset.kind == "battleye",
+                    "xna" => asset.kind == "xna",
                     _ => false,
                 }
         })
@@ -2868,6 +2960,7 @@ fn is_game_runtime_installer_candidate(asset: &BottleRuntimeAsset, component_id:
                 || lower_name == "beservice.exe"
                 || lower_name == "beservice_x64.exe"
         },
+        "xna" => lower_name.contains("xnafx") || lower_name.contains("xna"),
         _ => false,
     }
 }
@@ -3370,9 +3463,13 @@ fn component_source_policy(id: &str, arch: BottleArch) -> ComponentSourcePolicy 
         };
     }
     let installer = resolve_component_installer(id, arch);
+    let source = installer
+        .as_ref()
+        .map(|installer| component_installer_source_label(&installer.path))
+        .unwrap_or("missing_local_asset");
     ComponentSourcePolicy {
         id: id.to_string(),
-        source: if installer.is_some() { "local_redist_asset" } else { "missing_local_asset" }.to_string(),
+        source: source.to_string(),
         available: installer.is_some(),
         detail: match id {
             "dotnet40" => "Uses Steam CommonRedist or ~/.metalsharp/runtime/redist .NET 4.0 offline installers",
@@ -3386,7 +3483,9 @@ fn component_source_policy(id: &str, arch: BottleArch) -> ComponentSourcePolicy 
             "webview2" => "Uses Steam CommonRedist or ~/.metalsharp/runtime/redist WebView2 evergreen installer",
             "directx_jun2010" => "DirectX June 2010 — checks d3dx9_43, d3dx10_43, d3dx11_43, xinput1_3, xaudio2_7, x3daudio1_7, D3DCompiler_43",
             "openal" => "Uses Steam CommonRedist or ~/.metalsharp/runtime/redist OpenAL installer",
-            "xna" => "Uses Steam CommonRedist or ~/.metalsharp/runtime/redist XNA 4.0 installer",
+            "xna" => {
+                "Uses Steam CommonRedist, Sharp Library installer bottles, or ~/.metalsharp/runtime/redist XNA 4.0 installer"
+            },
             "physx" => "Uses Steam CommonRedist or ~/.metalsharp/runtime/redist PhysX installer",
             "easyanticheat_eos" => "Uses game-local Easy Anti-Cheat EOS setup assets when present",
             "battleye" => "Uses game-local BattlEye setup/service assets when present",
@@ -3394,6 +3493,15 @@ fn component_source_policy(id: &str, arch: BottleArch) -> ComponentSourcePolicy 
         }
         .to_string(),
         path: installer.map(|installer| installer.path.to_string_lossy().to_string()),
+    }
+}
+
+fn component_installer_source_label(path: &Path) -> &'static str {
+    let normalized = path.to_string_lossy();
+    if normalized.contains("/bottles/") && normalized.contains("/installers/") {
+        "sharp_library_installer"
+    } else {
+        "local_redist_asset"
     }
 }
 
@@ -3821,9 +3929,16 @@ fn redist_source_guides() -> Vec<RedistSourceGuide> {
             local_targets: vec![
                 redist.join("XNA").join("4.0").join("xnafx40_redist.msi").to_string_lossy().to_string(),
                 redist.join("XNA").join("4.0").join("xnafx40_redist.exe").to_string_lossy().to_string(),
+                crate::platform::metalsharp_home_dir()
+                    .join("bottles")
+                    .join("*")
+                    .join("installers")
+                    .join("xnafx40_redist.msi")
+                    .to_string_lossy()
+                    .to_string(),
             ],
             policy: "official_download_or_steam_commonredist".to_string(),
-            notes: "Use local or Steam-provided XNA 4.0 redist assets; this stays receipt-driven per bottle.".to_string(),
+            notes: "Use local, Sharp Library staged, or Steam-provided XNA 4.0 redist assets; this stays receipt-driven per bottle.".to_string(),
         },
         RedistSourceGuide {
             id: "physx".to_string(),
@@ -4503,6 +4618,109 @@ mod tests {
         assert_eq!(xna_installer.path, xna);
         assert_eq!(physx_installer.path, physx);
         let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn xna_installed_state_accepts_wine_mono_gac_layout() {
+        let prefix = test_dir("xna-mono-gac");
+        let gac = prefix
+            .join("drive_c")
+            .join("windows")
+            .join("mono")
+            .join("mono-2.0")
+            .join("lib")
+            .join("mono")
+            .join("gac")
+            .join("Microsoft.Xna.Framework")
+            .join("4.0.0.0__842cf8be1de50553");
+        fs::create_dir_all(&gac).expect("create xna mono gac");
+        fs::write(gac.join("Microsoft.Xna.Framework.dll"), b"xna").expect("write xna assembly");
+
+        assert_eq!(inspect_component_state(&prefix, "xna", ComponentState::Missing), ComponentState::Installed);
+        let _ = fs::remove_dir_all(prefix);
+    }
+
+    #[test]
+    fn resolver_uses_sharp_library_xna_installer_bottle_payload() {
+        let root = test_dir("sharp-xna-installer-source");
+        let bottle_id = "installer_xna_test";
+        let payload = root.join(bottle_id).join("installers").join("xnafx40_redist.msi");
+        fs::create_dir_all(payload.parent().expect("payload parent")).expect("create payload dir");
+        fs::write(&payload, b"xna").expect("write xna installer");
+        let manifest = BottleManifest {
+            id: bottle_id.into(),
+            name: "xnafx40_redist".into(),
+            custom_name: None,
+            bottle_type: BottleType::Installer,
+            steam_app_id: None,
+            prefix_path: root.join(bottle_id).join("prefix").to_string_lossy().to_string(),
+            arch: BottleArch::Wow64,
+            runtime_profile: RuntimeProfile::Plain,
+            preferred_pipeline: None,
+            installed_components: Vec::new(),
+            source_installer_path: None,
+            installer_kind: Some(InstallerKind::Msi),
+            game_install_path: None,
+            runtime_assets: Vec::new(),
+            installed_app_detections: Vec::new(),
+            health: BottleHealth::NeedsRepair,
+            last_launch_log: None,
+            last_launch_pid: None,
+            last_launch_status: None,
+            last_launch_finished_at: None,
+            created_at: timestamp_secs(),
+            updated_at: timestamp_secs(),
+        };
+        fs::write(
+            root.join(bottle_id).join(MANIFEST_FILE),
+            serde_json::to_vec_pretty(&manifest).expect("serialize bottle"),
+        )
+        .expect("write bottle manifest");
+
+        let installer =
+            resolve_sharp_library_component_installer_from_root("xna", &root).expect("resolve xna installer");
+
+        assert_eq!(installer.path, payload);
+        assert_eq!(installer.args, vec!["/quiet".to_string(), "/norestart".to_string()]);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn game_runtime_asset_xna_repair_preserves_msi_silent_args() {
+        let manifest = BottleManifest {
+            id: "steam_105600".into(),
+            name: "Terraria".into(),
+            custom_name: None,
+            bottle_type: BottleType::Steam,
+            steam_app_id: Some(105600),
+            prefix_path: "/tmp/metalsharp-test-prefix".into(),
+            arch: BottleArch::Wow64,
+            runtime_profile: RuntimeProfile::FnaX86,
+            preferred_pipeline: None,
+            installed_components: vec![RuntimeComponent { id: "xna".into(), state: ComponentState::Missing }],
+            source_installer_path: None,
+            installer_kind: None,
+            game_install_path: None,
+            runtime_assets: vec![BottleRuntimeAsset {
+                id: "xna:xnafx40_redist.msi".into(),
+                kind: "xna".into(),
+                source_path: "/tmp/_CommonRedist/XNA/4.0/xnafx40_redist.msi".into(),
+                present: true,
+            }],
+            installed_app_detections: Vec::new(),
+            health: BottleHealth::NeedsRepair,
+            last_launch_log: None,
+            last_launch_pid: None,
+            last_launch_status: None,
+            last_launch_finished_at: None,
+            created_at: timestamp_secs(),
+            updated_at: timestamp_secs(),
+        };
+
+        let installer = resolve_game_runtime_asset_installer(&manifest, "xna").expect("resolve game xna installer");
+
+        assert_eq!(installer.path, PathBuf::from("/tmp/_CommonRedist/XNA/4.0/xnafx40_redist.msi"));
+        assert_eq!(installer.args, vec!["/quiet".to_string(), "/norestart".to_string()]);
     }
 
     #[test]

--- a/app/src-rust/src/bottles.rs
+++ b/app/src-rust/src/bottles.rs
@@ -1327,6 +1327,48 @@ pub fn repair_component(
         });
     }
 
+    if component_id == "fna" {
+        if dry_run {
+            let state = inspect_fna_runtime_component().unwrap_or(ComponentState::Unknown);
+            return Ok(ComponentRepairReport {
+                id: component_id.to_string(),
+                status: if matches!(state, ComponentState::Installed | ComponentState::NeedsRepair) {
+                    "runtime_repair_available"
+                } else {
+                    "asset_missing"
+                }
+                .to_string(),
+                detail: if matches!(state, ComponentState::Installed | ComponentState::NeedsRepair) {
+                    "FNA native macOS shims can be rebuilt from MetalSharp runtime sources".to_string()
+                } else {
+                    "FNA runtime assemblies are not staged locally".to_string()
+                },
+                asset_path: None,
+                log_path: None,
+                pid: None,
+            });
+        }
+
+        let repaired = crate::mtsp::launcher::repair_fna_native_runtime_shims()?;
+        let state = inspect_fna_runtime_component().unwrap_or(ComponentState::Unknown);
+        mark_component_state(&mut manifest, component_id, state);
+        manifest.health = if components_ready(&manifest.installed_components) {
+            BottleHealth::Ready
+        } else {
+            BottleHealth::NeedsRepair
+        };
+        manifest.updated_at = timestamp_secs();
+        save_bottle(&manifest)?;
+        return Ok(ComponentRepairReport {
+            id: component_id.to_string(),
+            status: if state == ComponentState::Installed { "installed" } else { "needs_repair" }.to_string(),
+            detail: format!("Repaired {} FNA native macOS shim(s) in MetalSharp runtime", repaired),
+            asset_path: None,
+            log_path: None,
+            pid: None,
+        });
+    }
+
     if matches!(component_id, "gpu_vendor_stubs" | "gptk_amd_stub") {
         let home = dirs::home_dir().unwrap_or_default();
         let ms_root = crate::platform::metalsharp_home_dir_for(&home).join("runtime").join("wine");
@@ -2537,12 +2579,23 @@ fn inspect_host_mono_component(runtime_id: &str) -> Option<ComponentState> {
 fn inspect_fna_runtime_component() -> Option<ComponentState> {
     let home = dirs::home_dir()?;
     let runtime = crate::platform::metalsharp_home_dir_for(&home).join("runtime");
-    let candidates = [
+    let required = [
         runtime.join("fna").join("FNA.dll"),
         runtime.join("shims").join("libFNA3D.dylib"),
         runtime.join("shims").join("libSDL3.dylib"),
+        runtime.join("shims").join("libkernel32.dylib"),
+        runtime.join("shims").join("libuser32.dylib"),
+        runtime.join("shims").join("libCarbon.dylib"),
+        runtime.join("shims").join("libmetalsharp_carbon_interpose.dylib"),
     ];
-    Some(if candidates.iter().any(|path| path.exists()) { ComponentState::Installed } else { ComponentState::Missing })
+    let present = required.iter().filter(|path| path.exists()).count();
+    Some(if present == required.len() {
+        ComponentState::Installed
+    } else if present > 0 {
+        ComponentState::NeedsRepair
+    } else {
+        ComponentState::Missing
+    })
 }
 
 fn core_fonts_installed(fonts_dir: &Path) -> bool {
@@ -3451,7 +3504,11 @@ fn component_source_policy(id: &str, arch: BottleArch) -> ComponentSourcePolicy 
         return ComponentSourcePolicy {
             id: id.to_string(),
             source: "metalsharp_native_runtime".to_string(),
-            available: state == ComponentState::Installed,
+            available: if id == "fna" {
+                matches!(state, ComponentState::Installed | ComponentState::NeedsRepair)
+            } else {
+                state == ComponentState::Installed
+            },
             detail: match id {
                 "mono-arm64" => "Native ARM64 Mono runtime for Terraria/FNA-style macOS launch wrappers",
                 "mono-x86" => "Native x86_64 Mono runtime for legacy Celeste/FNA-style launch wrappers under Rosetta",

--- a/app/src-rust/src/bottles.rs
+++ b/app/src-rust/src/bottles.rs
@@ -1436,6 +1436,49 @@ pub fn repair_component(
         });
     }
 
+    if component_id == "d3d12_agility" {
+        let home = dirs::home_dir().ok_or("no home dir")?;
+        let appid = manifest.steam_app_id.ok_or("D3D12 Agility repair requires a Steam app id")?;
+        let game_dir = manifest
+            .game_install_path
+            .as_deref()
+            .map(PathBuf::from)
+            .ok_or("D3D12 Agility repair requires a game install path")?;
+        if dry_run {
+            return Ok(ComponentRepairReport {
+                id: component_id.to_string(),
+                status: if game_dir.is_dir() { "runtime_repair_available" } else { "asset_missing" }.to_string(),
+                detail: if game_dir.is_dir() {
+                    "D3D12 Agility SDK payload can be downloaded and staged for this game".to_string()
+                } else {
+                    "Game install path is missing, so the Agility SDK payload cannot be staged".to_string()
+                },
+                asset_path: Some(game_dir.to_string_lossy().to_string()),
+                log_path: None,
+                pid: None,
+            });
+        }
+
+        crate::setup::stage_agility_sdk_for_game(appid, &game_dir, &home)?;
+        let state = inspect_component_state(&prefix, component_id, ComponentState::Unknown);
+        mark_component_state(&mut manifest, component_id, state);
+        manifest.health = if components_ready(&manifest.installed_components) {
+            BottleHealth::Ready
+        } else {
+            BottleHealth::NeedsRepair
+        };
+        manifest.updated_at = timestamp_secs();
+        save_bottle(&manifest)?;
+        return Ok(ComponentRepairReport {
+            id: component_id.to_string(),
+            status: if state == ComponentState::Installed { "installed" } else { "needs_repair" }.to_string(),
+            detail: "Downloaded and staged the D3D12 Agility SDK payload for the M12 launch path".to_string(),
+            asset_path: Some(game_dir.to_string_lossy().to_string()),
+            log_path: None,
+            pid: None,
+        });
+    }
+
     let Some(installer) = resolve_component_installer(component_id, manifest.arch)
         .or_else(|| resolve_game_runtime_asset_installer(&manifest, component_id))
     else {
@@ -1954,7 +1997,7 @@ fn runtime_profile_definition(profile: RuntimeProfile) -> RuntimeProfileDefiniti
             "D3D12 Metal",
             BottleArch::Win64,
             true,
-            &["d3d12", "d3d11", "dxgi", "vcrun2019", "gpu_vendor_stubs", "corefonts"][..],
+            &["d3d12", "d3d12_agility", "d3d11", "dxgi", "vcrun2019", "gpu_vendor_stubs", "corefonts"][..],
             crate::mtsp::engine::PipelineId::M12,
         ),
         RuntimeProfile::M13 => (
@@ -2419,6 +2462,7 @@ fn inspect_component_state(prefix: &Path, id: &str, fallback: ComponentState) ->
         "mono-arm64" => inspect_host_mono_component("mono-arm64").unwrap_or(fallback),
         "mono-x86" => inspect_host_mono_component("mono-x86").unwrap_or(fallback),
         "fna" => inspect_fna_runtime_component().unwrap_or(fallback),
+        "d3d12_agility" => inspect_d3d12_agility_component().unwrap_or(fallback),
         "gecko" => {
             if windows.join("gecko").exists() || system32.join("gecko").exists() || syswow64.join("gecko").exists() {
                 ComponentState::Installed
@@ -2596,6 +2640,17 @@ fn inspect_fna_runtime_component() -> Option<ComponentState> {
     } else {
         ComponentState::Missing
     })
+}
+
+fn inspect_d3d12_agility_component() -> Option<ComponentState> {
+    let home = dirs::home_dir()?;
+    let root = crate::platform::metalsharp_home_dir_for(&home).join("runtime").join("redist").join("agility");
+    let known_versions = ["1.614.1", "1.615.1", "1.619.3"];
+    let found = known_versions.iter().any(|version| {
+        let bin = root.join(version).join("build").join("native").join("bin").join("x64");
+        bin.join("D3D12Core.dll").exists() && bin.join("d3d12SDKLayers.dll").exists()
+    });
+    Some(if found { ComponentState::Installed } else { ComponentState::Missing })
 }
 
 fn core_fonts_installed(fonts_dir: &Path) -> bool {
@@ -3487,11 +3542,12 @@ fn component_source_policy(id: &str, arch: BottleArch) -> ComponentSourcePolicy 
             path: None,
         };
     }
-    if matches!(id, "mono-arm64" | "mono-x86" | "fna") {
+    if matches!(id, "mono-arm64" | "mono-x86" | "fna" | "d3d12_agility") {
         let state = match id {
             "mono-arm64" => inspect_host_mono_component("mono-arm64"),
             "mono-x86" => inspect_host_mono_component("mono-x86"),
             "fna" => inspect_fna_runtime_component(),
+            "d3d12_agility" => inspect_d3d12_agility_component(),
             _ => None,
         }
         .unwrap_or(ComponentState::Unknown);
@@ -3499,12 +3555,15 @@ fn component_source_policy(id: &str, arch: BottleArch) -> ComponentSourcePolicy 
             "mono-arm64" => crate::platform::metalsharp_home_dir_for(&home).join("runtime/mono-arm64/bin/mono"),
             "mono-x86" => crate::platform::metalsharp_home_dir_for(&home).join("runtime/mono-x86/bin/mono"),
             "fna" => crate::platform::metalsharp_home_dir_for(&home).join("runtime/fna"),
+            "d3d12_agility" => crate::platform::metalsharp_home_dir_for(&home).join("runtime/redist/agility"),
             _ => crate::platform::metalsharp_home_dir_for(&home).join("runtime"),
         });
         return ComponentSourcePolicy {
             id: id.to_string(),
             source: "metalsharp_native_runtime".to_string(),
-            available: if id == "fna" {
+            available: if id == "d3d12_agility" {
+                true
+            } else if id == "fna" {
                 matches!(state, ComponentState::Installed | ComponentState::NeedsRepair)
             } else {
                 state == ComponentState::Installed
@@ -3513,6 +3572,7 @@ fn component_source_policy(id: &str, arch: BottleArch) -> ComponentSourcePolicy 
                 "mono-arm64" => "Native ARM64 Mono runtime for Terraria/FNA-style macOS launch wrappers",
                 "mono-x86" => "Native x86_64 Mono runtime for legacy Celeste/FNA-style launch wrappers under Rosetta",
                 "fna" => "FNA/XNA compatibility assemblies and native shims staged in MetalSharp runtime",
+                "d3d12_agility" => "D3D12 Agility SDK x64 runtime payload staged for M12/D3D12 games",
                 _ => "MetalSharp native runtime component",
             }
             .to_string(),
@@ -3539,6 +3599,7 @@ fn component_source_policy(id: &str, arch: BottleArch) -> ComponentSourcePolicy 
             "corefonts" => "Requires a local core fonts payload or a mapped font installation strategy",
             "webview2" => "Uses Steam CommonRedist or ~/.metalsharp/runtime/redist WebView2 evergreen installer",
             "directx_jun2010" => "DirectX June 2010 — checks d3dx9_43, d3dx10_43, d3dx11_43, xinput1_3, xaudio2_7, x3daudio1_7, D3DCompiler_43",
+            "d3d12_agility" => "Uses NuGet Microsoft.Direct3D.D3D12 x64 runtime payload for the game-declared D3D12SDKVersion",
             "openal" => "Uses Steam CommonRedist or ~/.metalsharp/runtime/redist OpenAL installer",
             "xna" => {
                 "Uses Steam CommonRedist, Sharp Library installer bottles, or ~/.metalsharp/runtime/redist XNA 4.0 installer"
@@ -3568,6 +3629,7 @@ fn component_action_detail(id: &str) -> String {
         "mono-arm64" => "Install MetalSharp ARM64 Mono runtime".to_string(),
         "mono-x86" => "Install MetalSharp x86_64 Mono runtime".to_string(),
         "fna" => "Install FNA/XNA compatibility assemblies and native shims".to_string(),
+        "d3d12_agility" => "Download and stage the D3D12 Agility SDK payload".to_string(),
         "gecko" => "Install Wine Gecko for embedded browser surfaces".to_string(),
         "dotnet40" => "Install the native .NET Framework 4.0 runtime for CLR v4 titles".to_string(),
         "dotnet48" => "Install a compatible .NET 4.x runtime strategy for this bottle".to_string(),
@@ -5329,6 +5391,7 @@ mod tests {
         let m12_ids = m12.iter().map(|c| c.id.as_str()).collect::<Vec<_>>();
         assert!(m12_ids.contains(&"gpu_vendor_stubs"));
         assert!(m12_ids.contains(&"corefonts"));
+        assert!(m12_ids.contains(&"d3d12_agility"));
         assert!(!m12_ids.contains(&"gptk_amd_stub"));
 
         let m13 = default_components_for(RuntimeProfile::M13);
@@ -5343,6 +5406,15 @@ mod tests {
         assert!(guides.iter().any(|g| g.id == "vcrun2010"));
         assert!(guides.iter().any(|g| g.id == "vcrun2013"));
         assert!(guides.iter().any(|g| g.id == "vcrun2019"));
+    }
+
+    #[test]
+    fn d3d12_agility_component_is_repairable_native_runtime_payload() {
+        let policy = component_source_policy("d3d12_agility", BottleArch::Win64);
+
+        assert_eq!(policy.source, "metalsharp_native_runtime");
+        assert!(policy.available);
+        assert!(policy.detail.contains("Agility SDK"));
     }
 
     #[test]

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -11,6 +11,65 @@ const AGILITY_614_VERSION: &str = "1.614.1";
 const DXC_VERSION: &str = "v1.9.2602";
 const DXC_ARCHIVE: &str = "dxc_2026_02_20.zip";
 const DXC_SHA256: &str = "a1e89031421cf3c1fca6627766ab3020ca4f962ac7e2caa7fab2b33a8436151e";
+const FNA_CARBON_SHIM: &str = "libCarbon.dylib";
+const FNA_CARBON_INTERPOSE_SHIM: &str = "libmetalsharp_carbon_interpose.dylib";
+
+#[derive(Clone, Copy)]
+enum FnaShimSource {
+    RepoC { parts: &'static [&'static str] },
+    RepoObjC { parts: &'static [&'static str], frameworks: &'static [&'static str] },
+    BundledNative,
+}
+
+#[derive(Clone, Copy)]
+struct FnaNativeShimSpec {
+    output: &'static str,
+    source: FnaShimSource,
+    symlinks: &'static [&'static str],
+    required_for_launch: bool,
+}
+
+const FNA_NATIVE_SHIMS: &[FnaNativeShimSpec] = &[
+    FnaNativeShimSpec {
+        output: "libkernel32.dylib",
+        source: FnaShimSource::RepoC { parts: &["src", "fna", "shims", "kernel32_shim.c"] },
+        symlinks: &[],
+        required_for_launch: true,
+    },
+    FnaNativeShimSpec {
+        output: "libuser32.dylib",
+        source: FnaShimSource::RepoC { parts: &["src", "fna", "shims", "user32_shim.c"] },
+        symlinks: &[],
+        required_for_launch: true,
+    },
+    FnaNativeShimSpec {
+        output: FNA_CARBON_SHIM,
+        source: FnaShimSource::RepoObjC {
+            parts: &["src", "fna", "shims", "carbon_hiview_shim.m"],
+            frameworks: &["Cocoa", "Carbon"],
+        },
+        symlinks: &[],
+        required_for_launch: true,
+    },
+    FnaNativeShimSpec {
+        output: FNA_CARBON_INTERPOSE_SHIM,
+        source: FnaShimSource::RepoC { parts: &["src", "fna", "shims", "carbon_interpose.c"] },
+        symlinks: &[],
+        required_for_launch: true,
+    },
+    FnaNativeShimSpec {
+        output: "xaudio2_9.dylib",
+        source: FnaShimSource::BundledNative,
+        symlinks: &["xaudio2_8.dylib", "xaudio2_7.dylib"],
+        required_for_launch: false,
+    },
+    FnaNativeShimSpec {
+        output: "xinput1_4.dylib",
+        source: FnaShimSource::BundledNative,
+        symlinks: &["xinput1_3.dylib", "xinput9_1_0.dylib"],
+        required_for_launch: false,
+    },
+];
 
 pub fn bridge_port() -> u16 {
     parse_bridge_port(std::env::var("METALSHARP_STEAM_BRIDGE_PORT").ok().as_deref()).unwrap_or(DEFAULT_BRIDGE_PORT)
@@ -1060,6 +1119,9 @@ fn launch_fna_arm64(appid: u32) -> Result<(u32, &'static str, PathBuf), Box<dyn 
         .env("MONO_PATH", mono_path)
         .stdout(Stdio::from(stdout))
         .stderr(Stdio::from(stderr));
+    for (key, value) in fna_native_launch_env(dir) {
+        cmd.env(key, value);
+    }
 
     let cache_paths = build_cache_paths(&home, node, appid);
     apply_cache_env(
@@ -1578,6 +1640,8 @@ fn deploy_fna_assemblies(appid: u32, game_dir: &PathBuf) {
     }
 
     let shims_dir = PathBuf::from(find_shims_dir());
+    let _ = std::fs::create_dir_all(&shims_dir);
+    deploy_fna_native_shims(game_dir, &shims_dir);
     let shared_native_libs = [
         ("libFNA3D.dylib", None),
         ("libFNA3D.0.dylib", Some("libFNA3D.dylib")),
@@ -1670,6 +1734,175 @@ fn deploy_fna_assemblies(appid: u32, game_dir: &PathBuf) {
 
     let _ = std::fs::write(game_dir.join("steam_appid.txt"), appid.to_string());
     deploy_offline_steamworks_net(game_dir, &metalsharp_home);
+}
+
+fn deploy_fna_native_shims(game_dir: &PathBuf, shims_dir: &PathBuf) {
+    for spec in FNA_NATIVE_SHIMS {
+        ensure_fna_native_shim_in_cache(spec, shims_dir);
+        copy_fna_native_lib(game_dir, shims_dir, spec.output, None);
+        if game_dir.join(spec.output).exists() {
+            for symlink in spec.symlinks {
+                ensure_fna_symlink(game_dir, spec.output, symlink);
+            }
+        }
+    }
+}
+
+pub fn repair_fna_native_runtime_shims() -> Result<usize, Box<dyn std::error::Error>> {
+    let home = dirs::home_dir().ok_or("no home dir")?;
+    let shims_dir = crate::platform::metalsharp_home_dir_for(&home).join("runtime").join("shims");
+    std::fs::create_dir_all(&shims_dir)?;
+
+    for spec in FNA_NATIVE_SHIMS {
+        ensure_fna_native_shim_in_cache(spec, &shims_dir);
+    }
+
+    let installed_required = FNA_NATIVE_SHIMS
+        .iter()
+        .filter(|spec| spec.required_for_launch)
+        .filter(|spec| shims_dir.join(spec.output).exists())
+        .count();
+    let required = FNA_NATIVE_SHIMS.iter().filter(|spec| spec.required_for_launch).count();
+    if installed_required != required {
+        return Err(format!(
+            "FNA native shim repair incomplete: {}/{} required macOS framework shims are staged",
+            installed_required, required
+        )
+        .into());
+    }
+    Ok(FNA_NATIVE_SHIMS.iter().filter(|spec| shims_dir.join(spec.output).exists()).count())
+}
+
+fn ensure_fna_native_shim_in_cache(spec: &FnaNativeShimSpec, shims_dir: &PathBuf) {
+    let dst = shims_dir.join(spec.output);
+    if dst.exists() {
+        return;
+    }
+
+    match spec.source {
+        FnaShimSource::RepoC { parts } => {
+            if let Some(source) = find_fna_shim_source(parts) {
+                let _ = build_fna_c_shim(&source, &dst, spec.output, &[]);
+            }
+        },
+        FnaShimSource::RepoObjC { parts, frameworks } => {
+            if let Some(source) = find_fna_shim_source(parts) {
+                let _ = build_fna_c_shim(&source, &dst, spec.output, frameworks);
+            }
+        },
+        FnaShimSource::BundledNative => {
+            if let Some(source) = find_bundled_native_shim(spec.output) {
+                let _ = std::fs::copy(source, &dst);
+                codesign_fna_shim(&dst);
+            }
+        },
+    }
+}
+
+fn build_fna_c_shim(source: &PathBuf, output: &PathBuf, install_name: &str, frameworks: &[&str]) -> bool {
+    if let Some(parent) = output.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+
+    let mut cmd = Command::new("clang");
+    cmd.arg("-shared");
+    for arg in fna_native_arch_args() {
+        cmd.arg(arg);
+    }
+    if source.extension().and_then(|ext| ext.to_str()) == Some("m") {
+        cmd.arg("-fobjc-arc");
+    }
+    cmd.arg("-o").arg(output).arg(source).args(["-install_name", &format!("@loader_path/{}", install_name)]);
+    for framework in frameworks {
+        cmd.args(["-framework", framework]);
+    }
+    let success = cmd
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false);
+    if success {
+        codesign_fna_shim(output);
+    }
+    success
+}
+
+fn fna_native_arch_args() -> Vec<&'static str> {
+    if crate::platform::current() == crate::platform::HostPlatform::Macos {
+        vec!["-arch", "arm64", "-arch", "x86_64"]
+    } else {
+        Vec::new()
+    }
+}
+
+fn find_bundled_native_shim(name: &str) -> Option<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(resources) = crate::platform::app_resources_dir() {
+        candidates.push(resources.join("scripts").join("tools").join("native").join(name));
+        candidates.push(resources.join("runtime").join("shims").join(name));
+    }
+    if let Some(source) = find_repo_source(&["app", "native", name]) {
+        candidates.push(source);
+    }
+    if let Some(source) = find_repo_source(&["build", name]) {
+        candidates.push(source);
+    }
+    candidates.into_iter().find(|candidate| candidate.is_file() && file_has_payload(candidate))
+}
+
+fn find_fna_shim_source(parts: &[&str]) -> Option<PathBuf> {
+    if let Some(source) = find_repo_source(parts) {
+        return Some(source);
+    }
+    let filename = parts.last()?;
+    let resources = crate::platform::app_resources_dir()?;
+    let candidates = [
+        resources.join("runtime").join("shim-sources").join("fna").join("shims").join(filename),
+        resources.join("scripts").join("tools").join("fna").join("shims").join(filename),
+    ];
+    candidates.into_iter().find(|candidate| candidate.is_file())
+}
+
+fn file_has_payload(path: &PathBuf) -> bool {
+    std::fs::metadata(path).map(|metadata| metadata.len() > 0).unwrap_or(false)
+}
+
+fn codesign_fna_shim(path: &PathBuf) {
+    if crate::platform::current() != crate::platform::HostPlatform::Macos || !path.exists() {
+        return;
+    }
+    let _ = Command::new("codesign")
+        .args(["--force", "-s", "-"])
+        .arg(path)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+}
+
+fn fna_native_launch_env(game_dir: &PathBuf) -> Vec<(String, String)> {
+    let carbon = game_dir.join(FNA_CARBON_SHIM);
+    let interpose = game_dir.join(FNA_CARBON_INTERPOSE_SHIM);
+    let mut env = Vec::new();
+    if carbon.exists() {
+        env.push(("METALSHARP_CARBON_SHIM".to_string(), carbon.to_string_lossy().to_string()));
+    }
+    if interpose.exists() {
+        let existing = std::env::var("DYLD_INSERT_LIBRARIES").ok();
+        env.push((
+            "DYLD_INSERT_LIBRARIES".to_string(),
+            append_path_env(existing.as_deref(), &interpose.to_string_lossy()),
+        ));
+    }
+    env
+}
+
+fn append_path_env(existing: Option<&str>, value: &str) -> String {
+    match existing.map(str::trim).filter(|v| !v.is_empty()) {
+        Some(existing) if existing.split(':').any(|item| item == value) => existing.to_string(),
+        Some(existing) => format!("{}:{}", existing, value),
+        None => value.to_string(),
+    }
 }
 
 fn deploy_terraria_runtime(game_dir: &PathBuf, metalsharp_home: &PathBuf) {
@@ -2343,6 +2576,53 @@ mod tests {
             let node = get_pipeline(pipeline_id);
             assert!(!node.uses_winedllpath_routing(), "{:?} should not use WINEDLLPATH routing", pipeline_id);
         }
+    }
+
+    #[test]
+    fn fna_native_shim_manifest_includes_macos_framework_routes() {
+        let outputs: std::collections::HashSet<_> = FNA_NATIVE_SHIMS.iter().map(|spec| spec.output).collect();
+
+        assert!(outputs.contains("libkernel32.dylib"));
+        assert!(outputs.contains("libuser32.dylib"));
+        assert!(outputs.contains(FNA_CARBON_SHIM));
+        assert!(outputs.contains(FNA_CARBON_INTERPOSE_SHIM));
+        assert!(outputs.contains("xaudio2_9.dylib"));
+        assert!(outputs.contains("xinput1_4.dylib"));
+        assert!(FNA_NATIVE_SHIMS
+            .iter()
+            .any(|spec| spec.output == "xaudio2_9.dylib" && spec.symlinks.contains(&"xaudio2_7.dylib")));
+        assert!(FNA_NATIVE_SHIMS
+            .iter()
+            .any(|spec| spec.output == "xinput1_4.dylib" && spec.symlinks.contains(&"xinput1_3.dylib")));
+    }
+
+    #[test]
+    fn fna_native_launch_env_enables_carbon_interpose_when_deployed() {
+        let game_dir = test_dir("fna-native-env");
+        std::fs::create_dir_all(&game_dir).expect("game dir");
+        std::fs::write(game_dir.join(FNA_CARBON_SHIM), b"carbon").expect("carbon shim");
+        std::fs::write(game_dir.join(FNA_CARBON_INTERPOSE_SHIM), b"interpose").expect("interpose shim");
+
+        let env = fna_native_launch_env(&game_dir);
+        assert_eq!(
+            env.iter().find(|(key, _)| key == "METALSHARP_CARBON_SHIM").map(|(_, value)| value.as_str()),
+            Some(game_dir.join(FNA_CARBON_SHIM).to_string_lossy().as_ref())
+        );
+        assert_eq!(
+            env.iter().find(|(key, _)| key == "DYLD_INSERT_LIBRARIES").map(|(_, value)| value.as_str()),
+            Some(game_dir.join(FNA_CARBON_INTERPOSE_SHIM).to_string_lossy().as_ref())
+        );
+        let _ = std::fs::remove_dir_all(game_dir);
+    }
+
+    #[test]
+    fn append_path_env_preserves_existing_insert_libraries() {
+        assert_eq!(append_path_env(None, "/tmp/new.dylib"), "/tmp/new.dylib");
+        assert_eq!(append_path_env(Some("/tmp/old.dylib"), "/tmp/new.dylib"), "/tmp/old.dylib:/tmp/new.dylib");
+        assert_eq!(
+            append_path_env(Some("/tmp/old.dylib:/tmp/new.dylib"), "/tmp/new.dylib"),
+            "/tmp/old.dylib:/tmp/new.dylib"
+        );
     }
 
     #[test]

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -670,6 +670,7 @@ fn launch_dxmt_metal_with_context(
     for ev in &node.env_vars {
         cmd.env(ev.key, ev.value);
     }
+    apply_app_launch_env(&mut cmd, appid, node.id);
     for (key, value) in extra_env {
         cmd.env(key, value);
     }
@@ -781,6 +782,10 @@ fn launch_wine_bare_with_context(
     let cache_paths = build_cache_paths(&home, node, appid);
     apply_cache_env(&mut cmd, node, cache_paths.as_ref(), &ms_root);
     cmd.env("MS_GRAPHICS_BACKEND", node.graphics_backend);
+    for ev in &node.env_vars {
+        cmd.env(ev.key, ev.value);
+    }
+    apply_app_launch_env(&mut cmd, appid, node.id);
     for (key, value) in extra_env {
         cmd.env(key, value);
     }
@@ -1179,6 +1184,16 @@ fn steam_pipeline_env_pairs(home: &PathBuf, node: &PipelineNode, appid: u32) -> 
 }
 
 fn app_compat_env_pairs(appid: u32, pipeline_id: PipelineId) -> Vec<(String, String)> {
+    if pipeline_id == PipelineId::M9 && is_m9_stuck_loading_title(appid) {
+        return vec![
+            ("DXMT_ASYNC_PIPELINE_COMPILE".to_string(), "0".to_string()),
+            ("DXMT_METALFX_SPATIAL_SWAPCHAIN".to_string(), "0".to_string()),
+            ("DXMT_METALFX_SPATIAL".to_string(), "0".to_string()),
+            ("DXMT_CONFIG".to_string(), "d3d11.preferredMaxFrameRate=60".to_string()),
+            ("METALSHARP_M9_SYNC_LOADING".to_string(), "1".to_string()),
+        ];
+    }
+
     if appid == 1962700 && pipeline_id == PipelineId::M12 {
         let mut env = vec![
             ("DXMT_DXGI_TRACE".to_string(), "1".to_string()),
@@ -1238,6 +1253,21 @@ fn app_compat_env_pairs(appid: u32, pipeline_id: PipelineId) -> Vec<(String, Str
         return env;
     }
     Vec::new()
+}
+
+fn is_m9_stuck_loading_title(appid: u32) -> bool {
+    matches!(appid, 774361 | 17410 | 49520)
+}
+
+fn apply_app_launch_env(cmd: &mut Command, appid: u32, pipeline_id: PipelineId) {
+    for (key, value) in app_compat_env_pairs(appid, pipeline_id) {
+        cmd.env(key, value);
+    }
+    if let Some(recipe) = super::rules::get_game_recipe(appid) {
+        for (key, value) in recipe.env {
+            cmd.env(key, value);
+        }
+    }
 }
 
 fn apply_cache_env(cmd: &mut Command, node: &PipelineNode, cache_paths: Option<&CachePaths>, ms_root: &PathBuf) {
@@ -2309,6 +2339,36 @@ mod tests {
     }
 
     #[test]
+    fn m9_stuck_loading_titles_disable_async_loading_features() {
+        for appid in [774361, 17410, 49520] {
+            let env = app_compat_env_pairs(appid, PipelineId::M9);
+
+            assert_eq!(env_value(&env, "DXMT_ASYNC_PIPELINE_COMPILE"), Some("0"));
+            assert_eq!(env_value(&env, "DXMT_METALFX_SPATIAL_SWAPCHAIN"), Some("0"));
+            assert_eq!(env_value(&env, "DXMT_METALFX_SPATIAL"), Some("0"));
+            assert_eq!(env_value(&env, "DXMT_CONFIG"), Some("d3d11.preferredMaxFrameRate=60"));
+            assert_eq!(env_value(&env, "METALSHARP_M9_SYNC_LOADING"), Some("1"));
+        }
+
+        assert!(app_compat_env_pairs(123456, PipelineId::M9).is_empty());
+        assert!(app_compat_env_pairs(774361, PipelineId::M10).is_empty());
+    }
+
+    #[test]
+    fn steam_pipeline_env_applies_m9_stuck_loading_overrides_after_defaults() {
+        let home = test_dir("m9-stuck-loading-env");
+        let node = get_pipeline(PipelineId::M9);
+
+        let env = steam_pipeline_env_pairs(&home, node, 774361);
+
+        assert_eq!(last_env_value(&env, "DXMT_ASYNC_PIPELINE_COMPILE"), Some("0"));
+        assert_eq!(last_env_value(&env, "DXMT_METALFX_SPATIAL_SWAPCHAIN"), Some("0"));
+        assert_eq!(last_env_value(&env, "DXMT_CONFIG"), Some("d3d11.preferredMaxFrameRate=60"));
+        assert_eq!(last_env_value(&env, "METALSHARP_M9_SYNC_LOADING"), Some("1"));
+        let _ = std::fs::remove_dir_all(home);
+    }
+
+    #[test]
     fn m32_env_keeps_wine_fallback_cache_without_dxmt_config() {
         let home = test_dir("m32-env");
         let node = get_pipeline(PipelineId::M32);
@@ -2587,6 +2647,14 @@ mod tests {
         let mut dir = std::env::temp_dir();
         dir.push(format!("metalsharp-launcher-{}-{}-{}", name, std::process::id(), unique_suffix()));
         dir
+    }
+
+    fn env_value<'a>(env: &'a [(String, String)], key: &str) -> Option<&'a str> {
+        env.iter().find(|(env_key, _)| env_key == key).map(|(_, value)| value.as_str())
+    }
+
+    fn last_env_value<'a>(env: &'a [(String, String)], key: &str) -> Option<&'a str> {
+        env.iter().rev().find(|(env_key, _)| env_key == key).map(|(_, value)| value.as_str())
     }
 
     fn unique_suffix() -> u128 {

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -7,10 +7,6 @@ use std::process::{Command, Stdio};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 const DEFAULT_BRIDGE_PORT: u16 = 18733;
-const AGILITY_614_VERSION: &str = "1.614.1";
-const DXC_VERSION: &str = "v1.9.2602";
-const DXC_ARCHIVE: &str = "dxc_2026_02_20.zip";
-const DXC_SHA256: &str = "a1e89031421cf3c1fca6627766ab3020ca4f962ac7e2caa7fab2b33a8436151e";
 const FNA_CARBON_SHIM: &str = "libCarbon.dylib";
 const FNA_CARBON_INTERPOSE_SHIM: &str = "libmetalsharp_carbon_interpose.dylib";
 
@@ -712,33 +708,7 @@ fn deploy_d3d12_agility_sidecars(
     }
 
     let home = dirs::home_dir().ok_or("no home dir")?;
-    let ms_root = crate::platform::metalsharp_home_dir_for(&home).join("runtime").join("wine");
-    let source_dir = find_or_fetch_agility_614_dir(&home, &ms_root)?;
-    let dxil_dll = find_or_fetch_dxil_dll(&home, &source_dir)?;
-
-    let mut roots = vec![exe_dir.to_path_buf()];
-    let engine_bin = game_dir.join("Engine").join("Binaries").join("Win64");
-    if engine_bin.is_dir() && !roots.iter().any(|root| root == &engine_bin) {
-        roots.push(engine_bin);
-    }
-
-    let targets: Vec<PathBuf> =
-        roots.into_iter().flat_map(|root| [root.join("D3D12").join("x64"), root.join("D3D12")]).collect();
-
-    for target in targets {
-        std::fs::create_dir_all(&target)?;
-        for dll in ["D3D12Core.dll", "d3d12SDKLayers.dll", "D3D12StateObjectCompiler.dll", "d3dconfig.exe"] {
-            let src = source_dir.join(dll);
-            if src.is_file() {
-                std::fs::copy(&src, target.join(dll))?;
-            } else if dll == "D3D12StateObjectCompiler.dll" {
-                let _ = std::fs::remove_file(target.join(dll));
-            }
-        }
-        std::fs::copy(&dxil_dll, target.join("dxil.dll"))?;
-    }
-
-    Ok(())
+    crate::setup::stage_agility_sdk_for_game(appid, game_dir, &home)
 }
 
 fn skips_app_local_agility_sidecars(appid: u32) -> bool {
@@ -760,161 +730,6 @@ fn remove_app_local_agility_sidecars(game_dir: &Path, exe_dir: &Path) -> Result<
     }
 
     Ok(())
-}
-
-fn find_or_fetch_agility_614_dir(home: &Path, ms_root: &Path) -> Result<PathBuf, Box<dyn std::error::Error>> {
-    if let Some(path) = std::env::var_os("METALSHARP_AGILITY_BIN") {
-        let dir = PathBuf::from(path);
-        if agility_payload_present(&dir) {
-            return Ok(dir);
-        }
-    }
-
-    let redist_dir = agility_614_redist_dir(home);
-    let candidates = [ms_root.join("lib").join("dxmt").join("x86_64-windows").join("D3D12"), redist_dir.clone()];
-    if let Some(found) = candidates.iter().find(|dir| agility_payload_present(dir)) {
-        return Ok(found.clone());
-    }
-
-    fetch_agility_614_redist(home)?;
-    if agility_payload_present(&redist_dir) {
-        return Ok(redist_dir);
-    }
-
-    Err("D3D12 Agility 1.614.1 payload missing: D3D12Core.dll and d3d12SDKLayers.dll were not found or fetched".into())
-}
-
-fn agility_payload_present(dir: &Path) -> bool {
-    dir.join("D3D12Core.dll").is_file() && dir.join("d3d12SDKLayers.dll").is_file()
-}
-
-fn agility_614_redist_dir(home: &Path) -> PathBuf {
-    crate::platform::metalsharp_home_dir_for(&home)
-        .join("runtime")
-        .join("redist")
-        .join("agility")
-        .join(AGILITY_614_VERSION)
-        .join("build")
-        .join("native")
-        .join("bin")
-        .join("x64")
-}
-
-fn fetch_agility_614_redist(home: &Path) -> Result<(), Box<dyn std::error::Error>> {
-    let package_root = crate::platform::metalsharp_home_dir_for(&home)
-        .join("runtime")
-        .join("redist")
-        .join("agility")
-        .join(AGILITY_614_VERSION);
-    let cache_dir = package_root.join(".download");
-    let package_file = cache_dir.join("Microsoft.Direct3D.D3D12.nupkg");
-    std::fs::create_dir_all(&cache_dir)?;
-    if !package_file.is_file() {
-        run_command(
-            Command::new("curl")
-                .arg("-L")
-                .arg("--fail")
-                .arg("--retry")
-                .arg("3")
-                .arg("-o")
-                .arg(&package_file)
-                .arg(format!("https://www.nuget.org/api/v2/package/Microsoft.Direct3D.D3D12/{}", AGILITY_614_VERSION)),
-            "download D3D12 Agility 1.614.1",
-        )?;
-    }
-    run_command(
-        Command::new("unzip").arg("-q").arg("-o").arg(&package_file).arg("-d").arg(&package_root),
-        "extract D3D12 Agility 1.614.1",
-    )?;
-    Ok(())
-}
-
-fn find_or_fetch_dxil_dll(home: &Path, agility_dir: &Path) -> Result<PathBuf, Box<dyn std::error::Error>> {
-    if let Some(path) = std::env::var_os("METALSHARP_DXIL_DLL") {
-        let dll = PathBuf::from(path);
-        if dll.is_file() {
-            return Ok(dll);
-        }
-    }
-
-    let redist_dll = dxc_redist_bin_dir(home).join("dxil.dll");
-    let candidates = [
-        agility_dir.join("dxil.dll"),
-        crate::platform::metalsharp_home_dir_for(&home).join("runtime").join("redist").join("dxil.dll"),
-        redist_dll.clone(),
-    ];
-    if let Some(found) = candidates.iter().find(|path| path.is_file()) {
-        return Ok(found.clone());
-    }
-
-    fetch_dxc_redist(home)?;
-    if redist_dll.is_file() {
-        return Ok(redist_dll);
-    }
-
-    Err("DXIL validator/runtime DLL missing: dxil.dll was not found or fetched".into())
-}
-
-fn dxc_redist_bin_dir(home: &Path) -> PathBuf {
-    crate::platform::metalsharp_home_dir_for(&home)
-        .join("runtime")
-        .join("redist")
-        .join("dxc")
-        .join(DXC_VERSION)
-        .join("bin")
-        .join("x64")
-}
-
-fn fetch_dxc_redist(home: &Path) -> Result<(), Box<dyn std::error::Error>> {
-    let redist_root =
-        crate::platform::metalsharp_home_dir_for(&home).join("runtime").join("redist").join("dxc").join(DXC_VERSION);
-    let download_dir = redist_root.join("downloads");
-    let archive_path = download_dir.join(DXC_ARCHIVE);
-    std::fs::create_dir_all(&download_dir)?;
-    if !archive_path.is_file() {
-        run_command(
-            Command::new("curl").arg("-L").arg("--fail").arg("--retry").arg("3").arg("-o").arg(&archive_path).arg(
-                format!(
-                    "https://github.com/microsoft/DirectXShaderCompiler/releases/download/{}/{}",
-                    DXC_VERSION, DXC_ARCHIVE
-                ),
-            ),
-            "download DirectXShaderCompiler",
-        )?;
-    }
-
-    let actual = command_output(
-        Command::new("shasum").arg("-a").arg("256").arg(&archive_path),
-        "hash DirectXShaderCompiler archive",
-    )?;
-    let actual_hash = actual.split_whitespace().next().unwrap_or_default();
-    if actual_hash != DXC_SHA256 {
-        return Err(format!("DXC archive checksum mismatch: expected {}, got {}", DXC_SHA256, actual_hash).into());
-    }
-
-    run_command(
-        Command::new("unzip").arg("-q").arg("-o").arg(&archive_path).arg("-d").arg(&redist_root),
-        "extract DirectXShaderCompiler",
-    )?;
-    Ok(())
-}
-
-fn run_command(cmd: &mut Command, label: &str) -> Result<(), Box<dyn std::error::Error>> {
-    let output = cmd.output()?;
-    if output.status.success() {
-        return Ok(());
-    }
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    Err(format!("{} failed: {}", label, stderr.trim()).into())
-}
-
-fn command_output(cmd: &mut Command, label: &str) -> Result<String, Box<dyn std::error::Error>> {
-    let output = cmd.output()?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("{} failed: {}", label, stderr.trim()).into());
-    }
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
 fn launch_wine_bare(appid: u32, node: &PipelineNode) -> Result<(u32, &'static str), Box<dyn std::error::Error>> {

--- a/app/src-rust/src/setup.rs
+++ b/app/src-rust/src/setup.rs
@@ -593,7 +593,11 @@ struct AgilitySdkRequirement {
     sdk_path: String,
 }
 
-fn stage_agility_sdk_for_game(appid: u32, game_dir: &Path, home: &Path) -> Result<(), Box<dyn std::error::Error>> {
+pub(crate) fn stage_agility_sdk_for_game(
+    appid: u32,
+    game_dir: &Path,
+    home: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
     let exe_path = crate::mtsp::recipe::resolve_game_exe(appid, game_dir)?;
     let exe_dir = exe_path.parent().ok_or("game exe parent not found")?;
     if appid == 1962700 {
@@ -804,7 +808,7 @@ fn fetch_agility_sdk_bin_native(
 }
 
 fn download_agility_package(package_version: &str, package_file: &Path) -> Result<(), Box<dyn std::error::Error>> {
-    let url = format!("https://www.nuget.org/api/v2/package/Microsoft.Direct3D.D3D12/{}", package_version);
+    let url = agility_package_download_url(package_version);
     let config =
         ureq::config::Config::builder().user_agent(format!("MetalSharp/{}", env!("CARGO_PKG_VERSION"))).build();
     let agent = ureq::Agent::new_with_config(config);
@@ -815,6 +819,13 @@ fn download_agility_package(package_version: &str, package_file: &Path) -> Resul
     std::io::copy(&mut input, &mut output)?;
     std::fs::rename(tmp_file, package_file)?;
     Ok(())
+}
+
+fn agility_package_download_url(package_version: &str) -> String {
+    format!(
+        "https://api.nuget.org/v3-flatcontainer/microsoft.direct3d.d3d12/{0}/microsoft.direct3d.d3d12.{0}.nupkg",
+        package_version.to_ascii_lowercase()
+    )
 }
 
 fn extract_agility_package(package_file: &Path, package_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
@@ -926,6 +937,7 @@ fn agility_user_package_dir(home: &Path, package_version: &str) -> PathBuf {
 fn agility_package_version(sdk_version: u32) -> Option<&'static str> {
     match sdk_version {
         614 => Some("1.614.1"),
+        615 => Some("1.615.1"),
         619 => Some("1.619.3"),
         _ => None,
     }
@@ -1628,7 +1640,16 @@ mod tests {
     fn agility_default_requirement_uses_fetchable_runtime_package() {
         assert_eq!(agility_package_version_for_requirement(None), "1.614.1");
         assert_eq!(agility_package_version_for_requirement(Some(614)), "1.614.1");
+        assert_eq!(agility_package_version_for_requirement(Some(615)), "1.615.1");
         assert_eq!(agility_package_version_for_requirement(Some(619)), "1.619.3");
+    }
+
+    #[test]
+    fn agility_package_download_uses_nuget_flat_container() {
+        assert_eq!(
+            agility_package_download_url("1.615.1"),
+            "https://api.nuget.org/v3-flatcontainer/microsoft.direct3d.d3d12/1.615.1/microsoft.direct3d.d3d12.1.615.1.nupkg"
+        );
     }
 
     #[test]

--- a/app/src/renderer/views/SettingsView.vue
+++ b/app/src/renderer/views/SettingsView.vue
@@ -341,7 +341,7 @@ function toggleDeveloperMode(enabled: boolean) {
           <div class="settings-desc">Show launch routing, doctor controls, and advanced card tools</div>
         </div>
         <div class="settings-value">
-          <label class="settings-toggle">
+          <label class="settings-toggle toggle-label" aria-label="Developer Tools">
             <input
               type="checkbox"
               :checked="developerMode"

--- a/docs/compatibility/GAMES-SUPPORTED.md
+++ b/docs/compatibility/GAMES-SUPPORTED.md
@@ -52,7 +52,7 @@ Internal routes still exist for diagnostics and compatibility records:
 | Hollow Knight: Silksong | `steam_1030300` | Still working. Routes to M12 and runs correctly. | **M12** |
 | Ghostrunner | `steam_1139900` | Auto-routes to M11 and runs correctly. M12 saved config produced unexpected Wine Mono installer prompt behavior. | **M11**, M12 if possible |
 | Combat Master | `steam_2281730` | Auto-routed to DX12 but hit Agility error. Saved M11 bottle config ran gameplay with no issues. | **M11** |
-| Blasphemous | `steam_774361` | Auto-routed to M11, but the game is 32-bit. Saved to M9 bottle and ran perfectly. | **M9** |
+| Blasphemous | `steam_774361` | Auto-routed to M11, but the game is 32-bit. M9 reaches the menu and first text dialogue, then can hit an infinite blank loading transition. The M9 launch profile now uses a sync-loading mitigation for this title. | **M9**, sync-loading mitigation |
 | Dave the Diver | `steam_1868140` | Auto-routed to M11, but the game is 32-bit. Saved to M9 and ran beautifully after deploying D3D9, vcrun2019, and DirectX June 2010. | **M9** |
 | Peak | `steam_3527290` | DX12 game. With M12 applied to the bottle, it launched and played perfectly on medium settings. Should auto-route to M12 instead of M11. | **M12**, Medium settings |
 | Dark Deception | `steam_332950` | Routed to M12 and hit Agility SDK not found. Saved config to M11 launched with no input. A one-time internal Steam handoff installed needed runtime assets, then the saved route launched and worked normally. | **M11** after runtime bootstrap |
@@ -77,9 +77,9 @@ Internal routes still exist for diagnostics and compatibility records:
 | Minecraft Legends | `steam_1928870` | Only launches with M12 pipeline but does not render. | **M12**, render-path investigation |
 | Stardew Valley | `steam_413150` | Launches from Steam, then crashes with Wine debug output. Earlier testing was stuck on an old native-macOS handoff label that is no longer a public route option. | Needs fresh public-route test |
 | Palworld | `steam_1623730` | DX12/DX11 game. M11 and M12 both produce a black loading window with no visible output. | M11/M12 render-path investigation |
-| Mirror's Edge | `steam_17410` | Auto-routed to M11 and launched, but this is a DX9 game and the routing does not make sense. Loaded oddly. | Should route to **M9** |
+| Mirror's Edge | `steam_17410` | Auto-routed to M11 and launched, but this is a DX9 game and the routing does not make sense. M9 showed the same loading/setup clog pattern seen in other DX9 titles, so the M9 launch profile now disables async loading features for this title. | **M9**, sync-loading mitigation |
 | Resident Evil Village | `steam_1196590` | DX12 game. M12 stages DLLs but does not launch because Agility SDK x64 payload is not found for version `default`. With DLLs staged, it reached a black launch before Wine debug crash. | **M12**, Agility payload fix |
-| Borderlands 2 | `steam_49520` | Only launches on M9 without immediate crash, but never makes it past the loading screen. | **M9**, loading investigation |
+| Borderlands 2 | `steam_49520` | Only launches on M9 without immediate crash, but never makes it past the loading screen. The M9 launch profile now uses the same sync-loading mitigation as Blasphemous and Mirror's Edge. | **M9**, sync-loading mitigation |
 | InZOI | `steam_2456740` | DX12-exclusive game. Requires feature level 2. Auto-routes to M12 and launches with M12, but does not enter game or output color. Useful DX12-specific test target. | **M12**, feature/render investigation |
 | Black Myth Wukong | `steam_2358720` | DX12/DX11 game. Routed to M12 and hit Agility SDK not found. Changed to M11 bottle config with no error but no launch. Launched with Steam using `-d3d11` and compatibility mode. | Needs to launch through D3D11/D3D12 pipelines from the app |
 

--- a/docs/runtime/metalsharp-host-shim-inventory.md
+++ b/docs/runtime/metalsharp-host-shim-inventory.md
@@ -32,7 +32,7 @@ Purpose: Phase 0 inventory of existing C, C++, and Objective-C host shims that c
 | Win32 shim layer | `src/win32/kernel32/*.cpp`, `include/metalsharp/Win32Types.h`, `include/metalsharp/ExtraShims.h` | Larger native-loader Win32 shim set for kernel32/ntdll/network/extra APIs. | stable | Use selectively for ABI service mapping; avoid duplicating behavior between FNA C shims and C++ Win32 shims. |
 | Anti-cheat database | `include/metalsharp/AntiCheatDB.h`, `src/runtime/DRMDetector.cpp` | Static detection tables now use evidence-backed support status strings instead of compatible/incompatible booleans. | diagnostic | Keep static statuses aligned with launch-recipe evidence and live protected-launch proof. |
 | Offline EAC mode naming | `app/src-rust/src/installer.rs`, `app/src-rust/src/main.rs` | Installer/UI text now avoids bypass wording, but endpoint names still expose the legacy `eac-toggle` route. | legacy-risk | Audit behavior, keep naming explicit if legitimate compatibility flag, remove if bypass-like. |
-| Runtime deploy glue | `app/src-rust/src/mtsp/launcher.rs`, `app/src-rust/src/setup.rs` | Copies shims into runtime/game folders and assembles launch env. | prototype | Move shim deployment into manifest-driven runtime asset selection. |
+| Runtime deploy glue | `app/src-rust/src/mtsp/launcher.rs`, `app/src-rust/src/setup.rs` | Copies shims into runtime/game folders and assembles launch env. The Mono/FNA launcher now has a native shim manifest for kernel32/user32/Carbon interpose plus bundled CoreAudio/GameController dylibs. | prototype | Extend the manifest pattern into versioned Host Runtime ABI asset selection and self-tests. |
 
 ## Strongest Existing Pattern
 
@@ -52,7 +52,7 @@ That pattern is safer than ad hoc interposition because:
 
 ## Weakest Current Pattern
 
-The weakest pattern is per-game dylib/stub deployment without a central manifest:
+The weakest remaining pattern is per-game dylib/stub deployment outside the Mono/FNA native shim manifest:
 
 - hardcoded ports
 - hardcoded user paths

--- a/docs/runtime/mono-runtime-lanes.md
+++ b/docs/runtime/mono-runtime-lanes.md
@@ -23,7 +23,7 @@ MetalSharp now treats Mono/FNA as a first-class public route, not a global depen
 
 ## Current Mono/FNA Route Contract
 
-The route stages FNA/XNA assemblies, native FNA3D/FAudio/SDL/Steam libraries when available, FMOD/FMOD Studio stubs, `steam_appid.txt`, and Steamworks compatibility shims. Celeste-style games select x86_64 Mono under Rosetta; Terraria-style games can use the Terraria runtime patch/stub path. Celeste and Terraria are now supported through this lane; future Mono/FNA titles should still be promoted only after per-game launch proof.
+The route stages FNA/XNA assemblies, native FNA3D/FAudio/SDL/Steam libraries when available, FMOD/FMOD Studio stubs, `steam_appid.txt`, and Steamworks compatibility shims. It also deploys the macOS framework-backed MetalSharp shims expected by the dllmaps: `libkernel32.dylib`, `libuser32.dylib`, `libCarbon.dylib`, the Carbon interpose shim, and bundled CoreAudio/GameController shims such as `xaudio2_9.dylib` and `xinput1_4.dylib` when present. Celeste-style games select x86_64 Mono under Rosetta; Terraria-style games can use the Terraria runtime patch/stub path. Celeste and Terraria are now supported through this lane; future Mono/FNA titles should still be promoted only after per-game launch proof.
 
 ## Phase 11 Minecraft Finding
 

--- a/docs/runtime/redistributable-runtime.md
+++ b/docs/runtime/redistributable-runtime.md
@@ -2,7 +2,7 @@
 
 Status: Phase 4 foundation
 
-Redistributables are modeled as bottle components. MetalSharp looks for legal local assets in Steam Common Redistributables and in `~/.metalsharp/runtime/redist/`, then records missing, installed, or repair-needed state in the bottle.
+Redistributables are modeled as bottle components. MetalSharp looks for legal local assets in Steam Common Redistributables, Sharp Library installer bottles, and `~/.metalsharp/runtime/redist/`, then records missing, installed, or repair-needed state in the bottle.
 
 ## Component IDs
 
@@ -41,10 +41,11 @@ The repair resolver searches:
 
 ```text
 ~/.metalsharp/prefix-steam/drive_c/Program Files (x86)/Steam/steamapps/common/Steamworks Shared/_CommonRedist/
+~/.metalsharp/bottles/*/installers/
 ~/.metalsharp/runtime/redist/
 ```
 
-MSI redistributables are launched through `msiexec /i`; EXE redistributables are launched directly with silent arguments where known. Every repair writes a per-bottle component log.
+MSI redistributables are launched through `msiexec /i`; EXE redistributables are launched directly with silent arguments where known. XNA Framework 4.0 repairs also reuse a matching Sharp Library installer-bottle payload when the user has already installed or staged `xnafx40_redist.msi` through Sharp Library. Every repair writes a per-bottle component log.
 
 ## Remaining Work
 

--- a/src/fna/shims/carbon_hiview_shim.m
+++ b/src/fna/shims/carbon_hiview_shim.m
@@ -7,11 +7,15 @@
 #pragma mark - View registry
 
 static CFMutableDictionaryRef s_viewMap = NULL;
+static CFMutableDictionaryRef s_refMap = NULL;
 static NSInteger s_nextTag = 1000;
 
 static void ensureViewMap(void) {
     if (!s_viewMap) {
         s_viewMap = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, NULL, NULL);
+    }
+    if (!s_refMap) {
+        s_refMap = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, NULL, NULL);
     }
 }
 
@@ -24,16 +28,17 @@ static NSView* viewForRef(HIViewRef ref) {
 static void associateView(HIViewRef ref, NSView* view) {
     ensureViewMap();
     CFDictionarySetValue(s_viewMap, (const void*)ref, (__bridge const void*)(view));
+    CFDictionarySetValue(s_refMap, (__bridge const void*)(view), (const void*)ref);
 }
 
 static HIViewRef refForView(NSView* view) {
     ensureViewMap();
-    NSInteger tag = [view tag];
-    if (tag < 1000) {
-        tag = s_nextTag++;
-        [view setTag:tag];
+    HIViewRef ref = (HIViewRef)CFDictionaryGetValue(s_refMap, (__bridge const void*)(view));
+    if (!ref) {
+        ref = (HIViewRef)(intptr_t)s_nextTag++;
+        associateView(ref, view);
     }
-    return (HIViewRef)(intptr_t)tag;
+    return ref;
 }
 
 #pragma mark - HIView shims (reimplemented for 64-bit via NSView)
@@ -141,11 +146,11 @@ OSStatus HIViewSetZOrder(HIViewRef inView, HIViewZOrderOp inOrder, HIViewRef inO
         NSView* sv = view.superview;
         [view removeFromSuperview];
         if (inOrder == kHIViewZOrderAbove && other) {
-            [sv insertSubview:view aboveSubview:other];
+            [sv addSubview:view positioned:NSWindowAbove relativeTo:other];
         } else if (inOrder == kHIViewZOrderBelow && other) {
-            [sv insertSubview:view belowSubview:other];
+            [sv addSubview:view positioned:NSWindowBelow relativeTo:other];
         } else if (inOrder == 1) {
-            [sv insertSubview:view atIndex:0];
+            [sv addSubview:view positioned:NSWindowBelow relativeTo:nil];
         } else {
             [sv addSubview:view];
         }

--- a/tools/d3d12-metal-sdk/scripts/fetch-agility.sh
+++ b/tools/d3d12-metal-sdk/scripts/fetch-agility.sh
@@ -38,7 +38,9 @@ if [[ ! -f "$BIN_DIR/D3D12Core.dll" || ! -f "$BIN_DIR/d3d12SDKLayers.dll" ]]; th
   TMP_DIR="$(mktemp -d)"
   trap 'rm -rf "$TMP_DIR"' EXIT
   PACKAGE_FILE="$TMP_DIR/agility.nupkg"
-  curl -L --fail -o "$PACKAGE_FILE" "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.D3D12/$AGILITY_VERSION"
+  PACKAGE_VERSION_LOWER="$(printf '%s' "$AGILITY_VERSION" | tr '[:upper:]' '[:lower:]')"
+  curl -L --fail -o "$PACKAGE_FILE" \
+    "https://api.nuget.org/v3-flatcontainer/microsoft.direct3d.d3d12/$PACKAGE_VERSION_LOWER/microsoft.direct3d.d3d12.$PACKAGE_VERSION_LOWER.nupkg"
   rm -rf "$PACKAGE_DIR"
   mkdir -p "$PACKAGE_DIR"
   unzip -q "$PACKAGE_FILE" -d "$PACKAGE_DIR"


### PR DESCRIPTION
## Summary
- let XNA repair reuse `xnafx40_redist` staged by Sharp Library installer bottles
- accept game-local XNA redistributable assets through the bottle repair path with MSI silent args
- recognize XNA Framework 4.0 installed through Wine Mono GAC layouts so doctor status can turn green
- document Sharp Library installer bottles as legal redistributable repair sources

## Validation
- `cargo test --manifest-path app/src-rust/Cargo.toml xna -- --nocapture`
- `cargo test --manifest-path app/src-rust/Cargo.toml`
- `git diff --check`