### PR TITLE
fix: repair CI DMG artifact handoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,9 +206,6 @@ jobs:
     name: Verify Developer SDK Bundle
     needs: [shell, metal, vue, rust, electron, native, dmg-workflow]
     runs-on: macos-14
-    concurrency:
-      group: metalsharp-developer-sdk-bundles
-      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
 
@@ -218,11 +215,14 @@ jobs:
       - name: Build Rust backend
         run: cd app/src-rust && cargo build --release
 
-      - name: Build host runtime ABI
+      - name: Build C++ engine and host runtime ABI
         run: |
           mkdir -p build && cd build
           cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=OFF
-          cmake --build . --target metalsharp_host_runtime --parallel $(sysctl -n hw.ncpu)
+          cmake --build . --parallel $(sysctl -n hw.ncpu)
+          mkdir -p ../app/native
+          cp libd3d11.dylib libd3d12.dylib libdxgi.dylib libxaudio2_9.dylib libxinput1_4.dylib ../app/native/ 2>/dev/null || true
+          cp metalsharp metalsharp_launcher MetalSharpMigrator ../app/native/ 2>/dev/null || true
           cd ..
           METALSHARP_BUILD_DIR="$PWD/build" tools/package/create-host-runtime.sh
 
@@ -259,7 +259,16 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: metalsharp-build-artifacts
-          path: .
+          path: app
+
+      - name: Verify downloaded build artifacts
+        run: |
+          test -s app/src-rust/target/release/metalsharp-backend
+          test -d app/native
+          test -s app/native/libd3d12.dylib
+          test -s app/native/metalsharp_launcher
+          test -s app/native/host/libmetalsharp_host_runtime.dylib
+          find app/native -maxdepth 2 -type f | sort
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/tools/ci/verify-dmg-workflow.py
+++ b/tools/ci/verify-dmg-workflow.py
@@ -114,6 +114,23 @@ def check_workflows() -> None:
     for required in ["Verify Developer SDK Bundle", "Build DMG", "Verify DMG runtime assets"]:
         if required not in main:
             fail(f"main CI missing staging job: {required}")
+    for required in [
+        "metalsharp-build-artifacts",
+        "Build C++ engine and host runtime ABI",
+        "cmake --build . --parallel",
+        "cp libd3d11.dylib libd3d12.dylib libdxgi.dylib",
+        "Download build artifacts",
+        "path: app",
+        "Verify downloaded build artifacts",
+        "app/src-rust/target/release/metalsharp-backend",
+        "app/native/libd3d12.dylib",
+        "app/native/metalsharp_launcher",
+        "app/native/host/libmetalsharp_host_runtime.dylib",
+    ]:
+        if required not in main:
+            fail(f"main CI missing build artifact handoff contract: {required}")
+    if "group: metalsharp-developer-sdk-bundles" in main:
+        fail("main CI verifier must not share the release SDK publish concurrency group")
 
     for required in [
         "Publish Developer SDK Bundle",


### PR DESCRIPTION
## Summary
- restore full native artifact production in the main CI developer-SDK producer job
- download the uploaded build artifact under `app/` so the DMG job sees `app/src-rust/...` and `app/native/...` where Electron Builder expects them
- remove the main CI SDK verifier from the release SDK publish concurrency group and extend the DMG workflow contract check to catch this class of breakage

## Root Cause
The previous CI optimization uploaded `app/src-rust/target/release/metalsharp-backend` and `app/native/`, then downloaded the artifact to repo root. `actions/upload-artifact` stores those paths relative to their shared `app/` parent, so the download landed as `src-rust/...` and `native/...` instead of `app/src-rust/...` and `app/native/...`. The same change also stopped building the full native engine binaries before packaging the DMG.

Main CI also shared the release publisher concurrency group even though its SDK job only verifies; that can block the all-in-one `CI -> Build DMG` path behind tag release publishing.

## Validation
- `python3 tools/ci/verify-dmg-workflow.py`
- `python3 -m py_compile tools/ci/verify-dmg-workflow.py`
- `git diff --check`