### PR TITLE
fix: mount updater DMG on private handoff path

### DIFF
--- a/app/updater/update.py
+++ b/app/updater/update.py
@@ -26,6 +26,7 @@ import shlex
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 from typing import List, Optional, Tuple
@@ -197,27 +198,44 @@ def verify_dmg(dmg_path: Path) -> bool:
 
 
 def mount_dmg(dmg_path: Path) -> Optional[str]:
+    mount_dir = Path(tempfile.mkdtemp(prefix="metalsharp-update-mount-"))
     try:
-        result = run(["hdiutil", "attach", "-plist", "-nobrowse", str(dmg_path)], timeout=120)
+        result = run(
+            ["hdiutil", "attach", "-plist", "-nobrowse", "-mountpoint", str(mount_dir), str(dmg_path)],
+            timeout=120,
+        )
     except Exception:
         result = subprocess.CompletedProcess([], 1, "", "")
 
     if result.returncode == 0:
         mount_point = parse_attach_plist(result.stdout.encode("utf-8"))
-        if mount_point:
+        if mount_point and Path(mount_point).resolve() == mount_dir.resolve():
             return mount_point
+        if mount_dir.is_dir() and any(mount_dir.iterdir()):
+            return str(mount_dir)
 
-    # Rarely, attaching a downloaded image may require a system prompt.
-    escaped = str(dmg_path).replace('"', '\\"')
-    script = f'do shell script "hdiutil attach -nobrowse \\"{escaped}\\"" with administrator privileges'
+    # Rarely, attaching a downloaded image may require a system prompt. Keep the
+    # mount point private so install source discovery cannot accidentally reuse
+    # an older /Volumes/MetalSharp mount from a previous update attempt.
+    escaped_dmg = str(dmg_path).replace('"', '\\"')
+    escaped_mount = str(mount_dir).replace('"', '\\"')
+    script = (
+        'do shell script "hdiutil attach -nobrowse -mountpoint '
+        f'\\"{escaped_mount}\\" \\"{escaped_dmg}\\"" with administrator privileges'
+    )
     try:
         result = run(["osascript", "-e", script], timeout=180)
     except Exception:
+        cleanup_mount_dir(mount_dir)
         return None
     if result.returncode != 0:
+        cleanup_mount_dir(mount_dir)
         return None
     time.sleep(2)
-    return find_mount_for_dmg(dmg_path)
+    if mount_dir.is_dir() and any(mount_dir.iterdir()):
+        return str(mount_dir)
+    cleanup_mount_dir(mount_dir)
+    return None
 
 
 def parse_attach_plist(raw: bytes) -> Optional[str]:
@@ -249,6 +267,13 @@ def find_mount_for_dmg(dmg_path: Path) -> Optional[str]:
     return None
 
 
+def cleanup_mount_dir(mount_point: Path) -> None:
+    try:
+        mount_point.rmdir()
+    except Exception:
+        pass
+
+
 def detach_mount(mount_point: Optional[str]) -> None:
     if not mount_point:
         return
@@ -256,6 +281,7 @@ def detach_mount(mount_point: Optional[str]) -> None:
         run(["hdiutil", "detach", mount_point, "-quiet"], timeout=30)
     except Exception:
         pass
+    cleanup_mount_dir(Path(mount_point))
 
 
 def find_app_in_mount(mount_point: str) -> Optional[Path]:

--- a/app/updater/update.sh
+++ b/app/updater/update.sh
@@ -131,7 +131,7 @@ verify_app_bundle() {
         "$app_path/Contents/Resources/runtime/metalsharp-backend"
     do
         if [ ! -s "$required" ]; then
-            write_status "error" 78 "Update app is missing ${required#$app_path/}" "app_bundle_invalid"
+            write_status "error" 78 "Update app is missing ${required#"$app_path"/}" "app_bundle_invalid"
             return 1
         fi
     done
@@ -166,21 +166,33 @@ find_mount_for_dmg() {
 }
 
 mount_dmg() {
-    local output
-    output="$(hdiutil attach -nobrowse "$DMG_PATH" 2>&1)" || true
-    MOUNT_POINT="$(echo "$output" | awk '/\/Volumes\// { idx = index($0, "/Volumes/"); print substr($0, idx); exit }')"
-    if [ -z "$MOUNT_POINT" ]; then
-        local escaped="${DMG_PATH//\"/\\\"}"
-        osascript -e "do shell script \"hdiutil attach -nobrowse \\\"$escaped\\\"\" with administrator privileges" >/dev/null 2>&1 || true
-        sleep 2
-        MOUNT_POINT="$(find_mount_for_dmg "$DMG_PATH")"
+    local mount_dir escaped_dmg escaped_mount
+    mount_dir="$(mktemp -d "${TMPDIR:-/tmp}/metalsharp-update-mount.XXXXXX")" || return 1
+    hdiutil attach -nobrowse -mountpoint "$mount_dir" "$DMG_PATH" >/dev/null 2>&1 || true
+    if [ -d "$mount_dir" ] && [ -n "$(find "$mount_dir" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]; then
+        MOUNT_POINT="$mount_dir"
+        return 0
     fi
-    [ -n "$MOUNT_POINT" ] && [ -d "$MOUNT_POINT" ]
+
+    # Keep the update image on a private mount point so install source discovery
+    # cannot accidentally reuse an older /Volumes/MetalSharp mount from a prior
+    # update attempt.
+    escaped_dmg="${DMG_PATH//\"/\\\"}"
+    escaped_mount="${mount_dir//\"/\\\"}"
+    osascript -e "do shell script \"hdiutil attach -nobrowse -mountpoint \\\"$escaped_mount\\\" \\\"$escaped_dmg\\\"\" with administrator privileges" >/dev/null 2>&1 || true
+    sleep 2
+    if [ -d "$mount_dir" ] && [ -n "$(find "$mount_dir" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]; then
+        MOUNT_POINT="$mount_dir"
+        return 0
+    fi
+    rmdir "$mount_dir" 2>/dev/null || true
+    return 1
 }
 
 detach_mount() {
     if [ -n "$MOUNT_POINT" ] && [ -d "$MOUNT_POINT" ]; then
         hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null || true
+        rmdir "$MOUNT_POINT" 2>/dev/null || true
     fi
 }
 

--- a/tools/ci/verify-dmg-workflow.py
+++ b/tools/ci/verify-dmg-workflow.py
@@ -85,6 +85,15 @@ def check_dmg_verifier(assets: list[str]) -> None:
             fail(f"DMG verifier no longer checks bundle asset {asset}")
 
 
+def check_updater_handoff() -> None:
+    python_updater = read("app/updater/update.py")
+    shell_updater = read("app/updater/update.sh")
+    for path, updater in [("app/updater/update.py", python_updater), ("app/updater/update.sh", shell_updater)]:
+        for needle in ["hdiutil", "attach", "-mountpoint", "metalsharp-update-mount", "detach_mount(mount_point" if path.endswith(".py") else "detach_mount"]:
+            if needle not in updater:
+                fail(f"{path} no longer mounts the downloaded DMG on a private update mount point before install")
+
+
 def check_bundle_scripts() -> None:
     create_bundles = read("tools/dmg/create-bundles.sh")
     for needle in [
@@ -175,6 +184,7 @@ def main() -> int:
     assets = manifest_assets()
     check_package_resources(assets)
     check_dmg_verifier(assets)
+    check_updater_handoff()
     check_bundle_scripts()
     check_workflows()
     print(f"DMG workflow contract verified ({len(assets)} mac bundle assets).")


### PR DESCRIPTION
## Summary
- Mount the downloaded updater DMG onto a fresh private temp mount point before discovering MetalSharp.app
- Avoid falling back to stale /Volumes/MetalSharp mounts from prior update attempts
- Clean up private mount dirs after detach and add a CI workflow guard for updater handoff mounting

## Validation
- python3 -m py_compile app/updater/update.py tools/ci/verify-dmg-workflow.py
- python3 tools/ci/verify-dmg-workflow.py
- bash -n app/updater/update.sh
- shellcheck app/updater/update.sh
- Created a temporary DMG and verified update.py mounts it on a private temp path, finds MetalSharp.app, and detaches/removes the mount dir