### PR TITLE
fix: route chip label doesn't update after bottle pipeline save

### DIFF
--- a/app/src/renderer/components/GameCard.vue
+++ b/app/src/renderer/components/GameCard.vue
@@ -212,7 +212,7 @@ async function refreshPipelineMetadata() {
     pipelines: PipelineOption[];
   }>("GET", `/mtsp/pipelines?appid=${props.game.appid}`);
   if (gp?.ok && gp.recommended_name) {
-    pipelineName.value = props.game.launch_method_name || gp.preferred_name || gp.recommended_name;
+    pipelineName.value = gp.preferred_name || gp.recommended_name;
     pipelineOptions.value = gp.pipelines ?? [];
   }
 }


### PR DESCRIPTION
## Problem
When a user changes a game's bottle graphics backend (e.g. M11 → M9) via the bottle workspace dropdown and saves, the green route chip on the app card continues showing the old auto-routed pipeline name (M11) instead of the user's selection (M9). The runtime itself works correctly — only the label is stale.

## Root Cause
`saveBottleEdit()` correctly sets `pipelineName` to the user's choice, but then calls `refreshPipelineMetadata()` which overwrites it. That function was prioritizing `props.game.launch_method_name` (the stale auto-routed value from the parent library data, which isn't reloaded on save) over `gp.preferred_name` (the freshly fetched bottle preference from the backend).

## Fix
Remove `props.game.launch_method_name` from the priority chain in `refreshPipelineMetadata()` so the backend's actual preferred/recommended pipeline name is used instead of the stale prop.

```diff
- pipelineName.value = props.game.launch_method_name || gp.preferred_name || gp.recommended_name;
+ pipelineName.value = gp.preferred_name || gp.recommended_name;
```

## Testing
- Change a game's bottle pipeline from M11 to M9, save → chip should show M9
- Change back to M11, save → chip should show M11
- Games with no bottle preference set should still show the auto-routed recommendation