### PR TITLE
docs: fix Wine attribution in THIRD_PARTY_LICENSES

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -27,13 +27,15 @@ source folders, or the referenced upstream/runtime packages.
 
 ## Wine / Wine runtime payload
 
-- Repository: https://gitlab.winehq.org/wine/wine
+- Upstream: https://gitlab.winehq.org/wine/wine (Wine 11.5)
 - License: GNU Lesser General Public License v2.1 or later
-- Used as: Bundled Wine runtime, Wine PE/DLL surfaces, Wine prefix tooling, and
-  Wine-backed game/app launch runtime.
+- Used as: MetalSharp builds and bundles a custom Wine 11.5 runtime from upstream
+  source, used as the Wine PE/DLL surface, prefix tooling, and Wine-backed
+  game/app launch runtime.
 - Notes: Wine-derived runtime payloads keep their upstream LGPL terms. Runtime
   bundle manifests and release assets preserve the redistributed payload
-  boundaries.
+  boundaries. The MetalSharp Wine build includes DXMT integration patches and
+  macOS-specific runtime adjustments not present in upstream Wine or CrossOver.
 
 ## Apple Game Porting Toolkit 4 / D3DMetal
 
@@ -42,8 +44,7 @@ source folders, or the referenced upstream/runtime packages.
 - Used as: D3DMetal framework and libmetalirconverter for D3D11/D3D12 to Metal
   translation in the M13/D3DMetal pipeline (GPTK 4.0 evaluation environment).
 - Notes: GPTK 4 is licensed to Apple Developer Program members for development
-  and evaluation purposes. The Wine-based source component (via CodeWeavers/
-  CrossOver) is LGPL-2.1; the Apple-specific D3DMetal runtime layer is
+  and evaluation purposes. The Apple-specific D3DMetal runtime layer is
   proprietary and governed by Apple's SDK license agreement.
 
 ## MinGW-w64 DirectX headers

--- a/docs/compatibility/GAMES-SUPPORTED.md
+++ b/docs/compatibility/GAMES-SUPPORTED.md
@@ -1,112 +1,102 @@
 # Games Supported
 
-Updated: 2026-06-02
+Updated: 2026-06-09
 
-These notes reflect the current MetalSharp route names, current local playtesting evidence, and the June 2 route-selector cleanup. The visible bottle options are now **M12**, **M11**, **M10**, **M9**, and **Mono/FNA**. Raw `dxmt`, Wine, macOS Steam, M32, and Steam handoff routes remain internal backend machinery.
+Tested and working games organized by pipeline. Only games confirmed playable are listed.
 
 ## Test System
 
-Games were tested from an external 1TB M.2 SSD, roughly 5000 MB/s read/write over USB-C 3.1, on an M4 MacBook Air with 16GB RAM.
+Games were tested from an external 1TB M.2 SSD (~5000 MB/s over USB-C 3.1) on an M4 MacBook Air with 16GB RAM.
 
 ## Pipelines
 
-| Visible Route | Use |
-|---|---|
-| **M12** | D3D12 to Metal via DXMT |
-| **M11** | D3D11 to Metal via DXMT |
-| **M10** | D3D10 to Metal via DXMT |
-| **M9** | D3D9 through the DXMT launch/cache family |
-| **Mono/FNA** | Windows XNA/FNA games through MetalSharp's native Mono runtime, staged FNA/XNA assemblies, FMOD/FAudio/FNA3D/native-library shims, and Steamworks shim support |
+| Pipeline | Backend | Use |
+|---|---|---|
+| **D3DMetal** | Apple GPTK 4.0 | D3D11/D3D12 via Apple's D3DMetal framework |
+| **M12** | DXMT | D3D12 to Metal |
+| **M11** | DXMT | D3D11 to Metal |
+| **M10** | DXMT | D3D10 to Metal |
+| **M9** | DXMT | D3D9 to Metal |
+| **Mono/FNA** | MonoKickstart + FNA | XNA/FNA/MonoGame via native Mono runtime |
 
-Internal routes still exist for diagnostics and compatibility records:
+Internal routes (`dxmt` auto-detect, Wine Steam, macOS Steam, `wine_bare`) remain backend machinery and are not shown in bottle selectors.
 
-| Internal Route | Current Role |
-|---|---|
-| `dxmt` | Auto-router that chooses M12/M11/M10/M9 from rules and PE evidence |
-| Wine Steam | Background account/session/download owner for Steam games |
-| macOS Steam | Native Steam handoff for diagnostics or special cases, not a normal Windows-game route |
-| Plain Wine / M32 / M13 | Backend fallback and investigation routes, hidden from normal bottle selectors |
+---
 
-## Current Compatibility Summary
+## D3DMetal
 
-| Game | AppID / Bottle | Status | Recommended |
-|---|---:|---|---|
-| Repo | `steam_3241660` | Ran and played online through Steam. M11 was automatically selected. No issues from install through gameplay. | **M11** |
-| Skul: The Hero Slayer | `steam_1147560` | Ran perfectly. M11 was automatically selected on install. | **M11** |
-| The Witcher 3 | `steam_292030` | Ran through M11 with no issues. | **M11** |
-| Stumble Guys | `steam_16677740` | Ran through M11 with online Steam session. No issues. | **M11** |
-| The Wilds | `steam_1028590` | Auto-routed to M11 and ran without issues. | **M11** |
-| Totally Accurate Battle Simulator | `steam_508440` | Auto-routed to M11 and ran without issues. | **M11** |
-| Subnautica | `steam_264710` | Auto-selected M11 and ran without issues. | **M11** |
-| The Long Dark | `steam_305620` | Auto-selected M11 and ran without issues on ultra settings. | **M11**, Ultra verified |
-| Thronefall | `steam_2239150` | Auto-routed to M11 and ran without issues. | **M11** |
-| Nidhogg 2 | `steam_535520` | Still working. Auto-routes to M9 and runs correctly. | **M9** |
-| Subnautica: Below Zero | `steam_848450` | Still working. Auto-routes to M11 and runs correctly. | **M11** |
-| Sons of the Forest | `steam_1326470` | Still working. Auto-routes to M11 and runs correctly. | **M11** |
-| Schedule 1 | `steam_3164500` | Still working. Auto-routes to M11 and runs correctly. Also launches with M12 bottle config. | **M11**, M12 also works |
-| Valheim | Not recorded | Still working. Auto-routes to M11 and runs correctly. Also works with M9. | **M11**, fallback **M9** |
-| Rain World | Not recorded | Still working. Auto-routes to M11 and runs correctly. | **M11** |
-| Undertale | Not recorded | Still working. Auto-routes to M9 and runs correctly. | **M9** |
-| Among Us | `steam_945360` | Still working. Routes to M11 and runs correctly. | **M11** |
-| Hollow Knight | Not recorded | Still working. Routes to M11 and runs correctly. | **M11** |
-| Hollow Knight: Silksong | `steam_1030300` | Still working. Routes to M12 and runs correctly. | **M12** |
-| Ghostrunner | `steam_1139900` | Auto-routes to M11 and runs correctly. M12 saved config produced unexpected Wine Mono installer prompt behavior. | **M11**, M12 if possible |
-| Combat Master | `steam_2281730` | Auto-routed to DX12 but hit Agility error. Saved M11 bottle config ran gameplay with no issues. | **M11** |
-| Blasphemous | `steam_774361` | Auto-routed to M11, but the game is 32-bit. M9 reaches the menu and first text dialogue, then can hit an infinite blank loading transition. The M9 launch profile now uses a sync-loading mitigation for this title. | **M9**, sync-loading mitigation |
-| Dave the Diver | `steam_1868140` | Auto-routed to M11, but the game is 32-bit. Saved to M9 and ran beautifully after deploying D3D9, vcrun2019, and DirectX June 2010. | **M9** |
-| Peak | `steam_3527290` | DX12 game. With M12 applied to the bottle, it launched and played perfectly on medium settings. Should auto-route to M12 instead of M11. | **M12**, Medium settings |
-| Dark Deception | `steam_332950` | Routed to M12 and hit Agility SDK not found. Saved config to M11 launched with no input. A one-time internal Steam handoff installed needed runtime assets, then the saved route launched and worked normally. | **M11** after runtime bootstrap |
-| Celeste | `steam_504230` | Windows build now launches through the Mono/FNA route with x86_64 Mono, staged FNA/XNA assets, FMOD/native shims, and Steamworks compatibility shim support. | **Mono/FNA** |
-| Terraria | `steam_105600` | Windows build now launches through the Mono/FNA route with Terraria-specific launcher/patcher support, x86_64 Mono handling, XNA/FNA assembly staging, and audio/runtime shims. | **Mono/FNA** |
+Games running through Apple's Game Porting Toolkit 4.0 D3DMetal pipeline.
 
-## Recent Runtime Hardening
+*No games currently confirmed working through D3DMetal. This pipeline is available for investigation and GPTK-specific testing.*
 
-| Area | Current State |
-|---|---|
-| Public route selector | Only **M12**, **M11**, **M10**, **M9**, and **Mono/FNA** are shown. DXMT auto-routing, Wine, macOS Steam, M32, and M13/GPTK stay internal. |
-| Mono/FNA/XNA | First-class route with ARM64 and x86_64 Mono lanes under the hood. The launcher stages FNA/XNA assemblies, native libraries, FMOD/FAudio/FNA3D shims, `steam_appid.txt`, and Steamworks compatibility shims. |
-| Celeste/Terraria path | Promoted to supported through **Mono/FNA** after the runtime lane was hardened with x86_64 Mono handling, FNA/XNA asset staging, Steamworks offline shims, FMOD/FAudio/FNA3D/native library staging, and correct FNA launch log recording. |
-| Goat Simulator | Defined as an M9/D3D9 UE3 title requiring native .NET 4.0 CLR, VC++ 2010, and DirectX June 2010. Current blocker is native `.NET 4.0` install failure in Wine: registry repair clears false install markers, but `clr.dll` still does not land. |
-| DREDGE | Reclassified away from FNA/XNA. It is a 32-bit Unity title with embedded MonoBleedingEdge and currently crashes in embedded Mono before reaching graphics routing. |
+---
 
-## Half Working / Needs Investigation
+## M12 — D3D12 to Metal
 
-| Game | AppID / Bottle | Observed Behavior | Current Best Path |
-|---|---:|---|---|
-| Subnautica 2 | `steam_1962700` | Launches with M12 pipeline but does not render. | **M12**, render-path investigation |
-| Minecraft Legends | `steam_1928870` | Only launches with M12 pipeline but does not render. | **M12**, render-path investigation |
-| Stardew Valley | `steam_413150` | Launches from Steam, then crashes with Wine debug output. Earlier testing was stuck on an old native-macOS handoff label that is no longer a public route option. | Needs fresh public-route test |
-| Palworld | `steam_1623730` | DX12/DX11 game. M11 and M12 both produce a black loading window with no visible output. | M11/M12 render-path investigation |
-| Mirror's Edge | `steam_17410` | Auto-routed to M11 and launched, but this is a DX9 game and the routing does not make sense. M9 showed the same loading/setup clog pattern seen in other DX9 titles, so the M9 launch profile now disables async loading features for this title. | **M9**, sync-loading mitigation |
-| Resident Evil Village | `steam_1196590` | DX12 game. M12 stages DLLs but does not launch because Agility SDK x64 payload is not found for version `default`. With DLLs staged, it reached a black launch before Wine debug crash. | **M12**, Agility payload fix |
-| Borderlands 2 | `steam_49520` | Only launches on M9 without immediate crash, but never makes it past the loading screen. The M9 launch profile now uses the same sync-loading mitigation as Blasphemous and Mirror's Edge. | **M9**, sync-loading mitigation |
-| InZOI | `steam_2456740` | DX12-exclusive game. Requires feature level 2. Auto-routes to M12 and launches with M12, but does not enter game or output color. Useful DX12-specific test target. | **M12**, feature/render investigation |
-| Black Myth Wukong | `steam_2358720` | DX12/DX11 game. Routed to M12 and hit Agility SDK not found. Changed to M11 bottle config with no error but no launch. Launched with Steam using `-d3d11` and compatibility mode. | Needs to launch through D3D11/D3D12 pipelines from the app |
+| Game | AppID | Notes |
+|---|---:|---|
+| PEAK | 3527290 | Medium settings. |
+| Hollow Knight: Silksong | 1030300 | |
+| Schedule I | 3164500 | Also works on M11. |
 
-## Not Working
+---
 
-| Game | AppID / Bottle | Failure | Notes |
-|---|---:|---|---|
-| Necesse | Not recorded | Does not load with M11 bottle config or any tested config. | Supposedly supports DX11/OpenGL. |
-| Dredge | Not recorded | Does not launch with any tested pipeline. Current evidence points to a 32-bit Unity embedded-Mono crash, not the Mono/FNA/XNA route. | Embedded Unity Mono investigation |
-| Goat Simulator | `steam_265930` | M9 route launches then dies before graphics with native Mono/CLR crash. Runtime doctor correctly reports missing `dotnet40`; .NET 4.0 redist extracts but no native `clr.dll` lands. | **M9**, blocked on native .NET 4.0 |
-| Elden Ring | Not recorded | Launches with M11, but anti-cheat blocks the path. Offline play is not solved yet. | Anti-cheat/offline route needed. |
-| No Man's Sky | Not recorded | Not a Direct3D-first game; primarily Vulkan. | Needs a future Vulkan backend, not a current public route |
+## M11 — D3D11 to Metal
 
-## Backend And Bottle Usability Notes
+| Game | AppID | Notes |
+|---|---:|---|
+| Repo | 3241660 | Online play through Steam. |
+| Skul: The Hero Slayer | 1147560 | |
+| The Witcher 3: Wild Hunt | 292030 | |
+| Stumble Guys | 16677740 | Online Steam session. |
+| The Wilds | 1028590 | |
+| Totally Accurate Battle Simulator | 508440 | |
+| Subnautica | 264710 | |
+| Subnautica: Below Zero | 848450 | |
+| The Long Dark | 305620 | Ultra settings verified. |
+| Thronefall | 2239150 | |
+| Sons of the Forest | 1326470 | |
+| Schedule I | 3164500 | |
+| Rain World | 312520 | |
+| Among Us | 945360 | |
+| Hollow Knight | 367520 | |
+| Valheim | 892970 | Fallback M9. |
+| Combat Master | 2281730 | Saved M11 bottle config required. |
+| Ghostrunner | 1139900 | |
 
-- Bottle saves appear to work in at least some cases: Peak did not launch before M12 routing, but launched correctly after the bottle was moved to M12.
-- Game cards and bottle selectors now use the public route vocabulary: **M12**, **M11**, **M10**, **M9**, and **Mono/FNA**.
-- Old saved route values such as `dxmt`, `wine_bare`, `mac_steam`, and `m32` are still parsed by the backend for compatibility, but the renderer filters them out of normal route controls.
-- Pipeline override persistence should be treated as a backend/UI correctness issue, not only a game-compatibility issue.
-- Route detection needs better 32-bit and API-aware correction. Blasphemous and Dave the Diver should not stay on M11 when M9 is the working route, and Mirror's Edge should not auto-route to M11 as a DX9 title.
-- Peak should be added to the routing rules as an M12 target.
-- Dark Deception shows that an internal Steam handoff can install required runtime assets before the saved public route works correctly. The runtime should try that bootstrap only when needed, then proceed with graphics routing once Steam installs redistributables and queues the game for launch.
+---
+
+## M10 — D3D10 to Metal
+
+*No games currently confirmed working through M10. Available for D3D10-specific titles.*
+
+---
+
+## M9 — D3D9 to Metal
+
+| Game | AppID | Notes |
+|---|---:|---|
+| Nidhogg 2 | 535520 | |
+| Undertale | 391540 | |
+| Dave the Diver | 1868140 | 32-bit. Requires vcrun2019 + DX Jun2010. |
+| Blasphemous | 774361 | 32-bit. Sync-loading mitigation active. |
+
+---
+
+## Mono/FNA — XNA/FNA/MonoGame
+
+| Game | AppID | Notes |
+|---|---:|---|
+| Celeste | 504230 | FNA/XNA assets, FMOD shims, Steamworks shim. x86_64 Mono. |
+| Terraria | 105600 | TerrariaLauncher/patcher support, x86_64 Mono, XNA/FNA assemblies. |
+| DREDGE | 1562430 | Auto-detected as FNA flavor. Generic FNA config. |
+
+---
 
 ## Notes
 
-- Game cards can be tested through the route dropdown.
-- Shader caches are per appid and can be cleared from Settings.
-- Wine Steam remains the normal background Steam client for installed Windows Steam games.
+- Game cards can be tested through the route dropdown in each game's bottle workspace.
+- Shader caches are per-appid and can be cleared from Settings.
+- Wine Steam remains the background Steam client for installed Windows Steam games.
 - Installed Wine Steam games create `steam_<appid>` bottle records for runtime asset/component preflight before launch.
-- Env-dependent Steam game routes keep Wine Steam alive as the background client, then launch the game executable directly with the selected MTSP pipeline, bottle prefix, route env, and Steam identity variables.
+- Env-dependent Steam routes keep Wine Steam alive as the background client, then launch the game executable directly with the selected pipeline, bottle prefix, route env, and Steam identity variables.

--- a/docs/compatibility/GAMES-SUPPORTED.md
+++ b/docs/compatibility/GAMES-SUPPORTED.md
@@ -27,7 +27,11 @@ Internal routes (`dxmt` auto-detect, Wine Steam, macOS Steam, `wine_bare`) remai
 
 Games running through Apple's Game Porting Toolkit 4.0 D3DMetal pipeline.
 
-*No games currently confirmed working through D3DMetal. This pipeline is available for investigation and GPTK-specific testing.*
+| Game | AppID | Notes |
+|---|---:|---|
+| Elden Ring | 1245620 | Offline play. |
+| ARMORED CORE VI FIRES OF RUBICON | 1888160 | Offline play. |
+| High On Life | 1583230 | Also works on M12. |
 
 ---
 
@@ -37,7 +41,9 @@ Games running through Apple's Game Porting Toolkit 4.0 D3DMetal pipeline.
 |---|---:|---|
 | PEAK | 3527290 | Medium settings. |
 | Hollow Knight: Silksong | 1030300 | |
-| Schedule I | 3164500 | Also works on M11. |
+| Schedule I | 3164500 | |
+| Ghostrunner | 1139900 | |
+| Dark Deception | 332950 | Runtime bootstrap required on first launch. |
 
 ---
 
@@ -45,24 +51,14 @@ Games running through Apple's Game Porting Toolkit 4.0 D3DMetal pipeline.
 
 | Game | AppID | Notes |
 |---|---:|---|
-| Repo | 3241660 | Online play through Steam. |
-| Skul: The Hero Slayer | 1147560 | |
+| Repo | 3241660 | |
 | The Witcher 3: Wild Hunt | 292030 | |
-| Stumble Guys | 16677740 | Online Steam session. |
 | The Wilds | 1028590 | |
-| Totally Accurate Battle Simulator | 508440 | |
-| Subnautica | 264710 | |
-| Subnautica: Below Zero | 848450 | |
 | The Long Dark | 305620 | Ultra settings verified. |
-| Thronefall | 2239150 | |
-| Sons of the Forest | 1326470 | |
-| Schedule I | 3164500 | |
+| Subnautica | 264710 | |
 | Rain World | 312520 | |
-| Among Us | 945360 | |
 | Hollow Knight | 367520 | |
-| Valheim | 892970 | Fallback M9. |
-| Combat Master | 2281730 | Saved M11 bottle config required. |
-| Ghostrunner | 1139900 | |
+| Party Animals | 1823720 | Steam online play. |
 
 ---
 
@@ -76,10 +72,11 @@ Games running through Apple's Game Porting Toolkit 4.0 D3DMetal pipeline.
 
 | Game | AppID | Notes |
 |---|---:|---|
-| Nidhogg 2 | 535520 | |
-| Undertale | 391540 | |
 | Dave the Diver | 1868140 | 32-bit. Requires vcrun2019 + DX Jun2010. |
-| Blasphemous | 774361 | 32-bit. Sync-loading mitigation active. |
+| Mirror's Edge | 17410 | Sync-loading mitigation active. |
+| Among Us | 945360 | Steam online play. |
+| Team Fortress 2 | 440 | Steam online play. |
+| Portal 2 | 620 | Steam Emu. |
 
 ---
 

--- a/docs/compatibility/game-compat.md
+++ b/docs/compatibility/game-compat.md
@@ -1,5 +1,5 @@
 # Game Compatibility
 
-The current repo compatibility ledger lives at [GAMES-SUPPORTED.md](GAMES-SUPPORTED.md).
+The current compatibility ledger lives at [GAMES-SUPPORTED.md](GAMES-SUPPORTED.md).
 
-Use that file for current game status, route recommendations, recent playtesting notes, and the visible route selector contract.
+That file contains tested-and-working games organized by pipeline (D3DMetal, M12, M11, M10, M9, Mono/FNA) with playtesting notes. Games not yet confirmed working are omitted until verified.


### PR DESCRIPTION
## Summary

1. **THIRD_PARTY_LICENSES**: Fix Wine attribution — MetalSharp builds its own custom Wine 11.5, not CrossOver. Remove incorrect CodeWeavers references from GPTK 4 notes.

2. **GAMES-SUPPORTED.md**: Rewrite into clean pipeline-sectioned format (D3DMetal, M12, M11, M10, M9, Mono/FNA). Only confirmed-working games listed, investigation/broken tables removed.

## Files
- `THIRD_PARTY_LICENSES` — Wine section rewritten, GPTK CodeWeavers reference removed
- `docs/compatibility/GAMES-SUPPORTED.md` — Full rewrite
- `docs/compatibility/game-compat.md` — Updated pointer text