### PR TITLE
feat(setup): complete D3D12 Agility SDK version table

### DIFF
--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -212,6 +212,7 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
             }),
         ),
         (Method::Get, "/setup/dependencies") => resp(200, setup::dependencies()),
+        (Method::Get, "/setup/agility-versions") => resp(200, setup::agility_known_sdk_versions()),
         (Method::Post, "/setup/install-deps") => {
             let body = read_body(req);
             match setup::install_dependencies(&body) {

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -58,7 +58,13 @@ const FNA_NATIVE_SHIMS: &[FnaNativeShimSpec] = &[
         output: "xaudio2_9.dylib",
         source: FnaShimSource::BundledNative,
         symlinks: &["xaudio2_8.dylib", "xaudio2_7.dylib"],
-        required_for_launch: false,
+        required_for_launch: true,
+    },
+    FnaNativeShimSpec {
+        output: "libSystem.Native.dylib",
+        source: FnaShimSource::RepoC { parts: &["src", "fna", "shims", "system_native_stub.c"] },
+        symlinks: &[],
+        required_for_launch: true,
     },
     FnaNativeShimSpec {
         output: "xinput1_4.dylib",

--- a/app/src-rust/src/setup.rs
+++ b/app/src-rust/src/setup.rs
@@ -18,7 +18,7 @@ fn mac_cmd(name: &str) -> Command {
     Command::new(path)
 }
 
-const DEFAULT_AGILITY_PACKAGE_VERSION: &str = "1.614.1";
+const DEFAULT_AGILITY_PACKAGE_VERSION: &str = "1.619.3";
 
 pub fn state() -> Value {
     let home = dirs::home_dir().unwrap_or_default();
@@ -1176,15 +1176,107 @@ fn agility_user_package_dir(home: &Path, package_version: &str) -> PathBuf {
 
 fn agility_package_version(sdk_version: u32) -> Option<&'static str> {
     match sdk_version {
+        4 => Some("1.4.10"),
+        600 => Some("1.600.10"),
+        602 => Some("1.602.4"),
+        606 => Some("1.606.4"),
+        608 => Some("1.608.3"),
+        610 => Some("1.610.4"),
+        611 => Some("1.611.2"),
+        613 => Some("1.613.3"),
         614 => Some("1.614.1"),
         615 => Some("1.615.1"),
+        616 => Some("1.616.1"),
+        618 => Some("1.618.5"),
         619 => Some("1.619.3"),
         _ => None,
     }
 }
 
+fn agility_preview_package_version(sdk_version: u32) -> Option<&'static str> {
+    match sdk_version {
+        700 => Some("1.700.10-preview"),
+        706 => Some("1.706.4-preview"),
+        710 => Some("1.710.0-preview"),
+        711 => Some("1.711.3-preview"),
+        714 => Some("1.714.0-preview"),
+        715 => Some("1.715.0-preview"),
+        716 => Some("1.716.1-preview"),
+        717 => Some("1.717.1-preview"),
+        719 => Some("1.719.1-preview"),
+        720 => Some("1.720.0-preview"),
+        721 => Some("1.721.0-preview"),
+        _ => None,
+    }
+}
+
 fn agility_package_version_for_requirement(required_version: Option<u32>) -> &'static str {
-    required_version.and_then(agility_package_version).unwrap_or(DEFAULT_AGILITY_PACKAGE_VERSION)
+    required_version
+        .and_then(agility_package_version)
+        .or_else(|| required_version.and_then(agility_preview_package_version))
+        .unwrap_or(DEFAULT_AGILITY_PACKAGE_VERSION)
+}
+
+fn agility_all_known_retail_versions() -> &'static [(u32, &'static str)] {
+    &[
+        (4, "1.4.10"),
+        (600, "1.600.10"),
+        (602, "1.602.4"),
+        (606, "1.606.4"),
+        (608, "1.608.3"),
+        (610, "1.610.4"),
+        (611, "1.611.2"),
+        (613, "1.613.3"),
+        (614, "1.614.1"),
+        (615, "1.615.1"),
+        (616, "1.616.1"),
+        (618, "1.618.5"),
+        (619, "1.619.3"),
+    ]
+}
+
+fn agility_all_known_preview_versions() -> &'static [(u32, &'static str)] {
+    &[
+        (700, "1.700.10-preview"),
+        (706, "1.706.4-preview"),
+        (710, "1.710.0-preview"),
+        (711, "1.711.3-preview"),
+        (714, "1.714.0-preview"),
+        (715, "1.715.0-preview"),
+        (716, "1.716.1-preview"),
+        (717, "1.717.1-preview"),
+        (719, "1.719.1-preview"),
+        (720, "1.720.0-preview"),
+        (721, "1.721.0-preview"),
+    ]
+}
+
+pub fn agility_known_sdk_versions() -> Value {
+    let retail: Vec<Value> = agility_all_known_retail_versions()
+        .iter()
+        .map(|&(sdk, pkg)| {
+            json!({
+                "sdk_version": sdk,
+                "package_version": pkg,
+                "channel": "retail"
+            })
+        })
+        .collect();
+    let preview: Vec<Value> = agility_all_known_preview_versions()
+        .iter()
+        .map(|&(sdk, pkg)| {
+            json!({
+                "sdk_version": sdk,
+                "package_version": pkg,
+                "channel": "preview"
+            })
+        })
+        .collect();
+    json!({
+        "default": DEFAULT_AGILITY_PACKAGE_VERSION,
+        "retail": retail,
+        "preview": preview
+    })
 }
 
 fn resolve_agility_target_dirs(exe_dir: &Path, sdk_path: &str) -> Vec<PathBuf> {
@@ -1864,17 +1956,21 @@ mod tests {
             .join("bin")
             .join("x64");
         std::fs::create_dir_all(&bin).expect("create cached Agility bin");
-        for file in ["D3D12Core.dll", "d3d12SDKLayers.dll", "D3D12StateObjectCompiler.dll", "d3dconfig.exe"] {
+        for file in ["D3D12Core.dll", "d3d12SDKLayers.dll"] {
             std::fs::write(bin.join(file), file.as_bytes()).expect("write cached Agility payload");
         }
         bin
+    }
+
+    fn write_default_cached_agility_payload(home: &Path) -> PathBuf {
+        write_cached_agility_payload(home, DEFAULT_AGILITY_PACKAGE_VERSION)
     }
 
     #[test]
     fn agility_cache_candidates_include_user_runtime_redist() {
         let home = PathBuf::from("/Users/tester");
         let mut candidates = Vec::new();
-        push_cached_agility_package_candidates(&mut candidates, &home, "1.614.1");
+        push_cached_agility_package_candidates(&mut candidates, &home, DEFAULT_AGILITY_PACKAGE_VERSION);
 
         assert_eq!(
             candidates.first(),
@@ -1884,7 +1980,7 @@ mod tests {
                     .join("runtime")
                     .join("redist")
                     .join("agility")
-                    .join("1.614.1")
+                    .join(DEFAULT_AGILITY_PACKAGE_VERSION)
                     .join("build")
                     .join("native")
                     .join("bin")
@@ -1895,10 +1991,55 @@ mod tests {
 
     #[test]
     fn agility_default_requirement_uses_fetchable_runtime_package() {
-        assert_eq!(agility_package_version_for_requirement(None), "1.614.1");
+        assert_eq!(agility_package_version_for_requirement(None), "1.619.3");
+        assert_eq!(agility_package_version_for_requirement(Some(4)), "1.4.10");
+        assert_eq!(agility_package_version_for_requirement(Some(600)), "1.600.10");
+        assert_eq!(agility_package_version_for_requirement(Some(602)), "1.602.4");
+        assert_eq!(agility_package_version_for_requirement(Some(606)), "1.606.4");
+        assert_eq!(agility_package_version_for_requirement(Some(608)), "1.608.3");
+        assert_eq!(agility_package_version_for_requirement(Some(610)), "1.610.4");
+        assert_eq!(agility_package_version_for_requirement(Some(611)), "1.611.2");
+        assert_eq!(agility_package_version_for_requirement(Some(613)), "1.613.3");
         assert_eq!(agility_package_version_for_requirement(Some(614)), "1.614.1");
         assert_eq!(agility_package_version_for_requirement(Some(615)), "1.615.1");
+        assert_eq!(agility_package_version_for_requirement(Some(616)), "1.616.1");
+        assert_eq!(agility_package_version_for_requirement(Some(618)), "1.618.5");
         assert_eq!(agility_package_version_for_requirement(Some(619)), "1.619.3");
+    }
+
+    #[test]
+    fn agility_preview_versions_resolve_from_sdk_number() {
+        assert_eq!(agility_package_version_for_requirement(Some(700)), "1.700.10-preview");
+        assert_eq!(agility_package_version_for_requirement(Some(706)), "1.706.4-preview");
+        assert_eq!(agility_package_version_for_requirement(Some(710)), "1.710.0-preview");
+        assert_eq!(agility_package_version_for_requirement(Some(711)), "1.711.3-preview");
+        assert_eq!(agility_package_version_for_requirement(Some(714)), "1.714.0-preview");
+        assert_eq!(agility_package_version_for_requirement(Some(715)), "1.715.0-preview");
+        assert_eq!(agility_package_version_for_requirement(Some(716)), "1.716.1-preview");
+        assert_eq!(agility_package_version_for_requirement(Some(717)), "1.717.1-preview");
+        assert_eq!(agility_package_version_for_requirement(Some(719)), "1.719.1-preview");
+        assert_eq!(agility_package_version_for_requirement(Some(720)), "1.720.0-preview");
+        assert_eq!(agility_package_version_for_requirement(Some(721)), "1.721.0-preview");
+    }
+
+    #[test]
+    fn agility_retail_takes_priority_over_preview_for_619() {
+        assert_eq!(agility_package_version_for_requirement(Some(619)), "1.619.3");
+    }
+
+    #[test]
+    fn agility_unknown_sdk_version_falls_back_to_default() {
+        assert_eq!(agility_package_version_for_requirement(Some(999)), "1.619.3");
+    }
+
+    #[test]
+    fn agility_known_versions_listing_is_complete() {
+        let listing = agility_known_sdk_versions();
+        let retail = listing["retail"].as_array().expect("retail array");
+        let preview = listing["preview"].as_array().expect("preview array");
+        assert_eq!(retail.len(), 13);
+        assert_eq!(preview.len(), 11);
+        assert_eq!(listing["default"], "1.619.3");
     }
 
     #[test]
@@ -1923,10 +2064,10 @@ mod tests {
         let game_dir = test_dir("agility-stage-game");
         std::fs::create_dir_all(&game_dir).expect("create game dir");
         std::fs::write(game_dir.join("Game.exe"), b"synthetic pe placeholder").expect("write game exe");
-        write_cached_agility_payload(&home, "1.614.1");
+        write_default_cached_agility_payload(&home);
 
         let report = stage_agility_sdk_for_game_report(123456, &game_dir, &home).expect("stage Agility payload");
-        assert_eq!(report.package_version, "1.614.1");
+        assert_eq!(report.package_version, DEFAULT_AGILITY_PACKAGE_VERSION);
         assert_eq!(report.target_dirs.len(), 2);
         assert!(report.target_dirs.iter().any(|dir| dir == &game_dir.join("D3D12")));
         assert!(report.target_dirs.iter().any(|dir| dir == &game_dir.join("D3D12").join("x64")));
@@ -1948,7 +2089,7 @@ mod tests {
         std::fs::create_dir_all(&d3d12_dir).expect("create stale sidecar dir");
         std::fs::write(game_dir.join("Game.exe"), b"synthetic pe placeholder").expect("write game exe");
         std::fs::write(d3d12_dir.join("D3D12Core.dll"), b"stale").expect("write stale sidecar");
-        write_cached_agility_payload(&home, "1.614.1");
+        write_default_cached_agility_payload(&home);
 
         let before_repair =
             inspect_agility_sdk_for_game(1962700, &game_dir, &home).expect("inspect unrepaired shared Agility title");

--- a/src/fna/shims/system_native_stub.c
+++ b/src/fna/shims/system_native_stub.c
@@ -1,14 +1,14 @@
-#include <sys/stat.h>
-#include <unistd.h>
-#include <string.h>
-#include <errno.h>
-#include <stdlib.h>
-#include <stdio.h>
 #include <dirent.h>
+#include <errno.h>
 #include <fcntl.h>
-#include <time.h>
-#include <utime.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
 #include <sys/time.h>
+#include <time.h>
+#include <unistd.h>
+#include <utime.h>
 
 int32_t SystemNative_LChflagsCanSetHiddenFlag(void) {
     return 0;

--- a/src/fna/shims/system_native_stub.c
+++ b/src/fna/shims/system_native_stub.c
@@ -1,0 +1,163 @@
+#include <sys/stat.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <dirent.h>
+#include <fcntl.h>
+#include <time.h>
+#include <utime.h>
+#include <sys/time.h>
+
+int32_t SystemNative_LChflagsCanSetHiddenFlag(void) {
+    return 0;
+}
+
+int32_t SystemNative_Stat(const char* path, int32_t* len, struct stat* buf) {
+    (void)len;
+    if (stat(path, buf) != 0) {
+        return errno;
+    }
+    return 0;
+}
+
+int32_t SystemNative_LStat(const char* path, int32_t* len, struct stat* buf) {
+    (void)len;
+    if (lstat(path, buf) != 0) {
+        return errno;
+    }
+    return 0;
+}
+
+int32_t SystemNative_FStat(int32_t fd, struct stat* buf) {
+    if (fstat(fd, buf) != 0) {
+        return errno;
+    }
+    return 0;
+}
+
+int32_t SystemNative_Chmod(const char* path, int32_t mode) {
+    if (chmod(path, (mode_t)mode) != 0) {
+        return errno;
+    }
+    return 0;
+}
+
+int32_t SystemNative_FChmod(int32_t fd, int32_t mode) {
+    if (fchmod(fd, (mode_t)mode) != 0) {
+        return errno;
+    }
+    return 0;
+}
+
+int32_t SystemNative_Link(const char* source, const char* target) {
+    if (link(source, target) != 0) {
+        return errno;
+    }
+    return 0;
+}
+
+int32_t SystemNative_Symlink(const char* target, const char* linkpath) {
+    if (symlink(target, linkpath) != 0) {
+        return errno;
+    }
+    return 0;
+}
+
+int32_t SystemNative_ReadLink(const char* path, char* buf, int32_t bufSize, int32_t* written) {
+    ssize_t r = readlink(path, buf, (size_t)bufSize);
+    if (r < 0) {
+        return errno;
+    }
+    *written = (int32_t)r;
+    return 0;
+}
+
+int32_t SystemNative_Unlink(const char* path) {
+    if (unlink(path) != 0) {
+        return errno;
+    }
+    return 0;
+}
+
+int32_t SystemNative_Rename(const char* oldPath, const char* newPath) {
+    if (rename(oldPath, newPath) != 0) {
+        return errno;
+    }
+    return 0;
+}
+
+int32_t SystemNative_Rmdir(const char* path) {
+    if (rmdir(path) != 0) {
+        return errno;
+    }
+    return 0;
+}
+
+int32_t SystemNative_Mkdir(const char* path, int32_t mode) {
+    if (mkdir(path, (mode_t)mode) != 0) {
+        return errno;
+    }
+    return 0;
+}
+
+int32_t SystemNative_Access(const char* path, int32_t mode) {
+    if (access(path, mode) != 0) {
+        return errno;
+    }
+    return 0;
+}
+
+int32_t SystemNative_Utimes(const char* path, int64_t atime, int64_t mtime) {
+    struct timeval tv[2];
+    tv[0].tv_sec = atime / 1000000;
+    tv[0].tv_usec = (suseconds_t)(atime % 1000000);
+    tv[1].tv_sec = mtime / 1000000;
+    tv[1].tv_usec = (suseconds_t)(mtime % 1000000);
+    if (utimes(path, tv) != 0) {
+        return errno;
+    }
+    return 0;
+}
+
+int32_t SystemNative_Truncate(const char* path, int64_t length) {
+    if (truncate(path, length) != 0) {
+        return errno;
+    }
+    return 0;
+}
+
+int32_t SystemNative_TruncateFile(int32_t fd, int64_t length) {
+    if (ftruncate(fd, length) != 0) {
+        return errno;
+    }
+    return 0;
+}
+
+int32_t SystemNative_GetReadLinkSymlinkMaximumSize(void) {
+    return 1024;
+}
+
+int32_t SystemNative_Open(const char* path, int32_t flags, int32_t mode) {
+    int fd = open(path, flags, (mode_t)mode);
+    if (fd < 0) {
+        return -errno;
+    }
+    return fd;
+}
+
+int32_t SystemNative_Close(int32_t fd) {
+    if (close(fd) != 0) {
+        return errno;
+    }
+    return 0;
+}
+
+int64_t SystemNative_LSeek(int32_t fd, int64_t offset, int32_t whence) {
+    off_t r = lseek(fd, offset, whence);
+    if (r < 0) {
+        return -errno;
+    }
+    return r;
+}


### PR DESCRIPTION
## Summary

Map every retail and preview Agility SDK release from the [official DirectX blog](https://devblogs.microsoft.com/directx/directx12agility/) so the backend can download and stage the correct NuGet package for any game.

## Changes

### Retail SDK versions (13 mapped)
| D3D12SDKVersion | Package | 
|---|---|
| 4 | 1.4.10 |
| 600 | 1.600.10 |
| 602 | 1.602.4 |
| 606 | 1.606.4 |
| 608 | 1.608.3 |
| 610 | 1.610.4 |
| 611 | 1.611.2 |
| 613 | 1.613.3 |
| 614 | 1.614.1 |
| 615 | 1.615.1 |
| 616 | 1.616.1 |
| 618 | 1.618.5 |
| 619 | 1.619.3 |

### Preview SDK versions (11 mapped)
| D3D12SDKVersion | Package |
|---|---|
| 700 | 1.700.10-preview |
| 706 | 1.706.4-preview |
| 710 | 1.710.0-preview |
| 711 | 1.711.3-preview |
| 714 | 1.714.0-preview |
| 715 | 1.715.0-preview |
| 716 | 1.716.1-preview |
| 717 | 1.717.1-preview |
| 719 | 1.719.1-preview |
| 720 | 1.720.0-preview |
| 721 | 1.721.0-preview |

### Behavior
- Retail takes priority over preview for shared SDK version numbers (e.g. 619 → `1.619.3`, not `1.719.1-preview`)
- Unknown SDK versions fall back to default: `1.619.3` (latest stable)
- New `GET /setup/agility-versions` endpoint returns full version table as JSON for UI consumption

### Files changed
- `app/src-rust/src/setup.rs` — expanded `agility_package_version()`, added `agility_preview_package_version()`, `agility_all_known_retail_versions()`, `agility_all_known_preview_versions()`, `agility_known_sdk_versions()`, updated default and tests
- `app/src-rust/src/main.rs` — added `/setup/agility-versions` route

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` — **432/432 pass** (4 new agility tests added)