### PR TITLE
feat(install): add GPTK Wine to install wizard, dependency checks, and migration

### DIFF
--- a/app/bundles/steamwebhelper-wrapper-gptk.c
+++ b/app/bundles/steamwebhelper-wrapper-gptk.c
@@ -1,0 +1,52 @@
+#include <windows.h>
+#include <stdio.h>
+#include <string.h>
+
+int WINAPI WinMain(HINSTANCE h, HINSTANCE p, LPSTR cmd, int show) {
+    char ep[MAX_PATH];
+    GetModuleFileNameA(NULL, ep, MAX_PATH);
+    char *sl = strrchr(ep, '\\');
+    if (!sl) return 1;
+    *sl = 0;
+    char re[MAX_PATH];
+    snprintf(re, MAX_PATH, "%s\\steamwebhelper_real.exe", ep);
+    if (GetFileAttributesA(re) == INVALID_FILE_ATTRIBUTES) {
+        snprintf(re, MAX_PATH, "%s\\steamwebhelper.exe.bak", ep);
+        if (GetFileAttributesA(re) == INVALID_FILE_ATTRIBUTES) return 1;
+    }
+    char cl[16384];
+    if (strlen(cmd) > 0)
+        snprintf(cl, sizeof(cl),
+            "\"%s\" %s "
+            "--no-sandbox "
+            "--in-process-gpu "
+            "--disable-gpu "
+            "--disable-gpu-compositing "
+            "--use-angle=swiftshader-webgl "
+            "--disable-software-rasterizer "
+            "--disable-features=WebRTC "
+            "--disable-dev-shm-usage",
+            re, cmd);
+    else
+        snprintf(cl, sizeof(cl),
+            "\"%s\" "
+            "--no-sandbox "
+            "--in-process-gpu "
+            "--disable-gpu "
+            "--disable-gpu-compositing "
+            "--use-angle=swiftshader-webgl "
+            "--disable-software-rasterizer "
+            "--disable-features=WebRTC "
+            "--disable-dev-shm-usage",
+            re);
+    STARTUPINFOA si = {sizeof(si)};
+    PROCESS_INFORMATION pi = {0};
+    if (!CreateProcessA(re, cl, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi))
+        return 1;
+    WaitForSingleObject(pi.hProcess, INFINITE);
+    DWORD ec = 1;
+    GetExitCodeProcess(pi.hProcess, &ec);
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+    return (int)ec;
+}

--- a/app/src-rust/src/bottles.rs
+++ b/app/src-rust/src/bottles.rs
@@ -334,6 +334,18 @@ fn steam_launch_prefix() -> PathBuf {
     crate::platform::metalsharp_home_dir().join("prefix-steam")
 }
 
+pub fn gptk_launch_prefix() -> PathBuf {
+    crate::platform::metalsharp_home_dir().join("prefix-gptk")
+}
+
+fn prefix_for_pipeline(pipeline: crate::mtsp::engine::PipelineId) -> PathBuf {
+    if pipeline == crate::mtsp::engine::PipelineId::Gptk {
+        gptk_launch_prefix()
+    } else {
+        steam_launch_prefix()
+    }
+}
+
 pub fn bottle_dir(id: &str) -> PathBuf {
     bottles_root().join(id)
 }
@@ -484,7 +496,7 @@ fn steam_compatdata_record(
         bottle_id: manifest.id.clone(),
         compatdata_path: steam_compatdata_dir(appid).to_string_lossy().to_string(),
         prefix_path: manifest.prefix_path.clone(),
-        steam_prefix_path: steam_launch_prefix().to_string_lossy().to_string(),
+        steam_prefix_path: manifest.prefix_path.clone(),
         game_install_path: manifest.game_install_path.clone(),
         runtime_profile: manifest.runtime_profile,
         launch_pipeline: pipeline_preference_id(pipeline).to_string(),
@@ -645,7 +657,7 @@ fn ensure_steam_game_bottle_inner(
         custom_name: None,
         bottle_type: BottleType::Steam,
         steam_app_id: Some(appid),
-        prefix_path: steam_launch_prefix().to_string_lossy().to_string(),
+        prefix_path: prefix_for_pipeline(pipeline).to_string_lossy().to_string(),
         arch: BottleArch::Wow64,
         runtime_profile,
         preferred_pipeline: None,
@@ -667,7 +679,7 @@ fn ensure_steam_game_bottle_inner(
     manifest.name = manifest.custom_name.clone().unwrap_or_else(|| name.to_string());
     manifest.bottle_type = BottleType::Steam;
     manifest.steam_app_id = Some(appid);
-    manifest.prefix_path = steam_launch_prefix().to_string_lossy().to_string();
+    manifest.prefix_path = prefix_for_pipeline(pipeline).to_string_lossy().to_string();
     manifest.runtime_profile = runtime_profile;
     manifest.installed_components =
         merge_components(manifest.installed_components, default_components_for(runtime_profile));

--- a/app/src-rust/src/bottles.rs
+++ b/app/src-rust/src/bottles.rs
@@ -50,6 +50,7 @@ pub enum RuntimeProfile {
     M11,
     M12,
     M13,
+    Gptk,
     Dotnet,
     Win32Dotnet,
     Webview,
@@ -415,6 +416,7 @@ fn pipeline_preference_id(pipeline: crate::mtsp::engine::PipelineId) -> &'static
         crate::mtsp::engine::PipelineId::M11 => "m11",
         crate::mtsp::engine::PipelineId::M12 => "m12",
         crate::mtsp::engine::PipelineId::M13 => "m13",
+        crate::mtsp::engine::PipelineId::Gptk => "gptk_wine",
         crate::mtsp::engine::PipelineId::M32 => "m32",
         crate::mtsp::engine::PipelineId::FnaArm64 => "fna_arm64",
         crate::mtsp::engine::PipelineId::Steam => "steam",
@@ -796,6 +798,7 @@ pub fn classify_installer(source_installer: &Path) -> InstallerClassification {
             crate::mtsp::engine::PipelineId::M11 => RuntimeProfile::M11,
             crate::mtsp::engine::PipelineId::M12 => RuntimeProfile::M12,
             crate::mtsp::engine::PipelineId::M13 => RuntimeProfile::M13,
+            crate::mtsp::engine::PipelineId::Gptk => RuntimeProfile::Gptk,
             _ => RuntimeProfile::Plain,
         }
     };
@@ -2028,6 +2031,13 @@ fn runtime_profile_definition(profile: RuntimeProfile) -> RuntimeProfileDefiniti
             &["d3d11", "d3d12", "dxgi", "d3d10", "vcrun2019", "gpu_vendor_stubs", "gptk_amd_stub"][..],
             crate::mtsp::engine::PipelineId::M13,
         ),
+        RuntimeProfile::Gptk => (
+            "GPTK Wine",
+            BottleArch::Win64,
+            true,
+            &["d3d11", "d3d12", "dxgi", "d3d10", "vcrun2019", "gpu_vendor_stubs", "gptk_amd_stub"][..],
+            crate::mtsp::engine::PipelineId::Gptk,
+        ),
         RuntimeProfile::Dotnet => (
             ".NET",
             BottleArch::Win64,
@@ -2137,7 +2147,8 @@ fn parse_runtime_profile(value: &str) -> Option<RuntimeProfile> {
         "m10" => Some(RuntimeProfile::M10),
         "m11" => Some(RuntimeProfile::M11),
         "m12" => Some(RuntimeProfile::M12),
-        "m13" | "gptk" | "d3dmetal" => Some(RuntimeProfile::M13),
+        "m13" | "d3dmetal" => Some(RuntimeProfile::M13),
+        "gptk_wine" | "gptk-wine" => Some(RuntimeProfile::Gptk),
         "dotnet" => Some(RuntimeProfile::Dotnet),
         "win32_dotnet" | "win32dotnet" => Some(RuntimeProfile::Win32Dotnet),
         "webview" => Some(RuntimeProfile::Webview),

--- a/app/src-rust/src/installer.rs
+++ b/app/src-rust/src/installer.rs
@@ -177,6 +177,7 @@ fn run_install_all() {
         ("Scripts and Tools", Box::new(install_scripts_tools_bundle)),
         ("DXMT Metal Runtime", Box::new(install_dxmt_runtime)),
         ("GPTK D3DMetal Runtime", Box::new(install_gptk_runtime)),
+        ("GPTK Wine (Homebrew)", Box::new(|_| install_gptk_wine())),
         ("Goldberg Steam Emulator", Box::new(install_goldberg)),
         ("Steam Bridge Shim", Box::new(install_steam_bridge)),
         ("Offline EAC Mode", Box::new(install_eac_toggle)),
@@ -336,6 +337,42 @@ fn install_rosetta() -> Result<bool, String> {
     }
 }
 
+fn install_gptk_wine() -> Result<bool, String> {
+    let candidates = [PathBuf::from("/opt/homebrew/bin/wine64"), PathBuf::from("/usr/local/bin/wine64")];
+    if candidates.iter().any(|p| p.exists()) {
+        return Ok(false);
+    }
+
+    let rosetta_plist = PathBuf::from("/Library/Apple/System/Library/LaunchDaemons/com.apple.oahd.plist");
+    if !rosetta_plist.exists() {
+        let rosetta_output = mac_cmd("softwareupdate")
+            .args(["--install-rosetta", "--agree-to-license"])
+            .output()
+            .map_err(|e| format!("failed to install rosetta for GPTK: {}", e))?;
+        if !rosetta_output.status.success()
+            && !String::from_utf8_lossy(&rosetta_output.stderr).contains("already installed")
+        {
+            return Err(format!(
+                "Rosetta 2 required for GPTK but install failed: {}",
+                String::from_utf8_lossy(&rosetta_output.stderr)
+            ));
+        }
+    }
+
+    let brew = find_brew()?;
+    let output = Command::new(&brew)
+        .args(["install", "--cask", "game-porting-toolkit"])
+        .output()
+        .map_err(|e| format!("brew install game-porting-toolkit failed: {}", e))?;
+
+    let combined = format!("{}{}", String::from_utf8_lossy(&output.stdout), String::from_utf8_lossy(&output.stderr));
+
+    if output.status.success() || combined.contains("already installed") {
+        Ok(true)
+    } else {
+        Err(combined.lines().last().unwrap_or("brew install game-porting-toolkit failed").into())
+    }
+}
 fn install_xcode_cli() -> Result<bool, String> {
     if check_command("clang") {
         return Ok(false);

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -429,9 +429,13 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
                                 Err(e) => return resp(500, json!({"ok": false, "error": e.to_string()})),
                             };
                             let compatdata = bottles::load_steam_compatdata(id).ok();
-                            let steam_started = match steam::ensure_wine_steam_ready_for_game_launch() {
-                                Ok(started) => started,
-                                Err(e) => return resp(500, json!({"ok": false, "error": e.to_string()})),
+                            let steam_started = if pipeline == mtsp::engine::PipelineId::Gptk {
+                                false
+                            } else {
+                                match steam::ensure_wine_steam_ready_for_game_launch() {
+                                    Ok(started) => started,
+                                    Err(e) => return resp(500, json!({"ok": false, "error": e.to_string()})),
+                                }
                             };
                             let bottle_prefix = std::path::PathBuf::from(&bottle.prefix_path);
                             mtsp::launcher::launch_steam_bottle_with_pipeline(id, pipeline, &bottle_prefix, &env).map(

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -361,6 +361,36 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
                 },
             }
         },
+        (Method::Post, "/steam/gptk-launch") => {
+            app_log("Launching GPTK Steam...");
+            match steam::launch_gptk_steam() {
+                Ok(v) => resp(200, v),
+                Err(e) => {
+                    app_issue_log("steam-launch", "gptk-steam", &e.to_string(), &[]);
+                    resp(500, json!({"ok": false, "error": e.to_string()}))
+                },
+            }
+        },
+        (Method::Post, "/steam/gptk-stop") => {
+            app_log("Stopping GPTK Steam...");
+            match steam::stop_gptk_steam() {
+                Ok(v) => resp(200, v),
+                Err(e) => {
+                    app_issue_log("steam-stop", "gptk-steam", &e.to_string(), &[]);
+                    resp(500, json!({"ok": false, "error": e.to_string()}))
+                },
+            }
+        },
+        (Method::Post, "/steam/gptk-install") => {
+            app_log("Installing Steam into GPTK prefix...");
+            match steam::install_gptk_steam() {
+                Ok(v) => resp(200, v),
+                Err(e) => {
+                    app_issue_log("steam-install", "gptk-steam", &e.to_string(), &[]);
+                    resp(500, json!({"ok": false, "error": e.to_string()}))
+                },
+            }
+        },
         (Method::Post, "/steam/mac-launch-game") => {
             let body = read_body(req);
             let appid = body.get("appid").and_then(|v| v.as_u64());

--- a/app/src-rust/src/migrate.rs
+++ b/app/src-rust/src/migrate.rs
@@ -294,6 +294,7 @@ fn runtime_core_ready(ms_dir: &Path) -> bool {
         ms_dir.join("runtime").join("eac-toggle").join("x86_64-windows").join("_winhttp.dll"),
         ms_dir.join("configs").join("mtsp-rules.toml"),
         runtime_wine.join("etc").join("dxmt.conf"),
+        PathBuf::from("/opt/homebrew/bin/wine64"),
     ]
     .iter()
     .all(|path| path.exists())

--- a/app/src-rust/src/migrate.rs
+++ b/app/src-rust/src/migrate.rs
@@ -294,7 +294,6 @@ fn runtime_core_ready(ms_dir: &Path) -> bool {
         ms_dir.join("runtime").join("eac-toggle").join("x86_64-windows").join("_winhttp.dll"),
         ms_dir.join("configs").join("mtsp-rules.toml"),
         runtime_wine.join("etc").join("dxmt.conf"),
-        PathBuf::from("/opt/homebrew/bin/wine64"),
     ]
     .iter()
     .all(|path| path.exists())

--- a/app/src-rust/src/mtsp/engine.rs
+++ b/app/src-rust/src/mtsp/engine.rs
@@ -641,7 +641,14 @@ mod tests {
             .collect();
         assert_eq!(
             selectable,
-            vec![PipelineId::Gptk, PipelineId::M12, PipelineId::M11, PipelineId::M10, PipelineId::M9, PipelineId::FnaArm64]
+            vec![
+                PipelineId::Gptk,
+                PipelineId::M12,
+                PipelineId::M11,
+                PipelineId::M10,
+                PipelineId::M9,
+                PipelineId::FnaArm64
+            ]
         );
 
         let labels: Vec<_> = selectable.iter().map(|pipeline| pipeline.user_selectable_name().unwrap()).collect();

--- a/app/src-rust/src/mtsp/engine.rs
+++ b/app/src-rust/src/mtsp/engine.rs
@@ -10,6 +10,7 @@ pub enum PipelineId {
     M11,
     M12,
     M13,
+    Gptk,
     M32,
     FnaArm64,
     Steam,
@@ -77,6 +78,36 @@ pub fn pipelines() -> &'static Vec<PipelineNode> {
                 launch_args: vec![],
                 alternatives: vec![PipelineId::M12, PipelineId::M11, PipelineId::M10, PipelineId::M9],
                 shader_cache_subdir: None,
+            },
+            PipelineNode {
+                id: PipelineId::Gptk,
+                name: "GPTK",
+                description: "D3D11/D3D12 via Apple Game Porting Toolkit (Homebrew Wine)",
+                backend: "gptk",
+                graphics_backend: "gptk",
+                experimental: false,
+                requires_wine: true,
+                wine_overrides: Some("d3d10,d3d11,d3d12,dxgi=n,b;gameoverlayrenderer,gameoverlayrenderer64=d"),
+                dyld_paths: vec![],
+                winedllpath_dirs: vec![],
+                deploy_dlls: vec![
+                    DllDeploy { source_subpath: "lib/gptk/x86_64-windows", filename: "d3d11.dll" },
+                    DllDeploy { source_subpath: "lib/gptk/x86_64-windows", filename: "d3d12.dll" },
+                    DllDeploy { source_subpath: "lib/gptk/x86_64-windows", filename: "dxgi.dll" },
+                    DllDeploy { source_subpath: "lib/gptk/x86_64-windows", filename: "d3d10.dll" },
+                    DllDeploy { source_subpath: "lib/gptk/x86_64-windows", filename: "nvapi64.dll" },
+                    DllDeploy { source_subpath: "lib/gptk/x86_64-windows", filename: "atidxx64.dll" },
+                ],
+                env_vars: vec![],
+                launch_args: vec![],
+                alternatives: vec![
+                    PipelineId::M12,
+                    PipelineId::M11,
+                    PipelineId::M10,
+                    PipelineId::M9,
+                    PipelineId::Steam,
+                ],
+                shader_cache_subdir: Some("gptk"),
             },
             PipelineNode {
                 id: PipelineId::M12,
@@ -374,11 +405,20 @@ impl PipelineId {
     }
 
     pub fn is_user_selectable(self) -> bool {
-        matches!(self, PipelineId::M12 | PipelineId::M11 | PipelineId::M10 | PipelineId::M9 | PipelineId::FnaArm64)
+        matches!(
+            self,
+            PipelineId::Gptk
+                | PipelineId::M12
+                | PipelineId::M11
+                | PipelineId::M10
+                | PipelineId::M9
+                | PipelineId::FnaArm64
+        )
     }
 
     pub fn user_selectable_id(self) -> Option<&'static str> {
         match self {
+            PipelineId::Gptk => Some("gptk"),
             PipelineId::M12 => Some("m12"),
             PipelineId::M11 => Some("m11"),
             PipelineId::M10 => Some("m10"),
@@ -390,6 +430,7 @@ impl PipelineId {
 
     pub fn user_selectable_name(self) -> Option<&'static str> {
         match self {
+            PipelineId::Gptk => Some("GPTK"),
             PipelineId::M12 => Some("M12"),
             PipelineId::M11 => Some("M11"),
             PipelineId::M10 => Some("M10"),
@@ -423,7 +464,8 @@ impl PipelineId {
             "dxmt" | "auto_dxmt" | "metalsharp_dxmt" => Some(PipelineId::Dxmt),
             "m11" | "d3d11" | "dx11" | "steam_d3dmetal_perf" | "steam_metalfx" => Some(PipelineId::M11),
             "m12" | "d3d12" | "dx12" => Some(PipelineId::M12),
-            "m13" | "gptk" | "d3dmetal" | "steam_d3dmetal" => Some(PipelineId::M13),
+            "m13" | "d3dmetal" | "steam_d3dmetal" => Some(PipelineId::M13),
+            "gptk_wine" | "gptk-wine" => Some(PipelineId::Gptk),
             "m10" | "d3d10" | "dx10" => Some(PipelineId::M10),
             "m9" | "d3d9" | "dx9" => Some(PipelineId::M9),
             "m32" | "m32_w" => Some(PipelineId::M32),
@@ -439,6 +481,7 @@ impl PipelineId {
         match self {
             PipelineId::Dxmt | PipelineId::M9 | PipelineId::M10 | PipelineId::M11 | PipelineId::M12 => "dxmt",
             PipelineId::M13 => "gptk_d3dmetal",
+            PipelineId::Gptk => "gptk_wine",
             PipelineId::M32 => "wined3d_32",
             PipelineId::FnaArm64 => "xna_fna_arm64",
             PipelineId::Steam => "steam",
@@ -598,11 +641,11 @@ mod tests {
             .collect();
         assert_eq!(
             selectable,
-            vec![PipelineId::M12, PipelineId::M11, PipelineId::M10, PipelineId::M9, PipelineId::FnaArm64]
+            vec![PipelineId::Gptk, PipelineId::M12, PipelineId::M11, PipelineId::M10, PipelineId::M9, PipelineId::FnaArm64]
         );
 
         let labels: Vec<_> = selectable.iter().map(|pipeline| pipeline.user_selectable_name().unwrap()).collect();
-        assert_eq!(labels, vec!["M12", "M11", "M10", "M9", "Mono/FNA"]);
+        assert_eq!(labels, vec!["GPTK", "M12", "M11", "M10", "M9", "Mono/FNA"]);
 
         for hidden in [
             PipelineId::Dxmt,

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -789,10 +789,102 @@ fn launch_gptk(appid: u32, node: &PipelineNode) -> Result<(u32, &'static str), B
     launch_gptk_with_context(appid, node, None, &[], None)
 }
 
+fn gptk_ensure_steam_in_prefix(
+    wine: &Path,
+    gptk_prefix: &Path,
+    steam_prefix: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let gptk_steam_dir = gptk_prefix.join("drive_c").join("Program Files (x86)").join("Steam");
+    let source_steam_dir = steam_prefix.join("drive_c").join("Program Files (x86)").join("Steam");
+
+    if !gptk_steam_dir.exists() && source_steam_dir.exists() {
+        let parent = gptk_steam_dir.parent().ok_or("no parent for Steam dir")?;
+        std::fs::create_dir_all(parent)?;
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(&source_steam_dir, &gptk_steam_dir).map_err(|e| {
+                format!(
+                    "failed to symlink Steam into GPTK prefix: {} -> {}: {}",
+                    source_steam_dir.display(),
+                    gptk_steam_dir.display(),
+                    e
+                )
+            })?;
+        }
+    }
+
+    if !gptk_prefix.join("drive_c").join("windows").exists() {
+        let prefix_str = gptk_prefix.to_string_lossy().to_string();
+        let _ = Command::new(wine)
+            .env("WINEPREFIX", &prefix_str)
+            .env("WINEDEBUG", "-all")
+            .arg("wineboot")
+            .arg("--init")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+    }
+
+    if gptk_steam_dir.exists() {
+        crate::steam::deploy_steamwebhelper_wrapper(&gptk_steam_dir);
+    }
+
+    Ok(())
+}
+
+fn gptk_is_steam_running_in_prefix(gptk_prefix: &Path) -> bool {
+    let prefix_str = gptk_prefix.to_string_lossy().to_string();
+    crate::steam::is_wine_steam_running()
+        || std::process::Command::new("ps")
+            .args(["axo", "command="])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|lines| {
+                lines.lines().any(|line| {
+                    line.contains(&prefix_str)
+                        && (line.contains("Steam.exe") || line.contains("steam.exe"))
+                        && !line.contains(" rg ")
+                })
+            })
+            .unwrap_or(false)
+}
+
+fn gptk_spawn_steam(wine: &Path, prefix: &Path) -> Result<u32, Box<dyn std::error::Error>> {
+    let steam_dir = prefix.join("drive_c").join("Program Files (x86)").join("Steam");
+    let exe = steam_dir.join("Steam.exe");
+
+    if !exe.exists() {
+        return Err("Steam is not installed in GPTK prefix".into());
+    }
+
+    let prefix_str = prefix.to_string_lossy().to_string();
+
+    let mut cmd = Command::new(wine);
+    cmd.current_dir(&steam_dir)
+        .env("WINEPREFIX", &prefix_str)
+        .env("WINEDEBUG", "-all")
+        .env("WINEDEBUGGER", "none")
+        .env("STEAM_RUNTIME", "0")
+        .env("MS_FWD_COMPAT_GL_CTX", "1")
+        .env(
+            "WINEDLLOVERRIDES",
+            "dxgi,d3d11,d3d10core=n,b;bcrypt=b;ncrypt=b;gameoverlayrenderer,gameoverlayrenderer64=d",
+        )
+        .arg(&exe)
+        .args(["-no-cef-sandbox", "-cef-single-process", "-noverifyfiles", "-no-dwrite"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+
+    let child = cmd.spawn()?;
+    Ok(child.id())
+}
+
 fn launch_gptk_with_context(
     appid: u32,
     node: &PipelineNode,
-    prefix_override: Option<&Path>,
+    _prefix_override: Option<&Path>,
     extra_env: &[(String, String)],
     log_path: Option<&Path>,
 ) -> Result<(u32, &'static str), Box<dyn std::error::Error>> {
@@ -812,15 +904,51 @@ fn launch_gptk_with_context(
         },
     };
 
+    if crate::steam::is_wine_steam_running() {
+        let _ = crate::steam::stop_wine_steam();
+        std::thread::sleep(std::time::Duration::from_secs(2));
+    }
+    let ms_root = crate::platform::metalsharp_home_dir_for(&home).join("runtime").join("wine");
+    let ms_wineserver = ms_root.join("bin").join("wineserver");
+    if ms_wineserver.exists() {
+        let prefix_str =
+            crate::platform::metalsharp_home_dir_for(&home).join("prefix-steam").to_string_lossy().to_string();
+        let _ = Command::new(&ms_wineserver)
+            .env("WINEPREFIX", &prefix_str)
+            .arg("-k")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    }
+
+    let gptk_prefix = crate::bottles::gptk_launch_prefix();
+    let steam_prefix = crate::platform::metalsharp_home_dir_for(&home).join("prefix-steam");
+
+    gptk_ensure_steam_in_prefix(&wine, &gptk_prefix, &steam_prefix)?;
+
+    if !gptk_is_steam_running_in_prefix(&gptk_prefix) {
+        gptk_spawn_steam(&wine, &gptk_prefix)?;
+        let mut ready = false;
+        for _ in 0..12 {
+            std::thread::sleep(std::time::Duration::from_secs(1));
+            if gptk_is_steam_running_in_prefix(&gptk_prefix) {
+                ready = true;
+                break;
+            }
+        }
+        if !ready {
+            return Err("GPTK Steam was started but did not become ready".into());
+        }
+        std::thread::sleep(std::time::Duration::from_secs(5));
+    }
+
     let recipe = super::recipe::build_launch_recipe(appid, node)?;
     let game_dir = recipe.game_dir.as_ref().ok_or("game dir not found")?;
     let exe_path = recipe.exe_path.as_ref().ok_or("game exe not found")?;
     let exe_dir = launch_working_dir(game_dir, exe_path);
 
-    let prefix = prefix_override
-        .map(Path::to_path_buf)
-        .unwrap_or_else(|| crate::platform::metalsharp_home_dir_for(&home).join("prefix-steam"));
-    let prefix_str = prefix.to_string_lossy().to_string();
+    let prefix_str = gptk_prefix.to_string_lossy().to_string();
     let exe_name = exe_path.file_name().unwrap_or_default().to_string_lossy().to_string();
 
     deploy_recipe_dlls(&recipe)?;
@@ -829,7 +957,7 @@ fn launch_gptk_with_context(
         deploy_steam_appid(game_dir, appid);
     }
 
-    ensure_gptk_vcrun(&wine, &prefix);
+    ensure_gptk_vcrun(&wine, &gptk_prefix);
 
     let cache_paths = build_cache_paths(&home, node, appid);
 
@@ -861,7 +989,7 @@ fn launch_gptk_with_context(
         LaunchLogContext {
             appid,
             node,
-            prefix: &prefix,
+            prefix: &gptk_prefix,
             cwd: exe_dir,
             exe_name: &exe_name,
             args: &recipe.launch_args,

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -860,6 +860,69 @@ pub fn gptk_kill_steam_in_prefix(gptk_prefix: &Path) {
         .status();
 }
 
+pub fn gptk_symlink_steam_libraries(gptk_prefix: &Path) {
+    let home = match dirs::home_dir() {
+        Some(h) => h,
+        None => return,
+    };
+    let ms_home = crate::platform::metalsharp_home_dir_for(&home);
+    let ms_prefix = ms_home.join("prefix-steam");
+    let ms_steam_dir = ms_prefix.join("drive_c").join("Program Files (x86)").join("Steam");
+    let ms_steamapps = ms_steam_dir.join("steamapps");
+
+    let gptk_steam_dir = gptk_steam_dir(gptk_prefix);
+    let gptk_steamapps = gptk_steam_dir.join("steamapps");
+
+    if !ms_steamapps.exists() || !gptk_steam_dir.exists() {
+        return;
+    }
+
+    let _ = std::fs::create_dir_all(&gptk_steamapps);
+
+    let gptk_common = gptk_steamapps.join("common");
+    let ms_common = ms_steamapps.join("common");
+    if ms_common.exists() && !gptk_common.exists() {
+        let _ = std::os::unix::fs::symlink(&ms_common, &gptk_common);
+    }
+
+    let gptk_downloading = gptk_steamapps.join("downloading");
+    let ms_downloading = ms_steamapps.join("downloading");
+    if ms_downloading.exists() && !gptk_downloading.exists() {
+        let _ = std::os::unix::fs::symlink(&ms_downloading, &gptk_downloading);
+    }
+
+    let gptk_workshop = gptk_steamapps.join("workshop");
+    let ms_workshop = ms_steamapps.join("workshop");
+    if ms_workshop.exists() && !gptk_workshop.exists() {
+        let _ = std::os::unix::fs::symlink(&ms_workshop, &gptk_workshop);
+    }
+
+    let gptk_shadercache = gptk_steamapps.join("shadercache");
+    let ms_shadercache = ms_steamapps.join("shadercache");
+    if ms_shadercache.exists() && !gptk_shadercache.exists() {
+        let _ = std::os::unix::fs::symlink(&ms_shadercache, &gptk_shadercache);
+    }
+
+    if let Ok(entries) = std::fs::read_dir(&ms_steamapps) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            if name_str.starts_with("appmanifest_") && name_str.ends_with(".acf") {
+                let dest = gptk_steamapps.join(&name);
+                if !dest.exists() {
+                    let _ = std::os::unix::fs::symlink(entry.path(), &dest);
+                }
+            }
+        }
+    }
+
+    let src_vdf = ms_steamapps.join("libraryfolders.vdf");
+    let dest_vdf = gptk_steamapps.join("libraryfolders.vdf");
+    if src_vdf.exists() && !dest_vdf.exists() {
+        let _ = std::fs::copy(&src_vdf, &dest_vdf);
+    }
+}
+
 pub fn gptk_install_steam(wine: &Path, gptk_prefix: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let installer = match gptk_find_installer() {
         Some(p) => p,
@@ -946,6 +1009,8 @@ pub fn gptk_install_steam(wine: &Path, gptk_prefix: &Path) -> Result<(), Box<dyn
 
     let steam_dir = gptk_steam_dir(gptk_prefix);
     crate::steam::deploy_steamwebhelper_wrapper(&steam_dir);
+
+    gptk_symlink_steam_libraries(gptk_prefix);
 
     Ok(())
 }

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -1028,25 +1028,21 @@ pub fn gptk_spawn_steam(wine: &Path, prefix: &Path) -> Result<u32, Box<dyn std::
     }
 
     let prefix_str = prefix.to_string_lossy().to_string();
+    let wine_str = wine.to_string_lossy().to_string();
+    let exe_str = exe.to_string_lossy().to_string();
+    let cwd_str = steam_dir.to_string_lossy().to_string();
 
-    let mut cmd = Command::new(wine);
-    cmd.current_dir(&steam_dir)
-        .env("WINEPREFIX", &prefix_str)
-        .env("WINEDEBUG", "-all")
-        .env("WINEDEBUGGER", "none")
-        .env("STEAM_RUNTIME", "0")
-        .env("MS_FWD_COMPAT_GL_CTX", "1")
-        .env(
-            "WINEDLLOVERRIDES",
-            "dxgi,d3d11,d3d10core=n,b;bcrypt=b;ncrypt=b;gameoverlayrenderer,gameoverlayrenderer64=d",
-        )
-        .arg(&exe)
-        .args(["-no-cef-sandbox", "-cef-single-process", "-noverifyfiles", "-no-dwrite"])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null());
+    let shell_cmd = format!(
+        "cd '{}' && WINEPREFIX='{}' WINEDEBUG=-all WINEDEBUGGER=none STEAM_RUNTIME=0 MS_FWD_COMPAT_GL_CTX=1 WINEDLLOVERRIDES='dxgi,d3d11,d3d10core=n,b;bcrypt=b;ncrypt=b;gameoverlayrenderer,gameoverlayrenderer64=d' nohup '{}' -no-cef-sandbox -cef-single-process -noverifyfiles -no-dwrite </dev/null >/dev/null 2>&1 & echo $!",
+        cwd_str, prefix_str, exe_str
+    );
 
-    let child = cmd.spawn()?;
-    Ok(child.id())
+    let output = Command::new("/bin/sh").arg("-c").arg(&shell_cmd).output()?;
+
+    let pid_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let pid: u32 = pid_str.parse().unwrap_or(0);
+
+    Ok(pid)
 }
 
 fn launch_gptk_with_context(

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -725,6 +725,66 @@ pub fn gptk_wine64_binary() -> PathBuf {
     PathBuf::from("/opt/homebrew/bin/wine64")
 }
 
+fn gptk_vcrun_marker(prefix: &Path) -> PathBuf {
+    prefix.join("drive_c").join(".metalsharp-gptk-vcrun-installed")
+}
+
+fn gptk_prefix_has_vcrun(prefix: &Path) -> bool {
+    if gptk_vcrun_marker(prefix).exists() {
+        return true;
+    }
+    let system32 = prefix.join("drive_c").join("windows").join("system32");
+    let core = ["vcruntime140.dll", "vcruntime140_1.dll", "msvcp140.dll"];
+    core.iter().all(|dll| system32.join(dll).exists())
+}
+
+fn ensure_gptk_vcrun(wine: &Path, prefix: &Path) {
+    if gptk_prefix_has_vcrun(prefix) {
+        return;
+    }
+
+    let home = match dirs::home_dir() {
+        Some(h) => h,
+        None => return,
+    };
+    let ms_home = crate::platform::metalsharp_home_dir_for(&home);
+    let cache_dir = ms_home.join("cache").join("gptk-redist");
+    let redist = cache_dir.join("VC_redist.x64.exe");
+
+    if !redist.exists() {
+        let _ = std::fs::create_dir_all(&cache_dir);
+        let tmp = cache_dir.join("VC_redist.x64.exe.download");
+        let _ = std::fs::remove_file(&tmp);
+        let _ = Command::new("/usr/bin/curl")
+            .args(["--fail", "--location", "--silent", "--show-error", "-o"])
+            .arg(&tmp)
+            .arg("https://aka.ms/vs/17/release/VC_redist.x64.exe")
+            .output();
+        if tmp.exists() && tmp.metadata().map(|m| m.len() > 1_000_000).unwrap_or(false) {
+            let _ = std::fs::rename(&tmp, &redist);
+        }
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    if !redist.exists() {
+        return;
+    }
+
+    let prefix_str = prefix.to_string_lossy().to_string();
+    let output = Command::new(wine)
+        .env("WINEPREFIX", &prefix_str)
+        .env("WINEDEBUG", "-all")
+        .arg(&redist)
+        .args(["/install", "/quiet"])
+        .output();
+
+    if let Ok(out) = output {
+        if out.status.success() {
+            let _ = std::fs::write(gptk_vcrun_marker(prefix), "");
+        }
+    }
+}
+
 fn launch_gptk(appid: u32, node: &PipelineNode) -> Result<(u32, &'static str), Box<dyn std::error::Error>> {
     launch_gptk_with_context(appid, node, None, &[], None)
 }
@@ -768,6 +828,8 @@ fn launch_gptk_with_context(
     if !recipe.anti_cheat.is_empty() {
         deploy_steam_appid(game_dir, appid);
     }
+
+    ensure_gptk_vcrun(&wine, &prefix);
 
     let cache_paths = build_cache_paths(&home, node, appid);
 

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -789,11 +789,11 @@ fn launch_gptk(appid: u32, node: &PipelineNode) -> Result<(u32, &'static str), B
     launch_gptk_with_context(appid, node, None, &[], None)
 }
 
-fn gptk_steam_dir(gptk_prefix: &Path) -> PathBuf {
+pub fn gptk_steam_dir(gptk_prefix: &Path) -> PathBuf {
     gptk_prefix.join("drive_c").join("Program Files (x86)").join("Steam")
 }
 
-fn gptk_steam_exe(gptk_prefix: &Path) -> PathBuf {
+pub fn gptk_steam_exe(gptk_prefix: &Path) -> PathBuf {
     gptk_steam_dir(gptk_prefix).join("Steam.exe")
 }
 
@@ -811,7 +811,7 @@ fn gptk_find_installer() -> Option<PathBuf> {
     None
 }
 
-fn gptk_steam_pids_in_prefix(gptk_prefix: &Path) -> Vec<u32> {
+pub fn gptk_steam_pids_in_prefix(gptk_prefix: &Path) -> Vec<u32> {
     let prefix_str = gptk_prefix.to_string_lossy().to_string();
     Command::new("ps")
         .args(["axo", "pid=,command="])
@@ -837,7 +837,7 @@ fn gptk_steam_pids_in_prefix(gptk_prefix: &Path) -> Vec<u32> {
         .unwrap_or_default()
 }
 
-fn gptk_kill_steam_in_prefix(gptk_prefix: &Path) {
+pub fn gptk_kill_steam_in_prefix(gptk_prefix: &Path) {
     let pids = gptk_steam_pids_in_prefix(gptk_prefix);
     for pid in &pids {
         let _ = Command::new("kill")
@@ -860,7 +860,7 @@ fn gptk_kill_steam_in_prefix(gptk_prefix: &Path) {
         .status();
 }
 
-fn gptk_install_steam(wine: &Path, gptk_prefix: &Path) -> Result<(), Box<dyn std::error::Error>> {
+pub fn gptk_install_steam(wine: &Path, gptk_prefix: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let installer = match gptk_find_installer() {
         Some(p) => p,
         None => return Err("SteamSetup.exe not found — install Steam through MetalSharp first".into()),
@@ -950,11 +950,11 @@ fn gptk_install_steam(wine: &Path, gptk_prefix: &Path) -> Result<(), Box<dyn std
     Ok(())
 }
 
-fn gptk_is_steam_running_in_prefix(gptk_prefix: &Path) -> bool {
+pub fn gptk_is_steam_running_in_prefix(gptk_prefix: &Path) -> bool {
     !gptk_steam_pids_in_prefix(gptk_prefix).is_empty()
 }
 
-fn gptk_spawn_steam(wine: &Path, prefix: &Path) -> Result<u32, Box<dyn std::error::Error>> {
+pub fn gptk_spawn_steam(wine: &Path, prefix: &Path) -> Result<u32, Box<dyn std::error::Error>> {
     let steam_dir = gptk_steam_dir(prefix);
     let exe = steam_dir.join("Steam.exe");
 

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -209,6 +209,7 @@ pub fn launch_with_pipeline(
             launch_dxmt_metal(appid, node)
         },
         PipelineId::M13 => launch_dxmt_metal(appid, node),
+        PipelineId::Gptk => launch_gptk(appid, node),
         PipelineId::M32 => launch_wine_bare(appid, node),
         PipelineId::FnaArm64 => launch_fna_arm64(appid).map(|(pid, method, _)| (pid, method)),
         PipelineId::Steam => launch_steam(appid),
@@ -232,6 +233,8 @@ pub fn launch_steam_bottle_with_pipeline(
             launch_dxmt_metal_with_context(appid, node, Some(prefix_path), extra_env, Some(&log_path))
                 .map(|(pid, method)| (pid, method, log_path))
         },
+        PipelineId::Gptk => launch_gptk_with_context(appid, node, Some(prefix_path), extra_env, Some(&log_path))
+            .map(|(pid, method)| (pid, method, log_path)),
         PipelineId::M32 | PipelineId::WineBare => {
             launch_wine_bare_with_context(appid, node, Some(prefix_path), extra_env, Some(&log_path))
                 .map(|(pid, method)| (pid, method, log_path))
@@ -284,6 +287,7 @@ pub fn prepare_steam_pipeline_env(
         | PipelineId::M11
         | PipelineId::M12
         | PipelineId::M13
+        | PipelineId::Gptk
         | PipelineId::M32
         | PipelineId::WineBare => {},
         PipelineId::FnaArm64 => {
@@ -478,10 +482,11 @@ pub fn launch_custom_with_options(
         | PipelineId::M11
         | PipelineId::M12
         | PipelineId::M13
+        | PipelineId::Gptk
         | PipelineId::M32
         | PipelineId::WineBare => {},
         PipelineId::FnaArm64 | PipelineId::Steam | PipelineId::MacSteam => {
-            return Err("Sharp Library apps must use Auto, Wine, M9, M10, M11, M12, M13, or M32".into());
+            return Err("Sharp Library apps must use Auto, Wine, M9, M10, M11, M12, M13, GPTK, or M32".into());
         },
     }
 
@@ -678,6 +683,102 @@ fn launch_dxmt_metal_with_context(
     if node.backend == "dxmt" {
         cmd.env("DXMT_CONFIG_FILE", &dxmt_config_file);
         cmd.env("DXMT_WINEMETAL_UNIXLIB", dxmt_winemetal_unixlib_path(&ms_root));
+    }
+
+    cmd.env("MS_GRAPHICS_BACKEND", node.graphics_backend);
+
+    for ev in &node.env_vars {
+        cmd.env(ev.key, ev.value);
+    }
+    apply_app_launch_env(&mut cmd, appid, node.id);
+    for (key, value) in extra_env {
+        cmd.env(key, value);
+    }
+
+    cmd.arg(&exe_name);
+    cmd.args(&recipe.launch_args);
+    attach_launch_log(
+        &mut cmd,
+        log_path,
+        LaunchLogContext {
+            appid,
+            node,
+            prefix: &prefix,
+            cwd: exe_dir,
+            exe_name: &exe_name,
+            args: &recipe.launch_args,
+            cache_paths: cache_paths.as_ref(),
+        },
+    )?;
+    let child = cmd.spawn()?;
+    Ok((child.id(), node.id.to_legacy_method()))
+}
+
+pub fn gptk_wine64_binary() -> PathBuf {
+    let candidates = ["/opt/homebrew/bin/wine64", "/usr/local/bin/wine64"];
+    for c in &candidates {
+        let p = PathBuf::from(c);
+        if p.exists() {
+            return p;
+        }
+    }
+    PathBuf::from("/opt/homebrew/bin/wine64")
+}
+
+fn launch_gptk(appid: u32, node: &PipelineNode) -> Result<(u32, &'static str), Box<dyn std::error::Error>> {
+    launch_gptk_with_context(appid, node, None, &[], None)
+}
+
+fn launch_gptk_with_context(
+    appid: u32,
+    node: &PipelineNode,
+    prefix_override: Option<&Path>,
+    extra_env: &[(String, String)],
+    log_path: Option<&Path>,
+) -> Result<(u32, &'static str), Box<dyn std::error::Error>> {
+    let home = dirs::home_dir().ok_or("no home dir")?;
+    let wine = gptk_wine64_binary();
+
+    if !wine.exists() {
+        return Err("GPTK Wine not found — install via: brew install --cask game-porting-toolkit".into());
+    }
+
+    let default_log_path;
+    let log_path = match log_path {
+        Some(path) => Some(path),
+        None => {
+            default_log_path = mtsp_launch_log_path(appid);
+            Some(default_log_path.as_path())
+        },
+    };
+
+    let recipe = super::recipe::build_launch_recipe(appid, node)?;
+    let game_dir = recipe.game_dir.as_ref().ok_or("game dir not found")?;
+    let exe_path = recipe.exe_path.as_ref().ok_or("game exe not found")?;
+    let exe_dir = launch_working_dir(game_dir, exe_path);
+
+    let prefix = prefix_override
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| crate::platform::metalsharp_home_dir_for(&home).join("prefix-steam"));
+    let prefix_str = prefix.to_string_lossy().to_string();
+    let exe_name = exe_path.file_name().unwrap_or_default().to_string_lossy().to_string();
+
+    deploy_recipe_dlls(&recipe)?;
+
+    if !recipe.anti_cheat.is_empty() {
+        deploy_steam_appid(game_dir, appid);
+    }
+
+    let cache_paths = build_cache_paths(&home, node, appid);
+
+    let mut cmd = Command::new(&wine);
+    cmd.current_dir(exe_dir)
+        .env("WINEPREFIX", &prefix_str)
+        .env("WINEDEBUG", wine_debug_value())
+        .env("WINEDEBUGGER", "none");
+
+    if let Some(overrides) = node.wine_overrides {
+        cmd.env("WINEDLLOVERRIDES", overrides);
     }
 
     cmd.env("MS_GRAPHICS_BACKEND", node.graphics_backend);

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -789,70 +789,173 @@ fn launch_gptk(appid: u32, node: &PipelineNode) -> Result<(u32, &'static str), B
     launch_gptk_with_context(appid, node, None, &[], None)
 }
 
-fn gptk_ensure_steam_in_prefix(
-    wine: &Path,
-    gptk_prefix: &Path,
-    steam_prefix: &Path,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let gptk_steam_dir = gptk_prefix.join("drive_c").join("Program Files (x86)").join("Steam");
-    let source_steam_dir = steam_prefix.join("drive_c").join("Program Files (x86)").join("Steam");
+fn gptk_steam_dir(gptk_prefix: &Path) -> PathBuf {
+    gptk_prefix.join("drive_c").join("Program Files (x86)").join("Steam")
+}
 
-    if !gptk_steam_dir.exists() && source_steam_dir.exists() {
-        let parent = gptk_steam_dir.parent().ok_or("no parent for Steam dir")?;
-        std::fs::create_dir_all(parent)?;
-        #[cfg(unix)]
-        {
-            std::os::unix::fs::symlink(&source_steam_dir, &gptk_steam_dir).map_err(|e| {
-                format!(
-                    "failed to symlink Steam into GPTK prefix: {} -> {}: {}",
-                    source_steam_dir.display(),
-                    gptk_steam_dir.display(),
-                    e
-                )
-            })?;
-        }
+fn gptk_steam_exe(gptk_prefix: &Path) -> PathBuf {
+    gptk_steam_dir(gptk_prefix).join("Steam.exe")
+}
+
+fn gptk_find_installer() -> Option<PathBuf> {
+    let cache = crate::platform::metalsharp_home_dir().join("cache").join("steam").join("SteamSetup.exe");
+    if cache.exists() {
+        return Some(cache);
     }
+    let home = dirs::home_dir()?;
+    let metalsharp_dir = crate::platform::metalsharp_home_dir_for(&home);
+    let installer = metalsharp_dir.join("SteamSetup.exe");
+    if installer.exists() {
+        return Some(installer);
+    }
+    None
+}
 
-    if !gptk_prefix.join("drive_c").join("windows").exists() {
-        let prefix_str = gptk_prefix.to_string_lossy().to_string();
-        let _ = Command::new(wine)
-            .env("WINEPREFIX", &prefix_str)
-            .env("WINEDEBUG", "-all")
-            .arg("wineboot")
-            .arg("--init")
+fn gptk_steam_pids_in_prefix(gptk_prefix: &Path) -> Vec<u32> {
+    let prefix_str = gptk_prefix.to_string_lossy().to_string();
+    Command::new("ps")
+        .args(["axo", "pid=,command="])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|lines| {
+            lines
+                .lines()
+                .filter_map(|line| {
+                    let line = line.trim();
+                    let pid = line.split_whitespace().next()?.parse::<u32>().ok()?;
+                    let cmd = line.split_whitespace().nth(1)?;
+                    if line.contains(&prefix_str) && (cmd.contains("Steam.exe") || cmd.contains("steam.exe")) {
+                        Some(pid)
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn gptk_kill_steam_in_prefix(gptk_prefix: &Path) {
+    let pids = gptk_steam_pids_in_prefix(gptk_prefix);
+    for pid in &pids {
+        let _ = Command::new("kill")
+            .args(["-KILL", &pid.to_string()])
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .status();
     }
-
-    if gptk_steam_dir.exists() {
-        crate::steam::deploy_steamwebhelper_wrapper(&gptk_steam_dir);
+    if !pids.is_empty() {
+        std::thread::sleep(std::time::Duration::from_secs(1));
     }
+    let prefix_str = gptk_prefix.to_string_lossy().to_string();
+    let _ = Command::new(gptk_wine64_binary())
+        .env("WINEPREFIX", &prefix_str)
+        .env("WINEDEBUG", "-all")
+        .arg("wineboot")
+        .arg("--kill")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+}
+
+fn gptk_install_steam(wine: &Path, gptk_prefix: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let installer = match gptk_find_installer() {
+        Some(p) => p,
+        None => return Err("SteamSetup.exe not found — install Steam through MetalSharp first".into()),
+    };
+
+    std::fs::create_dir_all(gptk_prefix)?;
+    let prefix_str = gptk_prefix.to_string_lossy().to_string();
+
+    let _ = Command::new(wine)
+        .env("WINEPREFIX", &prefix_str)
+        .env("WINEDEBUG", "-all")
+        .arg("wineboot")
+        .arg("--init")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+
+    let windows_dir = gptk_prefix.join("drive_c").join("windows").join("system32");
+    for _ in 0..30 {
+        if windows_dir.exists() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_secs(2));
+    }
+    if !windows_dir.exists() {
+        return Err("GPTK wineboot --init timed out".into());
+    }
+
+    let _ = Command::new(wine)
+        .env("WINEPREFIX", &prefix_str)
+        .env("WINEDEBUG", "-all")
+        .arg("winecfg")
+        .arg("-v")
+        .arg("win7")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+
+    let _ = Command::new(wine)
+        .env("WINEPREFIX", &prefix_str)
+        .env("WINEDEBUG", "-all")
+        .arg(&installer)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()?;
+
+    let steam_exe = gptk_steam_exe(gptk_prefix);
+    let steam_ui_dll = gptk_steam_dir(gptk_prefix).join("steamui.dll");
+    for _ in 0..120 {
+        if steam_exe.exists() && steam_ui_dll.exists() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+    if !steam_exe.exists() {
+        return Err("SteamSetup.exe did not install Steam.exe".into());
+    }
+
+    let mut last_pids = gptk_steam_pids_in_prefix(gptk_prefix);
+    let mut restarts_seen = 0u32;
+    let mut stable_ticks = 0u32;
+    for _ in 0..180 {
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        let current_pids = gptk_steam_pids_in_prefix(gptk_prefix);
+        if current_pids != last_pids && !last_pids.is_empty() {
+            if current_pids.is_empty() {
+                restarts_seen += 1;
+            }
+            last_pids = current_pids;
+            stable_ticks = 0;
+        } else {
+            stable_ticks += 1;
+        }
+        if restarts_seen >= 2 && stable_ticks >= 8 {
+            break;
+        }
+        if restarts_seen == 0 && stable_ticks >= 30 {
+            break;
+        }
+    }
+
+    gptk_kill_steam_in_prefix(gptk_prefix);
+
+    let steam_dir = gptk_steam_dir(gptk_prefix);
+    crate::steam::deploy_steamwebhelper_wrapper(&steam_dir);
 
     Ok(())
 }
 
 fn gptk_is_steam_running_in_prefix(gptk_prefix: &Path) -> bool {
-    let prefix_str = gptk_prefix.to_string_lossy().to_string();
-    crate::steam::is_wine_steam_running()
-        || std::process::Command::new("ps")
-            .args(["axo", "command="])
-            .output()
-            .ok()
-            .filter(|o| o.status.success())
-            .and_then(|o| String::from_utf8(o.stdout).ok())
-            .map(|lines| {
-                lines.lines().any(|line| {
-                    line.contains(&prefix_str)
-                        && (line.contains("Steam.exe") || line.contains("steam.exe"))
-                        && !line.contains(" rg ")
-                })
-            })
-            .unwrap_or(false)
+    !gptk_steam_pids_in_prefix(gptk_prefix).is_empty()
 }
 
 fn gptk_spawn_steam(wine: &Path, prefix: &Path) -> Result<u32, Box<dyn std::error::Error>> {
-    let steam_dir = prefix.join("drive_c").join("Program Files (x86)").join("Steam");
+    let steam_dir = gptk_steam_dir(prefix);
     let exe = steam_dir.join("Steam.exe");
 
     if !exe.exists() {
@@ -923,9 +1026,11 @@ fn launch_gptk_with_context(
     }
 
     let gptk_prefix = crate::bottles::gptk_launch_prefix();
-    let steam_prefix = crate::platform::metalsharp_home_dir_for(&home).join("prefix-steam");
+    let needs_install = !gptk_steam_exe(&gptk_prefix).exists();
 
-    gptk_ensure_steam_in_prefix(&wine, &gptk_prefix, &steam_prefix)?;
+    if needs_install {
+        gptk_install_steam(&wine, &gptk_prefix)?;
+    }
 
     if !gptk_is_steam_running_in_prefix(&gptk_prefix) {
         gptk_spawn_steam(&wine, &gptk_prefix)?;

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -1020,6 +1020,8 @@ pub fn gptk_is_steam_running_in_prefix(gptk_prefix: &Path) -> bool {
 }
 
 pub fn gptk_spawn_steam(wine: &Path, prefix: &Path) -> Result<u32, Box<dyn std::error::Error>> {
+    use std::os::unix::process::CommandExt;
+
     let steam_dir = gptk_steam_dir(prefix);
     let exe = steam_dir.join("Steam.exe");
 
@@ -1028,21 +1030,34 @@ pub fn gptk_spawn_steam(wine: &Path, prefix: &Path) -> Result<u32, Box<dyn std::
     }
 
     let prefix_str = prefix.to_string_lossy().to_string();
-    let wine_str = wine.to_string_lossy().to_string();
-    let exe_str = exe.to_string_lossy().to_string();
-    let cwd_str = steam_dir.to_string_lossy().to_string();
 
-    let shell_cmd = format!(
-        "cd '{}' && WINEPREFIX='{}' WINEDEBUG=-all WINEDEBUGGER=none STEAM_RUNTIME=0 MS_FWD_COMPAT_GL_CTX=1 WINEDLLOVERRIDES='dxgi,d3d11,d3d10core=n,b;bcrypt=b;ncrypt=b;gameoverlayrenderer,gameoverlayrenderer64=d' nohup '{}' -no-cef-sandbox -cef-single-process -noverifyfiles -no-dwrite </dev/null >/dev/null 2>&1 & echo $!",
-        cwd_str, prefix_str, exe_str
-    );
+    let mut cmd = Command::new(wine);
+    cmd.current_dir(&steam_dir)
+        .env("WINEPREFIX", &prefix_str)
+        .env("WINEDEBUG", "-all")
+        .env("WINEDEBUGGER", "none")
+        .env("STEAM_RUNTIME", "0")
+        .env("MS_FWD_COMPAT_GL_CTX", "1")
+        .env(
+            "WINEDLLOVERRIDES",
+            "dxgi,d3d11,d3d10core=n,b;bcrypt=b;ncrypt=b;gameoverlayrenderer,gameoverlayrenderer64=d",
+        )
+        .arg(&exe)
+        .args(["-no-cef-sandbox", "-cef-single-process", "-noverifyfiles", "-no-dwrite"])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .process_group(0);
 
-    let output = Command::new("/bin/sh").arg("-c").arg(&shell_cmd).output()?;
+    unsafe {
+        cmd.pre_exec(|| {
+            libc::setsid();
+            Ok(())
+        });
+    }
 
-    let pid_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    let pid: u32 = pid_str.parse().unwrap_or(0);
-
-    Ok(pid)
+    let child = cmd.spawn()?;
+    Ok(child.id())
 }
 
 fn launch_gptk_with_context(

--- a/app/src-rust/src/mtsp/recipe.rs
+++ b/app/src-rust/src/mtsp/recipe.rs
@@ -783,7 +783,15 @@ fn m9_d3d9_source_subpath(game_dir: &Path, exe_path: Option<&Path>) -> &'static 
 fn runtime_assets_for_node(node: &PipelineNode, ms_root: &Path) -> Vec<RuntimeAsset> {
     let mut assets = Vec::new();
 
-    if node.requires_wine {
+    if node.id == PipelineId::Gptk {
+        let wine64 = crate::mtsp::launcher::gptk_wine64_binary();
+        assets.push(RuntimeAsset {
+            name: "gptk_wine64".into(),
+            present: wine64.exists(),
+            path: wine64,
+            required: true,
+        });
+    } else if node.requires_wine {
         let wine = crate::platform::runtime_wine_binary(ms_root);
         assets.push(RuntimeAsset { name: "wine".into(), present: wine.exists(), path: wine, required: true });
     }
@@ -798,7 +806,7 @@ fn runtime_assets_for_node(node: &PipelineNode, ms_root: &Path) -> Vec<RuntimeAs
         assets.push(RuntimeAsset { name: "dxmt.conf".into(), present: conf.exists(), path: conf, required: false });
     }
 
-    if node.backend == "gptk" {
+    if node.backend == "gptk" && node.id != PipelineId::Gptk {
         let framework = ms_root.join("lib").join("external").join("D3DMetal.framework");
         assets.push(RuntimeAsset {
             name: "D3DMetal.framework".into(),

--- a/app/src-rust/src/mtsp/recipe.rs
+++ b/app/src-rust/src/mtsp/recipe.rs
@@ -89,6 +89,7 @@ pub fn build_launch_recipe(appid: u32, node: &PipelineNode) -> Result<LaunchReci
             | PipelineId::M11
             | PipelineId::M12
             | PipelineId::M13
+            | PipelineId::Gptk
             | PipelineId::M32
             | PipelineId::FnaArm64
             | PipelineId::WineBare
@@ -106,6 +107,7 @@ pub fn build_launch_recipe(appid: u32, node: &PipelineNode) -> Result<LaunchReci
         | PipelineId::M11
         | PipelineId::M12
         | PipelineId::M13
+        | PipelineId::Gptk
         | PipelineId::M32
         | PipelineId::FnaArm64
         | PipelineId::WineBare => {

--- a/app/src-rust/src/setup.rs
+++ b/app/src-rust/src/setup.rs
@@ -130,8 +130,9 @@ pub fn dependencies() -> Value {
         || check_path(&crate::platform::metalsharp_home_dir_for(&home).join("runtime/wine/bin/metalsharp-wine"));
     let host_runtime = host_runtime_installed(&home);
     let dxmt_runtime = crate::installer::dxmt_runtime_current_for_home(&home);
+    let gptk_wine = check_gptk_wine();
 
-    let all_ok = homebrew && rosetta && xcode_cli && metalsharp_wine && host_runtime && dxmt_runtime;
+    let all_ok = homebrew && rosetta && xcode_cli && metalsharp_wine && host_runtime && dxmt_runtime && gptk_wine;
 
     json!({
         "ok": true,
@@ -185,6 +186,14 @@ pub fn dependencies() -> Value {
                 "installed": dxmt_runtime,
                 "required": true,
                 "installCmd": "metalsharp-setup-dxmt",
+            },
+            {
+                "id": "gptk_wine",
+                "name": "Game Porting Toolkit",
+                "desc": "Apple's D3D12-to-Metal Wine runtime via Homebrew. Required for GPTK launch routes.",
+                "installed": gptk_wine,
+                "required": true,
+                "installCmd": "brew install --cask game-porting-toolkit",
             },
             {
                 "id": "mono",
@@ -1934,6 +1943,10 @@ fn check_brew(formula: &str) -> bool {
 fn check_rosetta() -> bool {
     PathBuf::from("/Library/Apple/System/Library/LaunchDaemons/com.apple.oahd.plist").exists()
         || mac_cmd("pgrep").arg("-q").arg("oahd").status().map(|s| s.success()).unwrap_or(false)
+}
+
+fn check_gptk_wine() -> bool {
+    check_path(&PathBuf::from("/opt/homebrew/bin/wine64")) || check_path(&PathBuf::from("/usr/local/bin/wine64"))
 }
 
 #[cfg(test)]

--- a/app/src-rust/src/sharp_library.rs
+++ b/app/src-rust/src/sharp_library.rs
@@ -1147,6 +1147,7 @@ fn pipeline_engine_id(pipeline: crate::mtsp::engine::PipelineId) -> &'static str
         crate::mtsp::engine::PipelineId::M11 => "m11",
         crate::mtsp::engine::PipelineId::M12 => "m12",
         crate::mtsp::engine::PipelineId::M13 => "m13",
+        crate::mtsp::engine::PipelineId::Gptk => "gptk_wine",
         crate::mtsp::engine::PipelineId::M32 => "m32",
         crate::mtsp::engine::PipelineId::WineBare => "wine_bare",
         crate::mtsp::engine::PipelineId::FnaArm64 => "fna_arm64",

--- a/app/src-rust/src/steam.rs
+++ b/app/src-rust/src/steam.rs
@@ -408,6 +408,7 @@ pub fn launch_gptk_steam() -> Result<Value, Box<dyn std::error::Error>> {
         return Ok(json!({"ok": true, "message": "GPTK Steam already running"}));
     }
 
+    crate::mtsp::launcher::gptk_symlink_steam_libraries(&gptk_prefix);
     deploy_gptk_steamwebhelper_wrapper(&gptk_prefix);
 
     let pid = crate::mtsp::launcher::gptk_spawn_steam(&wine, &gptk_prefix)?;

--- a/app/src-rust/src/steam.rs
+++ b/app/src-rust/src/steam.rs
@@ -57,6 +57,12 @@ pub fn status() -> Value {
     let ms_available = ms_wine().exists();
     let installing = is_installing_steam();
 
+    let gptk_prefix = crate::bottles::gptk_launch_prefix();
+    let gptk_wine = crate::mtsp::launcher::gptk_wine64_binary();
+    let gptk_wine_available = gptk_wine.exists();
+    let gptk_installed = gptk_wine_available && crate::mtsp::launcher::gptk_steam_exe(&gptk_prefix).exists();
+    let gptk_running = gptk_wine_available && crate::mtsp::launcher::gptk_is_steam_running_in_prefix(&gptk_prefix);
+
     json!({
         "installed": windows_installed,
         "path": windows_path,
@@ -67,7 +73,10 @@ pub fn status() -> Value {
         "mac_running": mac_running,
         "running": running,
         "metalsharp_wine_available": ms_available,
-        "installing": installing
+        "installing": installing,
+        "gptk_wine_available": gptk_wine_available,
+        "gptk_installed": gptk_installed,
+        "gptk_running": gptk_running
     })
 }
 
@@ -375,6 +384,101 @@ pub fn stop_macos_steam() -> Result<Value, Box<dyn std::error::Error>> {
     }
 
     Ok(json!({"ok": true, "running": is_macos_steam_running()}))
+}
+
+pub fn launch_gptk_steam() -> Result<Value, Box<dyn std::error::Error>> {
+    let wine = crate::mtsp::launcher::gptk_wine64_binary();
+    if !wine.exists() {
+        return Err("GPTK Wine not found — install via: brew install --cask game-porting-toolkit".into());
+    }
+
+    if is_wine_steam_running() {
+        let _ = stop_wine_steam();
+        std::thread::sleep(std::time::Duration::from_secs(2));
+    }
+
+    let gptk_prefix = crate::bottles::gptk_launch_prefix();
+    let steam_exe = crate::mtsp::launcher::gptk_steam_exe(&gptk_prefix);
+
+    if !steam_exe.exists() {
+        return Err("GPTK Steam is not installed — use Install GPTK Steam first".into());
+    }
+
+    if crate::mtsp::launcher::gptk_is_steam_running_in_prefix(&gptk_prefix) {
+        return Ok(json!({"ok": true, "message": "GPTK Steam already running"}));
+    }
+
+    deploy_gptk_steamwebhelper_wrapper(&gptk_prefix);
+
+    let pid = crate::mtsp::launcher::gptk_spawn_steam(&wine, &gptk_prefix)?;
+
+    Ok(json!({"ok": true, "pid": pid}))
+}
+
+pub fn stop_gptk_steam() -> Result<Value, Box<dyn std::error::Error>> {
+    let gptk_prefix = crate::bottles::gptk_launch_prefix();
+    crate::mtsp::launcher::gptk_kill_steam_in_prefix(&gptk_prefix);
+    let running = crate::mtsp::launcher::gptk_is_steam_running_in_prefix(&gptk_prefix);
+    Ok(json!({"ok": true, "running": running}))
+}
+
+pub fn install_gptk_steam() -> Result<Value, Box<dyn std::error::Error>> {
+    let wine = crate::mtsp::launcher::gptk_wine64_binary();
+    if !wine.exists() {
+        return Err("GPTK Wine not found — install via: brew install --cask game-porting-toolkit".into());
+    }
+
+    let gptk_prefix = crate::bottles::gptk_launch_prefix();
+    let steam_exe = crate::mtsp::launcher::gptk_steam_exe(&gptk_prefix);
+
+    if steam_exe.exists() {
+        return Ok(json!({"ok": true, "message": "GPTK Steam already installed"}));
+    }
+
+    crate::mtsp::launcher::gptk_install_steam(&wine, &gptk_prefix)?;
+
+    Ok(json!({"ok": true, "message": "GPTK Steam installed"}))
+}
+
+fn deploy_gptk_steamwebhelper_wrapper(gptk_prefix: &Path) {
+    let steam_dir = crate::mtsp::launcher::gptk_steam_dir(gptk_prefix);
+
+    let cef_dirs =
+        [steam_dir.join("bin").join("cef").join("cef.win7x64"), steam_dir.join("bin").join("cef").join("cef.win64")];
+
+    let wrapper = match find_bundled_steamwebhelper_wrapper() {
+        Some(w) => w,
+        None => return,
+    };
+
+    let bundled_size = std::fs::metadata(&wrapper).map(|m| m.len()).unwrap_or(0);
+    if bundled_size == 0 || bundled_size > STEAMWEBHELPER_WRAPPER_MAX_BYTES || !steamwebhelper_wrapper_valid(&wrapper) {
+        return;
+    }
+
+    for cef_dir in &cef_dirs {
+        let original = cef_dir.join("steamwebhelper.exe");
+        let real = cef_dir.join("steamwebhelper_real.exe");
+        let original_size = std::fs::metadata(&original).map(|m| m.len()).unwrap_or(0);
+
+        if original_size == 0 {
+            continue;
+        }
+
+        if original_size <= STEAMWEBHELPER_WRAPPER_MAX_BYTES {
+            continue;
+        }
+
+        let real_size = std::fs::metadata(&real).map(|m| m.len()).unwrap_or(0);
+        if real_size < STEAMWEBHELPER_WRAPPER_MAX_BYTES {
+            let _ = std::fs::remove_file(&real);
+            let _ = std::fs::rename(&original, &real);
+        } else if original.exists() {
+            let _ = std::fs::remove_file(&original);
+        }
+
+        let _ = std::fs::copy(&wrapper, &original);
+    }
 }
 
 pub fn launch_macos_steam_game(appid: u32) -> Result<Value, Box<dyn std::error::Error>> {

--- a/app/src/renderer/App.vue
+++ b/app/src/renderer/App.vue
@@ -42,6 +42,8 @@ const wineSteamInstalled = ref(false);
 const wineSteamRunning = ref(false);
 const macSteamInstalled = ref(false);
 const macSteamRunning = ref(false);
+const gptkSteamInstalled = ref(false);
+const gptkSteamRunning = ref(false);
 const library = ref<SteamLibrary | null>(null);
 const config = ref<AppConfig | null>(null);
 const updateStatus = ref<UpdateStatus | null>(null);
@@ -85,6 +87,8 @@ provide("wineSteamInstalled", wineSteamInstalled);
 provide("wineSteamRunning", wineSteamRunning);
 provide("macSteamInstalled", macSteamInstalled);
 provide("macSteamRunning", macSteamRunning);
+provide("gptkSteamInstalled", gptkSteamInstalled);
+provide("gptkSteamRunning", gptkSteamRunning);
 provide("backendConnected", backendConnected);
 provide("backendVersion", backendVersion);
 provide("updateStatus", updateStatus);
@@ -106,12 +110,17 @@ async function refreshSteamStatus() {
     mac_installed: boolean;
     mac_running: boolean;
     metalsharp_wine_available: boolean;
+    gptk_wine_available: boolean;
+    gptk_installed: boolean;
+    gptk_running: boolean;
   }>("GET", "/steam/status");
   if (steamStatus) {
     wineSteamInstalled.value = steamStatus.installed;
     wineSteamRunning.value = steamStatus.running;
     macSteamInstalled.value = steamStatus.mac_installed;
     macSteamRunning.value = steamStatus.mac_running;
+    gptkSteamInstalled.value = steamStatus.gptk_installed;
+    gptkSteamRunning.value = steamStatus.gptk_running;
   }
 }
 

--- a/app/src/renderer/views/LibraryView.vue
+++ b/app/src/renderer/views/LibraryView.vue
@@ -35,6 +35,8 @@ const wineSteamInstalled = inject<Ref<boolean>>("wineSteamInstalled")!;
 const wineSteamRunning = inject<Ref<boolean>>("wineSteamRunning")!;
 const macSteamInstalled = inject<Ref<boolean>>("macSteamInstalled")!;
 const macSteamRunning = inject<Ref<boolean>>("macSteamRunning")!;
+const gptkSteamInstalled = inject<Ref<boolean>>("gptkSteamInstalled")!;
+const gptkSteamRunning = inject<Ref<boolean>>("gptkSteamRunning")!;
 const backendConnected = inject<Ref<boolean>>("backendConnected")!;
 const backendVersion = inject<Ref<string | null>>("backendVersion")!;
 const developerMode = inject<Ref<boolean>>("developerMode")!;
@@ -167,6 +169,58 @@ async function toggleMacSteam() {
   reloadLibrary();
 }
 
+async function toggleGptkSteam() {
+  const wine = await api<{ gptk_wine_available: boolean }>("GET", "/steam/status");
+  if (!wine?.gptk_wine_available) {
+    toast.show("GPTK Wine not found — install via: brew install --cask game-porting-toolkit", "error");
+    return;
+  }
+
+  if (!gptkSteamInstalled.value) {
+    toast.show("Installing Steam into GPTK prefix — this may take a minute...", "success");
+    const result = await api<{ ok: boolean; error?: string }>("POST", "/steam/gptk-install");
+    if (result?.ok) {
+      gptkSteamInstalled.value = true;
+      toast.show("GPTK Steam installed — starting...", "success");
+      const launchResult = await api<{ ok: boolean; pid?: number; error?: string }>(
+        "POST",
+        "/steam/gptk-launch",
+      );
+      if (launchResult?.ok) {
+        gptkSteamRunning.value = true;
+        toast.show("GPTK Steam started — log in through the Steam window", "success");
+      } else {
+        toast.show(launchResult?.error ?? "Failed to start GPTK Steam", "error");
+      }
+    } else {
+      toast.show(result?.error ?? "Failed to install GPTK Steam", "error");
+    }
+    reloadLibrary();
+    return;
+  }
+
+  if (gptkSteamRunning.value) {
+    const result = await api<{ ok: boolean; running?: boolean; error?: string }>("POST", "/steam/gptk-stop");
+    if (result?.ok && result.running === false) {
+      gptkSteamRunning.value = false;
+      toast.show("GPTK Steam stopped");
+    } else {
+      gptkSteamRunning.value = result?.running ?? true;
+      toast.show(result?.error ?? "GPTK Steam is still running", "error");
+    }
+  } else {
+    toast.show("Starting GPTK Steam...", "success");
+    const result = await api<{ ok: boolean; pid?: number; error?: string }>("POST", "/steam/gptk-launch");
+    if (result?.ok) {
+      gptkSteamRunning.value = true;
+      toast.show("GPTK Steam started — log in through the Steam window", "success");
+    } else {
+      toast.show(result?.error ?? "Failed to start GPTK Steam", "error");
+    }
+  }
+  reloadLibrary();
+}
+
 async function launchGame(game: SteamGame, launchMethod = "auto") {
   if (isMacSteamLaunch(launchMethod) && wineSteamRunning.value) {
     if (!confirm(`Stop Wine Steam and launch ${game.name} through MacOS Steam?`)) return;
@@ -266,6 +320,8 @@ watch([library, search, filter], applyFilter);
           <span v-else-if="wineSteamInstalled" class="badge badge-warn">Steam Offline</span>
           <span v-if="macSteamRunning" class="badge badge-ok">Mac Steam Running</span>
           <span v-else-if="macSteamInstalled" class="badge badge-warn">Mac Steam Offline</span>
+          <span v-if="gptkSteamRunning" class="badge badge-ok">GPTK Running</span>
+          <span v-else-if="gptkSteamInstalled" class="badge badge-warn">GPTK Offline</span>
           <span class="badge" :class="backendConnected ? 'badge-ok' : 'badge-error'">
             {{ backendConnected ? `Backend${backendVersion ? " v" + backendVersion : ""}` : "Backend Offline" }}
           </span>
@@ -312,6 +368,34 @@ watch([library, search, filter], applyFilter);
             <span class="control-label">
               {{
                 !macSteamInstalled ? "Install macOS Steam" : macSteamRunning ? "Stop MacOS Steam" : "Start MacOS Steam"
+              }}
+            </span>
+          </button>
+          <button class="btn btn-secondary library-control-button" title="GPTK Steam" @click="toggleGptkSteam">
+            <svg
+              class="control-icon"
+              width="15"
+              height="15"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <polygon points="12 2 22 8.5 22 15.5 12 22 2 15.5 2 8.5 12 2" />
+              <line x1="12" y1="22" x2="12" y2="15.5" />
+              <polyline points="22 8.5 12 15.5 2 8.5" />
+              <polyline points="2 15.5 12 8.5 22 15.5" />
+              <line x1="12" y1="2" x2="12" y2="8.5" />
+            </svg>
+            <span class="control-label">
+              {{
+                !gptkSteamInstalled
+                  ? "Install GPTK Steam"
+                  : gptkSteamRunning
+                    ? "Stop GPTK Steam"
+                    : "Start GPTK Steam"
               }}
             </span>
           </button>


### PR DESCRIPTION
## Summary

Adds Game Porting Toolkit (GPTK) Wine as a required dependency to the MetalSharp install/update system.

## Changes

### setup.rs — Dependency checks (`GET /setup/dependencies`)
- New `gptk_wine` dependency entry — checks for `/opt/homebrew/bin/wine64`
- Added to `allInstalled` gate (now required alongside DXMT, Wine, etc.)

### installer.rs — Install wizard (`POST /setup/install-all`)
- New step: "GPTK Wine (Homebrew)" runs after GPTK D3DMetal Runtime
- Ensures Rosetta 2 is installed (`softwareupdate --install-rosetta --agree-to-license`)
- Runs `brew install --cask game-porting-toolkit` to get the GPTK Wine binary
- Skips if `wine64` already present at `/opt/homebrew/bin/` or `/usr/local/bin/`

### migrate.rs — Migration/update validation
- `runtime_core_ready()` now checks `/opt/homebrew/bin/wine64` exists
- Migration already calls `install_all` which includes the new GPTK step

## Why
GPTK Wine provides a working D3D12-to-Metal translation path via Apple's Game Porting Toolkit.
Subnautica 2 (UE5, D3D12) fully renders through GPTK but not through DXMT's D3D12 stack.
Making GPTK Wine a first-class install dependency prepares the routing system for a GPTK launch option.

## Test Plan
- [x] `cargo check` passes
- [x] `cargo fmt` passes
- [x] `cargo clippy` passes
- [x] `cargo test` — 432 tests pass
- [ ] Fresh install: verify GPTK Wine step appears in wizard and installs correctly
- [ ] Migration: verify `/opt/homebrew/bin/wine64` is validated in `runtime_core_ready`