### PR TITLE
docs: simplify README, add GPTK guide, add install-from-source guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,94 +1,65 @@
 <div align="center">
 
-# M E T A L S H A R P
+# MetalSharp
 
-**Run Windows Steam games and Windows programs on macOS with Metal.**
+**Run Windows Steam games on macOS with Metal.**
 
 <a href="https://github.com/aaf2tbz/metalsharp/actions"><img src="https://img.shields.io/github/actions/workflow/status/aaf2tbz/metalsharp/ci.yml?branch=main&style=for-the-badge" alt="CI"></a>
 <a href="https://github.com/aaf2tbz/metalsharp/releases"><img src="https://img.shields.io/github/v/release/aaf2tbz/metalsharp?style=for-the-badge" alt="Release"></a>
 <a href="https://github.com/aaf2tbz/metalsharp/discussions"><img src="https://img.shields.io/github/discussions/aaf2tbz/metalsharp?style=for-the-badge" alt="Discussions"></a>
 <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="MIT"></a>
 
-**Beta 7**
-
 </div>
 
 ---
 
-MetalSharp is an ARM64 app for Apple Silicon that bundles its own Wine runtime, DXMT Metal graphics support, Windows Steam setup, game detection, runtime bottles, Mono/FNA/XNA support, logs, and launch diagnostics.
+MetalSharp is a macOS app for Apple Silicon that translates Direct3D calls to Metal via DXMT, bundles its own Wine runtime, and manages Steam game detection, launch routing, and runtime bottles.
 
-## Runtime
+## Quick Start
 
-MetalSharp keeps state under `~/.metalsharp/`:
+Download the latest DMG from [Releases](https://github.com/aaf2tbz/metalsharp/releases), drag MetalSharp into `/Applications`, and open it. The setup wizard handles the rest.
 
-```text
-~/.metalsharp/
-├── runtime/wine/   MetalSharp Wine, DXMT, D3D/DXGI DLLs, shims
-├── runtime/redist/ Optional user-supplied redistributables
-├── prefix-steam/   Shared Windows Steam prefix and live Steam session
-├── bottles/        Runtime bottle manifests, prefixes, logs, assets
-├── games/          Prepared game payloads
-├── sharp-library/  Imported Windows apps
-├── shader-cache/   Per-game graphics caches
-├── configs/        Pipeline/runtime rules
-├── cache/          Steam/update cache
-├── logs/           App, launch, crash, setup, migration logs
-└── crashes/        Preserved crash reports
-```
+For building from source, see [Install from Source](docs/guides/install-from-source.md).
 
-`prefix-steam` remains the shared Wine Steam prefix. Wine Steam stays alive as the background client/session owner for Steam games.
+## Routes
 
-`bottles` is the runtime authority layer. Installer and Sharp Library bottles use their own prefixes. Steam game bottles use ids like `steam_620` and preflight the actual shared Steam prefix. Env-dependent Steam routes launch the selected game executable directly through the chosen MTSP pipeline with the bottle prefix, route env, and `SteamAppId`/`SteamGameId`, while Wine Steam remains alive for Steamworks connectivity.
-
-## Launching
-
-When Play is clicked, MetalSharp resolves the best route, syncs the bottle/runtime record, checks required components/assets, prepares DLLs/cache/env/logs, ensures Wine Steam is ready when needed, then launches the game through the selected MTSP path. The visible route selector is intentionally small; `dxmt` is the internal auto-router, not a manual button.
-
-| Mode | Purpose |
+| Route | Engine |
 |---|---|
 | **M12** | D3D12 to Metal |
 | **M11** | D3D11 to Metal |
 | **M10** | D3D10 to Metal |
-| **M9** | D3D9 / 32-bit capable DXMT-family route |
-| **Mono/FNA** | Windows XNA/FNA games through MetalSharp's native Mono runtime, FNA assemblies, XNA compatibility shims, FMOD/FAudio/FNA3D/native-library staging, and Steamworks shim support |
+| **M9** | D3D9 / 32-bit DXMT |
+| **Mono/FNA** | Windows XNA/FNA via native Mono |
+| **D3DMetal** | Apple Game Porting Toolkit |
 
-Internal routes such as Wine Steam, macOS Steam, plain Wine, M32, and raw DXMT remain available to the backend for auto-routing, compatibility records, diagnostics, and legacy repair paths, but they are not exposed as normal bottle options.
+## Features
 
-## Sharp Library
-
-Sharp Library manages Windows apps, demos, launchers, and installers. Use **Install Windows Program** for standalone `.exe` files, MSI packages, launcher bootstrapper apps, .NET installers, WebView apps, Java launchers, and game installers.
-
-Installer bottles classify the program, apply known launcher recipes where possible, launch it with the right profile, keep per-bottle logs, scan for installed app candidates, and import detected apps back into Sharp Library with their `bottle_id`.
-
-## Diagnostics and Migration
-
-Use Logs and Runtime Doctor when something fails. Doctor checks common blockers like Wine Mono, native .NET CLR files, Gecko, VC runtime, DirectX June 2010, WebView2, core fonts, Mono/FNA runtime assets, runtime profile, app detection, launch state, and redistributable assets.
-
-Upgrades preserve `setup.json`, Steam settings/cache, `prefix-steam`, `games`, `sharp-library`, `bottles`, and Steam game compatdata.
-
-## Download
-
-Get the latest DMG from [Releases](https://github.com/aaf2tbz/metalsharp/releases), drag MetalSharp into `/Applications`, and open it.
+- **Sharp Library** - Import and run standalone Windows programs, installers, and launchers
+- **Runtime Bottles** - Per-game isolated Wine prefixes with component tracking and repair
+- **MTSP Routing** - Automatic pipeline selection based on game compatibility data
+- **Steam Integration** - Detects your Steam library, manages the Wine Steam session, and deploys the CEF wrapper
 
 ## Requirements
 
-- macOS DMG: Apple Silicon Mac, macOS 14 or newer
+- Apple Silicon Mac, macOS 14+
 - About 2 GB free space
+- Homebrew (installed by setup wizard)
 
-## Help
+## Documentation
 
+- [Install from Source](docs/guides/install-from-source.md)
 - [How to Use MetalSharp](docs/guides/how-to-use-metalsharp.md)
-- [Docs Map](docs/README.md)
-- [Runtime Bundles and Steam Routing](docs/runtime/runtime-bundles-and-steam-routing.md)
+- [GPTK (D3DMetal) Guide](docs/guides/gptk-guide.md)
+- [Game Compatibility](docs/compatibility/GAMES-SUPPORTED.md)
 - [Launch Architecture](docs/architecture/launch-architecture.md)
-- [Wine Architecture](docs/runtime/wine-architecture.md)
-- [Game Compatibility](docs/compatibility/game-compat.md)
-- [Supported Games](docs/compatibility/GAMES-SUPPORTED.md)
-- [Third-Party Licenses](THIRD_PARTY_LICENSES)
+- [Docs Map](docs/README.md)
+
+## Community
+
 - [Releases](https://github.com/aaf2tbz/metalsharp/releases)
 - [Discussions](https://github.com/aaf2tbz/metalsharp/discussions)
 - [Issues](https://github.com/aaf2tbz/metalsharp/issues)
 
 ## License
 
-MetalSharp is MIT licensed. Third-party runtime and source components keep their original licenses; see [THIRD_PARTY_LICENSES](THIRD_PARTY_LICENSES).
+MIT licensed. Third-party components keep their original licenses; see [THIRD_PARTY_LICENSES](THIRD_PARTY_LICENSES).

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,8 @@ Use this page as the repo map before changing launch/runtime code.
 ## Guides
 
 - [How to Use MetalSharp](guides/how-to-use-metalsharp.md) - install, launch, diagnose, and update flow.
+- [Install from Source](guides/install-from-source.md) - build MetalSharp from source without the DMG.
+- [GPTK (D3DMetal) Guide](guides/gptk-guide.md) - Game Porting Toolkit setup, prefix management, and troubleshooting.
 
 ## Compatibility
 

--- a/docs/guides/gptk-guide.md
+++ b/docs/guides/gptk-guide.md
@@ -1,0 +1,81 @@
+# GPTK (D3DMetal) Guide
+
+MetalSharp supports Apple's Game Porting Toolkit (GPTK) as the **D3DMetal** route. This route uses Apple's D3DMetal framework for D3D11/D3D12 translation instead of the DXMT Metal path used by M11/M12.
+
+## How It Works
+
+The D3DMetal route is architecturally different from the other MetalSharp routes:
+
+- **Shared prefix**: All D3DMetal games share a single Wine prefix at `~/.metalsharp/prefix-gptk/`, seeded from your Wine Steam prefix
+- **GPTK Wine binary**: Uses Apple's `wine64` from the Game Porting Toolkit, not MetalSharp's built-in Wine
+- **D3DMetal framework**: Translation happens through Apple's D3DMetal.framework and its PE DLLs (`d3d11.dll`, `d3d12.dll`, `dxgi.dll`, etc.)
+- **External game storage**: D3DMetal games can be migrated to external SSDs for better performance
+
+## Setup
+
+1. Install the Game Porting Toolkit via Homebrew:
+   ```bash
+   brew install game-porting-toolkit
+   ```
+   Or install it through MetalSharp's setup wizard.
+
+2. MetalSharp creates the GPTK prefix automatically when you first launch a D3DMetal game. The prefix is seeded with:
+   - Your Wine Steam prefix registry hives (`system.reg`, `user.reg`, `userdef.reg`)
+   - Steam directory structure
+   - VC++ 2015-2022 redistributable (x86 + x64)
+   - Dosdevice symlinks matching your Wine Steam prefix
+
+3. The VC++ runtime is installed automatically during prefix seeding. If it's missing, use Runtime Doctor or the bottle repair option.
+
+## When to Use D3DMetal vs M11/M12
+
+| | D3DMetal | M11/M12 |
+|---|---|---|
+| **Translation** | Apple D3DMetal framework | DXMT (custom Metal backend) |
+| **Wine** | GPTK `wine64` | MetalSharp Wine |
+| **Prefix** | Shared (`prefix-gptk`) | Per-game bottle |
+| **Best for** | Games that need Apple's translation | Most games, better compatibility tracking |
+
+Use M11 or M12 as the default. Switch to D3DMetal if a game has specific rendering issues on the DXMT path.
+
+## GPTK Prefix Location
+
+```
+~/.metalsharp/prefix-gptk/
+├── .gptk-ready          Marks prefix as fully seeded
+├── drive_c/
+│   ├── windows/         Windows system directory with GPTK DLLs
+│   └── Program Files (x86)/Steam/   Steam directory (synced from prefix-steam)
+├── dosdevices/          Drive letter symlinks
+├── system.reg           Registry (copied from prefix-steam)
+├── user.reg             Registry (copied from prefix-steam)
+└── userdef.reg          Registry (copied from prefix-steam)
+```
+
+## Prefix Syncing
+
+MetalSharp syncs the GPTK prefix with your Wine Steam prefix on every D3DMetal launch:
+
+- Copies `user.reg` from `prefix-steam` to `prefix-gptk`
+- Syncs Steam config files
+- Ensures dosdevice symlinks are intact
+
+## Component Repair
+
+The D3DMetal bottle profile includes these components:
+
+| Component | Purpose |
+|---|---|
+| `gptk` | Game Porting Toolkit installation |
+| `rosetta` | Rosetta 2 for x86_64 translation |
+| `gptk_prefix` | Prefix seeding and readiness |
+| `vcrun2019` | VC++ 2015-2022 redistributable |
+
+Use Runtime Doctor (`POST /bottles/doctor`) or the bottle repair UI to check and fix these components.
+
+## Troubleshooting
+
+- **"GPTK prefix is not ready"**: Repair the `gptk_prefix` component in bottle settings. This re-seeds the prefix from your Wine Steam prefix.
+- **VC++ missing**: Repair the `vcrun2019` component. MetalSharp will download and install the Microsoft VC++ redistributable into the GPTK prefix.
+- **Game can't find Steam**: Ensure the dosdevice symlinks in `~/.metalsharp/prefix-gptk/dosdevices/` are correct. MetalSharp auto-creates these during prefix sync.
+- **External drive not visible**: Add a dosdevice symlink: `ln -sf /Volumes/YourDrive ~/.metalsharp/prefix-gptk/dosdevices/z:`

--- a/docs/guides/install-from-source.md
+++ b/docs/guides/install-from-source.md
@@ -1,0 +1,76 @@
+# Install from Source
+
+Build MetalSharp from source without using the DMG. Requires macOS 14+ on Apple Silicon.
+
+## Prerequisites
+
+```bash
+# Xcode CLI Tools
+xcode-select --install
+
+# Homebrew
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+eval "$(/opt/homebrew/bin/brew shellenv)"
+
+# Build dependencies
+brew install cmake node zstd
+```
+
+## Clone
+
+```bash
+git clone --recurse-submodules https://github.com/aaf2tbz/metalsharp.git
+cd metalsharp
+```
+
+## Build
+
+```bash
+# Native engine (C++ D3D/Metal layer) - x86_64 for Rosetta 2 PE translation
+mkdir -p build
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON
+cmake --build build --parallel $(sysctl -n hw.ncpu)
+
+# Rust backend
+cd app/src-rust && cargo build --release && cd ../..
+
+# Electron frontend
+cd app && npm install && npm run build && cd ..
+```
+
+## Fetch Runtime Bundles
+
+Downloads Wine, DXMT, GPTK DLLs, Steam setup files, and other runtime assets from the GitHub release:
+
+```bash
+./tools/dmg/create-bundles.sh
+```
+
+## Run
+
+```bash
+cd app && npx electron .
+```
+
+## Build a Signed App
+
+For an ad-hoc signed `.app` (no Apple Developer account needed):
+
+```bash
+cd app && npx electron-builder --dir --mac --arm64
+codesign --force --deep --sign - ../dist/electron/mac-arm64/MetalSharp.app
+open ../dist/electron/mac-arm64/MetalSharp.app
+```
+
+For a distributable DMG with hardened runtime (requires Apple Developer certificate):
+
+```bash
+cd app && npm run dmg
+```
+
+## Troubleshooting
+
+- **`cmake` fails**: Ensure Xcode CLI tools are installed (`xcode-select -p` should return a path)
+- **`npm install` fails**: Make sure Node 18+ is installed (`brew install node`)
+- **Missing bundles**: Run `./tools/dmg/create-bundles.sh` — this downloads all runtime assets from GitHub
+- **App won't open**: If you see a Gatekeeper warning, run `xattr -cr /path/to/MetalSharp.app`


### PR DESCRIPTION
## Changes

- **README**: Removed spaced-out `M E T A L S H A R P` title, removed stale Beta 7 label, simplified to concise feature list with route table including D3DMetal, linked new guides
- **docs/guides/install-from-source.md**: Complete terminal-only build instructions from clone to signed app, including prerequisites, troubleshooting
- **docs/guides/gptk-guide.md**: D3DMetal route setup, shared prefix architecture, prefix syncing, component repair, VC++ troubleshooting, when to use D3DMetal vs M11/M12
- **docs/README.md**: Added links to new guides

No code changes — docs only.