### PR TITLE
fix: install MinGW toolchain in release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,8 +52,11 @@ jobs:
         run: |
           brew list meson >/dev/null 2>&1 || brew install meson
           brew list ninja >/dev/null 2>&1 || brew install ninja
+          brew list mingw-w64 >/dev/null 2>&1 || brew install mingw-w64
           meson --version
           ninja --version
+          x86_64-w64-mingw32-gcc --version
+          x86_64-w64-mingw32-g++ --version
 
       - name: Build staged M12 DXMT runtime
         run: |
@@ -172,8 +175,11 @@ jobs:
         run: |
           brew list meson >/dev/null 2>&1 || brew install meson
           brew list ninja >/dev/null 2>&1 || brew install ninja
+          brew list mingw-w64 >/dev/null 2>&1 || brew install mingw-w64
           meson --version
           ninja --version
+          x86_64-w64-mingw32-gcc --version
+          x86_64-w64-mingw32-g++ --version
 
       - name: Build staged M12 DXMT runtime
         run: |


### PR DESCRIPTION
## Summary
- install Homebrew mingw-w64 before release M12 DXMT runtime build
- verify x86_64-w64-mingw32 gcc/g++ are available in both developer SDK and DMG jobs
- fixes current release CI failure: Unknown compiler x86_64-w64-mingw32-gcc

## Validation
- python3 tools/ci/verify-dmg-workflow.py