### PR TITLE
fix: preserve graphics runtime payload in CI repair

### DIFF
--- a/tools/dmg/create-bundles.sh
+++ b/tools/dmg/create-bundles.sh
@@ -38,11 +38,9 @@ repair_graphics_m12_bundle() {
   root="$tmp/root"
   mkdir -p "$root"
   tar --use-compress-program=unzstd -xf "$archive" -C "$root"
-  mkdir -p "$root/Graphics/dll"
-  rm -rf "$root/Graphics/dll/dxmt-m12"
-  mkdir -p "$root/Graphics/dll/dxmt-m12"
-  cp -R -p "$m12_root/x86_64-unix" "$root/Graphics/dll/dxmt-m12/x86_64-unix"
-  cp -R -p "$m12_root/x86_64-windows" "$root/Graphics/dll/dxmt-m12/x86_64-windows"
+  mkdir -p "$root/Graphics/dll/dxmt-m12/x86_64-unix" "$root/Graphics/dll/dxmt-m12/x86_64-windows"
+  cp -R -p "$m12_root/x86_64-unix/." "$root/Graphics/dll/dxmt-m12/x86_64-unix/"
+  cp -R -p "$m12_root/x86_64-windows/." "$root/Graphics/dll/dxmt-m12/x86_64-windows/"
   (
     cd "$root"
     tar -cf "$tmp/metalsharp-graphics-dll.tar" Graphics


### PR DESCRIPTION
## Summary
- preserve existing dxmt-m12 graphics bundle files when repairing the staged M12 payload
- overlay rebuilt CI files instead of replacing the whole dxmt-m12 directory
- fixes current release CI failure where repaired graphics bundle dropped d3d10core/d3d11/nvapi/nvngx files

## Validation
- bash -n tools/dmg/create-bundles.sh
- python3 tools/ci/verify-dmg-workflow.py