### PR TITLE
fix(fna): fix doubled osx/ path in MonoKickstart dylib lookup

### DIFF
--- a/.github/workflows/build-monokickstart.yml
+++ b/.github/workflows/build-monokickstart.yml
@@ -36,7 +36,7 @@ jobs:
           fi
 
           cp "$MONO_LIB/libmonosgen-2.0.1.dylib" libmonosgen-2.0.1.dylib
-          install_name_tool -id "@rpath/osx/libmonosgen-2.0.1.dylib" libmonosgen-2.0.1.dylib
+          install_name_tool -id "@rpath/libmonosgen-2.0.1.dylib" libmonosgen-2.0.1.dylib
 
           clang -arch x86_64 -arch arm64 \
             -mmacosx-version-min=11.0 \

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -1332,6 +1332,15 @@ fn launch_fna_kickstart(
 
     let _ = std::fs::copy(&kick_bin, &game_kick);
 
+    let source_libmono = kickstart_dir.join("osx").join("libmonosgen-2.0.1.dylib");
+    if source_libmono.exists() {
+        let _ = Command::new("/usr/bin/install_name_tool")
+            .arg("-id")
+            .arg("@rpath/libmonosgen-2.0.1.dylib")
+            .arg(&source_libmono)
+            .output();
+    }
+
     let game_osx = dir.join("osx");
     let _ = std::fs::create_dir_all(&game_osx);
 
@@ -1353,6 +1362,14 @@ fn launch_fna_kickstart(
                     }
                 }
             }
+        }
+        let game_libmono = game_osx.join("libmonosgen-2.0.1.dylib");
+        if game_libmono.exists() {
+            let _ = Command::new("/usr/bin/install_name_tool")
+                .arg("-id")
+                .arg("@rpath/libmonosgen-2.0.1.dylib")
+                .arg(&game_libmono)
+                .output();
         }
     }
 


### PR DESCRIPTION
## Summary

The MonoKickstart `kick.bin.osx` rpath is `@executable_path/osx`, but `libmonosgen-2.0.1.dylib` was given install_name `@rpath/osx/libmonosgen-2.0.1.dylib`. At runtime this resolves to `<game>/osx/osx/libmonosgen-2.0.1.dylib` — a doubled `osx/` path, causing SIGABRT on every FNA/Mono launch.

## Fix
- **CI workflow**: Changed dylib install_name from `@rpath/osx/libmonosgen-2.0.1.dylib` to `@rpath/libmonosgen-2.0.1.dylib`
- **launch_fna_kickstart**: Added `install_name_tool -id` repair on both the source runtime dylib and the copy placed in the game's `osx/` dir, fixing existing installs that already have the bad install_name

## Testing
- Terraria and DREDGE both hit this exact SIGABRT before the fix
- 443 Rust tests pass, clippy clean, fmt clean