### PR TITLE
fix(d3d12): eliminate shader cache data race + always attach vertex descriptor

### DIFF
--- a/vendor/dxmt/src/d3d12/d3d12_pipeline_state.cpp
+++ b/vendor/dxmt/src/d3d12/d3d12_pipeline_state.cpp
@@ -1005,7 +1005,10 @@ bool MTLD3D12PipelineState::CompileShader(const void *bytecode, SIZE_T size,
 
             if (out_func.handle) {
               PSTRACE("  DXIL shader compiled OK! entry=%s", entry_name);
-              s_shader_cache[hash] = out_func;
+              {
+                std::lock_guard<std::mutex> lock(s_shader_mutex);
+                s_shader_cache[hash] = out_func;
+              }
 
               if (type == ShaderType::Vertex)
                 m_vs_uses_stage_in = true;
@@ -1073,7 +1076,10 @@ bool MTLD3D12PipelineState::CompileShader(const void *bytecode, SIZE_T size,
                 out_func = library.newFunction("ps_main");
               if (out_func.handle) {
                 PSTRACE("  DXIL loaded from cache OK! entry=%s", fn_name);
-                s_shader_cache[hash] = out_func;
+                {
+                  std::lock_guard<std::mutex> lock(s_shader_mutex);
+                  s_shader_cache[hash] = out_func;
+                }
                 if (type == ShaderType::Vertex)
                   m_vs_uses_stage_in = true;
                 char *tg = strstr(rbuf, "\"tg_size\"");
@@ -1693,7 +1699,7 @@ bool MTLD3D12PipelineState::Compile() {
       PSTRACE("D3D12 PSO input-layout compiled for SM50 vertex pulling; Metal vertex descriptor disabled");
     }
   }
-  if (m_vs_uses_stage_in) {
+  {
     constexpr uint32_t kSyntheticStageInAttributes = 16;
     constexpr uint32_t kSyntheticStageInStride = 16 * kSyntheticStageInAttributes;
     for (uint32_t i = 0; i < kSyntheticStageInAttributes && i < WMT_MAX_VERTEX_ATTRIBUTES; i++) {
@@ -1709,7 +1715,7 @@ bool MTLD3D12PipelineState::Compile() {
     vtx_desc.layouts[0].step_function = WMTVertexStepFunctionPerVertex;
     vtx_desc.layouts[0].step_rate = 1;
     info.vertex_descriptor = &vtx_desc;
-    PSTRACE("D3D12 PSO synthetic vertex descriptor attached for DXIL stage_in attrs=%u stride=%u",
+    PSTRACE("D3D12 PSO synthetic vertex descriptor attached attrs=%u stride=%u",
             vtx_desc.attribute_count, vtx_desc.layouts[0].stride);
   }
 


### PR DESCRIPTION
## Problem

Subnautica 2 (UE5/DXIL on M12/D3D12) shows a black screen. Every graphics PSO compile fails with:

> Vertex function has input attributes but no vertex descriptor was set.

All 23 draw calls are skipped. PEAK and Schedule I (Unity/D3D11) are unaffected.

## Root Cause

Two bugs found via multi-agent investigation:

### 1. Data race on s_shader_cache

The DXIL compile path (d3d12_pipeline_state.cpp:1008) and DXIL cache-load path (:1076) write to the shared std::unordered_map without holding s_shader_mutex. The SM50 path (:1258) correctly locks. With async PSO workers enabled (DXMT_ASYNC_PIPELINE_COMPILE=1, DXMT_D3D12_PSO_WORKERS=6), concurrent writes cause undefined behavior — a rehash from one thread invalidates another thread's iterator.

### 2. Vertex descriptor gated on m_vs_uses_stage_in

The synthetic vertex descriptor block was inside if (m_vs_uses_stage_in), meaning any code path that failed to set the flag would skip attaching info.vertex_descriptor. The DXIL paths do set it, but the data race above could corrupt the flag or prevent it from being visible to the compile thread, causing Metal to reject the PSO.

## Fix

1. Wrap both DXIL s_shader_cache writes with std::lock_guard<std::mutex>(s_shader_mutex)
2. Remove the if (m_vs_uses_stage_in) guard — always attach the synthetic vertex descriptor unconditionally

## Testing

- 25/25 C++ tests pass
- Full build succeeds (cmake Release + all targets)