### PR TITLE
fix: repair runtime hook migration

### DIFF
--- a/app/src-rust/src/installer.rs
+++ b/app/src-rust/src/installer.rs
@@ -14,6 +14,7 @@ const RUNTIME_BUNDLE: &str = "metalsharp-runtime";
 const GRAPHICS_DLL_BUNDLE: &str = "metalsharp-graphics-dll";
 const ASSETS_BUNDLE: &str = "metalsharp-assets";
 const SCRIPTS_TOOLS_BUNDLE: &str = "metalsharp-scripts-tools";
+const METALSHARP_NTDLL_HOOK_DLL: &str = "metalsharp_ntdll_hook.dll";
 const DXMT_REQUIRED_PE: &[&str] = &[
     "d3d10core.dll",
     "d3d11.dll",
@@ -292,6 +293,7 @@ fn install_metalsharp_bundle(home: &PathBuf) -> Result<bool, String> {
     if ms_wine.exists()
         && host_runtime_ready(&host_dir)
         && file_nonempty(&backend)
+        && metalsharp_runtime_lib_ready(&runtime_dir.join("wine"))
         && bundle.as_ref().is_some_and(|archive| split_bundle_current(home, RUNTIME_BUNDLE, archive))
     {
         return Ok(false);
@@ -330,6 +332,9 @@ fn install_metalsharp_bundle(home: &PathBuf) -> Result<bool, String> {
             }
             if !file_nonempty(&backend) {
                 return Err("MetalSharp runtime bundle installed but backend executable is missing".into());
+            }
+            if !metalsharp_runtime_lib_ready(&runtime_dir.join("wine")) {
+                return Err("MetalSharp runtime bundle installed but MetalSharp hook DLL is missing".into());
             }
 
             let wine_check = Command::new(&ms_wine).arg("--version").output();
@@ -410,6 +415,10 @@ fn host_runtime_ready(dir: &Path) -> bool {
 
 fn file_nonempty(path: &Path) -> bool {
     path.metadata().map(|meta| meta.is_file() && meta.len() > 0).unwrap_or(false)
+}
+
+pub(crate) fn metalsharp_runtime_lib_ready(wine_dir: &Path) -> bool {
+    file_nonempty(&wine_dir.join("lib").join("metalsharp").join("x86_64-windows").join(METALSHARP_NTDLL_HOOK_DLL))
 }
 
 fn split_bundle_marker_dir(home: &Path) -> PathBuf {

--- a/app/src-rust/src/installer.rs
+++ b/app/src-rust/src/installer.rs
@@ -241,18 +241,30 @@ fn ensure_runtime_bundle_assets(_home: &PathBuf) -> Result<bool, String> {
 
     for asset in runtime_bundle_assets_for_host() {
         let had_local = bundled_file_valid_exists(asset);
-        match find_bundled_file(asset) {
-            Some(path) if file_nonempty(&path) => {
-                downloaded |= !had_local;
+        if had_local {
+            continue;
+        }
+
+        write_progress(2, 12, "Runtime Bundle Downloads", "downloading", &format!("Downloading {}...", asset), None);
+        match download_bundled_file(asset) {
+            Some(path) if file_nonempty(&path) && bundled_artifact_valid(asset, &path) => {
+                downloaded = true;
+                write_progress(2, 12, "Runtime Bundle Downloads", "done", &format!("Downloaded {}", asset), None);
             },
-            _ => missing.push(*asset),
+            _ => {
+                missing.push(*asset);
+                write_progress(2, 12, "Runtime Bundle Downloads", "error", &format!("Failed to download {}", asset), Some(&format!("Missing bundle: {}", asset)));
+            },
         }
     }
 
     if missing.is_empty() {
         Ok(downloaded)
     } else {
-        Err(format!("Missing required runtime bundle asset(s): {}", missing.join(", ")))
+        Err(format!(
+            "Missing required runtime bundle asset(s) that could not be downloaded: {}. Please check your internet connection and try again.",
+            missing.join(", ")
+        ))
     }
 }
 
@@ -1335,6 +1347,65 @@ fn find_bundled_archive(name: &str) -> Option<PathBuf> {
     download_from_github_release(&format!("{}.tar.zst", name))
 }
 
+fn download_bundled_file(name: &str) -> Option<PathBuf> {
+    let cache_dir = crate::platform::metalsharp_home_dir().join("cache").join("bundles");
+    let _ = fs::create_dir_all(&cache_dir);
+    let cached = cache_dir.join(name);
+    let tmp = cache_dir.join(format!("{}.download", name));
+
+    if file_nonempty(&cached) && bundled_artifact_valid(name, &cached) {
+        return Some(cached);
+    }
+
+    let url = format!("https://github.com/aaf2tbz/metalsharp/releases/download/bundles/{}", name);
+
+    let _ = fs::remove_file(&tmp);
+    
+    for retry in 0..3 {
+        let output = Command::new("curl")
+            .args([
+                "--fail",
+                "--location",
+                "--silent",
+                "--show-error",
+                "--retry", "2",
+                "--connect-timeout", "30",
+                "--max-time", "600",
+                "-o",
+            ])
+            .arg(&tmp)
+            .arg(&url)
+            .output();
+
+        match output {
+            Ok(o) if o.status.success() && file_nonempty(&tmp) => {
+                if bundled_artifact_valid(name, &tmp) {
+                    if fs::rename(&tmp, &cached).is_ok() {
+                        return Some(cached);
+                    }
+                } else {
+                    let _ = fs::remove_file(&tmp);
+                    return None;
+                }
+            },
+            Ok(_) => {
+                let _ = fs::remove_file(&tmp);
+                if retry < 2 {
+                    std::thread::sleep(std::time::Duration::from_secs(2));
+                }
+            },
+            Err(_) => {
+                let _ = fs::remove_file(&tmp);
+                if retry < 2 {
+                    std::thread::sleep(std::time::Duration::from_secs(2));
+                }
+            },
+        }
+    }
+
+    None
+}
+
 fn find_bundled_file(name: &str) -> Option<PathBuf> {
     if let Some(resources) = crate::platform::app_resources_dir() {
         let file = resources.join(format!("bundles/{}", name));
@@ -1348,45 +1419,11 @@ fn find_bundled_file(name: &str) -> Option<PathBuf> {
         return Some(dev);
     }
 
-    download_from_github_release(name)
+    download_bundled_file(name)
 }
 
 fn download_from_github_release(filename: &str) -> Option<PathBuf> {
-    let cache_dir = crate::platform::metalsharp_home_dir().join("cache").join("bundles");
-    let _ = fs::create_dir_all(&cache_dir);
-    let cached = cache_dir.join(filename);
-    let tmp = cache_dir.join(format!("{}.download", filename));
-
-    if file_nonempty(&cached) && bundled_artifact_valid(filename, &cached) {
-        return Some(cached);
-    }
-    if filename == "dxmt.tar.zst" {
-        let _ = fs::remove_file(&cached);
-    }
-
-    let url = format!("https://github.com/aaf2tbz/metalsharp/releases/download/bundles/{}", filename);
-
-    let _ = fs::remove_file(&tmp);
-    let output = Command::new("curl")
-        .args(["--fail", "--location", "--silent", "--show-error", "--retry", "3", "--connect-timeout", "20", "-o"])
-        .arg(&tmp)
-        .arg(&url)
-        .output()
-        .ok()?;
-
-    if output.status.success()
-        && file_nonempty(&tmp)
-        && bundled_artifact_valid(filename, &tmp)
-        && fs::rename(&tmp, &cached).or_else(|_| fs::copy(&tmp, &cached).map(|_| ())).is_ok()
-        && file_nonempty(&cached)
-    {
-        let _ = fs::remove_file(&tmp);
-        return Some(cached);
-    }
-
-    let _ = fs::remove_file(&tmp);
-    let _ = fs::remove_file(&cached);
-    None
+    download_bundled_file(filename)
 }
 
 fn bundled_artifact_valid(name: &str, path: &Path) -> bool {
@@ -1724,6 +1761,53 @@ mod tests {
             std::process::id(),
             std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).expect("system time").as_nanos()
         ))
+    }
+
+    #[test]
+    fn bundled_file_valid_exists_rejects_empty_files() {
+        let home = test_home("empty-file-validation");
+        let ms_dir = crate::platform::metalsharp_home_dir_for(&home);
+        let bundles_dir = ms_dir.join("cache").join("bundles");
+        fs::create_dir_all(&bundles_dir).expect("create bundles dir");
+        
+        let empty_file = bundles_dir.join("metalsharp-runtime.tar.zst");
+        fs::write(&empty_file, b"").expect("create empty file");
+        
+        assert!(!bundled_file_valid_exists("metalsharp-runtime.tar.zst"));
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn bundled_file_valid_exists_rejects_nonexistent_files() {
+        assert!(!bundled_file_valid_exists("metalsharp-runtime.tar.zst"));
+    }
+
+    #[test]
+    fn bundled_file_valid_exists_rejects_invalid_archives() {
+        let home = test_home("invalid-archive-validation");
+        let ms_dir = crate::platform::metalsharp_home_dir_for(&home);
+        let bundles_dir = ms_dir.join("cache").join("bundles");
+        fs::create_dir_all(&bundles_dir).expect("create bundles dir");
+        
+        let invalid_file = bundles_dir.join("metalsharp-runtime.tar.zst");
+        fs::write(&invalid_file, b"not a valid zst archive").expect("create invalid archive");
+        
+        assert!(!bundled_file_valid_exists("metalsharp-runtime.tar.zst"));
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn bundled_artifact_valid_accepts_non_bundle_files() {
+        let home = test_home("non-bundle-file");
+        let ms_dir = crate::platform::metalsharp_home_dir_for(&home);
+        let bundles_dir = ms_dir.join("cache").join("bundles");
+        fs::create_dir_all(&bundles_dir).expect("create bundles dir");
+        
+        let non_bundle = bundles_dir.join("other-file.bin");
+        fs::write(&non_bundle, b"some content").expect("create non-bundle file");
+        
+        assert!(bundled_artifact_valid("other-file.bin", &non_bundle));
+        let _ = fs::remove_dir_all(home);
     }
 
     fn write_dxmt_runtime_files(dxmt_dir: &Path) {

--- a/app/src-rust/src/installer.rs
+++ b/app/src-rust/src/installer.rs
@@ -245,15 +245,22 @@ fn ensure_runtime_bundle_assets(_home: &PathBuf) -> Result<bool, String> {
             continue;
         }
 
-        write_progress(2, 12, "Runtime Bundle Downloads", "downloading", &format!("Downloading {}...", asset), None);
+        write_progress(3, 14, "Runtime Bundle Downloads", "downloading", &format!("Downloading {}...", asset), None);
         match download_bundled_file(asset) {
             Some(path) if file_nonempty(&path) && bundled_artifact_valid(asset, &path) => {
                 downloaded = true;
-                write_progress(2, 12, "Runtime Bundle Downloads", "done", &format!("Downloaded {}", asset), None);
+                write_progress(3, 14, "Runtime Bundle Downloads", "done", &format!("Downloaded {}", asset), None);
             },
             _ => {
                 missing.push(*asset);
-                write_progress(2, 12, "Runtime Bundle Downloads", "error", &format!("Failed to download {}", asset), Some(&format!("Missing bundle: {}", asset)));
+                write_progress(
+                    3,
+                    14,
+                    "Runtime Bundle Downloads",
+                    "error",
+                    &format!("Failed to download {}", asset),
+                    Some(&format!("Missing bundle: {}", asset)),
+                );
             },
         }
     }
@@ -1360,7 +1367,7 @@ fn download_bundled_file(name: &str) -> Option<PathBuf> {
     let url = format!("https://github.com/aaf2tbz/metalsharp/releases/download/bundles/{}", name);
 
     let _ = fs::remove_file(&tmp);
-    
+
     for retry in 0..3 {
         let output = Command::new("curl")
             .args([
@@ -1368,9 +1375,12 @@ fn download_bundled_file(name: &str) -> Option<PathBuf> {
                 "--location",
                 "--silent",
                 "--show-error",
-                "--retry", "2",
-                "--connect-timeout", "30",
-                "--max-time", "600",
+                "--retry",
+                "2",
+                "--connect-timeout",
+                "30",
+                "--max-time",
+                "600",
                 "-o",
             ])
             .arg(&tmp)
@@ -1380,12 +1390,17 @@ fn download_bundled_file(name: &str) -> Option<PathBuf> {
         match output {
             Ok(o) if o.status.success() && file_nonempty(&tmp) => {
                 if bundled_artifact_valid(name, &tmp) {
-                    if fs::rename(&tmp, &cached).is_ok() {
+                    if fs::rename(&tmp, &cached).or_else(|_| fs::copy(&tmp, &cached).map(|_| ())).is_ok() {
+                        let _ = fs::remove_file(&tmp);
                         return Some(cached);
                     }
-                } else {
                     let _ = fs::remove_file(&tmp);
                     return None;
+                } else {
+                    let _ = fs::remove_file(&tmp);
+                    if retry < 2 {
+                        std::thread::sleep(std::time::Duration::from_secs(1));
+                    }
                 }
             },
             Ok(_) => {
@@ -1769,10 +1784,10 @@ mod tests {
         let ms_dir = crate::platform::metalsharp_home_dir_for(&home);
         let bundles_dir = ms_dir.join("cache").join("bundles");
         fs::create_dir_all(&bundles_dir).expect("create bundles dir");
-        
+
         let empty_file = bundles_dir.join("metalsharp-runtime.tar.zst");
         fs::write(&empty_file, b"").expect("create empty file");
-        
+
         assert!(!bundled_file_valid_exists("metalsharp-runtime.tar.zst"));
         let _ = fs::remove_dir_all(home);
     }
@@ -1788,10 +1803,10 @@ mod tests {
         let ms_dir = crate::platform::metalsharp_home_dir_for(&home);
         let bundles_dir = ms_dir.join("cache").join("bundles");
         fs::create_dir_all(&bundles_dir).expect("create bundles dir");
-        
+
         let invalid_file = bundles_dir.join("metalsharp-runtime.tar.zst");
         fs::write(&invalid_file, b"not a valid zst archive").expect("create invalid archive");
-        
+
         assert!(!bundled_file_valid_exists("metalsharp-runtime.tar.zst"));
         let _ = fs::remove_dir_all(home);
     }
@@ -1802,10 +1817,10 @@ mod tests {
         let ms_dir = crate::platform::metalsharp_home_dir_for(&home);
         let bundles_dir = ms_dir.join("cache").join("bundles");
         fs::create_dir_all(&bundles_dir).expect("create bundles dir");
-        
+
         let non_bundle = bundles_dir.join("other-file.bin");
         fs::write(&non_bundle, b"some content").expect("create non-bundle file");
-        
+
         assert!(bundled_artifact_valid("other-file.bin", &non_bundle));
         let _ = fs::remove_dir_all(home);
     }

--- a/app/src-rust/src/installer.rs
+++ b/app/src-rust/src/installer.rs
@@ -14,6 +14,7 @@ const RUNTIME_BUNDLE: &str = "metalsharp-runtime";
 const GRAPHICS_DLL_BUNDLE: &str = "metalsharp-graphics-dll";
 const ASSETS_BUNDLE: &str = "metalsharp-assets";
 const SCRIPTS_TOOLS_BUNDLE: &str = "metalsharp-scripts-tools";
+const STEAM_BUNDLE: &str = "metalsharp-steam";
 const METALSHARP_NTDLL_HOOK_DLL: &str = "metalsharp_ntdll_hook.dll";
 const DXMT_REQUIRED_PE: &[&str] = &[
     "d3d10core.dll",
@@ -25,6 +26,45 @@ const DXMT_REQUIRED_PE: &[&str] = &[
     "nvapi64.dll",
     "nvngx.dll",
 ];
+const RUNTIME_REQUIRED_ARCHIVE_FILES: &[&str] = &[
+    "runtime/wine/bin/metalsharp-wine",
+    "runtime/metalsharp-backend",
+    "runtime/host/manifest.json",
+    "runtime/host/HostRuntimeABI.h",
+    "runtime/host/libmetalsharp_host_runtime.dylib",
+    "runtime/wine/lib/metalsharp/x86_64-windows/metalsharp_ntdll_hook.dll",
+];
+const GRAPHICS_REQUIRED_ARCHIVE_FILES: &[&str] = &[
+    "Graphics/dll/dxmt/x86_64-unix/winemetal.so",
+    "Graphics/dll/dxmt/x86_64-windows/d3d10core.dll",
+    "Graphics/dll/dxmt/x86_64-windows/d3d11.dll",
+    "Graphics/dll/dxmt/x86_64-windows/d3d12.dll",
+    "Graphics/dll/dxmt/x86_64-windows/dxgi.dll",
+    "Graphics/dll/dxmt/x86_64-windows/dxgi_dxmt.dll",
+    "Graphics/dll/dxmt/x86_64-windows/nvapi64.dll",
+    "Graphics/dll/dxmt/x86_64-windows/nvngx.dll",
+    "Graphics/dll/dxmt/x86_64-windows/winemetal.dll",
+];
+const ASSETS_REQUIRED_ARCHIVE_FILES: &[&str] = &[
+    "assets/eac-toggle/x86_64-windows/_winhttp.dll",
+    "assets/goldberg/x64/steam_api64.dll",
+    "assets/goldberg/x86/steam_api.dll",
+    "assets/gptk/external/D3DMetal.framework/Versions/A/D3DMetal",
+    "assets/gptk/external/D3DMetal.framework/Versions/A/Resources/libmetalirconverter.dylib",
+    "assets/gptk/x86_64-windows/atidxx64.dll",
+    "assets/gptk/x86_64-windows/d3d10.dll",
+    "assets/gptk/x86_64-windows/d3d11.dll",
+    "assets/gptk/x86_64-windows/d3d12.dll",
+    "assets/gptk/x86_64-windows/dxgi.dll",
+    "assets/gptk/x86_64-windows/nvapi64.dll",
+    "assets/gptk/x86_64-windows/nvngx-on-metalfx.dll",
+    "assets/mono-arm64/bin/mono-sgen",
+    "assets/shims/libsteam_api.dylib",
+];
+const SCRIPTS_TOOLS_REQUIRED_ARCHIVE_FILES: &[&str] =
+    &["scripts/tools/configs/mtsp-rules.toml", "scripts/tools/updater/update.sh"];
+const STEAM_REQUIRED_ARCHIVE_FILES: &[&str] =
+    &["steam/SteamSetup.exe", "steam/steamwebhelper.exe", "steam/steamwebhelper-wrapper.c"];
 
 const MAC_RUNTIME_BUNDLE_ASSETS: &[&str] = &[
     "metalsharp-runtime.tar.zst",
@@ -200,7 +240,7 @@ fn ensure_runtime_bundle_assets(_home: &PathBuf) -> Result<bool, String> {
     let mut missing = Vec::new();
 
     for asset in runtime_bundle_assets_for_host() {
-        let had_local = bundled_file_exists(asset);
+        let had_local = bundled_file_valid_exists(asset);
         match find_bundled_file(asset) {
             Some(path) if file_nonempty(&path) => {
                 downloaded |= !had_local;
@@ -216,20 +256,25 @@ fn ensure_runtime_bundle_assets(_home: &PathBuf) -> Result<bool, String> {
     }
 }
 
-fn bundled_file_exists(name: &str) -> bool {
+fn bundled_file_valid_exists(name: &str) -> bool {
     if let Some(resources) = crate::platform::app_resources_dir() {
-        if file_nonempty(&resources.join(format!("bundles/{}", name))) {
+        let file = resources.join(format!("bundles/{}", name));
+        if bundled_artifact_valid(name, &file) {
             return true;
         }
     }
 
-    if file_nonempty(&PathBuf::from(format!("app/bundles/{}", name))) {
+    let dev = PathBuf::from(format!("app/bundles/{}", name));
+    if bundled_artifact_valid(name, &dev) {
         return true;
     }
 
     dirs::home_dir()
         .map(|home| {
-            file_nonempty(&crate::platform::metalsharp_home_dir_for(&home).join("cache").join("bundles").join(name))
+            bundled_artifact_valid(
+                name,
+                &crate::platform::metalsharp_home_dir_for(&home).join("cache").join("bundles").join(name),
+            )
         })
         .unwrap_or(false)
 }
@@ -1350,15 +1395,31 @@ fn bundled_artifact_valid(name: &str, path: &Path) -> bool {
     }
 
     if name == RUNTIME_BUNDLE || name == "metalsharp-runtime.tar.zst" {
-        return runtime_bundle_host_valid(path);
+        return archive_required_files_valid(path, RUNTIME_REQUIRED_ARCHIVE_FILES);
+    }
+
+    if name == GRAPHICS_DLL_BUNDLE || name == "metalsharp-graphics-dll.tar.zst" {
+        return archive_required_files_valid(path, GRAPHICS_REQUIRED_ARCHIVE_FILES);
+    }
+
+    if name == ASSETS_BUNDLE || name == "metalsharp-assets.tar.zst" {
+        return archive_required_files_valid(path, ASSETS_REQUIRED_ARCHIVE_FILES);
+    }
+
+    if name == SCRIPTS_TOOLS_BUNDLE || name == "metalsharp-scripts-tools.tar.zst" {
+        return archive_required_files_valid(path, SCRIPTS_TOOLS_REQUIRED_ARCHIVE_FILES);
+    }
+
+    if name == STEAM_BUNDLE || name == "metalsharp-steam.tar.zst" {
+        return archive_required_files_valid(path, STEAM_REQUIRED_ARCHIVE_FILES);
     }
 
     true
 }
 
-fn runtime_bundle_host_valid(path: &Path) -> bool {
+fn archive_required_files_valid(path: &Path, required_files: &[&str]) -> bool {
     let tmp = std::env::temp_dir().join(format!(
-        "metalsharp-runtime-validate-{}-{}",
+        "metalsharp-archive-validate-{}-{}",
         std::process::id(),
         std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).map(|d| d.as_nanos()).unwrap_or(0)
     ));
@@ -1372,11 +1433,12 @@ fn runtime_bundle_host_valid(path: &Path) -> bool {
         .arg(path)
         .arg("-C")
         .arg(&tmp)
-        .arg("runtime/host")
+        .args(required_files)
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .status();
-    let ready = status.map(|s| s.success()).unwrap_or(false) && host_runtime_ready(&tmp.join("runtime").join("host"));
+    let ready = status.map(|s| s.success()).unwrap_or(false)
+        && required_files.iter().all(|required| file_nonempty(&tmp.join(required)));
     let _ = fs::remove_dir_all(&tmp);
     ready
 }
@@ -1547,6 +1609,14 @@ mod tests {
 
         assert!(!bundled_artifact_valid("metalsharp-runtime", &stale));
         assert!(!bundled_artifact_valid("metalsharp-runtime.tar.zst", &stale));
+        assert!(!bundled_artifact_valid("metalsharp-graphics-dll", &stale));
+        assert!(!bundled_artifact_valid("metalsharp-graphics-dll.tar.zst", &stale));
+        assert!(!bundled_artifact_valid("metalsharp-assets", &stale));
+        assert!(!bundled_artifact_valid("metalsharp-assets.tar.zst", &stale));
+        assert!(!bundled_artifact_valid("metalsharp-scripts-tools", &stale));
+        assert!(!bundled_artifact_valid("metalsharp-scripts-tools.tar.zst", &stale));
+        assert!(!bundled_artifact_valid("metalsharp-steam", &stale));
+        assert!(!bundled_artifact_valid("metalsharp-steam.tar.zst", &stale));
         assert!(bundled_artifact_valid("unmanaged-test-asset.bin", &stale));
 
         let _ = fs::remove_dir_all(home);

--- a/app/src-rust/src/migrate.rs
+++ b/app/src-rust/src/migrate.rs
@@ -590,20 +590,38 @@ fn run_wineboot_update(wine: &Path, runtime_wine: &Path, prefix: &Path) -> Resul
         .stderr(std::process::Stdio::null());
     crate::platform::set_runtime_library_env(&mut cmd, runtime_wine);
 
-    let mut child = cmd.spawn().map_err(|e| format!("spawn wineboot for {}: {}", prefix.display(), e))?;
-    for _ in 0..240 {
-        if let Some(status) = child.try_wait().map_err(|e| format!("wait wineboot for {}: {}", prefix.display(), e))? {
+    log_to_file(&format!("Starting wineboot -u for prefix: {}", prefix.display()));
+
+    let mut child = cmd.spawn().map_err(|e| {
+        log_to_file(&format!("Failed to spawn wineboot for {}: {}", prefix.display(), e));
+        format!("spawn wineboot for {}: {}", prefix.display(), e)
+    })?;
+    
+    for attempt in 0..240 {
+        if let Some(status) = child.try_wait().map_err(|e| {
+            log_to_file(&format!("Failed to wait for wineboot for {}: {}", prefix.display(), e));
+            format!("wait wineboot for {}: {}", prefix.display(), e)
+        })? {
             if status.success() {
+                log_to_file(&format!("wineboot -u completed successfully for prefix: {}", prefix.display()));
                 return Ok(());
             }
-            return Err(format!("wineboot -u failed for {} with {}", prefix.display(), status));
+            let error_msg = format!("wineboot -u failed for {} with exit code: {:?}", prefix.display(), status.code());
+            log_to_file(&error_msg);
+            return Err(error_msg);
         }
         std::thread::sleep(std::time::Duration::from_millis(500));
+        
+        if attempt == 120 {
+            log_to_file(&format!("wineboot -u still running after 60 seconds for prefix: {}", prefix.display()));
+        }
     }
 
+    let error_msg = format!("wineboot -u timed out (120 seconds) for {}", prefix.display());
+    log_to_file(&error_msg);
     let _ = child.kill();
     let _ = child.wait();
-    Err(format!("wineboot -u timed out for {}", prefix.display()))
+    Err(error_msg)
 }
 
 fn temp_suffix() -> u128 {

--- a/app/src-rust/src/migrate.rs
+++ b/app/src-rust/src/migrate.rs
@@ -52,6 +52,7 @@ const MIGRATION_SETTINGS_FILE_NAMES: &[&str] = &[
     "steam_autocloud.vdf",
 ];
 const MIGRATION_SETTINGS_EXTENSIONS: &[&str] = &["json", "toml", "plist", "vdf", "reg", "ini", "cfg", "conf"];
+const MIGRATION_TOTAL_STEPS: usize = 6;
 
 static MIGRATING: AtomicBool = AtomicBool::new(false);
 
@@ -168,6 +169,10 @@ fn runtime_core_ready(ms_dir: &Path) -> bool {
         return false;
     }
 
+    if !crate::installer::metalsharp_runtime_lib_ready(&runtime_wine) {
+        return false;
+    }
+
     [
         runtime_wine.join("lib").join("wine").join("x86_64-unix"),
         runtime_wine.join("lib").join("wine").join("x86_64-windows").join("d3d9.dll"),
@@ -272,7 +277,7 @@ fn run_migration() {
         return;
     }
 
-    let total_steps = 5usize;
+    let total_steps = MIGRATION_TOTAL_STEPS;
     let mut step = 0usize;
 
     step += 1;
@@ -323,6 +328,16 @@ fn run_migration() {
     step += 1;
     write_migrate_progress("running", step, total_steps, "Restoring preserved user data...", None);
     restore_user_data(&ms_dir, &preserved);
+
+    if install_ok {
+        step += 1;
+        write_migrate_progress("running", step, total_steps, "Updating Wine prefixes...", None);
+        if let Err(e) = update_existing_wine_prefixes(&ms_dir, step) {
+            write_migrate_progress("error", step, total_steps, &format!("Wine prefix update failed: {}", e), Some(&e));
+            log_to_file(&format!("Migration to v{} failed while updating Wine prefixes: {}", MIGRATE_VERSION, e));
+            return;
+        }
+    }
 
     if install_ok {
         update_migration_metadata(&ms_dir);
@@ -434,7 +449,7 @@ fn preserve_user_data(ms_dir: &PathBuf) -> PreservedData {
     let steam_config_path = ms_dir.join("cache").join("steam_config.json");
     let steam_config_json = steam_config_path.exists().then(|| fs::read(&steam_config_path).ok()).flatten();
 
-    write_migrate_progress("running", 2, 5, "Preserving user data (cache metadata)...", None);
+    write_migrate_progress("running", 2, MIGRATION_TOTAL_STEPS, "Preserving user data (cache metadata)...", None);
     let cache_tmp = tmp.join("cache");
     let cache = ms_dir.join("cache");
     if cache.exists() {
@@ -442,7 +457,13 @@ fn preserve_user_data(ms_dir: &PathBuf) -> PreservedData {
         preserve_selective(&cache, &cache_tmp, &["downloads", "updates", "updater-tools", "tmp"]);
     }
 
-    write_migrate_progress("running", 2, 5, "Preserving user settings (Steam prefix metadata)...", None);
+    write_migrate_progress(
+        "running",
+        2,
+        MIGRATION_TOTAL_STEPS,
+        "Preserving user settings (Steam prefix metadata)...",
+        None,
+    );
     let prefix_steam_tmp = tmp.join("prefix-steam");
     let prefix_steam = ms_dir.join("prefix-steam");
     if prefix_steam.exists() {
@@ -450,7 +471,7 @@ fn preserve_user_data(ms_dir: &PathBuf) -> PreservedData {
         preserve_settings_only(&prefix_steam, &prefix_steam_tmp);
     }
 
-    write_migrate_progress("running", 2, 5, "Preserving user settings (game metadata)...", None);
+    write_migrate_progress("running", 2, MIGRATION_TOTAL_STEPS, "Preserving user settings (game metadata)...", None);
     let games_tmp = tmp.join("games");
     let games = ms_dir.join("games");
     if games.exists() {
@@ -458,7 +479,7 @@ fn preserve_user_data(ms_dir: &PathBuf) -> PreservedData {
         preserve_settings_only(&games, &games_tmp);
     }
 
-    write_migrate_progress("running", 2, 5, "Preserving user settings (library metadata)...", None);
+    write_migrate_progress("running", 2, MIGRATION_TOTAL_STEPS, "Preserving user settings (library metadata)...", None);
     let sharp_library_tmp = tmp.join("sharp-library");
     let sharp_library = ms_dir.join("sharp-library");
     if sharp_library.exists() {
@@ -466,7 +487,7 @@ fn preserve_user_data(ms_dir: &PathBuf) -> PreservedData {
         preserve_settings_only(&sharp_library, &sharp_library_tmp);
     }
 
-    write_migrate_progress("running", 2, 5, "Preserving user settings (bottle metadata)...", None);
+    write_migrate_progress("running", 2, MIGRATION_TOTAL_STEPS, "Preserving user settings (bottle metadata)...", None);
     let bottles_tmp = tmp.join("bottles");
     let bottles = ms_dir.join("bottles");
     if bottles.exists() {
@@ -474,7 +495,13 @@ fn preserve_user_data(ms_dir: &PathBuf) -> PreservedData {
         preserve_settings_only(&bottles, &bottles_tmp);
     }
 
-    write_migrate_progress("running", 2, 5, "Preserving user settings (compatdata metadata)...", None);
+    write_migrate_progress(
+        "running",
+        2,
+        MIGRATION_TOTAL_STEPS,
+        "Preserving user settings (compatdata metadata)...",
+        None,
+    );
     let compatdata_tmp = tmp.join("compatdata");
     let compatdata = ms_dir.join("compatdata");
     if compatdata.exists() {
@@ -492,6 +519,91 @@ fn preserve_user_data(ms_dir: &PathBuf) -> PreservedData {
         bottles_tmp,
         compatdata_tmp,
     }
+}
+
+fn update_existing_wine_prefixes(ms_dir: &Path, step: usize) -> Result<usize, String> {
+    let runtime_wine = ms_dir.join("runtime").join("wine");
+    let wine = crate::platform::runtime_wine_binary(&runtime_wine);
+    if !wine.exists() {
+        return Err(format!("MetalSharp Wine not found at {}", wine.display()));
+    }
+
+    let mut updated = 0usize;
+    for prefix in collect_existing_wine_prefixes(ms_dir) {
+        write_migrate_progress(
+            "running",
+            step,
+            MIGRATION_TOTAL_STEPS,
+            &format!("Updating Wine prefix {}...", prefix.display()),
+            None,
+        );
+        run_wineboot_update(&wine, &runtime_wine, &prefix)?;
+        updated += 1;
+    }
+
+    Ok(updated)
+}
+
+fn collect_existing_wine_prefixes(ms_dir: &Path) -> Vec<PathBuf> {
+    let mut prefixes = Vec::new();
+    push_existing_prefix(&mut prefixes, ms_dir.join("prefix-steam"));
+
+    let bottles = ms_dir.join("bottles");
+    if let Ok(entries) = fs::read_dir(&bottles) {
+        for entry in entries.flatten() {
+            let bottle_dir = entry.path();
+            push_existing_prefix(&mut prefixes, bottle_dir.join("prefix"));
+
+            let manifest = bottle_dir.join("bottle.json");
+            let Some(prefix_path) = fs::read_to_string(&manifest)
+                .ok()
+                .and_then(|contents| serde_json::from_str::<serde_json::Value>(&contents).ok())
+                .and_then(|value| value.get("prefix_path").and_then(|v| v.as_str()).map(PathBuf::from))
+            else {
+                continue;
+            };
+            push_existing_prefix(&mut prefixes, prefix_path);
+        }
+    }
+
+    prefixes
+}
+
+fn push_existing_prefix(prefixes: &mut Vec<PathBuf>, prefix: PathBuf) {
+    if !prefix.exists() {
+        return;
+    }
+    if prefixes.iter().any(|existing| existing == &prefix) {
+        return;
+    }
+    prefixes.push(prefix);
+}
+
+fn run_wineboot_update(wine: &Path, runtime_wine: &Path, prefix: &Path) -> Result<(), String> {
+    let mut cmd = Command::new(wine);
+    cmd.env("WINEPREFIX", prefix.to_string_lossy().to_string())
+        .env("WINEDEBUG", "-all")
+        .env("WINEDEBUGGER", "none")
+        .arg("wineboot")
+        .arg("-u")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    crate::platform::set_runtime_library_env(&mut cmd, runtime_wine);
+
+    let mut child = cmd.spawn().map_err(|e| format!("spawn wineboot for {}: {}", prefix.display(), e))?;
+    for _ in 0..240 {
+        if let Some(status) = child.try_wait().map_err(|e| format!("wait wineboot for {}: {}", prefix.display(), e))? {
+            if status.success() {
+                return Ok(());
+            }
+            return Err(format!("wineboot -u failed for {} with {}", prefix.display(), status));
+        }
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+    Err(format!("wineboot -u timed out for {}", prefix.display()))
 }
 
 fn temp_suffix() -> u128 {
@@ -833,6 +945,55 @@ mod tests {
     }
 
     #[test]
+    fn missing_metalsharp_hook_requests_runtime_repair() {
+        let home = test_dir("missing-metalsharp-hook");
+        let ms_dir = crate::platform::metalsharp_home_dir_for(&home);
+        write_runtime_core(&ms_dir);
+
+        fs::remove_file(
+            ms_dir
+                .join("runtime")
+                .join("wine")
+                .join("lib")
+                .join("metalsharp")
+                .join("x86_64-windows")
+                .join("metalsharp_ntdll_hook.dll"),
+        )
+        .expect("remove MetalSharp ntdll hook");
+
+        assert!(!runtime_core_ready(&ms_dir));
+        assert!(runtime_needs_repair(&home, true));
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn migration_collects_existing_wine_prefixes_for_update() {
+        let home = test_dir("prefix-update");
+        let ms_dir = crate::platform::metalsharp_home_dir_for(&home);
+        let steam_prefix = ms_dir.join("prefix-steam");
+        let bottle_dir = ms_dir.join("bottles").join("installer_demo");
+        let bottle_prefix = bottle_dir.join("prefix");
+        fs::create_dir_all(&steam_prefix).expect("create Steam prefix");
+        fs::create_dir_all(&bottle_prefix).expect("create bottle prefix");
+        fs::write(
+            bottle_dir.join("bottle.json"),
+            serde_json::to_vec(&json!({
+                "id": "installer_demo",
+                "prefix_path": bottle_prefix.to_string_lossy().to_string(),
+            }))
+            .expect("serialize bottle manifest"),
+        )
+        .expect("write bottle manifest");
+
+        let prefixes = collect_existing_wine_prefixes(&ms_dir);
+
+        assert!(prefixes.contains(&steam_prefix));
+        assert!(prefixes.contains(&bottle_prefix));
+        assert_eq!(prefixes.iter().filter(|prefix| *prefix == &bottle_prefix).count(), 1);
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
     fn migration_preserves_bottles_across_runtime_cleanup() {
         let home = test_dir("preserve-bottles");
         let ms_dir = crate::platform::metalsharp_home_dir_for(&home);
@@ -1026,6 +1187,7 @@ mod tests {
             runtime_wine.join("lib").join("dxmt").join("x86_64-windows").join("winemetal.dll"),
             runtime_wine.join("lib").join("dxmt").join("x86_64-windows").join("nvapi64.dll"),
             runtime_wine.join("lib").join("dxmt").join("x86_64-windows").join("nvngx.dll"),
+            runtime_wine.join("lib").join("metalsharp").join("x86_64-windows").join("metalsharp_ntdll_hook.dll"),
             runtime_wine.join("lib").join("dxmt").join("x86_64-unix").join("winemetal.so"),
             runtime_wine.join("lib").join("gptk").join("x86_64-windows").join("d3d10.dll"),
             runtime_wine.join("lib").join("gptk").join("x86_64-windows").join("d3d11.dll"),

--- a/app/src-rust/src/migrate.rs
+++ b/app/src-rust/src/migrate.rs
@@ -596,7 +596,7 @@ fn run_wineboot_update(wine: &Path, runtime_wine: &Path, prefix: &Path) -> Resul
         log_to_file(&format!("Failed to spawn wineboot for {}: {}", prefix.display(), e));
         format!("spawn wineboot for {}: {}", prefix.display(), e)
     })?;
-    
+
     for attempt in 0..240 {
         if let Some(status) = child.try_wait().map_err(|e| {
             log_to_file(&format!("Failed to wait for wineboot for {}: {}", prefix.display(), e));
@@ -611,7 +611,7 @@ fn run_wineboot_update(wine: &Path, runtime_wine: &Path, prefix: &Path) -> Resul
             return Err(error_msg);
         }
         std::thread::sleep(std::time::Duration::from_millis(500));
-        
+
         if attempt == 120 {
             log_to_file(&format!("wineboot -u still running after 60 seconds for prefix: {}", prefix.display()));
         }

--- a/app/src-rust/src/setup.rs
+++ b/app/src-rust/src/setup.rs
@@ -9,6 +9,9 @@ pub fn state() -> Value {
     let config_path = crate::platform::metalsharp_home_dir_for(&home).join("setup.json");
     let dxmt_runtime = crate::installer::dxmt_runtime_status();
     let dxmt_current = dxmt_runtime.get("current").and_then(|v| v.as_bool()).unwrap_or(false);
+    let wine_dir = crate::platform::metalsharp_home_dir_for(&home).join("runtime").join("wine");
+    let metalsharp_runtime_lib_ready = crate::installer::metalsharp_runtime_lib_ready(&wine_dir);
+    let runtime_current = dxmt_current && metalsharp_runtime_lib_ready;
 
     if config_path.exists() {
         if let Ok(contents) = std::fs::read_to_string(&config_path) {
@@ -16,13 +19,14 @@ pub fn state() -> Value {
                 let saved_completed = cfg.get("completed").and_then(|v| v.as_bool()).unwrap_or(false);
                 return json!({
                     "ok": true,
-                    "completed": saved_completed && dxmt_current,
+                    "completed": saved_completed && runtime_current,
                     "savedCompleted": saved_completed,
                     "step": cfg.get("step").and_then(|v| v.as_u64()).unwrap_or(0),
                     "deviceName": cfg.get("deviceName").and_then(|v| v.as_str()).unwrap_or(""),
                     "steamApiKeySet": cfg.get("steamApiKeySet").and_then(|v| v.as_bool()).unwrap_or(false),
-                    "runtimeMigrationRequired": saved_completed && !dxmt_current,
+                    "runtimeMigrationRequired": saved_completed && !runtime_current,
                     "dxmtRuntime": dxmt_runtime,
+                    "metalsharpRuntimeLibReady": metalsharp_runtime_lib_ready,
                 });
             }
         }
@@ -37,6 +41,7 @@ pub fn state() -> Value {
         "steamApiKeySet": false,
         "runtimeMigrationRequired": false,
         "dxmtRuntime": dxmt_runtime,
+        "metalsharpRuntimeLibReady": metalsharp_runtime_lib_ready,
     })
 }
 

--- a/app/src/renderer/components/SetupWizard.vue
+++ b/app/src/renderer/components/SetupWizard.vue
@@ -133,6 +133,8 @@ async function finish() {
     }
   }
 
+  await api("POST", "/steam/stop");
+
   emit("done");
 }
 

--- a/app/src/renderer/views/LibraryView.vue
+++ b/app/src/renderer/views/LibraryView.vue
@@ -315,6 +315,29 @@ watch([library, search, filter], applyFilter);
               }}
             </span>
           </button>
+          <button
+            class="btn btn-secondary library-control-button refresh-button"
+            title="Refresh"
+            @click="reloadLibrary()"
+          >
+            <svg
+              class="control-icon"
+              width="15"
+              height="15"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M21 12a9 9 0 0 1-15.5 6.2" />
+              <path d="M3 12A9 9 0 0 1 18.5 5.8" />
+              <path d="M18 2v4h4" />
+              <path d="M6 22v-4H2" />
+            </svg>
+            <span class="control-label">Refresh</span>
+          </button>
         </div>
         <div class="library-controls-center">
           <input v-model="search" class="control-input" type="text" placeholder="Search games..." />
@@ -324,29 +347,6 @@ watch([library, search, filter], applyFilter);
             <option value="not_installed">Not Installed</option>
           </select>
         </div>
-        <button
-          class="btn btn-secondary library-control-button refresh-button"
-          title="Refresh"
-          @click="reloadLibrary()"
-        >
-          <svg
-            class="control-icon"
-            width="15"
-            height="15"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <path d="M21 12a9 9 0 0 1-15.5 6.2" />
-            <path d="M3 12A9 9 0 0 1 18.5 5.8" />
-            <path d="M18 2v4h4" />
-            <path d="M6 22v-4H2" />
-          </svg>
-          <span class="control-label">Refresh</span>
-        </button>
       </div>
     </div>
 
@@ -422,7 +422,7 @@ watch([library, search, filter], applyFilter);
 
 .library-controls {
   display: grid;
-  grid-template-columns: minmax(260px, auto) minmax(280px, 1fr) auto;
+  grid-template-columns: auto minmax(280px, 1fr);
   align-items: center;
   gap: 12px;
   min-width: 0;
@@ -431,6 +431,7 @@ watch([library, search, filter], applyFilter);
   display: flex;
   align-items: center;
   gap: 10px;
+  flex-wrap: wrap;
   min-width: 0;
 }
 .library-controls-center {
@@ -461,9 +462,6 @@ watch([library, search, filter], applyFilter);
   .library-controls {
     grid-template-columns: 1fr;
   }
-  .refresh-button {
-    justify-self: start;
-  }
 }
 
 @media (max-width: 880px) {
@@ -483,7 +481,7 @@ watch([library, search, filter], applyFilter);
   }
   .library-launch-actions {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr 1fr 1fr;
   }
   .library-controls-center {
     grid-template-columns: 1fr;

--- a/tools/bundles/create-split-bundles.py
+++ b/tools/bundles/create-split-bundles.py
@@ -223,6 +223,11 @@ def build_staging(tmp: Path) -> dict[str, Path]:
     require_host_runtime(APP_DIR / "native" / "host")
     copy_tree(APP_DIR / "native" / "host", roots["runtime"] / "host")
     require_host_runtime(roots["runtime"] / "host")
+    require_file(
+        PROJECT_ROOT / "lib" / "metalsharp" / "x86_64-windows" / "metalsharp_ntdll_hook.dll",
+        "MetalSharp ntdll hook DLL",
+    )
+    copy_tree(PROJECT_ROOT / "lib" / "metalsharp", roots["runtime"] / "wine" / "lib" / "metalsharp")
 
     copy_tree(source_dxmt / "x86_64-unix", roots["graphics"] / "dxmt" / "x86_64-unix")
     copy_tree(source_dxmt / "x86_64-windows", roots["graphics"] / "dxmt" / "x86_64-windows")

--- a/tools/bundles/verify-bundles.sh
+++ b/tools/bundles/verify-bundles.sh
@@ -75,15 +75,23 @@ verify_local() {
       failed=1
       continue
     fi
-    if [ "$asset" = "metalsharp-runtime.tar.zst" ] && ! verify_runtime_host "$path"; then
+    if [ "$asset" = "metalsharp-runtime.tar.zst" ] && ! verify_runtime_core "$path"; then
       failed=1
       continue
     fi
-    if [ "$asset" = "metalsharp-runtime.tar.zst" ] && ! verify_runtime_metalsharp_lib "$path"; then
+    if [ "$asset" = "metalsharp-graphics-dll.tar.zst" ] && ! verify_graphics_core "$path"; then
       failed=1
       continue
     fi
-    if [ "$asset" = "metalsharp-scripts-tools.tar.zst" ] && ! verify_scripts_tools_configs "$path"; then
+    if [ "$asset" = "metalsharp-assets.tar.zst" ] && ! verify_assets_core "$path"; then
+      failed=1
+      continue
+    fi
+    if [ "$asset" = "metalsharp-scripts-tools.tar.zst" ] && ! verify_scripts_tools_core "$path"; then
+      failed=1
+      continue
+    fi
+    if [ "$asset" = "metalsharp-steam.tar.zst" ] && ! verify_steam_core "$path"; then
       failed=1
       continue
     fi
@@ -101,80 +109,84 @@ archive_contains_root() {
     <<< "$listing"
 }
 
-verify_runtime_host() {
+verify_required_files() {
   local path="$1"
+  local label="$2"
+  shift 2
   local tmp
-  tmp="$(mktemp -d "${TMPDIR:-/tmp}/metalsharp-runtime-host.XXXXXX")"
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/metalsharp-bundle-core.XXXXXX")"
 
-  if ! tar --use-compress-program=unzstd -xf "$path" -C "$tmp" runtime/host && [ ! -d "$tmp/runtime/host" ]; then
-    echo "HOST RUNTIME MISSING: $path does not contain runtime/host/" >&2
+  if ! tar --use-compress-program=unzstd -xf "$path" -C "$tmp" "$@"; then
+    echo "$label INVALID: $path is missing one or more required files" >&2
     rm -rf "$tmp"
     return 1
   fi
 
-  local host="$tmp/runtime/host"
   local failed=0
-  for required in manifest.json HostRuntimeABI.h; do
-    if [ ! -s "$host/$required" ]; then
-      echo "HOST RUNTIME INVALID: $path has missing or empty runtime/host/$required" >&2
+  local required
+  for required in "$@"; do
+    if [ ! -s "$tmp/$required" ]; then
+      echo "$label INVALID: $path has missing or empty $required" >&2
       failed=1
     fi
   done
-
-  if [ ! -s "$host/libmetalsharp_host_runtime.dylib" ] \
-    && [ ! -s "$host/libmetalsharp_host_runtime.so" ] \
-    && [ ! -s "$host/metalsharp_host_runtime.dll" ]; then
-    echo "HOST RUNTIME INVALID: $path has no non-empty host runtime shared library" >&2
-    failed=1
-  fi
 
   rm -rf "$tmp"
   return "$failed"
 }
 
-verify_runtime_metalsharp_lib() {
-  local path="$1"
-  local tmp
-  tmp="$(mktemp -d "${TMPDIR:-/tmp}/metalsharp-runtime-lib.XXXXXX")"
-
-  if ! tar --use-compress-program=unzstd -xf "$path" -C "$tmp" \
-    runtime/wine/lib/metalsharp/x86_64-windows/metalsharp_ntdll_hook.dll \
-    && [ ! -e "$tmp/runtime/wine/lib/metalsharp/x86_64-windows/metalsharp_ntdll_hook.dll" ]; then
-    echo "METALSHARP RUNTIME INVALID: $path does not contain runtime/wine/lib/metalsharp/x86_64-windows/metalsharp_ntdll_hook.dll" >&2
-    rm -rf "$tmp"
-    return 1
-  fi
-
-  if [ ! -s "$tmp/runtime/wine/lib/metalsharp/x86_64-windows/metalsharp_ntdll_hook.dll" ]; then
-    echo "METALSHARP RUNTIME INVALID: $path has empty runtime/wine/lib/metalsharp/x86_64-windows/metalsharp_ntdll_hook.dll" >&2
-    rm -rf "$tmp"
-    return 1
-  fi
-
-  rm -rf "$tmp"
-  return 0
+verify_runtime_core() {
+  verify_required_files "$1" "RUNTIME" \
+    runtime/wine/bin/metalsharp-wine \
+    runtime/metalsharp-backend \
+    runtime/host/manifest.json \
+    runtime/host/HostRuntimeABI.h \
+    runtime/host/libmetalsharp_host_runtime.dylib \
+    runtime/wine/lib/metalsharp/x86_64-windows/metalsharp_ntdll_hook.dll
 }
 
-verify_scripts_tools_configs() {
-  local path="$1"
-  local tmp
-  tmp="$(mktemp -d "${TMPDIR:-/tmp}/metalsharp-scripts-tools.XXXXXX")"
+verify_graphics_core() {
+  verify_required_files "$1" "GRAPHICS" \
+    Graphics/dll/dxmt/x86_64-unix/winemetal.so \
+    Graphics/dll/dxmt/x86_64-windows/d3d10core.dll \
+    Graphics/dll/dxmt/x86_64-windows/d3d11.dll \
+    Graphics/dll/dxmt/x86_64-windows/d3d12.dll \
+    Graphics/dll/dxmt/x86_64-windows/dxgi.dll \
+    Graphics/dll/dxmt/x86_64-windows/dxgi_dxmt.dll \
+    Graphics/dll/dxmt/x86_64-windows/nvapi64.dll \
+    Graphics/dll/dxmt/x86_64-windows/nvngx.dll \
+    Graphics/dll/dxmt/x86_64-windows/winemetal.dll
+}
 
-  if ! tar --use-compress-program=unzstd -xf "$path" -C "$tmp" scripts/tools/configs/mtsp-rules.toml \
-    && [ ! -e "$tmp/scripts/tools/configs/mtsp-rules.toml" ]; then
-    echo "SCRIPTS TOOLS INVALID: $path does not contain scripts/tools/configs/mtsp-rules.toml" >&2
-    rm -rf "$tmp"
-    return 1
-  fi
+verify_assets_core() {
+  verify_required_files "$1" "ASSETS" \
+    assets/eac-toggle/x86_64-windows/_winhttp.dll \
+    assets/goldberg/x64/steam_api64.dll \
+    assets/goldberg/x86/steam_api.dll \
+    assets/gptk/external/D3DMetal.framework/Versions/A/D3DMetal \
+    assets/gptk/external/D3DMetal.framework/Versions/A/Resources/libmetalirconverter.dylib \
+    assets/gptk/x86_64-windows/atidxx64.dll \
+    assets/gptk/x86_64-windows/d3d10.dll \
+    assets/gptk/x86_64-windows/d3d11.dll \
+    assets/gptk/x86_64-windows/d3d12.dll \
+    assets/gptk/x86_64-windows/dxgi.dll \
+    assets/gptk/x86_64-windows/nvapi64.dll \
+    assets/gptk/x86_64-windows/nvngx-on-metalfx.dll \
+    assets/mono-arm64/bin/mono-sgen \
+    assets/shims/libsteam_api.dylib
+}
 
-  if [ ! -s "$tmp/scripts/tools/configs/mtsp-rules.toml" ]; then
-    echo "SCRIPTS TOOLS INVALID: $path has empty scripts/tools/configs/mtsp-rules.toml" >&2
-    rm -rf "$tmp"
-    return 1
-  fi
+verify_scripts_tools_core() {
+  verify_required_files "$1" "SCRIPTS TOOLS" \
+    scripts/tools/configs/mtsp-rules.toml \
+    scripts/tools/updater/update.sh
+}
 
-  rm -rf "$tmp"
-  return 0
+verify_steam_core() {
+  verify_required_files "$1" "STEAM" \
+    steam/SteamSetup.exe \
+    steam/steamwebhelper.exe \
+    steam/steamwebhelper-wrapper.c
 }
 
 verify_release() {

--- a/tools/bundles/verify-bundles.sh
+++ b/tools/bundles/verify-bundles.sh
@@ -79,6 +79,10 @@ verify_local() {
       failed=1
       continue
     fi
+    if [ "$asset" = "metalsharp-runtime.tar.zst" ] && ! verify_runtime_metalsharp_lib "$path"; then
+      failed=1
+      continue
+    fi
     if [ "$asset" = "metalsharp-scripts-tools.tar.zst" ] && ! verify_scripts_tools_configs "$path"; then
       failed=1
       continue
@@ -126,6 +130,29 @@ verify_runtime_host() {
 
   rm -rf "$tmp"
   return "$failed"
+}
+
+verify_runtime_metalsharp_lib() {
+  local path="$1"
+  local tmp
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/metalsharp-runtime-lib.XXXXXX")"
+
+  if ! tar --use-compress-program=unzstd -xf "$path" -C "$tmp" \
+    runtime/wine/lib/metalsharp/x86_64-windows/metalsharp_ntdll_hook.dll \
+    && [ ! -e "$tmp/runtime/wine/lib/metalsharp/x86_64-windows/metalsharp_ntdll_hook.dll" ]; then
+    echo "METALSHARP RUNTIME INVALID: $path does not contain runtime/wine/lib/metalsharp/x86_64-windows/metalsharp_ntdll_hook.dll" >&2
+    rm -rf "$tmp"
+    return 1
+  fi
+
+  if [ ! -s "$tmp/runtime/wine/lib/metalsharp/x86_64-windows/metalsharp_ntdll_hook.dll" ]; then
+    echo "METALSHARP RUNTIME INVALID: $path has empty runtime/wine/lib/metalsharp/x86_64-windows/metalsharp_ntdll_hook.dll" >&2
+    rm -rf "$tmp"
+    return 1
+  fi
+
+  rm -rf "$tmp"
+  return 0
 }
 
 verify_scripts_tools_configs() {

--- a/tools/dmg/repair-runtime-bundle.py
+++ b/tools/dmg/repair-runtime-bundle.py
@@ -13,6 +13,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_ARCHIVE = PROJECT_ROOT / "app" / "bundles" / "metalsharp-runtime.tar.zst"
 DEFAULT_HOST = PROJECT_ROOT / "app" / "native" / "host"
 DEFAULT_BACKEND = PROJECT_ROOT / "app" / "src-rust" / "target" / "release" / "metalsharp-backend"
+DEFAULT_METALSHARP_LIB = PROJECT_ROOT / "lib" / "metalsharp"
 
 
 def require_file(path: Path, description: str) -> None:
@@ -31,6 +32,13 @@ def require_host_runtime(host_dir: Path) -> None:
     if not any(path.is_file() and path.stat().st_size > 0 for path in libraries):
         names = ", ".join(str(path) for path in libraries)
         raise FileNotFoundError(f"missing required non-empty host runtime library; checked {names}")
+
+
+def require_metalsharp_lib(lib_dir: Path) -> None:
+    require_file(
+        lib_dir / "x86_64-windows" / "metalsharp_ntdll_hook.dll",
+        "MetalSharp ntdll hook DLL",
+    )
 
 
 def copy_tree(src: Path, dst: Path) -> None:
@@ -80,10 +88,11 @@ def write_archive(source_root: Path, output: Path) -> None:
         tar_path.unlink(missing_ok=True)
 
 
-def repair_runtime_bundle(archive: Path, host_dir: Path, backend: Path) -> None:
+def repair_runtime_bundle(archive: Path, host_dir: Path, backend: Path, metalsharp_lib: Path) -> None:
     require_file(archive, "runtime bundle archive")
     require_host_runtime(host_dir)
     require_file(backend, "runtime backend")
+    require_metalsharp_lib(metalsharp_lib)
 
     with tempfile.TemporaryDirectory(prefix="metalsharp-runtime-repair-") as tmp_name:
         tmp = Path(tmp_name)
@@ -97,8 +106,10 @@ def repair_runtime_bundle(archive: Path, host_dir: Path, backend: Path) -> None:
 
         copy_tree(host_dir, runtime_root / "host")
         shutil.copy2(backend, runtime_root / "metalsharp-backend")
+        copy_tree(metalsharp_lib, runtime_root / "wine" / "lib" / "metalsharp")
         require_host_runtime(runtime_root / "host")
         require_file(runtime_root / "metalsharp-backend", "runtime backend inside archive")
+        require_metalsharp_lib(runtime_root / "wine" / "lib" / "metalsharp")
 
         repaired = tmp / archive.name
         write_archive(extracted, repaired)
@@ -110,9 +121,10 @@ def main() -> None:
     parser.add_argument("--archive", type=Path, default=DEFAULT_ARCHIVE)
     parser.add_argument("--host-dir", type=Path, default=DEFAULT_HOST)
     parser.add_argument("--backend", type=Path, default=DEFAULT_BACKEND)
+    parser.add_argument("--metalsharp-lib", type=Path, default=DEFAULT_METALSHARP_LIB)
     args = parser.parse_args()
 
-    repair_runtime_bundle(args.archive, args.host_dir, args.backend)
+    repair_runtime_bundle(args.archive, args.host_dir, args.backend, args.metalsharp_lib)
     print(f"repaired runtime bundle: {args.archive}")
 
 


### PR DESCRIPTION
## Summary
- package `lib/metalsharp/x86_64-windows/metalsharp_ntdll_hook.dll` into the repaired and generated runtime bundles
- make setup/migration treat a missing MetalSharp hook DLL as a runtime repair requirement for already-installed users
- add a migration step that runs `wineboot -u` against existing Steam and bottle prefixes after the runtime reinstall
- harden installer-side bundle validation so new-user setup rejects corrupt/stale runtime, graphics, assets, scripts, and Steam archives before install
- harden `tools/bundles/verify-bundles.sh` to enforce the same critical payload contract in CI and release checks

## Root cause
The ntdll hook routes started requiring `lib/metalsharp/x86_64-windows`, but the installed Wine runtime and runtime bundle validators only checked a narrow subset of assets. More broadly, new-user setup accepted non-empty archives for most bundle families without proving they contained the critical runtime files needed by later install steps. A packaged or cached archive could therefore look present while install later failed on Wine, DXMT, GPTK, Goldberg, EAC, scripts, Steam, or the MetalSharp hook payload.

## Validation
- `cargo test migrate::tests -- --nocapture`
- `cargo test installer::tests -- --nocapture`
- `cargo test setup:: -- --nocapture`
- `cargo clippy --all-targets -- -D warnings`
- `tools/bundles/verify-bundles.sh --bundle-dir app/bundles metalsharp-runtime.tar.zst`
- `tools/bundles/verify-bundles.sh --bundle-dir app/bundles --require mac`
- `tools/ci/shellcheck.sh`
- verified archive contains `runtime/wine/lib/metalsharp/x86_64-windows/metalsharp_ntdll_hook.dll`

## Notes
The existing unstaged `app/src-rust/src/kernel_translation/ipc_bridge.rs` edit was left out of this PR.
