### PR TITLE
Add anti-cheat substrate planning endpoint

### DIFF
--- a/app/src-rust/src/anticheat.rs
+++ b/app/src-rust/src/anticheat.rs
@@ -473,6 +473,65 @@ pub fn handle_steam_anticheat_substrate_decision(body: &Map<String, Value>) -> V
     })
 }
 
+pub fn handle_steam_anticheat_substrate_plan(body: &Map<String, Value>) -> Value {
+    let appid = match body.get("appid").and_then(|v| v.as_u64()) {
+        Some(id) if id > 0 && id <= u32::MAX as u64 => id as u32,
+        _ => return json!({"ok": false, "error": "appid required"}),
+    };
+
+    let home = match dirs::home_dir() {
+        Some(home) => home,
+        None => return json!({"ok": false, "appid": appid, "error": "no home dir"}),
+    };
+
+    let prefix = crate::platform::metalsharp_home_dir_for(&home).join("prefix-steam");
+    let game_dir = resolve_anticheat_game_dir(appid);
+    let eac_identity = game_dir.as_ref().and_then(|dir| read_eac_identity(&dir.path));
+    let artifacts = collect_artifacts(&prefix, game_dir.as_ref().map(|dir| dir.path.as_path()));
+    let eac = summarize_eac(appid, &artifacts, eac_identity.as_ref());
+    let steam = summarize_steam(appid, &artifacts);
+    let module_assets = game_dir.as_ref().map(|dir| collect_module_assets(&dir.path)).unwrap_or_default();
+    let host_os = std::env::consts::OS;
+    let decision = substrate_decision(host_os, &eac, &module_assets);
+    let status = substrate_plan_status(&decision, &eac, host_os);
+
+    json!({
+        "ok": true,
+        "appid": appid,
+        "status": status,
+        "summary": substrate_plan_summary(&status),
+        "decision": decision,
+        "host": {
+            "os": host_os,
+            "arch": std::env::consts::ARCH,
+        },
+        "evidenceStatus": evidence_status(&eac, &steam, &artifacts),
+        "gameDir": game_dir.as_ref().map(|dir| dir.path.to_string_lossy().to_string()),
+        "gameDirSource": game_dir.as_ref().map(|dir| dir.source),
+        "gameDirStaged": game_dir.as_ref().map(|dir| dir.staged).unwrap_or(false),
+        "facts": {
+            "moduleTarget": eac.module_target,
+            "moduleMappingStatus": eac.module_mapping_status,
+            "launcherExitCode": eac.launcher_exit_code,
+            "setupExitCode": eac.setup_exit_code,
+            "canDlopenLinuxElfDirectly": can_dlopen_linux_elf_directly(host_os),
+            "hasVendorMacOSAsset": module_assets.iter().any(|asset| asset.get("format").and_then(|v| v.as_str()) == Some("mach_o")),
+        },
+        "prototypeScope": {
+            "mode": "synthetic_and_public_elf_only",
+            "loadsProtectedModules": false,
+            "modifiesProtectedModules": false,
+            "launchesProtectedGame": false,
+            "touchesSteamState": false,
+        },
+        "implementationStages": substrate_implementation_stages(&status),
+        "acceptanceGates": substrate_acceptance_gates(&status),
+        "allowedPaths": allowed_substrate_paths(&decision),
+        "rejectedPaths": substrate_rejected_paths(),
+        "nextActions": substrate_plan_next_actions(&status),
+    })
+}
+
 fn resolve_anticheat_game_dir(appid: u32) -> Option<GameDirEvidence> {
     let completed = crate::setup::resolve_game_dir(appid).map(|path| GameDirEvidence {
         path,
@@ -1450,6 +1509,142 @@ fn substrate_next_actions(decision: &str) -> Vec<&'static str> {
     }
 }
 
+fn substrate_plan_status(decision: &str, eac: &EacSummary, host_os: &str) -> String {
+    let selected_linux = eac.module_target.as_deref().unwrap_or("").starts_with("linux");
+    let mapped_failed = eac.module_mapping_status.as_deref() == Some("failed");
+    if decision == "requires_linux_user_space_substrate_or_vendor_macos_asset"
+        && host_os == "macos"
+        && selected_linux
+        && mapped_failed
+    {
+        "prototype_ready_linux_substrate".to_string()
+    } else if decision == "requires_linux_user_space_substrate_or_vendor_macos_asset" {
+        "substrate_research_ready".to_string()
+    } else if decision == "requires_loader_delta_audit" {
+        "needs_loader_delta_audit".to_string()
+    } else if decision == "investigate_vendor_macos_module" {
+        "vendor_macos_asset_investigation".to_string()
+    } else {
+        "needs_protected_launch_evidence".to_string()
+    }
+}
+
+fn substrate_plan_summary(status: &str) -> &'static str {
+    match status {
+        "prototype_ready_linux_substrate" => {
+            "Protected launch reached EAC's Linux module-mapping path on macOS; start a transparent Linux-user-space substrate prototype using synthetic/public ELF inputs only."
+        },
+        "substrate_research_ready" => {
+            "The evidence points toward a Linux-user-space substrate, but capture the exact module-mapping failure before writing runtime code."
+        },
+        "needs_loader_delta_audit" => {
+            "Module mapping failed without enough module-target proof; complete the loader delta audit before substrate work."
+        },
+        "vendor_macos_asset_investigation" => {
+            "A host-compatible vendor asset may exist; verify provenance and support before building Linux substrate work."
+        },
+        _ => "Collect a protected-launch evidence report before selecting a substrate implementation path.",
+    }
+}
+
+fn substrate_implementation_stages(status: &str) -> Vec<Value> {
+    match status {
+        "prototype_ready_linux_substrate" | "substrate_research_ready" => vec![
+            substrate_stage(
+                "elf_contract_lab",
+                "Synthetic ELF contract lab",
+                "Build a small host-side lab that maps synthetic and public test ELF shared objects, records loader failures, TLS expectations, relocations, executable page transitions, and symbol lookup gaps.",
+                "No protected anti-cheat bytes; no Steam launch; no process injection.",
+            ),
+            substrate_stage(
+                "linux_abi_minimums",
+                "Minimum Linux user-space ABI map",
+                "Compare Proton-observed needs against MetalSharp host capabilities for mmap, mprotect, futex-like waits, thread-local storage, signals, /proc-style metadata, file descriptors, monotonic clocks, and socket behavior.",
+                "Use public probes and Wine/runtime introspection only.",
+            ),
+            substrate_stage(
+                "wine_boundary_adapter",
+                "Wine boundary adapter",
+                "Prototype a transparent adapter between Wine's Unix-side loader boundary and the Linux ABI lab so module-host assumptions can be tested without changing protected launch behavior.",
+                "Adapter must identify itself honestly and avoid spoofing host identity.",
+            ),
+            substrate_stage(
+                "evidence_replay_gate",
+                "Evidence replay gate",
+                "Re-run /steam/anticheat-evidence, /steam/anticheat-probe, /steam/anticheat-contract-probe, and /steam/anticheat-delta-audit after each runtime change.",
+                "Do not claim online anti-cheat support until a vendor-supported protected module maps and the game launches.",
+            ),
+        ],
+        "needs_loader_delta_audit" => vec![substrate_stage(
+            "loader_delta_audit",
+            "Loader delta audit",
+            "Resolve the module target and compare Wine loader, wineserver, steamclient bridge, and executable mapping behavior with Proton before substrate design.",
+            "Evidence only.",
+        )],
+        _ => vec![substrate_stage(
+            "evidence_collection",
+            "Protected-launch evidence collection",
+            "Launch once through the protected Steam route and collect scoped EAC/BattlEye, Steam, Wine, and contract-probe evidence.",
+            "No runtime changes.",
+        )],
+    }
+}
+
+fn substrate_stage(id: &str, title: &str, goal: &str, guardrail: &str) -> Value {
+    json!({
+        "id": id,
+        "title": title,
+        "goal": goal,
+        "guardrail": guardrail,
+    })
+}
+
+fn substrate_acceptance_gates(status: &str) -> Vec<&'static str> {
+    match status {
+        "prototype_ready_linux_substrate" | "substrate_research_ready" => vec![
+            "A synthetic ELF probe records loader, relocation, TLS, symbol, and executable-memory outcomes without touching protected modules.",
+            "A Proton comparison names each Linux ABI expectation as present, shimmed, missing, or intentionally unsupported.",
+            "Every runtime change is followed by fresh evidence reports for the same appid.",
+            "No protected module is patched, injected into, decrypted, or loaded outside vendor-supported launch semantics.",
+            "User-facing status remains evidence-based until protected module mapping and launch are proven.",
+        ],
+        "needs_loader_delta_audit" => vec![
+            "Module target, Wine version, launcher exit code, and protected launcher path are all present in the evidence report.",
+            "Delta audit separates required runtime gaps from Proton-comparison-only gaps.",
+        ],
+        _ => vec!["A protected-launch evidence report exists for the target appid."],
+    }
+}
+
+fn substrate_plan_next_actions(status: &str) -> Vec<&'static str> {
+    match status {
+        "prototype_ready_linux_substrate" => vec![
+            "Create the synthetic ELF contract lab as the first runtime prototype.",
+            "Add a Proton comparison fixture for EAC module-host expectations.",
+            "Keep Elden Ring as the repeatable evidence target because it reaches module mapping and exits 206.",
+        ],
+        "substrate_research_ready" => vec![
+            "Re-run protected launch and capture a fresh EAC module-mapping failure.",
+            "Then promote the synthetic ELF contract lab.",
+        ],
+        "needs_loader_delta_audit" => {
+            vec!["Run /steam/anticheat-delta-audit and resolve missing module-target evidence."]
+        },
+        _ => vec!["Collect protected-launch evidence for the target appid first."],
+    }
+}
+
+fn substrate_rejected_paths() -> Vec<&'static str> {
+    vec![
+        "spoof anti-cheat host identity",
+        "hide MetalSharp or Wine from the protected launcher",
+        "fake kernel driver support",
+        "tamper with protected modules",
+        "load protected modules in a synthetic lab",
+        "claim online anti-cheat support before protected module mapping and launch are proven with vendor-supported semantics",
+    ]
+}
+
 fn classify_module_path(path: &Path) -> &'static str {
     let path_lc = path.to_string_lossy().to_ascii_lowercase();
     if path_lc.contains("battleye") || path_lc.contains("beclient") || path_lc.contains("beservice") {
@@ -1653,6 +1848,32 @@ mod tests {
     fn substrate_decision_requires_linux_substrate_for_linux_module_on_macos() {
         let eac = EacSummary { module_target: Some("linux64".to_string()), ..Default::default() };
         assert_eq!(substrate_decision("macos", &eac, &[]), "requires_linux_user_space_substrate_or_vendor_macos_asset");
+    }
+
+    #[test]
+    fn substrate_plan_promotes_linux_mapping_failure_to_prototype_ready() {
+        let eac = EacSummary {
+            module_target: Some("linux64".to_string()),
+            module_mapping_status: Some("failed".to_string()),
+            launcher_exit_code: Some(206),
+            ..Default::default()
+        };
+
+        let status = substrate_plan_status("requires_linux_user_space_substrate_or_vendor_macos_asset", &eac, "macos");
+        assert_eq!(status, "prototype_ready_linux_substrate");
+        assert!(substrate_plan_summary(&status).contains("Linux module-mapping path"));
+        assert!(substrate_implementation_stages(&status)
+            .iter()
+            .any(|stage| stage.get("id").and_then(|v| v.as_str()) == Some("elf_contract_lab")));
+    }
+
+    #[test]
+    fn substrate_plan_rejects_protected_module_lab_loading() {
+        let rejected = substrate_rejected_paths();
+        assert!(rejected.contains(&"load protected modules in a synthetic lab"));
+        assert!(substrate_acceptance_gates("prototype_ready_linux_substrate")
+            .iter()
+            .any(|gate| gate.contains("without touching protected modules")));
     }
 
     #[test]

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -888,6 +888,10 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
             let body = read_body(req);
             resp(200, anticheat::handle_steam_anticheat_substrate_decision(&body))
         },
+        (Method::Post, "/steam/anticheat-substrate-plan") => {
+            let body = read_body(req);
+            resp(200, anticheat::handle_steam_anticheat_substrate_plan(&body))
+        },
         (Method::Post, "/kernel-translation/probe") => {
             let body = read_body(req);
             resp(200, kernel_translation::handle_kernel_translation_probe(&body))

--- a/app/src-rust/src/migrate.rs
+++ b/app/src-rust/src/migrate.rs
@@ -679,6 +679,7 @@ fn update_existing_wine_prefixes(ms_dir: &Path, step: usize) -> Result<usize, St
 
     let mut updated = 0usize;
     for prefix in collect_existing_wine_prefixes(ms_dir) {
+        let steam_library_drive_links = collect_steam_library_drive_links(&prefix);
         write_migrate_progress(
             "running",
             step,
@@ -687,6 +688,7 @@ fn update_existing_wine_prefixes(ms_dir: &Path, step: usize) -> Result<usize, St
             None,
         );
         run_wineboot_update(&wine, &runtime_wine, &prefix)?;
+        restore_steam_library_drive_links(&prefix, &steam_library_drive_links);
         updated += 1;
     }
 
@@ -752,6 +754,198 @@ fn run_wineboot_update(wine: &Path, runtime_wine: &Path, prefix: &Path) -> Resul
     let _ = child.kill();
     let _ = child.wait();
     Err(error_msg)
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SteamLibraryDriveLink {
+    drive: char,
+    target: PathBuf,
+    library_path: String,
+}
+
+fn collect_steam_library_drive_links(prefix: &Path) -> Vec<SteamLibraryDriveLink> {
+    let mut links = Vec::new();
+    for libraryfolders in steam_libraryfolders_files(prefix) {
+        let Ok(contents) = fs::read_to_string(&libraryfolders) else {
+            continue;
+        };
+        for line in contents.lines() {
+            let Some(path) = parse_steam_vdf_path(line) else {
+                continue;
+            };
+            let Some((drive, rest)) = split_steam_library_wine_path(&path) else {
+                continue;
+            };
+            let Some(target) = resolve_steam_library_drive_target(prefix, drive, &rest) else {
+                continue;
+            };
+            if links.iter().any(|link: &SteamLibraryDriveLink| link.drive.eq_ignore_ascii_case(&drive)) {
+                continue;
+            }
+            links.push(SteamLibraryDriveLink { drive: drive.to_ascii_lowercase(), target, library_path: path });
+        }
+    }
+    links
+}
+
+fn steam_libraryfolders_files(prefix: &Path) -> Vec<PathBuf> {
+    let steam = prefix.join("drive_c").join("Program Files (x86)").join("Steam");
+    vec![steam.join("config").join("libraryfolders.vdf"), steam.join("steamapps").join("libraryfolders.vdf")]
+}
+
+fn parse_steam_vdf_path(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    if !trimmed.starts_with("\"path\"") {
+        return None;
+    }
+    let mut quoted = Vec::new();
+    let mut chars = trimmed.char_indices().peekable();
+    while let Some((start, ch)) = chars.next() {
+        if ch != '"' {
+            continue;
+        }
+        let value_start = start + ch.len_utf8();
+        let mut escaped = false;
+        while let Some((end, value_ch)) = chars.next() {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+            if value_ch == '\\' {
+                escaped = true;
+                continue;
+            }
+            if value_ch == '"' {
+                quoted.push(&trimmed[value_start..end]);
+                break;
+            }
+        }
+    }
+    quoted.get(1).map(|value| value.replace("\\\\", "\\"))
+}
+
+fn split_steam_library_wine_path(path: &str) -> Option<(char, String)> {
+    let mut chars = path.chars();
+    let drive = chars.next()?;
+    if chars.next()? != ':' || !drive.is_ascii_alphabetic() || drive.eq_ignore_ascii_case(&'c') {
+        return None;
+    }
+    let rest = path.get(2..)?.replace('\\', "/");
+    if !rest.starts_with('/') {
+        return None;
+    }
+    Some((drive.to_ascii_lowercase(), rest))
+}
+
+fn resolve_steam_library_drive_target(prefix: &Path, drive: char, rest: &str) -> Option<PathBuf> {
+    let dosdevice = prefix.join("dosdevices").join(format!("{}:", drive.to_ascii_lowercase()));
+    if let Ok(target) = fs::read_link(&dosdevice) {
+        if steam_library_target_has_steamapps(&target, rest) {
+            return Some(target);
+        }
+    }
+
+    if steam_library_path_prefers_root_mapping(rest) {
+        return Some(PathBuf::from("/"));
+    }
+
+    let root = Path::new("/");
+    if steam_library_target_has_steamapps(root, rest) {
+        return Some(root.to_path_buf());
+    }
+
+    None
+}
+
+fn steam_library_path_prefers_root_mapping(rest: &str) -> bool {
+    rest.starts_with("/Volumes/")
+        || rest.starts_with("/Users/")
+        || rest.starts_with("/private/")
+        || rest.starts_with("/Applications/")
+}
+
+fn steam_library_target_has_steamapps(target: &Path, rest: &str) -> bool {
+    target.join(rest.trim_start_matches('/')).join("steamapps").exists()
+}
+
+fn restore_steam_library_drive_links(prefix: &Path, links: &[SteamLibraryDriveLink]) {
+    if links.is_empty() {
+        return;
+    }
+
+    let dosdevices = prefix.join("dosdevices");
+    if let Err(e) = fs::create_dir_all(&dosdevices) {
+        log_to_file(&format!("Migration prefix update: failed to create dosdevices for {}: {}", prefix.display(), e));
+        return;
+    }
+
+    for link in links {
+        let dosdevice = dosdevices.join(format!("{}:", link.drive.to_ascii_lowercase()));
+        if let Ok(current) = fs::read_link(&dosdevice) {
+            if current == link.target {
+                continue;
+            }
+        }
+
+        match fs::symlink_metadata(&dosdevice) {
+            Ok(meta) if meta.file_type().is_symlink() || meta.is_file() => {
+                if let Err(e) = fs::remove_file(&dosdevice) {
+                    log_to_file(&format!(
+                        "Migration prefix update: failed to remove stale {} for Steam library {}: {}",
+                        dosdevice.display(),
+                        link.library_path,
+                        e
+                    ));
+                    continue;
+                }
+            },
+            Ok(meta) if meta.is_dir() => {
+                log_to_file(&format!(
+                    "Migration prefix update: skipped Steam library drive {} because {} is a directory",
+                    link.library_path,
+                    dosdevice.display()
+                ));
+                continue;
+            },
+            Ok(_) => {
+                if let Err(e) = fs::remove_file(&dosdevice) {
+                    log_to_file(&format!(
+                        "Migration prefix update: failed to remove stale {} for Steam library {}: {}",
+                        dosdevice.display(),
+                        link.library_path,
+                        e
+                    ));
+                    continue;
+                }
+            },
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {},
+            Err(e) => {
+                log_to_file(&format!(
+                    "Migration prefix update: failed to inspect {} for Steam library {}: {}",
+                    dosdevice.display(),
+                    link.library_path,
+                    e
+                ));
+                continue;
+            },
+        }
+
+        match std::os::unix::fs::symlink(&link.target, &dosdevice) {
+            Ok(()) => log_to_file(&format!(
+                "Migration prefix update: restored Steam library drive {} -> {} for {}",
+                dosdevice.display(),
+                link.target.display(),
+                link.library_path
+            )),
+            Err(e) => log_to_file(&format!(
+                "Migration prefix update: failed to restore Steam library drive {} -> {} for {}: {}",
+                dosdevice.display(),
+                link.target.display(),
+                link.library_path,
+                e
+            )),
+        }
+    }
 }
 
 fn temp_suffix() -> u128 {
@@ -1255,6 +1449,61 @@ mod tests {
     }
 
     #[test]
+    fn migration_prefix_update_restores_root_steam_library_drive() {
+        let home = test_dir("restore-root-steam-library-drive");
+        let ms_dir = crate::platform::metalsharp_home_dir_for(&home);
+        let prefix = ms_dir.join("prefix-steam");
+        let dosdevices = prefix.join("dosdevices");
+        fs::create_dir_all(&dosdevices).expect("create dosdevices");
+        write_steam_libraryfolders(&prefix, r#""path" "Z:\\Volumes\\AverySSD\\SteamLibrary""#);
+
+        let links = collect_steam_library_drive_links(&prefix);
+        assert_eq!(
+            links,
+            vec![SteamLibraryDriveLink {
+                drive: 'z',
+                target: PathBuf::from("/"),
+                library_path: String::from("Z:\\Volumes\\AverySSD\\SteamLibrary"),
+            }]
+        );
+
+        restore_steam_library_drive_links(&prefix, &links);
+
+        assert_eq!(fs::read_link(dosdevices.join("z:")).expect("read restored z drive"), PathBuf::from("/"));
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn migration_prefix_update_restores_existing_custom_steam_library_drive() {
+        let home = test_dir("restore-custom-steam-library-drive");
+        let ms_dir = crate::platform::metalsharp_home_dir_for(&home);
+        let prefix = ms_dir.join("prefix-steam");
+        let external = home.join("ExternalSteamDisk");
+        let dosdevices = prefix.join("dosdevices");
+        fs::create_dir_all(external.join("SteamLibrary").join("steamapps")).expect("create external steamapps");
+        fs::create_dir_all(&dosdevices).expect("create dosdevices");
+        std::os::unix::fs::symlink(&external, dosdevices.join("y:")).expect("create y drive symlink");
+        write_steam_libraryfolders(&prefix, r#""path" "Y:\\SteamLibrary""#);
+
+        let links = collect_steam_library_drive_links(&prefix);
+        assert_eq!(
+            links,
+            vec![SteamLibraryDriveLink {
+                drive: 'y',
+                target: external.clone(),
+                library_path: String::from("Y:\\SteamLibrary"),
+            }]
+        );
+
+        fs::remove_file(dosdevices.join("y:")).expect("remove y drive symlink");
+        std::os::unix::fs::symlink(&home, dosdevices.join("y:")).expect("simulate wineboot y rewrite");
+        restore_steam_library_drive_links(&prefix, &links);
+
+        assert_eq!(fs::read_link(dosdevices.join("y:")).expect("read restored y drive"), external);
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
     fn migration_preserves_bottle_settings_without_prefix_payloads() {
         let home = test_dir("skip-bottle-prefix-payloads");
         let ms_dir = crate::platform::metalsharp_home_dir_for(&home);
@@ -1522,6 +1771,26 @@ mod tests {
         fs::write(host.join("manifest.json"), br#"{"abi":"metalsharp-host-runtime"}"#).expect("write manifest");
         fs::write(host.join("HostRuntimeABI.h"), b"header").expect("write header");
         fs::write(host.join("libmetalsharp_host_runtime.dylib"), b"dylib").expect("write dylib");
+    }
+
+    fn write_steam_libraryfolders(prefix: &Path, path_line: &str) {
+        let config = prefix.join("drive_c").join("Program Files (x86)").join("Steam").join("config");
+        fs::create_dir_all(&config).expect("create Steam config dir");
+        fs::write(
+            config.join("libraryfolders.vdf"),
+            format!(
+                r#""libraryfolders"
+{{
+    "0"
+    {{
+        {}
+    }}
+}}
+"#,
+                path_line
+            ),
+        )
+        .expect("write libraryfolders.vdf");
     }
 
     fn test_dir(name: &str) -> PathBuf {

--- a/app/src-rust/src/migrate.rs
+++ b/app/src-rust/src/migrate.rs
@@ -478,6 +478,7 @@ fn run_migration() {
 
     let marker = post_update_marker_path(&ms_dir);
     let _ = fs::remove_file(&marker);
+    let _ = fs::remove_file(migration_steam_config_backup_path(&ms_dir));
     write_migrate_progress("complete", total_steps, total_steps, "MetalSharp is updated and ready.", None);
     log_to_file(&format!("Migration to v{} finished (install_ok=true)", MIGRATE_VERSION));
 }
@@ -595,8 +596,7 @@ fn preserve_user_data(ms_dir: &PathBuf) -> PreservedData {
 
     let setup_json = ms_dir.join("setup.json").exists().then(|| fs::read(ms_dir.join("setup.json")).ok()).flatten();
 
-    let steam_config_path = ms_dir.join("cache").join("steam_config.json");
-    let steam_config_json = steam_config_path.exists().then(|| fs::read(&steam_config_path).ok()).flatten();
+    let steam_config_json = read_preserved_steam_config(ms_dir);
 
     write_migrate_progress("running", 2, MIGRATION_TOTAL_STEPS, "Preserving user data (cache metadata)...", None);
     let cache_tmp = tmp.join("cache");
@@ -1100,6 +1100,9 @@ fn remove_old_runtime(ms_dir: &PathBuf) {
 }
 
 fn restore_user_data(ms_dir: &PathBuf, preserved: &PreservedData) {
+    let steam_config_json = preserved.steam_config_json.as_ref().map(|data| normalize_steam_config_json(data));
+    let steam_api_key_restored = steam_config_json.as_deref().is_some_and(steam_config_has_api_key);
+
     if preserved.prefix_steam_tmp.exists() {
         let dst = ms_dir.join("prefix-steam");
         if !dst.exists() {
@@ -1152,13 +1155,86 @@ fn restore_user_data(ms_dir: &PathBuf, preserved: &PreservedData) {
     }
 
     if let Some(ref data) = preserved.setup_json {
-        let _ = fs::write(ms_dir.join("setup.json"), data);
+        restore_setup_json(ms_dir, data, steam_api_key_restored);
     }
 
-    if let Some(ref data) = preserved.steam_config_json {
-        let cache_dir = ms_dir.join("cache");
-        let _ = fs::create_dir_all(&cache_dir);
-        let _ = fs::write(cache_dir.join("steam_config.json"), data);
+    if let Some(ref data) = steam_config_json {
+        restore_steam_config(ms_dir, data);
+    }
+}
+
+fn steam_config_path(ms_dir: &Path) -> PathBuf {
+    ms_dir.join("cache").join("steam_config.json")
+}
+
+fn migration_steam_config_backup_path(ms_dir: &Path) -> PathBuf {
+    ms_dir.join(".migration-steam_config.json")
+}
+
+fn read_preserved_steam_config(ms_dir: &Path) -> Option<Vec<u8>> {
+    for path in [steam_config_path(ms_dir), migration_steam_config_backup_path(ms_dir)] {
+        let Ok(data) = fs::read(&path) else {
+            continue;
+        };
+        let normalized = normalize_steam_config_json(&data);
+        if steam_config_has_api_key(&normalized) {
+            let _ = fs::write(migration_steam_config_backup_path(ms_dir), &normalized);
+        }
+        return Some(normalized);
+    }
+    None
+}
+
+fn normalize_steam_config_json(data: &[u8]) -> Vec<u8> {
+    let Ok(mut cfg) = serde_json::from_slice::<serde_json::Map<String, serde_json::Value>>(data) else {
+        return data.to_vec();
+    };
+
+    let mut changed = false;
+    let has_runtime_key = cfg.get("steam_api_key").and_then(|v| v.as_str()).is_some_and(|key| !key.is_empty());
+    if !has_runtime_key {
+        if let Some(legacy_key) =
+            cfg.get("api_key").and_then(|v| v.as_str()).filter(|key| !key.is_empty()).map(str::to_string)
+        {
+            cfg.insert("steam_api_key".into(), json!(legacy_key));
+            changed = true;
+        }
+    }
+
+    if !changed {
+        return data.to_vec();
+    }
+
+    serde_json::to_vec_pretty(&cfg).unwrap_or_else(|_| data.to_vec())
+}
+
+fn steam_config_has_api_key(data: &[u8]) -> bool {
+    serde_json::from_slice::<serde_json::Map<String, serde_json::Value>>(data)
+        .ok()
+        .and_then(|cfg| cfg.get("steam_api_key").and_then(|v| v.as_str()).map(str::to_string))
+        .is_some_and(|key| !key.is_empty())
+}
+
+fn restore_setup_json(ms_dir: &Path, data: &[u8], steam_api_key_restored: bool) {
+    if steam_api_key_restored {
+        if let Ok(mut cfg) = serde_json::from_slice::<serde_json::Map<String, serde_json::Value>>(data) {
+            cfg.insert("steamApiKeySet".into(), json!(true));
+            if let Ok(serialized) = serde_json::to_vec_pretty(&cfg) {
+                let _ = fs::write(ms_dir.join("setup.json"), serialized);
+                return;
+            }
+        }
+    }
+    let _ = fs::write(ms_dir.join("setup.json"), data);
+}
+
+fn restore_steam_config(ms_dir: &Path, data: &[u8]) {
+    let normalized = normalize_steam_config_json(data);
+    let cache_dir = ms_dir.join("cache");
+    let _ = fs::create_dir_all(&cache_dir);
+    let _ = fs::write(cache_dir.join("steam_config.json"), &normalized);
+    if steam_config_has_api_key(&normalized) {
+        let _ = fs::write(migration_steam_config_backup_path(ms_dir), &normalized);
     }
 }
 
@@ -1598,7 +1674,7 @@ mod tests {
             .expect("write setup preferences");
         fs::write(
             ms_dir.join("cache").join("steam_config.json"),
-            br#"{"api_key":"STEAM_WEB_API_KEY","steam_id":"76561198000000000"}"#,
+            br#"{"steam_api_key":"STEAM_WEB_API_KEY","steam_id":"76561198000000000"}"#,
         )
         .expect("write Steam API key");
 
@@ -1608,11 +1684,66 @@ mod tests {
         restore_user_data(&ms_dir, &preserved);
 
         let setup = fs::read_to_string(ms_dir.join("setup.json")).expect("read restored setup");
+        let setup_json: serde_json::Value = serde_json::from_str(&setup).expect("parse restored setup");
         let steam_config =
             fs::read_to_string(ms_dir.join("cache").join("steam_config.json")).expect("read restored Steam config");
 
-        assert!(setup.contains("\"deviceName\":\"Avery\""));
-        assert!(setup.contains("\"steamApiKeySet\":true"));
+        assert_eq!(setup_json.get("deviceName").and_then(|v| v.as_str()), Some("Avery"));
+        assert_eq!(setup_json.get("steamApiKeySet").and_then(|v| v.as_bool()), Some(true));
+        assert!(steam_config.contains("steam_api_key"));
+        assert!(steam_config.contains("STEAM_WEB_API_KEY"));
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn migration_normalizes_legacy_steam_api_key_alias() {
+        let home = test_dir("restore-legacy-steam-api-key");
+        let ms_dir = crate::platform::metalsharp_home_dir_for(&home);
+        fs::create_dir_all(ms_dir.join("cache")).expect("create cache dir");
+        fs::write(ms_dir.join("setup.json"), br#"{"completed":true,"steamApiKeySet":false}"#)
+            .expect("write setup preferences");
+        fs::write(
+            ms_dir.join("cache").join("steam_config.json"),
+            br#"{"api_key":"STEAM_WEB_API_KEY","steam_id":"76561198000000000"}"#,
+        )
+        .expect("write legacy Steam API key");
+
+        let preserved = preserve_user_data(&ms_dir);
+        remove_old_runtime(&ms_dir);
+        restore_user_data(&ms_dir, &preserved);
+
+        let setup = fs::read_to_string(ms_dir.join("setup.json")).expect("read restored setup");
+        let setup_json: serde_json::Value = serde_json::from_str(&setup).expect("parse restored setup");
+        let steam_config =
+            fs::read_to_string(ms_dir.join("cache").join("steam_config.json")).expect("read restored Steam config");
+
+        assert_eq!(setup_json.get("steamApiKeySet").and_then(|v| v.as_bool()), Some(true));
+        assert!(steam_config.contains("\"steam_api_key\""));
+        assert!(steam_config.contains("STEAM_WEB_API_KEY"));
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn migration_recovers_steam_api_key_from_durable_backup() {
+        let home = test_dir("restore-steam-api-key-backup");
+        let ms_dir = crate::platform::metalsharp_home_dir_for(&home);
+        fs::create_dir_all(&ms_dir).expect("create ms dir");
+        fs::write(ms_dir.join("setup.json"), br#"{"completed":true,"steamApiKeySet":true}"#)
+            .expect("write setup preferences");
+        fs::write(
+            migration_steam_config_backup_path(&ms_dir),
+            br#"{"steam_api_key":"STEAM_WEB_API_KEY","steam_id":"76561198000000000"}"#,
+        )
+        .expect("write durable Steam config backup");
+
+        let preserved = preserve_user_data(&ms_dir);
+        remove_old_runtime(&ms_dir);
+        restore_user_data(&ms_dir, &preserved);
+
+        let steam_config =
+            fs::read_to_string(ms_dir.join("cache").join("steam_config.json")).expect("read restored Steam config");
+
+        assert!(steam_config.contains("\"steam_api_key\""));
         assert!(steam_config.contains("STEAM_WEB_API_KEY"));
         let _ = fs::remove_dir_all(home);
     }

--- a/app/src-rust/src/migrate.rs
+++ b/app/src-rust/src/migrate.rs
@@ -806,7 +806,7 @@ fn parse_steam_vdf_path(line: &str) -> Option<String> {
         }
         let value_start = start + ch.len_utf8();
         let mut escaped = false;
-        while let Some((end, value_ch)) = chars.next() {
+        for (end, value_ch) in chars.by_ref() {
             if escaped {
                 escaped = false;
                 continue;


### PR DESCRIPTION
## Summary

- Add `POST /steam/anticheat-substrate-plan` for turning protected-launch anti-cheat evidence into a staged Linux-user-space substrate plan.
- Classify the Elden Ring-style `linux64` module-mapping failure as `prototype_ready_linux_substrate` when EAC reaches Wine module mapping and exits 206.
- Include explicit prototype scope, implementation stages, acceptance gates, allowed paths, and rejected paths so the work stays evidence-based and non-evasive.

## Why

Elden Ring EAC now reaches the legitimate Wine/Linux module-mapping path on macOS, downloads the `linux64` module, and fails at module mapping. That is enough signal to start a transparent substrate prototype, but the backend needs a repeatable planning surface before runtime changes.

## Validation

- `cargo fmt --all -- --check`
- `cargo test anticheat::tests -- --nocapture`

## Notes

- This endpoint is report-only. It does not launch Steam, load protected anti-cheat modules, modify protected modules, or touch Steam state.
- The first implementation stage is a synthetic/public ELF contract lab, not protected module loading.
