### PR TITLE
Feat: GOG Install / Launch

### DIFF
--- a/app/src-rust/src/bottles.rs
+++ b/app/src-rust/src/bottles.rs
@@ -162,7 +162,40 @@ pub fn vcpp_ensure_and_install_x86(prefix: &Path) -> Result<(), String> {
     }
 }
 
+pub fn vcpp_ensure_and_install_x86_quiet(prefix: &Path) -> Result<(), String> {
+    let (_x64, x86) = vcpp_ensure_downloaded()?;
+    run_quiet_vcpp_installer(prefix, &x86, "x86")?;
+    if vcpp_prefix_has_x86(prefix) {
+        eprintln!("vcredist: VC++ x86 verified in {}", prefix.display());
+        Ok(())
+    } else {
+        Err("VC++ x86 installer completed, but runtime DLLs were not found in syswow64".into())
+    }
+}
+
 fn run_interactive_vcpp_installer(prefix: &Path, installer: &Path, arch: &str) -> Result<(), String> {
+    run_vcpp_installer(prefix, installer, arch, &vcpp_setup_install_args(), true)
+}
+
+fn run_quiet_vcpp_installer(prefix: &Path, installer: &Path, arch: &str) -> Result<(), String> {
+    run_vcpp_installer(prefix, installer, arch, &vcpp_quiet_install_args(), false)
+}
+
+fn vcpp_setup_install_args() -> [&'static str; 1] {
+    ["/install"]
+}
+
+fn vcpp_quiet_install_args() -> [&'static str; 3] {
+    ["/install", "/quiet", "/norestart"]
+}
+
+fn run_vcpp_installer(
+    prefix: &Path,
+    installer: &Path,
+    arch: &str,
+    args: &[&str],
+    inherit_stdio: bool,
+) -> Result<(), String> {
     let home = dirs::home_dir().ok_or("no home dir")?;
     let ms_root = crate::platform::metalsharp_home_dir_for(&home).join("runtime").join("wine");
     let wine = crate::platform::runtime_wine_binary(&ms_root);
@@ -170,19 +203,22 @@ fn run_interactive_vcpp_installer(prefix: &Path, installer: &Path, arch: &str) -
         return Err("MetalSharp Wine not found".into());
     }
     let prefix_str = prefix.to_string_lossy().to_string();
-    eprintln!("vcredist: launching interactive VC++ 2015-2022 {} installer into {} ...", arch, prefix.display());
+    let mode = if inherit_stdio { "interactive" } else { "quiet" };
+    eprintln!("vcredist: launching {} VC++ 2015-2022 {} installer into {} ...", mode, arch, prefix.display());
     let mut cmd = Command::new(&wine);
     cmd.arg("start")
         .arg("/wait")
         .arg("/unix")
         .arg(installer)
-        .args(vcpp_setup_install_args())
+        .args(args)
         .env("WINEPREFIX", &prefix_str)
         .env("WINEARCH", "win64")
-        .env("WINEDEBUG", "-all")
-        .stdin(Stdio::inherit())
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit());
+        .env("WINEDEBUG", "-all");
+    if inherit_stdio {
+        cmd.stdin(Stdio::inherit()).stdout(Stdio::inherit()).stderr(Stdio::inherit());
+    } else {
+        cmd.stdin(Stdio::null()).stdout(Stdio::null()).stderr(Stdio::null());
+    }
     if let Some(parent) = installer.parent() {
         cmd.current_dir(parent);
     }
@@ -193,10 +229,6 @@ fn run_interactive_vcpp_installer(prefix: &Path, installer: &Path, arch: &str) -
     } else {
         Err(format!("VC++ {} installer exited with status {:?}", arch, status.code()))
     }
-}
-
-fn vcpp_setup_install_args() -> [&'static str; 1] {
-    ["/install"]
 }
 
 fn vcpp_installer_status_ok(code: Option<i32>) -> bool {
@@ -1038,6 +1070,18 @@ pub fn create_fresh_installer_bottle(
     classification: &InstallerClassification,
 ) -> Result<BottleManifest, Box<dyn std::error::Error>> {
     ensure_installer_bottle_with_id(source_installer, classification, fresh_installer_bottle_id(source_installer))
+}
+
+pub fn ensure_gog_galaxy_bottle(
+    source_installer: &Path,
+    classification: &InstallerClassification,
+    fresh: bool,
+) -> Result<BottleManifest, Box<dyn std::error::Error>> {
+    let id = "gog-prefix".to_string();
+    if fresh {
+        let _ = fs::remove_dir_all(bottle_dir(&id));
+    }
+    ensure_installer_bottle_with_id(source_installer, classification, id)
 }
 
 fn ensure_installer_bottle_with_id(

--- a/app/src-rust/src/bottles.rs
+++ b/app/src-rust/src/bottles.rs
@@ -3523,7 +3523,7 @@ fn known_launcher_recipes() -> &'static [KnownLauncherRecipe] {
         KnownLauncherRecipe {
             id: "gog_galaxy",
             label: "GOG Galaxy",
-            tokens: &["gog galaxy", "goggalaxy", "galaxyclient", "gog_galaxy"],
+            tokens: &["gog galaxy", "goggalaxy", "galaxyclient", "gog_galaxy", "setup_galaxy", "galaxysetup"],
             installer_kind: InstallerKind::Electron,
             runtime_profile: RuntimeProfile::GogGalaxy,
             forced_pipeline: None,

--- a/app/src-rust/src/bottles.rs
+++ b/app/src-rust/src/bottles.rs
@@ -5752,6 +5752,7 @@ fn is_probable_app_exe(name: &str) -> bool {
     ];
     lower.ends_with(".exe")
         && !builtins.contains(&lower.as_str())
+        && !is_ignored_gog_galaxy_exe_name(&lower)
         && !lower.starts_with("microsoftedgewebview_")
         && !lower.contains("setup")
         && !lower.contains("install")
@@ -5765,6 +5766,19 @@ fn is_probable_app_exe(name: &str) -> bool {
         && !lower.contains("update")
         && !lower.contains("webcore")
         && !lower.contains("cefsubprocess")
+}
+
+fn is_ignored_gog_galaxy_exe_name(lower_name: &str) -> bool {
+    matches!(
+        lower_name,
+        "gog_galaxy_2.0.exe"
+            | "galaxyinstaller.exe"
+            | "galaxysetup.exe"
+            | "galaxyclientservice.exe"
+            | "galaxyoverlay.exe"
+            | "galaxyclient_helper.exe"
+            | "galaxyclient_real.exe"
+    ) || lower_name.ends_with("_real.exe") && lower_name.contains("galaxy")
 }
 
 fn is_probable_app_exe_path(name: &str, path: &Path) -> bool {
@@ -5854,6 +5868,21 @@ mod tests {
 
         assert_ne!(fresh, stable);
         assert!(fresh.starts_with(&format!("{}_fresh_", stable)));
+    }
+
+    #[test]
+    fn gog_galaxy_detection_only_accepts_client_exe() {
+        assert!(is_probable_app_exe("GalaxyClient.exe"));
+        for exe in [
+            "GOG_Galaxy_2.0.exe",
+            "GalaxyInstaller.exe",
+            "GalaxySetup.exe",
+            "GalaxyClientService.exe",
+            "GalaxyOverlay.exe",
+            "GalaxyClient_real.exe",
+        ] {
+            assert!(!is_probable_app_exe(exe), "{exe} should not import as the installed launcher app");
+        }
     }
 
     #[test]

--- a/app/src-rust/src/bottles.rs
+++ b/app/src-rust/src/bottles.rs
@@ -261,6 +261,7 @@ pub enum RuntimeProfile {
     Dotnet,
     Win32Dotnet,
     Webview,
+    GogGalaxy,
     JavaLauncher,
     FnaArm64,
     FnaX86,
@@ -1402,6 +1403,7 @@ pub fn classify_installer(source_installer: &Path) -> InstallerClassification {
             _ => RuntimeProfile::Plain,
         }
     };
+    let arch = if matches!(runtime_profile, RuntimeProfile::GogGalaxy) { BottleArch::Wow64 } else { arch };
 
     InstallerClassification { arch, installer_kind, runtime_profile, pipeline, hints }
 }
@@ -3204,6 +3206,7 @@ fn runtime_profile_definitions() -> Vec<RuntimeProfileDefinition> {
         RuntimeProfile::Dotnet,
         RuntimeProfile::Win32Dotnet,
         RuntimeProfile::Webview,
+        RuntimeProfile::GogGalaxy,
         RuntimeProfile::JavaLauncher,
         RuntimeProfile::FnaArm64,
         RuntimeProfile::FnaX86,
@@ -3316,6 +3319,20 @@ fn runtime_profile_definition(profile: RuntimeProfile) -> RuntimeProfileDefiniti
             ][..],
             crate::mtsp::engine::PipelineId::WineBare,
         ),
+        RuntimeProfile::GogGalaxy => (
+            "GOG Galaxy",
+            BottleArch::Wow64,
+            true,
+            &[
+                "windows_version_win10",
+                "corefonts",
+                "vcrun2019_x86",
+                "vcrun2019_x64",
+                "d3dcompiler_47_x86",
+                "d3dcompiler_47_x64",
+            ][..],
+            crate::mtsp::engine::PipelineId::WineBare,
+        ),
         RuntimeProfile::JavaLauncher => (
             "Java Launcher",
             BottleArch::Wow64,
@@ -3423,6 +3440,7 @@ fn parse_runtime_profile(value: &str) -> Option<RuntimeProfile> {
         "dotnet" => Some(RuntimeProfile::Dotnet),
         "win32_dotnet" | "win32dotnet" => Some(RuntimeProfile::Win32Dotnet),
         "webview" => Some(RuntimeProfile::Webview),
+        "gog_galaxy" | "goggalaxy" => Some(RuntimeProfile::GogGalaxy),
         "java_launcher" | "javalauncher" => Some(RuntimeProfile::JavaLauncher),
         "fna_arm64" | "xna_fna_arm64" | "native_mono_arm64" => Some(RuntimeProfile::FnaArm64),
         "fna_x86" | "xna_fna_x86" | "native_mono_x86" | "mono_x86" => Some(RuntimeProfile::FnaX86),
@@ -3507,7 +3525,7 @@ fn known_launcher_recipes() -> &'static [KnownLauncherRecipe] {
             label: "GOG Galaxy",
             tokens: &["gog galaxy", "goggalaxy", "galaxyclient", "gog_galaxy"],
             installer_kind: InstallerKind::Electron,
-            runtime_profile: RuntimeProfile::Launcher,
+            runtime_profile: RuntimeProfile::GogGalaxy,
             forced_pipeline: None,
         },
     ]
@@ -3860,6 +3878,20 @@ fn inspect_component_state(prefix: &Path, id: &str, fallback: ComponentState) ->
                 ComponentState::Installed
             } else if has(&syswow64, "vcruntime140.dll") || has(&syswow64, "msvcp140.dll") {
                 ComponentState::NeedsRepair
+            } else {
+                ComponentState::Missing
+            }
+        },
+        "d3dcompiler_47_x64" => {
+            if system32.join("d3dcompiler_47.dll").is_file() {
+                ComponentState::Installed
+            } else {
+                ComponentState::Missing
+            }
+        },
+        "d3dcompiler_47_x86" => {
+            if syswow64.join("d3dcompiler_47.dll").is_file() {
+                ComponentState::Installed
             } else {
                 ComponentState::Missing
             }
@@ -5109,6 +5141,8 @@ fn component_source_policy(id: &str, arch: BottleArch) -> ComponentSourcePolicy 
             "rosetta" => "Apple Rosetta 2 x86_64 emulation layer — required for GPTK Wine (softwareupdate --install-rosetta)",
             "corefonts" => "Requires a local core fonts payload or a mapped font installation strategy",
             "webview2" => "Uses Steam CommonRedist or ~/.metalsharp/runtime/redist WebView2 evergreen installer",
+            "d3dcompiler_47_x64" => "Requires d3dcompiler_47.dll in system32 for Chromium/Galaxy rendering",
+            "d3dcompiler_47_x86" => "Requires d3dcompiler_47.dll in syswow64 for 32-bit Galaxy helper processes",
             "directx_jun2010" => "DirectX June 2010 — checks d3dx9_43, d3dx10_43, d3dx11_43, xinput1_3, xaudio2_7, x3daudio1_7, D3DCompiler_43",
             "d3d12_agility" => "Uses NuGet Microsoft.Direct3D.D3D12 x64 runtime payload for the game-declared D3D12SDKVersion",
             "openal" => "Uses Steam CommonRedist or ~/.metalsharp/runtime/redist OpenAL installer",
@@ -5160,6 +5194,8 @@ fn component_action_detail(id: &str) -> String {
         "rosetta" => "Install Apple Rosetta 2 for x86_64 emulation".to_string(),
         "corefonts" => "Install core Windows fonts".to_string(),
         "webview2" => "Install or emulate Microsoft Edge WebView2 runtime".to_string(),
+        "d3dcompiler_47_x64" => "Install or stage d3dcompiler_47.dll in system32".to_string(),
+        "d3dcompiler_47_x86" => "Install or stage d3dcompiler_47.dll in syswow64".to_string(),
         "directx_jun2010" => "Install DirectX June 2010 runtime payloads".to_string(),
         "openal" => "Install OpenAL audio runtime".to_string(),
         "xna" => "Install XNA Framework 4.0 runtime".to_string(),
@@ -6151,6 +6187,7 @@ mod tests {
         assert!(profiles.iter().any(|profile| profile.id == RuntimeProfile::GameInstall));
         assert!(profiles.iter().any(|profile| profile.id == RuntimeProfile::M10));
         assert!(profiles.iter().any(|profile| profile.id == RuntimeProfile::Webview));
+        assert!(profiles.iter().any(|profile| profile.id == RuntimeProfile::GogGalaxy));
         assert!(profiles.iter().any(|profile| profile.id == RuntimeProfile::FnaArm64));
         assert!(profiles.iter().any(|profile| profile.id == RuntimeProfile::FnaX86));
 
@@ -6159,6 +6196,17 @@ mod tests {
         assert!(webview.components.contains(&"dotnet48".to_string()));
         assert!(webview.components.contains(&"directx_jun2010".to_string()));
         assert!(webview.components.contains(&"openal".to_string()));
+
+        let gog = runtime_profile_definition(RuntimeProfile::GogGalaxy);
+        assert_eq!(gog.arch, BottleArch::Wow64);
+        assert_eq!(gog.launch_pipeline, crate::mtsp::engine::PipelineId::WineBare);
+        assert!(gog.components.contains(&"windows_version_win10".to_string()));
+        assert!(gog.components.contains(&"corefonts".to_string()));
+        assert!(gog.components.contains(&"vcrun2019_x86".to_string()));
+        assert!(gog.components.contains(&"vcrun2019_x64".to_string()));
+        assert!(gog.components.contains(&"d3dcompiler_47_x86".to_string()));
+        assert!(gog.components.contains(&"d3dcompiler_47_x64".to_string()));
+        assert!(!gog.components.contains(&"dotnet48".to_string()));
     }
 
     #[test]
@@ -6261,7 +6309,7 @@ mod tests {
             ("EpicGamesLauncherInstaller.exe", RuntimeProfile::Webview, "known_launcher:epic_games"),
             ("EpicInstaller.exe", RuntimeProfile::Webview, "known_launcher:epic_games"),
             ("Rockstar-Games-Launcher.exe", RuntimeProfile::Webview, "known_launcher:rockstar"),
-            ("GOG_Galaxy_2.0.exe", RuntimeProfile::Launcher, "known_launcher:gog_galaxy"),
+            ("GOG_Galaxy_2.0.exe", RuntimeProfile::GogGalaxy, "known_launcher:gog_galaxy"),
         ];
 
         for (name, profile, hint) in cases {
@@ -6305,7 +6353,7 @@ mod tests {
         let classification = classify_installer(&exe);
 
         assert_eq!(classification.installer_kind, InstallerKind::Squirrel);
-        assert_eq!(classification.runtime_profile, RuntimeProfile::Launcher);
+        assert_eq!(classification.runtime_profile, RuntimeProfile::GogGalaxy);
         assert!(classification.hints.iter().any(|hint| hint.starts_with("installer_kind:")));
         let _ = fs::remove_dir_all(dir);
     }

--- a/app/src-rust/src/bottles.rs
+++ b/app/src-rust/src/bottles.rs
@@ -6353,7 +6353,7 @@ mod tests {
         let classification = classify_installer(&exe);
 
         assert_eq!(classification.installer_kind, InstallerKind::Squirrel);
-        assert_eq!(classification.runtime_profile, RuntimeProfile::GogGalaxy);
+        assert_eq!(classification.runtime_profile, RuntimeProfile::Launcher);
         assert!(classification.hints.iter().any(|hint| hint.starts_with("installer_kind:")));
         let _ = fs::remove_dir_all(dir);
     }

--- a/app/src-rust/src/kernel_translation/ipc_bridge.rs
+++ b/app/src-rust/src/kernel_translation/ipc_bridge.rs
@@ -780,8 +780,6 @@ mod tests {
 
     #[test]
     fn test_ipc_header_roundtrip() {
-        VIRTUAL_HANDLES.lock().unwrap().clear();
-
         let mut req = Vec::new();
         req.extend_from_slice(&MS_IPC_MAGIC.to_le_bytes());
         req.extend_from_slice(&MS_IPC_VERSION.to_le_bytes());

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -1826,6 +1826,10 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
             app_log("[SHARP-LIB] launcher diagnostics: GOG Galaxy");
             resp(200, sharp_library::handle_gog_galaxy_diagnostics())
         },
+        (Method::Get, "/sharp-library/launchers/gogdl/diagnostics") => {
+            app_log("[SHARP-LIB] launcher diagnostics: GOGDL");
+            resp(200, sharp_library::handle_gogdl_diagnostics())
+        },
         (Method::Post, "/sharp-library/launchers/gog/show-card") => {
             app_log("[SHARP-LIB] launcher show card: GOG Galaxy");
             resp(200, sharp_library::handle_show_gog_galaxy_card())

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -37,7 +37,7 @@ mod sharp_library;
 mod steam;
 mod updater;
 
-use serde_json::json;
+use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -1829,6 +1829,48 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
         (Method::Get, "/sharp-library/launchers/gogdl/diagnostics") => {
             app_log("[SHARP-LIB] launcher diagnostics: GOGDL");
             resp(200, sharp_library::handle_gogdl_diagnostics())
+        },
+        (Method::Post, "/sharp-library/launchers/gogdl/auth") => {
+            let body = read_body(req);
+            app_log("[SHARP-LIB] launcher auth: GOGDL");
+            resp(200, sharp_library::handle_gogdl_auth(&Value::Object(body)))
+        },
+        (Method::Post, "/sharp-library/launchers/gogdl/info") => {
+            let body = read_body(req);
+            app_log(&format!(
+                "[SHARP-LIB] launcher info: GOGDL {}",
+                body.get("productId").or_else(|| body.get("id")).and_then(|v| v.as_str()).unwrap_or("?")
+            ));
+            resp(200, sharp_library::handle_gogdl_info(&Value::Object(body)))
+        },
+        (Method::Post, "/sharp-library/launchers/gogdl/download") => {
+            let body = read_body(req);
+            app_log(&format!(
+                "[SHARP-LIB] launcher download: GOGDL {}",
+                body.get("productId").or_else(|| body.get("id")).and_then(|v| v.as_str()).unwrap_or("?")
+            ));
+            resp(200, sharp_library::handle_gogdl_download(&Value::Object(body)))
+        },
+        (Method::Post, "/sharp-library/launchers/gogdl/import") => {
+            let body = read_body(req);
+            app_log("[SHARP-LIB] launcher import: GOGDL");
+            resp(200, sharp_library::handle_gogdl_import(&Value::Object(body)))
+        },
+        (Method::Post, "/sharp-library/launchers/gogdl/launch") => {
+            let body = read_body(req);
+            app_log(&format!(
+                "[SHARP-LIB] launcher launch: GOGDL {}",
+                body.get("productId").or_else(|| body.get("id")).and_then(|v| v.as_str()).unwrap_or("?")
+            ));
+            resp(200, sharp_library::handle_gogdl_launch(&Value::Object(body)))
+        },
+        (Method::Post, "/sharp-library/launchers/gogdl/save-sync") => {
+            let body = read_body(req);
+            app_log(&format!(
+                "[SHARP-LIB] launcher save sync: GOGDL {}",
+                body.get("productId").or_else(|| body.get("id")).and_then(|v| v.as_str()).unwrap_or("?")
+            ));
+            resp(200, sharp_library::handle_gogdl_save_sync(&Value::Object(body)))
         },
         (Method::Post, "/sharp-library/launchers/gog/show-card") => {
             app_log("[SHARP-LIB] launcher show card: GOG Galaxy");

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -1805,6 +1805,23 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
             let body = read_body(req);
             resp(200, launcher_evidence::handle_launcher_evidence(&body))
         },
+        (Method::Get, "/sharp-library/launchers") => resp(200, sharp_library::handle_launchers()),
+        (Method::Post, "/sharp-library/launchers/gog/install") => {
+            app_log("[SHARP-LIB] launcher install: GOG Galaxy");
+            resp(200, sharp_library::handle_install_gog_galaxy())
+        },
+        (Method::Post, "/sharp-library/launchers/gog/open") => {
+            app_log("[SHARP-LIB] launcher open: GOG Galaxy");
+            resp(200, sharp_library::handle_open_gog_galaxy())
+        },
+        (Method::Post, "/sharp-library/launchers/gog/repair") => {
+            app_log("[SHARP-LIB] launcher repair: GOG Galaxy");
+            resp(200, sharp_library::handle_repair_gog_galaxy())
+        },
+        (Method::Post, "/sharp-library/launchers/gog/show-card") => {
+            app_log("[SHARP-LIB] launcher show card: GOG Galaxy");
+            resp(200, sharp_library::handle_show_gog_galaxy_card())
+        },
         (Method::Post, "/sharp-library/install") => {
             let body = read_body(req);
             app_log(&format!("[SHARP-LIB] install: {}", body.get("srcPath").and_then(|v| v.as_str()).unwrap_or("?")));

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -1814,6 +1814,10 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
             app_log("[SHARP-LIB] launcher open: GOG Galaxy");
             resp(200, sharp_library::handle_open_gog_galaxy())
         },
+        (Method::Post, "/sharp-library/launchers/gog/stop") => {
+            app_log("[SHARP-LIB] launcher stop: GOG Galaxy");
+            resp(200, sharp_library::handle_stop_gog_galaxy())
+        },
         (Method::Post, "/sharp-library/launchers/gog/repair") => {
             app_log("[SHARP-LIB] launcher repair: GOG Galaxy");
             resp(200, sharp_library::handle_repair_gog_galaxy())

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -1818,6 +1818,10 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
             app_log("[SHARP-LIB] launcher repair: GOG Galaxy");
             resp(200, sharp_library::handle_repair_gog_galaxy())
         },
+        (Method::Get, "/sharp-library/launchers/gog/diagnostics") => {
+            app_log("[SHARP-LIB] launcher diagnostics: GOG Galaxy");
+            resp(200, sharp_library::handle_gog_galaxy_diagnostics())
+        },
         (Method::Post, "/sharp-library/launchers/gog/show-card") => {
             app_log("[SHARP-LIB] launcher show card: GOG Galaxy");
             resp(200, sharp_library::handle_show_gog_galaxy_card())

--- a/app/src-rust/src/sharp_library.rs
+++ b/app/src-rust/src/sharp_library.rs
@@ -788,6 +788,9 @@ fn is_supported_windows_program(src: &Path) -> bool {
 
 fn start_wine_installer(src: &Path, fresh_bottle: bool) -> Result<SharpInstallOutcome, Box<dyn std::error::Error>> {
     let classification = crate::bottles::classify_installer(src);
+    if classification.runtime_profile == crate::bottles::RuntimeProfile::GogGalaxy {
+        return start_gog_galaxy_installer(src, &classification, fresh_bottle);
+    }
     let pipeline = classification.pipeline;
     let bottle = if fresh_bottle {
         crate::bottles::create_fresh_installer_bottle(src, &classification)?
@@ -795,6 +798,143 @@ fn start_wine_installer(src: &Path, fresh_bottle: bool) -> Result<SharpInstallOu
         crate::bottles::ensure_installer_bottle(src, &classification)?
     };
     start_wine_installer_in_bottle(src, &classification, &bottle, pipeline)
+}
+
+fn start_gog_galaxy_installer(
+    src: &Path,
+    classification: &crate::bottles::InstallerClassification,
+    fresh_bottle: bool,
+) -> Result<SharpInstallOutcome, Box<dyn std::error::Error>> {
+    let bottle = if fresh_bottle {
+        crate::bottles::create_fresh_installer_bottle(src, classification)?
+    } else {
+        crate::bottles::ensure_installer_bottle(src, classification)?
+    };
+    kill_stale_gog_galaxy_processes(&PathBuf::from(&bottle.prefix_path));
+    let outcome = start_wine_installer_in_bottle(src, classification, &bottle, classification.pipeline)?;
+    if let SharpInstallOutcome::InstallerStarted { pid, .. } = &outcome {
+        spawn_gog_galaxy_install_watcher(bottle.id.clone(), *pid, src.to_path_buf());
+    }
+    Ok(outcome)
+}
+
+fn gog_galaxy_setup_cache_path() -> PathBuf {
+    crate::platform::metalsharp_home_dir().join("cache").join("gog-galaxy").join("GalaxySetup.exe")
+}
+
+fn spawn_gog_galaxy_install_watcher(bottle_id: String, mut watched_pid: u32, source_installer: PathBuf) {
+    std::thread::spawn(move || {
+        let mut retried_cached_setup = false;
+        for _ in 0..360 {
+            let Ok(bottle) = crate::bottles::load_bottle(&bottle_id) else {
+                break;
+            };
+            let prefix = PathBuf::from(&bottle.prefix_path);
+            if let Some(client) = gog_galaxy_client_in_prefix(&prefix) {
+                let _ = crate::bottles::refresh_app_detections(&bottle_id);
+                let _ = import_bottle_app(&bottle_id, &client.to_string_lossy(), Some("GOG Galaxy"));
+                break;
+            }
+            cache_downloaded_gog_galaxy_setup(&prefix);
+            let running = crate::launch::is_process_active(watched_pid as i32);
+            if !running && !retried_cached_setup && !is_gog_galaxy_setup_installer(&source_installer) {
+                let cached_setup = gog_galaxy_setup_cache_path();
+                if cached_setup.exists() {
+                    let classification = crate::bottles::classify_installer(&cached_setup);
+                    kill_stale_gog_galaxy_processes(&prefix);
+                    if let Ok(SharpInstallOutcome::InstallerStarted { pid, .. }) =
+                        start_wine_installer_in_bottle(&cached_setup, &classification, &bottle, classification.pipeline)
+                    {
+                        watched_pid = pid;
+                        retried_cached_setup = true;
+                    } else {
+                        retried_cached_setup = true;
+                    }
+                } else {
+                    retried_cached_setup = true;
+                }
+            }
+            if !running && retried_cached_setup {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_secs(5));
+        }
+    });
+}
+
+fn is_gog_galaxy_setup_installer(path: &Path) -> bool {
+    path.file_name()
+        .map(|name| name.to_string_lossy().to_ascii_lowercase())
+        .map(|name| name.starts_with("setup_galaxy") || name == "galaxysetup.exe")
+        .unwrap_or(false)
+}
+
+fn gog_galaxy_client_in_prefix(prefix: &Path) -> Option<PathBuf> {
+    [
+        prefix.join("drive_c").join("Program Files (x86)").join("GOG Galaxy").join("GalaxyClient.exe"),
+        prefix.join("drive_c").join("Program Files").join("GOG Galaxy").join("GalaxyClient.exe"),
+    ]
+    .into_iter()
+    .find(|path| path.exists())
+}
+
+fn gog_galaxy_setup_candidates(prefix: &Path) -> Vec<PathBuf> {
+    let users = prefix.join("drive_c").join("users");
+    let mut candidates = Vec::new();
+    if !users.exists() {
+        return candidates;
+    }
+    for entry in WalkDir::new(&users).max_depth(7).into_iter().flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let name = path.file_name().map(|name| name.to_string_lossy()).unwrap_or_default();
+        if !name.eq_ignore_ascii_case("GalaxySetup.exe") {
+            continue;
+        }
+        let parent = path.parent().and_then(|parent| parent.file_name()).map(|name| name.to_string_lossy());
+        if parent.map(|name| name.starts_with("GalaxyInstaller_")).unwrap_or(false) {
+            candidates.push(path.to_path_buf());
+        }
+    }
+    candidates.sort();
+    candidates
+}
+
+fn cache_downloaded_gog_galaxy_setup(prefix: &Path) {
+    let Some(candidate) = gog_galaxy_setup_candidates(prefix)
+        .into_iter()
+        .find(|path| path.metadata().map(|meta| meta.len() > 1_000_000).unwrap_or(false))
+    else {
+        return;
+    };
+    let cache = gog_galaxy_setup_cache_path();
+    if cache.exists() && same_file_hash(&candidate, &cache) {
+        return;
+    }
+    if let Some(parent) = cache.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let tmp = cache.with_extension("exe.download");
+    if fs::copy(&candidate, &tmp).is_ok() {
+        let _ = fs::rename(tmp, cache);
+    }
+}
+
+fn same_file_hash(a: &Path, b: &Path) -> bool {
+    matches!((crate::diagnostics::file_sha256(a), crate::diagnostics::file_sha256(b)), (Some(left), Some(right)) if left == right)
+}
+
+fn kill_stale_gog_galaxy_processes(prefix: &Path) {
+    let _ = Command::new("/usr/bin/pkill")
+        .arg("-f")
+        .arg("GalaxyClient|GalaxyClientService|GalaxyOverlay|GalaxySetup")
+        .status();
+    let wineserver =
+        crate::platform::runtime_wine_binary(&crate::platform::metalsharp_home_dir().join("runtime").join("wine"))
+            .with_file_name("wineserver");
+    let _ = Command::new(wineserver).env("WINEPREFIX", prefix).arg("-k").status();
 }
 
 fn start_wine_installer_in_bottle(
@@ -2135,6 +2275,36 @@ mod tests {
         assert!(apply_default_launcher_launch_args_to_app(&mut app));
         assert_eq!(app.launch_args, vec!["/runWithoutUpdating", "/deelevated"]);
         assert!(!apply_default_launcher_launch_args_to_app(&mut app));
+    }
+
+    #[test]
+    fn gog_galaxy_setup_watcher_finds_second_stage_installer() {
+        let prefix = test_dir("gog-setup-watcher");
+        let setup_dir = prefix
+            .join("drive_c")
+            .join("users")
+            .join("tester")
+            .join("AppData")
+            .join("Local")
+            .join("Temp")
+            .join("GalaxyInstaller_123");
+        fs::create_dir_all(&setup_dir).expect("create setup temp");
+        let setup = setup_dir.join("GalaxySetup.exe");
+        fs::write(&setup, b"setup").expect("write setup");
+
+        assert_eq!(gog_galaxy_setup_candidates(&prefix), vec![setup]);
+        let _ = fs::remove_dir_all(prefix);
+    }
+
+    #[test]
+    fn imported_bottle_apps_preserve_custom_names() {
+        let install_dir = PathBuf::from("/tmp/prefix/drive_c/Program Files (x86)/GOG Galaxy");
+        let mut existing = test_app("My Galaxy", "GalaxyClient.exe", &install_dir.to_string_lossy());
+        existing.bottle_id = Some("installer_gog".into());
+        let mut incoming = test_app("GOG Galaxy", "GalaxyClient.exe", &install_dir.to_string_lossy());
+        incoming.bottle_id = Some("installer_gog".into());
+
+        assert!(should_preserve_imported_bottle_app_name(&existing, &incoming));
     }
 
     #[test]

--- a/app/src-rust/src/sharp_library.rs
+++ b/app/src-rust/src/sharp_library.rs
@@ -469,7 +469,11 @@ fn default_installer_launch_args(src: &Path, classification: &crate::bottles::In
         // it an explicit install dir so its previous-install detection never
         // falls back to the Wine drive root ("Found GalaxyClientExePath under \\").
         if is_gog_galaxy_setup_installer(src) {
-            return vec!["/DIR=C:\\Program Files (x86)\\GOG Galaxy".to_string()];
+            return vec![
+                "/DIR=C:\\Program Files (x86)\\GOG Galaxy".to_string(),
+                "/CLOSEAPPLICATIONS".to_string(),
+                "/FORCECLOSEAPPLICATIONS".to_string(),
+            ];
         }
         return Vec::new();
     }
@@ -2398,7 +2402,10 @@ mod tests {
                 ],
             ),
             ("GOG_Galaxy_2.0.exe", vec![]),
-            ("GalaxySetup.exe", vec!["/DIR=C:\\Program Files (x86)\\GOG Galaxy"]),
+            (
+                "GalaxySetup.exe",
+                vec!["/DIR=C:\\Program Files (x86)\\GOG Galaxy", "/CLOSEAPPLICATIONS", "/FORCECLOSEAPPLICATIONS"],
+            ),
         ];
 
         for (filename, expected) in cases {

--- a/app/src-rust/src/sharp_library.rs
+++ b/app/src-rust/src/sharp_library.rs
@@ -4,7 +4,7 @@ use std::fs::{self, OpenOptions};
 use std::hash::{Hash, Hasher};
 use std::io::Write;
 use std::path::{Component, Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Command, Output, Stdio};
 use walkdir::WalkDir;
 
 const LIBRARY_DIR: &str = "sharp-library";
@@ -2147,6 +2147,7 @@ pub fn handle_get_library() -> Value {
 
 const GOG_GALAXY_INSTALLER_URL: &str = "https://webinstallers.gog-statics.com/download/GOG_Galaxy_2.0.exe";
 const GOGDL_AUTH_URL: &str = "https://auth.gog.com/auth?client_id=46899977096215655&redirect_uri=https%3A%2F%2Fembed.gog.com%2Fon_login_success%3Forigin%3Dclient&response_type=code&layout=galaxy";
+const GOG_PREFIX_BOTTLE_ID: &str = "gog-prefix";
 
 fn gog_galaxy_cache_path() -> PathBuf {
     crate::platform::metalsharp_home_dir().join("cache").join("gog-galaxy").join("GOG_Galaxy_2.0.exe")
@@ -2259,6 +2260,60 @@ fn gogdl_auth_config_path() -> PathBuf {
     crate::platform::metalsharp_home_dir().join("gog_store").join("auth.json")
 }
 
+fn gogdl_support_dir() -> PathBuf {
+    gogdl_config_dir().join("gog-support")
+}
+
+fn gogdl_default_install_dir(product_id: &str) -> PathBuf {
+    crate::platform::metalsharp_home_dir().join("gog-games").join(product_id)
+}
+
+fn gogdl_prefix_dir() -> PathBuf {
+    crate::bottles::bottle_dir(GOG_PREFIX_BOTTLE_ID).join("prefix")
+}
+
+fn gogdl_default_prefix_dir(_product_id: &str) -> PathBuf {
+    gogdl_prefix_dir()
+}
+
+fn gogdl_metalsharp_wine_root() -> PathBuf {
+    let home = dirs::home_dir().unwrap_or_default();
+    crate::platform::metalsharp_home_dir_for(&home).join("runtime").join("wine")
+}
+
+fn gogdl_metalsharp_wine_binary() -> PathBuf {
+    crate::platform::runtime_wine_binary(&gogdl_metalsharp_wine_root())
+}
+
+fn ensure_gogdl_prefix(prefix: &Path) -> Result<(), String> {
+    fs::create_dir_all(prefix).map_err(|error| format!("failed to create GOG prefix directory: {}", error))?;
+    if prefix.join("drive_c").is_dir() {
+        return Ok(());
+    }
+
+    let wine = gogdl_metalsharp_wine_binary();
+    if !wine.is_file() {
+        return Err(format!("MetalSharp Wine binary not found: {}", wine.display()));
+    }
+    let ms_root = gogdl_metalsharp_wine_root();
+    let mut command = Command::new(&wine);
+    command
+        .arg("wineboot")
+        .arg("-u")
+        .env("WINEPREFIX", prefix.to_string_lossy().to_string())
+        .env("WINEMSYNC", "1")
+        .env("WINEDEBUG", "-all")
+        .env("MS_FWD_COMPAT_GL_CTX", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    crate::platform::set_runtime_library_env(&mut command, &ms_root);
+    let status = command.status().map_err(|error| format!("failed to initialize GOG prefix: {}", error))?;
+    if !status.success() {
+        return Err(format!("failed to initialize GOG prefix with wineboot: {:?}", status.code()));
+    }
+    Ok(())
+}
+
 fn gogdl_candidate_paths_from_path_env(path_env: Option<&str>) -> Vec<PathBuf> {
     let mut candidates = Vec::new();
     if let Ok(explicit) = std::env::var("METALSHARP_GOGDL_BIN") {
@@ -2314,14 +2369,357 @@ fn gogdl_status_value() -> Value {
         "binaryPath": binary.map(|path| path.to_string_lossy().to_string()),
         "configPath": gogdl_config_dir().to_string_lossy().to_string(),
         "authConfigPath": auth_config.to_string_lossy().to_string(),
+        "supportPath": gogdl_support_dir().to_string_lossy().to_string(),
+        "bottleId": GOG_PREFIX_BOTTLE_ID,
+        "winePrefix": gogdl_prefix_dir().to_string_lossy().to_string(),
+        "prefixInitialized": gogdl_prefix_dir().join("drive_c").is_dir(),
+        "winePath": gogdl_metalsharp_wine_binary().to_string_lossy().to_string(),
         "authUrl": GOGDL_AUTH_URL,
         "galaxyFallbackId": "gog_galaxy",
         "capabilities": ["auth", "metadata", "download", "launch", "cloud_saves", "redists"],
     })
 }
 
+fn valid_gogdl_token(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 160
+        && value.chars().all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
+}
+
+fn gogdl_product_id(body: &Value) -> Result<String, String> {
+    let product_id = body
+        .get("productId")
+        .or_else(|| body.get("id"))
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .ok_or_else(|| "missing GOG productId".to_string())?;
+    if !valid_gogdl_token(product_id) {
+        return Err("invalid GOG productId".to_string());
+    }
+    Ok(product_id.to_string())
+}
+
+fn gogdl_platform(body: &Value) -> Result<String, String> {
+    let platform =
+        body.get("platform").or_else(|| body.get("os")).and_then(|value| value.as_str()).unwrap_or("windows");
+    match platform {
+        "windows" | "osx" | "linux" => Ok(platform.to_string()),
+        _ => Err("platform must be windows, osx, or linux".to_string()),
+    }
+}
+
+fn gogdl_string_field(body: &Value, name: &str) -> Option<String> {
+    body.get(name).and_then(|value| value.as_str()).map(str::trim).filter(|value| !value.is_empty()).map(str::to_string)
+}
+
+fn gogdl_output_stdout_json(output: &Output) -> Option<Value> {
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if stdout.is_empty() {
+        None
+    } else {
+        serde_json::from_str(&stdout).ok()
+    }
+}
+
+fn gogdl_error_from_output(context: &str, output: &Output) -> Value {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    json!({
+        "ok": false,
+        "error": format!("{} failed", context),
+        "status": output.status.code(),
+        "stderr": truncate_gogdl_text(&stderr),
+        "stdout": truncate_gogdl_text(&stdout),
+        "launcher": gogdl_status_value(),
+    })
+}
+
+fn truncate_gogdl_text(value: &str) -> String {
+    const LIMIT: usize = 8_192;
+    if value.len() <= LIMIT {
+        value.to_string()
+    } else {
+        format!("{}…", &value[..LIMIT])
+    }
+}
+
+fn gogdl_command() -> Result<Command, String> {
+    let binary = find_gogdl_binary()
+        .ok_or_else(|| "gogdl binary not found; set METALSHARP_GOGDL_BIN or install gogdl".to_string())?;
+    let auth_config = gogdl_auth_config_path();
+    if let Some(parent) = auth_config.parent() {
+        fs::create_dir_all(parent).map_err(|error| format!("failed to create GOG auth directory: {}", error))?;
+    }
+    fs::create_dir_all(gogdl_config_dir())
+        .map_err(|error| format!("failed to create GOGDL config directory: {}", error))?;
+    fs::create_dir_all(gogdl_support_dir())
+        .map_err(|error| format!("failed to create GOG support directory: {}", error))?;
+
+    let mut command = Command::new(binary);
+    command
+        .arg("--auth-config-path")
+        .arg(auth_config)
+        .env("GOGDL_CONFIG_PATH", gogdl_config_dir())
+        .env("GOGDL_SUPPORT_PATH", gogdl_support_dir());
+    Ok(command)
+}
+
+fn run_gogdl_output(args: &[String]) -> Result<Output, String> {
+    let mut command = gogdl_command()?;
+    command
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|error| format!("failed to run gogdl: {}", error))
+}
+
+fn spawn_gogdl(args: &[String]) -> Result<u32, String> {
+    let mut command = gogdl_command()?;
+    command.args(args).stdout(Stdio::null()).stderr(Stdio::null());
+    command.spawn().map(|child| child.id()).map_err(|error| format!("failed to spawn gogdl: {}", error))
+}
+
+fn gogdl_download_args(body: &Value) -> Result<(String, PathBuf, Vec<String>), String> {
+    let product_id = gogdl_product_id(body)?;
+    let platform = gogdl_platform(body)?;
+    let install_dir = gogdl_string_field(body, "installPath")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| gogdl_default_install_dir(&product_id));
+    let support_dir = gogdl_string_field(body, "supportPath")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| gogdl_support_dir().join(&product_id));
+    fs::create_dir_all(&install_dir).map_err(|error| format!("failed to create GOG install directory: {}", error))?;
+    fs::create_dir_all(&support_dir).map_err(|error| format!("failed to create GOG support directory: {}", error))?;
+
+    let mut args = vec![
+        "download".to_string(),
+        product_id.clone(),
+        "--platform".to_string(),
+        platform,
+        "--path".to_string(),
+        install_dir.to_string_lossy().to_string(),
+        "--support".to_string(),
+        support_dir.to_string_lossy().to_string(),
+    ];
+    if body.get("withDlcs").and_then(|value| value.as_bool()).unwrap_or(true) {
+        args.push("--with-dlcs".to_string());
+    } else {
+        args.push("--skip-dlcs".to_string());
+    }
+    if let Some(language) = gogdl_string_field(body, "language") {
+        args.extend(["--lang".to_string(), language]);
+    }
+    if let Some(build) = gogdl_string_field(body, "build") {
+        args.extend(["--build".to_string(), build]);
+    }
+    if let Some(branch) = gogdl_string_field(body, "branch") {
+        args.extend(["--branch".to_string(), branch]);
+    }
+    Ok((product_id, install_dir, args))
+}
+
+fn gogdl_info_args(body: &Value) -> Result<Vec<String>, String> {
+    let product_id = gogdl_product_id(body)?;
+    let platform = gogdl_platform(body)?;
+    let mut args = vec!["info".to_string(), product_id, "--platform".to_string(), platform];
+    if body.get("withDlcs").and_then(|value| value.as_bool()).unwrap_or(true) {
+        args.push("--with-dlcs".to_string());
+    } else {
+        args.push("--skip-dlcs".to_string());
+    }
+    if let Some(language) = gogdl_string_field(body, "language") {
+        args.extend(["--lang".to_string(), language]);
+    }
+    if let Some(build) = gogdl_string_field(body, "build") {
+        args.extend(["--build".to_string(), build]);
+    }
+    Ok(args)
+}
+
+fn gogdl_launch_args(body: &Value) -> Result<(String, PathBuf, PathBuf, Vec<String>), String> {
+    gogdl_launch_args_with_defaults(body, gogdl_default_prefix_dir, gogdl_metalsharp_wine_binary())
+}
+
+fn gogdl_launch_args_with_defaults(
+    body: &Value,
+    default_prefix: impl FnOnce(&str) -> PathBuf,
+    wine: PathBuf,
+) -> Result<(String, PathBuf, PathBuf, Vec<String>), String> {
+    let product_id = gogdl_product_id(body)?;
+    let platform = gogdl_platform(body)?;
+    let install_dir = gogdl_string_field(body, "installPath")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| gogdl_default_install_dir(&product_id));
+    if !install_dir.is_dir() {
+        return Err(format!("GOG install path does not exist: {}", install_dir.display()));
+    }
+    let prefix =
+        gogdl_string_field(body, "winePrefix").map(PathBuf::from).unwrap_or_else(|| default_prefix(&product_id));
+    if !wine.is_file() {
+        return Err(format!("MetalSharp Wine binary not found: {}", wine.display()));
+    }
+
+    let mut args = vec![
+        "launch".to_string(),
+        install_dir.to_string_lossy().to_string(),
+        product_id.clone(),
+        "--platform".to_string(),
+        platform,
+        "--wine".to_string(),
+        wine.to_string_lossy().to_string(),
+        "--wine-prefix".to_string(),
+        prefix.to_string_lossy().to_string(),
+    ];
+    if let Some(preferred_task) = gogdl_string_field(body, "preferredTask") {
+        args.extend(["--prefer-task".to_string(), preferred_task]);
+    }
+    if let Some(override_exe) = gogdl_string_field(body, "overrideExe") {
+        args.extend(["--override-exe".to_string(), override_exe]);
+    }
+    Ok((product_id, install_dir, prefix, args))
+}
+
 pub fn handle_gogdl_diagnostics() -> Value {
     json!({"ok": true, "launcher": gogdl_status_value(), "galaxyFallback": gog_launcher_status_value()})
+}
+
+pub fn handle_gogdl_auth(body: &Value) -> Value {
+    let Some(code) = gogdl_string_field(body, "code") else {
+        return json!({"ok": false, "error": "missing GOG authorization code", "launcher": gogdl_status_value()});
+    };
+    let args = vec!["auth".to_string(), "--code".to_string(), code];
+    match run_gogdl_output(&args) {
+        Ok(output) if output.status.success() => json!({
+            "ok": true,
+            "authenticated": gogdl_auth_config_path().is_file(),
+            "credentials": gogdl_output_stdout_json(&output).map(|_| json!({"redacted": true})),
+            "launcher": gogdl_status_value(),
+        }),
+        Ok(output) => gogdl_error_from_output("gogdl auth", &output),
+        Err(error) => json!({"ok": false, "error": error, "launcher": gogdl_status_value()}),
+    }
+}
+
+pub fn handle_gogdl_info(body: &Value) -> Value {
+    let args = match gogdl_info_args(body) {
+        Ok(args) => args,
+        Err(error) => return json!({"ok": false, "error": error, "launcher": gogdl_status_value()}),
+    };
+    match run_gogdl_output(&args) {
+        Ok(output) if output.status.success() => json!({
+            "ok": true,
+            "info": gogdl_output_stdout_json(&output),
+            "stdout": truncate_gogdl_text(String::from_utf8_lossy(&output.stdout).trim()),
+            "launcher": gogdl_status_value(),
+        }),
+        Ok(output) => gogdl_error_from_output("gogdl info", &output),
+        Err(error) => json!({"ok": false, "error": error, "launcher": gogdl_status_value()}),
+    }
+}
+
+pub fn handle_gogdl_download(body: &Value) -> Value {
+    let (product_id, install_dir, args) = match gogdl_download_args(body) {
+        Ok(args) => args,
+        Err(error) => return json!({"ok": false, "error": error, "launcher": gogdl_status_value()}),
+    };
+    match spawn_gogdl(&args) {
+        Ok(pid) => json!({
+            "ok": true,
+            "pid": pid,
+            "productId": product_id,
+            "installPath": install_dir.to_string_lossy().to_string(),
+            "message": "GOG download started",
+            "launcher": gogdl_status_value(),
+        }),
+        Err(error) => json!({"ok": false, "error": error, "launcher": gogdl_status_value()}),
+    }
+}
+
+pub fn handle_gogdl_import(body: &Value) -> Value {
+    let Some(path) = gogdl_string_field(body, "installPath").or_else(|| gogdl_string_field(body, "path")) else {
+        return json!({"ok": false, "error": "missing installPath", "launcher": gogdl_status_value()});
+    };
+    let args = vec!["import".to_string(), path.clone()];
+    match run_gogdl_output(&args) {
+        Ok(output) if output.status.success() => json!({
+            "ok": true,
+            "import": gogdl_output_stdout_json(&output),
+            "stdout": truncate_gogdl_text(String::from_utf8_lossy(&output.stdout).trim()),
+            "launcher": gogdl_status_value(),
+        }),
+        Ok(output) => gogdl_error_from_output("gogdl import", &output),
+        Err(error) => json!({"ok": false, "error": error, "launcher": gogdl_status_value()}),
+    }
+}
+
+pub fn handle_gogdl_launch(body: &Value) -> Value {
+    let (product_id, install_dir, prefix, args) = match gogdl_launch_args(body) {
+        Ok(args) => args,
+        Err(error) => return json!({"ok": false, "error": error, "launcher": gogdl_status_value()}),
+    };
+    if let Err(error) = ensure_gogdl_prefix(&prefix) {
+        return json!({"ok": false, "error": error, "launcher": gogdl_status_value()});
+    }
+    match spawn_gogdl(&args) {
+        Ok(pid) => json!({
+            "ok": true,
+            "pid": pid,
+            "productId": product_id,
+            "installPath": install_dir.to_string_lossy().to_string(),
+            "winePrefix": prefix.to_string_lossy().to_string(),
+            "bottleId": GOG_PREFIX_BOTTLE_ID,
+            "winePath": gogdl_metalsharp_wine_binary().to_string_lossy().to_string(),
+            "message": "GOG game launch started",
+            "launcher": gogdl_status_value(),
+        }),
+        Err(error) => json!({"ok": false, "error": error, "launcher": gogdl_status_value()}),
+    }
+}
+
+pub fn handle_gogdl_save_sync(body: &Value) -> Value {
+    let product_id = match gogdl_product_id(body) {
+        Ok(product_id) => product_id,
+        Err(error) => return json!({"ok": false, "error": error, "launcher": gogdl_status_value()}),
+    };
+    let platform = match gogdl_platform(body) {
+        Ok(platform) => platform,
+        Err(error) => return json!({"ok": false, "error": error, "launcher": gogdl_status_value()}),
+    };
+    let Some(save_path) = gogdl_string_field(body, "savePath") else {
+        return json!({"ok": false, "error": "missing savePath", "launcher": gogdl_status_value()});
+    };
+    let timestamp = gogdl_string_field(body, "timestamp").unwrap_or_else(|| "0".to_string());
+    let save_name = gogdl_string_field(body, "name").unwrap_or_else(|| "__default".to_string());
+    let mut args = vec![
+        "save-sync".to_string(),
+        save_path,
+        product_id.clone(),
+        "--os".to_string(),
+        platform,
+        "--ts".to_string(),
+        timestamp,
+        "--name".to_string(),
+        save_name,
+    ];
+    if let Some(mode) = gogdl_string_field(body, "mode") {
+        let flag = match mode.as_str() {
+            "upload" => Some("--skip-download"),
+            "download" => Some("--skip-upload"),
+            "forceupload" | "force_upload" => Some("--force-upload"),
+            "forcedownload" | "force_download" => Some("--force-download"),
+            _ => None,
+        };
+        if let Some(flag) = flag {
+            args.push(flag.to_string());
+        }
+    }
+    match spawn_gogdl(&args) {
+        Ok(pid) => {
+            json!({"ok": true, "pid": pid, "productId": product_id, "message": "GOG save sync started", "launcher": gogdl_status_value()})
+        },
+        Err(error) => json!({"ok": false, "error": error, "launcher": gogdl_status_value()}),
+    }
 }
 
 pub fn handle_launchers() -> Value {
@@ -2859,6 +3257,53 @@ mod tests {
         assert!(candidates.iter().any(|path| path.ends_with("tools/gogdl")));
         assert!(candidates.iter().any(|path| path.ends_with("runtime/gogdl")));
         assert!(candidates.iter().any(|path| path == &PathBuf::from("/usr/local/bin/gogdl")));
+    }
+
+    #[test]
+    fn gogdl_info_args_follow_heroic_command_shape() {
+        let args = gogdl_info_args(&json!({"productId": "1423049311", "platform": "windows"})).expect("args");
+        assert_eq!(args, ["info", "1423049311", "--platform", "windows", "--with-dlcs"]);
+    }
+
+    #[test]
+    fn gogdl_launch_args_use_metalsharp_wine_and_gog_scoped_prefix() {
+        let install_dir = test_dir("gogdl-launch-install");
+        let prefix_dir = test_dir("gog-prefix-launch").join("bottles").join("gog-prefix").join("prefix");
+        let wine = test_dir("gogdl-launch-wine").join("runtime").join("wine").join("bin").join("metalsharp-wine");
+        fs::create_dir_all(&install_dir).expect("create install dir");
+        fs::create_dir_all(wine.parent().expect("wine parent")).expect("create wine bin dir");
+        fs::write(&wine, b"#!/bin/sh\n").expect("write wine");
+
+        let (_product_id, _install_dir, prefix, args) = gogdl_launch_args_with_defaults(
+            &json!({
+                "productId": "1423049311",
+                "installPath": install_dir.to_string_lossy(),
+                "platform": "windows",
+                "preferredTask": "1"
+            }),
+            |_| prefix_dir.clone(),
+            wine.clone(),
+        )
+        .expect("args");
+
+        assert!(prefix.ends_with("bottles/gog-prefix/prefix"));
+        assert!(args.contains(&"launch".to_string()));
+        assert!(args.contains(&"--wine".to_string()));
+        assert!(args.contains(&wine.to_string_lossy().to_string()));
+        assert!(args.contains(&"--wine-prefix".to_string()));
+        assert!(args.contains(&prefix.to_string_lossy().to_string()));
+        assert!(args.windows(2).any(|pair| pair == ["--prefer-task", "1"]));
+        let _ = fs::remove_dir_all(install_dir);
+        let _ = fs::remove_dir_all(prefix_dir.parent().and_then(|path| path.parent()).unwrap_or(&prefix_dir));
+        let _ = fs::remove_dir_all(
+            wine.parent().and_then(|path| path.parent()).and_then(|path| path.parent()).unwrap_or(&wine),
+        );
+    }
+
+    #[test]
+    fn gogdl_rejects_path_like_product_ids() {
+        assert!(gogdl_product_id(&json!({"productId": "../bad"})).is_err());
+        assert!(gogdl_product_id(&json!({"productId": "1423049311"})).is_ok());
     }
 
     #[test]

--- a/app/src-rust/src/sharp_library.rs
+++ b/app/src-rust/src/sharp_library.rs
@@ -462,6 +462,12 @@ fn default_installer_launch_args(src: &Path, classification: &crate::bottles::In
     let Some(kind) = store_launcher_kind_for_installer(src, classification) else {
         return Vec::new();
     };
+    if kind == StoreLauncherKind::Gog {
+        // GOG's /runWithoutUpdating /deelevated flags are client launch flags;
+        // passing them to GOG_Galaxy_2.0.exe or GalaxySetup.exe can perturb the
+        // bootstrapper/setup flow.
+        return Vec::new();
+    }
     default_launcher_launch_args(kind).iter().map(|arg| arg.to_string()).collect()
 }
 
@@ -2358,7 +2364,7 @@ mod tests {
                     "--disable-gpu-sandbox",
                 ],
             ),
-            ("GOG_Galaxy_2.0.exe", vec!["/runWithoutUpdating", "/deelevated"]),
+            ("GOG_Galaxy_2.0.exe", vec![]),
         ];
 
         for (filename, expected) in cases {

--- a/app/src-rust/src/sharp_library.rs
+++ b/app/src-rust/src/sharp_library.rs
@@ -1945,6 +1945,132 @@ pub fn handle_repair_gog_galaxy() -> Value {
     handle_install_gog_galaxy()
 }
 
+pub fn handle_gog_galaxy_diagnostics() -> Value {
+    json!({"ok": true, "diagnostics": gog_galaxy_diagnostics_value(), "launcher": gog_launcher_status_value()})
+}
+
+fn gog_galaxy_diagnostics_value() -> Value {
+    let bottle = find_gog_galaxy_bottle();
+    let mut issues: Vec<Value> = Vec::new();
+    let mut logs: Vec<Value> = Vec::new();
+    let mut actions: Vec<Value> = Vec::new();
+
+    if bottle.is_none() {
+        issues.push(
+            json!({"id": "no_bottle", "severity": "error", "detail": "No dedicated GOG Galaxy bottle exists yet"}),
+        );
+        actions.push(gog_repair_action("install_gog_galaxy", "Install GOG Galaxy"));
+        return json!({"status": "not_installed", "issues": issues, "actions": actions, "logs": logs});
+    }
+
+    let bottle = bottle.expect("checked");
+    let prefix = PathBuf::from(&bottle.prefix_path);
+    let client = gog_galaxy_client_in_prefix(&prefix);
+    let cached_setup = gog_galaxy_setup_cache_path();
+    let setup_candidates = gog_galaxy_setup_candidates(&prefix);
+    let report = crate::bottles::diagnose_bottle(&bottle.id).ok();
+
+    for log_path in gog_galaxy_log_paths(&prefix) {
+        let text = read_text_lossy_limited(&log_path, 256 * 1024);
+        if text.is_empty() {
+            continue;
+        }
+        let lower = text.to_ascii_lowercase();
+        logs.push(json!({"path": log_path.to_string_lossy(), "size": text.len()}));
+        if lower.contains("client setup finished with return code: 1") || lower.contains("return code: 1") {
+            issues.push(json!({"id": "setup_return_code_1", "severity": "error", "detail": "GOG Galaxy setup exited with return code 1"}));
+        }
+        if lower.contains("already running") || lower.contains("galaxy already running") {
+            issues.push(json!({"id": "stale_galaxy_process", "severity": "error", "detail": "Installer reported that GOG Galaxy is already running"}));
+        }
+        if lower.contains("vcruntime") || lower.contains("msvcp") || lower.contains("visual c++") {
+            issues.push(
+                json!({"id": "vc_runtime", "severity": "warn", "detail": "Installer log mentions VC runtime state"}),
+            );
+        }
+        if lower.contains("d3dcompiler_47") || lower.contains("d3dcompiler") {
+            issues.push(json!({"id": "d3dcompiler_47", "severity": "warn", "detail": "Installer log mentions D3DCompiler state"}));
+        }
+        if lower.contains("font") {
+            issues.push(json!({"id": "fonts", "severity": "warn", "detail": "Installer log mentions font state"}));
+        }
+    }
+
+    if client.is_none() {
+        issues.push(json!({"id": "no_final_client", "severity": "error", "detail": "GalaxyClient.exe is not present in the GOG Galaxy bottle"}));
+    }
+    if setup_candidates.is_empty() && !cached_setup.exists() && client.is_none() {
+        issues.push(json!({"id": "installer_temp_missing", "severity": "warn", "detail": "No GalaxyInstaller_* temp setup or cached GalaxySetup.exe is available for retry"}));
+    }
+    if let Some(report) = report.as_ref() {
+        for component in &report.actions {
+            issues.push(json!({"id": format!("missing_component:{}", component.id), "severity": "warn", "detail": component.detail}));
+        }
+    }
+
+    if cached_setup.exists() {
+        actions.push(gog_repair_action("retry_cached_setup", "Retry with cached GalaxySetup.exe"));
+    }
+    actions.push(gog_repair_action("recreate_clean_bottle", "Recreate clean GOG bottle"));
+    actions.push(gog_repair_action("install_launcher_dependencies", "Install launcher dependencies"));
+    actions.push(gog_repair_action("disable_overlay", "Disable Galaxy overlay"));
+    actions.push(gog_repair_action("kill_stale_processes", "Kill stale Galaxy processes"));
+    actions.push(gog_repair_action("clear_installer_temp", "Clear GOG installer temp state"));
+    actions.push(gog_repair_action("use_offline_setup", "Use full/offline setup_galaxy installer"));
+
+    json!({
+        "status": if client.is_some() { "installed" } else { "needs_repair" },
+        "bottleId": bottle.id,
+        "clientPath": client.map(|path| path.to_string_lossy().to_string()),
+        "cachedSetupPath": if cached_setup.exists() { Some(cached_setup.to_string_lossy().to_string()) } else { None },
+        "setupCandidates": setup_candidates.iter().map(|path| path.to_string_lossy().to_string()).collect::<Vec<_>>(),
+        "issues": dedupe_json_issues(issues),
+        "actions": actions,
+        "logs": logs,
+    })
+}
+
+fn gog_repair_action(id: &str, label: &str) -> Value {
+    json!({"id": id, "label": label})
+}
+
+fn gog_galaxy_log_paths(prefix: &Path) -> Vec<PathBuf> {
+    let mut paths = vec![
+        prefix.join("drive_c/ProgramData/GOG.com/Galaxy/logs/InstallerBootstrapper.log"),
+        prefix.join("drive_c/ProgramData/GOG.com/Galaxy/logs/InstallerWebinstaller.log"),
+    ];
+    let users = prefix.join("drive_c/users");
+    if users.exists() {
+        for entry in WalkDir::new(users).max_depth(8).into_iter().flatten() {
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            let name = path.file_name().map(|name| name.to_string_lossy()).unwrap_or_default();
+            if name.starts_with("Setup Log ") && name.ends_with(".txt") {
+                paths.push(path.to_path_buf());
+            }
+        }
+    }
+    paths
+}
+
+fn read_text_lossy_limited(path: &Path, limit: usize) -> String {
+    let Ok(data) = fs::read(path) else {
+        return String::new();
+    };
+    let start = data.len().saturating_sub(limit);
+    String::from_utf8_lossy(&data[start..]).to_string()
+}
+
+fn dedupe_json_issues(issues: Vec<Value>) -> Vec<Value> {
+    let mut seen = HashSet::new();
+    issues
+        .into_iter()
+        .filter(|issue| seen.insert(issue.get("id").and_then(|id| id.as_str()).unwrap_or("").to_string()))
+        .collect()
+}
+
 pub fn handle_install(body: &serde_json::Map<String, Value>) -> Value {
     let src_path = body.get("srcPath").and_then(|v| v.as_str()).unwrap_or("");
     let custom_name = body.get("name").and_then(|v| v.as_str());

--- a/app/src-rust/src/sharp_library.rs
+++ b/app/src-rust/src/sharp_library.rs
@@ -485,7 +485,23 @@ fn default_launcher_launch_args(kind: StoreLauncherKind) -> &'static [&'static s
         StoreLauncherKind::Epic => {
             &["-SkipBuildPatchPrereq", "-OpenGL", "--disable-gpu-sandbox", "--disable-direct-composition"]
         },
-        StoreLauncherKind::Gog => &["/runWithoutUpdating", "/deelevated"],
+        StoreLauncherKind::Gog => &[
+            "/runWithoutUpdating",
+            "/deelevated",
+            "--disable-gpu",
+            "--disable-gpu-compositing",
+            "--disable-direct-composition",
+            "--disable-gpu-sandbox",
+            "--disable-accelerated-2d-canvas",
+            "--disable-accelerated-video-decode",
+            "--disable-zero-copy",
+            "--disable-native-gpu-memory-buffers",
+            "--disable-backgrounding-occluded-windows",
+            "--disable-renderer-backgrounding",
+            "--disable-features=NetworkService,VizDisplayCompositor,UseSkiaRenderer,CalculateNativeWinOcclusion",
+            "--disable-breakpad",
+            "--disable-crash-reporter",
+        ],
         StoreLauncherKind::Rockstar | StoreLauncherKind::Ubisoft => {
             &["--disable-gpu", "--disable-gpu-compositing", "--disable-direct-composition", "--disable-gpu-sandbox"]
         },
@@ -822,11 +838,7 @@ fn start_gog_galaxy_installer(
     classification: &crate::bottles::InstallerClassification,
     fresh_bottle: bool,
 ) -> Result<SharpInstallOutcome, Box<dyn std::error::Error>> {
-    let bottle = if fresh_bottle {
-        crate::bottles::create_fresh_installer_bottle(src, classification)?
-    } else {
-        crate::bottles::ensure_installer_bottle(src, classification)?
-    };
+    let bottle = crate::bottles::ensure_gog_galaxy_bottle(src, classification, fresh_bottle)?;
     kill_stale_gog_galaxy_processes(&PathBuf::from(&bottle.prefix_path));
     let outcome = start_wine_installer_in_bottle(src, classification, &bottle, classification.pipeline)?;
     if let SharpInstallOutcome::InstallerStarted { pid, .. } = &outcome {
@@ -965,14 +977,95 @@ fn same_file_hash(a: &Path, b: &Path) -> bool {
 }
 
 fn kill_stale_gog_galaxy_processes(prefix: &Path) {
-    let _ = Command::new("/usr/bin/pkill")
-        .arg("-f")
-        .arg("GalaxyClient|GalaxyClientService|GalaxyOverlay|GalaxySetup")
-        .status();
+    for pid in gog_galaxy_related_process_pids(Some(prefix), true) {
+        let _ = Command::new("/bin/kill").arg(pid.to_string()).status();
+    }
+    kill_gog_galaxy_wineserver(prefix);
+}
+
+fn kill_gog_galaxy_wineserver(prefix: &Path) {
     let wineserver =
         crate::platform::runtime_wine_binary(&crate::platform::metalsharp_home_dir().join("runtime").join("wine"))
             .with_file_name("wineserver");
     let _ = Command::new(wineserver).env("WINEPREFIX", prefix).arg("-k").status();
+}
+
+fn gog_galaxy_process_pids(prefix: Option<&Path>) -> Vec<u32> {
+    gog_galaxy_related_process_pids(prefix, false)
+}
+
+fn gog_galaxy_related_process_pids(prefix: Option<&Path>, include_installers: bool) -> Vec<u32> {
+    let prefix_text = prefix.map(|path| path.to_string_lossy().to_string());
+    process_lines()
+        .iter()
+        .filter_map(|line| parse_process_line(line))
+        .filter_map(|(pid, command)| {
+            if is_gog_galaxy_process_command(pid, &command, prefix_text.as_deref(), include_installers) {
+                Some(pid)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn is_gog_galaxy_running(prefix: Option<&Path>) -> bool {
+    !gog_galaxy_process_pids(prefix).is_empty()
+}
+
+fn is_gog_galaxy_process_command(pid: u32, command: &str, prefix: Option<&str>, include_installers: bool) -> bool {
+    if command.contains(" rg ") || command.contains("rg -i") || command.contains("ps axo") {
+        return false;
+    }
+    let lower = command.to_ascii_lowercase();
+    let is_client_process = lower.contains("galaxyclient.exe")
+        || lower.contains("galaxyclient_real.exe")
+        || lower.contains("galaxyclient helper.exe")
+        || lower.contains("galaxyclient helper_real.exe")
+        || lower.contains("galaxyclientservice.exe")
+        || lower.contains("galaxyoverlay.exe")
+        || lower.contains("galaxycommunication.exe")
+        || lower.contains("gog galaxy notifications renderer.exe");
+    let is_installer_process = include_installers
+        && (lower.contains("galaxysetup.exe")
+            || lower.contains("galaxyinstaller.exe")
+            || lower.contains("gog_galaxy_2.0.exe"));
+    if !is_client_process && !is_installer_process {
+        return false;
+    }
+    prefix.map(|prefix| command.contains(prefix) || process_open_files_contain_prefix(pid, prefix)).unwrap_or(true)
+}
+
+fn process_open_files_contain_prefix(pid: u32, prefix: &str) -> bool {
+    Command::new("/usr/sbin/lsof")
+        .arg("-p")
+        .arg(pid.to_string())
+        .arg("-Fn")
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|stdout| stdout.contains(prefix))
+        .unwrap_or(false)
+}
+
+fn process_lines() -> Vec<String> {
+    Command::new("ps")
+        .args(["axo", "pid=,command="])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|stdout| stdout.lines().map(str::to_string).collect())
+        .unwrap_or_default()
+}
+
+fn parse_process_line(line: &str) -> Option<(u32, String)> {
+    let trimmed = line.trim_start();
+    let split = trimmed.find(char::is_whitespace)?;
+    let (pid, command) = trimmed.split_at(split);
+    let pid = pid.parse::<u32>().ok()?;
+    Some((pid, command.trim_start().to_string()))
 }
 
 fn start_wine_installer_in_bottle(
@@ -1220,6 +1313,10 @@ pub fn launch_app(id: &str, engine: &str) -> Result<SharpLaunchResult, Box<dyn s
         return Err(format!("EXE not found: {}", exe_path.display()).into());
     }
 
+    if is_gog_galaxy_client_app(&app, &exe_path) {
+        return launch_gog_galaxy_client_app(&app, &exe_path);
+    }
+
     let cef_compat_deployed = maybe_deploy_cef_compat_wrapper(&app, &exe_path)?;
     let pipeline = resolve_sharp_pipeline(engine, &exe_path);
     let launch_id = stable_launch_id(&app.id);
@@ -1252,6 +1349,222 @@ pub fn launch_app(id: &str, engine: &str) -> Result<SharpLaunchResult, Box<dyn s
     }
 
     Ok(SharpLaunchResult { pid, game_type, pipeline, exe_path: exe_path.to_string_lossy().to_string(), warnings })
+}
+
+fn is_gog_galaxy_client_app(app: &SharpApp, exe_path: &Path) -> bool {
+    store_launcher_kind_for_app(app) == Some(StoreLauncherKind::Gog)
+        && exe_path
+            .file_name()
+            .map(|name| name.to_string_lossy().eq_ignore_ascii_case("GalaxyClient.exe"))
+            .unwrap_or(false)
+        && app.bottle_id.is_some()
+}
+
+fn restore_gog_galaxy_client_wrapper_artifacts(install_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let client = install_dir.join("GalaxyClient.exe");
+    let client_real = install_dir.join("GalaxyClient_real.exe");
+    let helper = install_dir.join("GalaxyClient Helper.exe");
+    let helper_real = install_dir.join("GalaxyClient Helper_real.exe");
+    let generic_marker = install_dir.join(".ms_cef_compat_GalaxyClient");
+    let gog_marker = install_dir.join(".ms_gog_helper_wrapper_deployed");
+    let old_gog_marker = install_dir.join(".ms_gog_wrapper_deployed");
+    let hook = install_dir.join("metalsharp-cefchildhook.dll");
+
+    restore_small_wrapper_to_real_exe(&client, &client_real)?;
+    restore_small_wrapper_to_real_exe(&helper, &helper_real)?;
+
+    let _ = fs::remove_file(generic_marker);
+    let _ = fs::remove_file(gog_marker);
+    let _ = fs::remove_file(old_gog_marker);
+    let _ = fs::remove_file(hook);
+    Ok(())
+}
+
+fn prepare_gog_galaxy_cef_render_files(install_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    // WineHQ AppDB notes that GOG Galaxy's bundled libGLESv2.dll can leave the
+    // login surface black under Wine. Hide only that ANGLE GLES DLL; keep
+    // libEGL.dll and d3dcompiler_47.dll available because hiding either made
+    // the renderer crash or fail to create a window in MetalSharp testing.
+    restore_disabled_gog_render_file(install_dir, "libEGL.dll")?;
+    restore_disabled_gog_render_file(install_dir, "d3dcompiler_47.dll")?;
+    let gles = install_dir.join("libGLESv2.dll");
+    let disabled = install_dir.join("libGLESv2.dll.metalsharp-disabled");
+    if gles.exists() && !disabled.exists() {
+        fs::rename(&gles, &disabled)?;
+    }
+    Ok(())
+}
+
+fn restore_disabled_gog_render_file(install_dir: &Path, name: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let file = install_dir.join(name);
+    let disabled = install_dir.join(format!("{}.metalsharp-disabled", name));
+    if disabled.exists() && !file.exists() {
+        fs::rename(disabled, file)?;
+    }
+    Ok(())
+}
+
+fn restore_small_wrapper_to_real_exe(target: &Path, real: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    if real.exists() {
+        let target_size = fs::metadata(target).map(|meta| meta.len()).unwrap_or(0);
+        let real_size = fs::metadata(real).map(|meta| meta.len()).unwrap_or(0);
+        if target_size <= 512 * 1024 && real_size > 512 * 1024 {
+            let _ = fs::remove_file(target);
+            fs::rename(real, target)?;
+        }
+    }
+    Ok(())
+}
+
+fn prepare_gog_galaxy_client_launch(install_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    restore_gog_galaxy_client_wrapper_artifacts(install_dir)?;
+    prepare_gog_galaxy_cef_render_files(install_dir)?;
+    let client = install_dir.join("GalaxyClient.exe");
+    if !client.exists() {
+        return Err(format!("GalaxyClient.exe not found: {}", client.display()).into());
+    }
+    Ok(())
+}
+
+fn clear_gog_galaxy_lock_files(prefix: &Path) {
+    let lock_dir = prefix.join("drive_c").join("ProgramData").join("GOG.com").join("Galaxy").join("lock-files");
+    if let Ok(entries) = fs::read_dir(lock_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_file() {
+                let _ = fs::remove_file(path);
+            }
+        }
+    }
+}
+
+fn launch_gog_galaxy_client_app(
+    app: &SharpApp,
+    _exe_path: &Path,
+) -> Result<SharpLaunchResult, Box<dyn std::error::Error>> {
+    let bottle_id = app.bottle_id.as_deref().ok_or("GOG Galaxy app is not linked to a bottle")?;
+    let bottle = crate::bottles::load_bottle(bottle_id)?;
+    let prefix = PathBuf::from(&bottle.prefix_path);
+    let install_dir = PathBuf::from(&app.install_dir);
+    prepare_gog_galaxy_client_launch(&install_dir)?;
+    let exe_path = install_dir.join("GalaxyClient.exe");
+    let running_pids = gog_galaxy_process_pids(Some(&prefix));
+    if let Some(pid) = running_pids.first().copied() {
+        return Ok(SharpLaunchResult {
+            pid,
+            game_type: "gog_galaxy",
+            pipeline: crate::mtsp::engine::PipelineId::WineBare,
+            exe_path: exe_path.to_string_lossy().to_string(),
+            warnings: vec!["GOG Galaxy is already running".to_string()],
+        });
+    }
+    kill_gog_galaxy_wineserver(&prefix);
+    clear_gog_galaxy_lock_files(&prefix);
+
+    let home = dirs::home_dir().ok_or("no home dir")?;
+    let ms_root = crate::platform::metalsharp_home_dir_for(&home).join("runtime").join("wine");
+    let wine = crate::platform::runtime_wine_binary(&ms_root);
+    if !wine.exists() {
+        return Err("MetalSharp Wine not found — run setup first".into());
+    }
+
+    let log_path = crate::bottles::next_launch_log_path(bottle_id);
+    if let Some(parent) = log_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut log = OpenOptions::new().create(true).append(true).open(&log_path)?;
+    writeln!(log, "launcher=gog_galaxy")?;
+    writeln!(log, "prefix={}", prefix.display())?;
+    writeln!(log, "cwd={}", install_dir.display())?;
+    writeln!(log, "exe=GalaxyClient.exe")?;
+    ensure_gog_galaxy_vcredist(&prefix, &mut log)?;
+    let launch_args = gog_galaxy_launch_args(app);
+    writeln!(log, "args={:?}", launch_args)?;
+    writeln!(log, "--- wine output ---")?;
+    let stdout = log.try_clone()?;
+
+    let mut cmd = Command::new(&wine);
+    cmd.current_dir(&install_dir)
+        .env("WINEPREFIX", prefix.to_string_lossy().to_string())
+        .env("WINEDEBUG", "-all")
+        .env("WINEDEBUGGER", "none")
+        .env("MS_FWD_COMPAT_GL_CTX", "1")
+        .env("WINEMSYNC", "1")
+        .env("WINEDLLOVERRIDES", "winedbg=d;gameoverlayrenderer,gameoverlayrenderer64=d;GalaxyOverlay.exe=d")
+        .arg(&exe_path)
+        .args(&launch_args)
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(log));
+    crate::platform::set_runtime_library_env(&mut cmd, &ms_root);
+    cmd.env(
+        "WINEDLLPATH",
+        format!(
+            "{}:{}",
+            ms_root.join("lib").join("wine").join("x86_64-windows").to_string_lossy(),
+            ms_root.join("lib").join("wine").join("i386-windows").to_string_lossy()
+        ),
+    );
+
+    let child = cmd.spawn()?;
+    let pid = child.id();
+    let _ = crate::bottles::set_launch_started(bottle_id, pid, &log_path);
+    crate::bottles::watch_bottle_launch(bottle_id.to_string(), pid);
+
+    Ok(SharpLaunchResult {
+        pid,
+        game_type: "gog_galaxy",
+        pipeline: crate::mtsp::engine::PipelineId::WineBare,
+        exe_path: exe_path.to_string_lossy().to_string(),
+        warnings: vec![],
+    })
+}
+
+fn ensure_gog_galaxy_vcredist(prefix: &Path, log: &mut std::fs::File) -> Result<(), Box<dyn std::error::Error>> {
+    if gog_galaxy_has_vcredist_x86(prefix) {
+        writeln!(log, "vcredist_x86=present")?;
+        return Ok(());
+    }
+
+    writeln!(log, "vcredist_x86=installing")?;
+    crate::bottles::vcpp_ensure_and_install_x86_quiet(prefix)
+        .map_err(|error| format!("GOG Galaxy VC++ x86 runtime install failed: {}", error))?;
+    if !gog_galaxy_has_vcredist_x86(prefix) {
+        return Err("GOG Galaxy VC++ x86 runtime install completed but mfc140u.dll is still missing".into());
+    }
+    writeln!(log, "vcredist_x86=installed")?;
+    Ok(())
+}
+
+fn gog_galaxy_has_vcredist_x86(prefix: &Path) -> bool {
+    let syswow64 = prefix.join("drive_c").join("windows").join("syswow64");
+    ["mfc140u.dll", "msvcp140.dll", "vcruntime140.dll"].iter().all(|dll| {
+        let path = syswow64.join(dll);
+        path.is_file() && path.metadata().map(|metadata| metadata.len() > 10_000).unwrap_or(false)
+    })
+}
+
+fn gog_galaxy_launch_args(app: &SharpApp) -> Vec<String> {
+    let mut args =
+        default_launcher_launch_args(StoreLauncherKind::Gog).iter().map(|arg| arg.to_string()).collect::<Vec<_>>();
+    let app_args = app
+        .launch_args
+        .iter()
+        .map(String::as_str)
+        .filter(|arg| !is_deprecated_gog_galaxy_launch_arg(arg))
+        .collect::<Vec<_>>();
+    append_unique_launch_args(&mut args, app_args.as_slice());
+    let user_args = app
+        .user_launch_args
+        .iter()
+        .map(String::as_str)
+        .filter(|arg| !is_deprecated_gog_galaxy_launch_arg(arg))
+        .collect::<Vec<_>>();
+    append_unique_launch_args(&mut args, user_args.as_slice());
+    args
+}
+
+fn is_deprecated_gog_galaxy_launch_arg(arg: &str) -> bool {
+    arg.eq_ignore_ascii_case("--single-process") || arg.eq_ignore_ascii_case("--disable-software-rasterizer")
 }
 
 fn maybe_deploy_cef_compat_wrapper(app: &SharpApp, exe_path: &Path) -> Result<bool, Box<dyn std::error::Error>> {
@@ -1839,13 +2152,16 @@ fn gog_galaxy_cache_path() -> PathBuf {
 }
 
 fn find_gog_galaxy_app(apps: &[SharpApp]) -> Option<&SharpApp> {
-    apps.iter().find(|app| {
+    let is_gog_client = |app: &&SharpApp| {
         store_launcher_kind_for_app(app) == Some(StoreLauncherKind::Gog)
             && Path::new(&app.exe_path)
                 .file_name()
                 .map(|name| name.to_string_lossy().eq_ignore_ascii_case("GalaxyClient.exe"))
                 .unwrap_or(false)
-    })
+    };
+    apps.iter()
+        .find(|app| is_gog_client(app) && app.bottle_id.as_deref() == Some("gog-prefix"))
+        .or_else(|| apps.iter().find(is_gog_client))
 }
 
 fn find_gog_galaxy_bottle() -> Option<crate::bottles::BottleManifest> {
@@ -1854,20 +2170,36 @@ fn find_gog_galaxy_bottle() -> Option<crate::bottles::BottleManifest> {
         .ok()?
         .into_iter()
         .filter(|bottle| {
-            bottle
-                .source_installer_path
-                .as_deref()
-                .map(|path| path == cache_path || path.to_ascii_lowercase().contains("gog_galaxy"))
-                .unwrap_or(false)
+            bottle.id == "gog-prefix"
+                || bottle
+                    .source_installer_path
+                    .as_deref()
+                    .map(|path| path == cache_path || path.to_ascii_lowercase().contains("gog_galaxy"))
+                    .unwrap_or(false)
                 || bottle.name.to_ascii_lowercase().contains("gog galaxy")
         })
         .collect::<Vec<_>>();
+
+    if let Some(dedicated) = candidates.iter().find(|bottle| bottle.id == "gog-prefix").cloned() {
+        return Some(dedicated);
+    }
+
     candidates.sort_by(|a, b| b.updated_at.cmp(&a.updated_at).then_with(|| b.id.cmp(&a.id)));
     candidates
         .iter()
         .find(|bottle| gog_galaxy_client_in_bottle(bottle).is_some())
         .cloned()
         .or_else(|| candidates.into_iter().next())
+}
+
+fn find_gog_galaxy_bottle_for_app(app: Option<&SharpApp>) -> Option<crate::bottles::BottleManifest> {
+    find_gog_galaxy_bottle()
+        .filter(|bottle| bottle.id == "gog-prefix")
+        .or_else(|| {
+            app.and_then(|app| app.bottle_id.as_deref())
+                .and_then(|bottle_id| crate::bottles::load_bottle(bottle_id).ok())
+        })
+        .or_else(find_gog_galaxy_bottle)
 }
 
 fn gog_galaxy_client_in_bottle(bottle: &crate::bottles::BottleManifest) -> Option<PathBuf> {
@@ -1883,15 +2215,20 @@ fn gog_galaxy_client_in_bottle(bottle: &crate::bottles::BottleManifest) -> Optio
 fn gog_launcher_status_value() -> Value {
     let apps = load_library().unwrap_or_default();
     let app = find_gog_galaxy_app(&apps);
-    let bottle = find_gog_galaxy_bottle();
-    let installing = bottle
-        .as_ref()
-        .and_then(|bottle| bottle.last_launch_pid)
-        .map(|pid| crate::launch::is_process_active(pid as i32))
-        .unwrap_or(false);
+    let bottle = find_gog_galaxy_bottle_for_app(app);
+    let running =
+        bottle.as_ref().map(|bottle| is_gog_galaxy_running(Some(Path::new(&bottle.prefix_path)))).unwrap_or(false);
+    let installing = !running
+        && bottle
+            .as_ref()
+            .and_then(|bottle| bottle.last_launch_pid)
+            .map(|pid| crate::launch::is_process_active(pid as i32))
+            .unwrap_or(false);
     let client_exists = app.map(|app| app_absolute_exe_path(app).exists()).unwrap_or(false)
         || bottle.as_ref().and_then(gog_galaxy_client_in_bottle).is_some();
-    let (status, detail) = if installing {
+    let (status, detail) = if running {
+        ("running", "Running")
+    } else if installing {
         ("installing", "Installing…")
     } else if client_exists {
         ("installed", "Installed")
@@ -1909,6 +2246,7 @@ fn gog_launcher_status_value() -> Value {
         "appId": app.map(|app| app.id.clone()),
         "bottleId": bottle.as_ref().map(|bottle| bottle.id.clone()),
         "installerUrl": GOG_GALAXY_INSTALLER_URL,
+        "running": running,
     })
 }
 
@@ -1968,6 +2306,14 @@ fn handle_install_gog_galaxy_with_fresh(fresh_bottle: bool) -> Value {
 
 fn import_installed_gog_galaxy_card() -> Result<SharpApp, Box<dyn std::error::Error>> {
     let apps = load_library()?;
+    if let Some(app) = find_gog_galaxy_app(&apps).filter(|app| app.bottle_id.as_deref() == Some("gog-prefix")) {
+        return Ok(app.clone());
+    }
+    if let Some(dedicated) = find_gog_galaxy_bottle().filter(|bottle| bottle.id == "gog-prefix") {
+        if let Some(client) = gog_galaxy_client_in_bottle(&dedicated) {
+            return import_bottle_app(&dedicated.id, &client.to_string_lossy(), Some("GOG Galaxy"));
+        }
+    }
     if let Some(app) = find_gog_galaxy_app(&apps) {
         return Ok(app.clone());
     }
@@ -1990,6 +2336,25 @@ pub fn handle_open_gog_galaxy() -> Value {
         },
         Err(e) => json!({"ok": false, "error": e.to_string(), "launcher": gog_launcher_status_value()}),
     }
+}
+
+pub fn handle_stop_gog_galaxy() -> Value {
+    let apps = load_library().unwrap_or_default();
+    let app = find_gog_galaxy_app(&apps);
+    let Some(prefix) = find_gog_galaxy_bottle_for_app(app).map(|bottle| PathBuf::from(bottle.prefix_path)) else {
+        return json!({"ok": true, "stoppedPids": [], "launcher": gog_launcher_status_value()});
+    };
+    let pids = gog_galaxy_process_pids(Some(&prefix));
+    for pid in &pids {
+        let _ = Command::new("/bin/kill").arg(pid.to_string()).status();
+    }
+    std::thread::sleep(std::time::Duration::from_millis(400));
+    for pid in gog_galaxy_process_pids(Some(&prefix)) {
+        let _ = Command::new("/bin/kill").arg("-9").arg(pid.to_string()).status();
+    }
+    kill_gog_galaxy_wineserver(&prefix);
+    clear_gog_galaxy_lock_files(&prefix);
+    json!({"ok": true, "stoppedPids": pids, "launcher": gog_launcher_status_value()})
 }
 
 pub fn handle_repair_gog_galaxy() -> Value {
@@ -2370,7 +2735,23 @@ mod tests {
         }
         assert_eq!(
             default_launcher_launch_args_for_app(&test_app("GOG Galaxy", "GalaxyClient.exe", "/tmp/GOG Galaxy")),
-            ["/runWithoutUpdating", "/deelevated"]
+            [
+                "/runWithoutUpdating",
+                "/deelevated",
+                "--disable-gpu",
+                "--disable-gpu-compositing",
+                "--disable-direct-composition",
+                "--disable-gpu-sandbox",
+                "--disable-accelerated-2d-canvas",
+                "--disable-accelerated-video-decode",
+                "--disable-zero-copy",
+                "--disable-native-gpu-memory-buffers",
+                "--disable-backgrounding-occluded-windows",
+                "--disable-renderer-backgrounding",
+                "--disable-features=NetworkService,VizDisplayCompositor,UseSkiaRenderer,CalculateNativeWinOcclusion",
+                "--disable-breakpad",
+                "--disable-crash-reporter",
+            ]
         );
     }
 
@@ -2466,8 +2847,149 @@ mod tests {
     fn gog_galaxy_client_gets_play_launch_args() {
         let mut app = test_app("GOG Galaxy", "GalaxyClient.exe", "/tmp/prefix/drive_c/Program Files (x86)/GOG Galaxy");
         assert!(apply_default_launcher_launch_args_to_app(&mut app));
-        assert_eq!(app.launch_args, vec!["/runWithoutUpdating", "/deelevated"]);
+        assert_eq!(
+            app.launch_args,
+            vec![
+                "/runWithoutUpdating",
+                "/deelevated",
+                "--disable-gpu",
+                "--disable-gpu-compositing",
+                "--disable-direct-composition",
+                "--disable-gpu-sandbox",
+                "--disable-accelerated-2d-canvas",
+                "--disable-accelerated-video-decode",
+                "--disable-zero-copy",
+                "--disable-native-gpu-memory-buffers",
+                "--disable-backgrounding-occluded-windows",
+                "--disable-renderer-backgrounding",
+                "--disable-features=NetworkService,VizDisplayCompositor,UseSkiaRenderer,CalculateNativeWinOcclusion",
+                "--disable-breakpad",
+                "--disable-crash-reporter",
+            ]
+        );
         assert!(!apply_default_launcher_launch_args_to_app(&mut app));
+    }
+
+    #[test]
+    fn gog_galaxy_launch_args_drop_deprecated_persisted_defaults() {
+        let mut app = test_app("GOG Galaxy", "GalaxyClient.exe", "/tmp/prefix/drive_c/Program Files (x86)/GOG Galaxy");
+        app.launch_args = vec!["--single-process".into(), "--disable-software-rasterizer".into(), "--custom".into()];
+        app.user_launch_args = vec!["--single-process".into(), "--user-custom".into()];
+
+        let args = gog_galaxy_launch_args(&app);
+
+        assert!(!args.iter().any(|arg| arg == "--single-process"));
+        assert!(!args.iter().any(|arg| arg == "--disable-software-rasterizer"));
+        assert!(args.iter().any(|arg| arg == "--custom"));
+        assert!(args.iter().any(|arg| arg == "--user-custom"));
+    }
+
+    #[test]
+    fn gog_galaxy_client_does_not_use_generic_cef_wrapper() {
+        let dir = test_dir("gog-no-generic-cef-wrapper");
+        fs::create_dir_all(&dir).expect("create app dir");
+        let exe = dir.join("GalaxyClient.exe");
+        fs::write(&exe, b"MZ").expect("write client");
+        fs::write(dir.join("libcef.dll"), b"cef").expect("write cef marker");
+        let mut app = test_app("GOG Galaxy", "GalaxyClient.exe", &dir.to_string_lossy());
+        app.bottle_id = Some("installer_gog".into());
+
+        assert!(!should_apply_cef_compat(&app, &exe));
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn gog_galaxy_restore_removes_accidental_wrapper_artifacts() {
+        let dir = test_dir("gog-restore-wrapper");
+        fs::create_dir_all(&dir).expect("create app dir");
+        let client = dir.join("GalaxyClient.exe");
+        let real = dir.join("GalaxyClient_real.exe");
+        fs::write(&client, vec![0u8; 16 * 1024]).expect("write wrapper");
+        fs::write(&real, vec![1u8; 2 * 1024 * 1024]).expect("write real client");
+        let helper = dir.join("GalaxyClient Helper.exe");
+        let helper_real = dir.join("GalaxyClient Helper_real.exe");
+        fs::write(&helper, vec![0u8; 16 * 1024]).expect("write helper wrapper");
+        fs::write(&helper_real, vec![2u8; 3 * 1024 * 1024]).expect("write real helper");
+        fs::write(dir.join("metalsharp-cefchildhook.dll"), b"hook").expect("write hook");
+        fs::write(dir.join(".ms_cef_compat_GalaxyClient"), b"deployed").expect("write marker");
+        fs::write(dir.join(".ms_gog_helper_wrapper_deployed"), b"deployed").expect("write gog marker");
+
+        restore_gog_galaxy_client_wrapper_artifacts(&dir).expect("restore client");
+
+        assert_eq!(fs::metadata(&client).expect("client exists").len(), 2 * 1024 * 1024);
+        assert_eq!(fs::metadata(&helper).expect("helper exists").len(), 3 * 1024 * 1024);
+        assert!(!real.exists());
+        assert!(!helper_real.exists());
+        assert!(!dir.join("metalsharp-cefchildhook.dll").exists());
+        assert!(!dir.join(".ms_cef_compat_GalaxyClient").exists());
+        assert!(!dir.join(".ms_gog_helper_wrapper_deployed").exists());
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn gog_galaxy_prepare_hides_only_problematic_bundled_gles() {
+        let dir = test_dir("gog-render-files");
+        fs::create_dir_all(&dir).expect("create app dir");
+        fs::write(dir.join("libGLESv2.dll"), b"gles").expect("write gles");
+        fs::write(dir.join("libEGL.dll.metalsharp-disabled"), b"egl").expect("write disabled egl");
+        fs::write(dir.join("d3dcompiler_47.dll.metalsharp-disabled"), b"d3d").expect("write disabled d3d");
+
+        prepare_gog_galaxy_cef_render_files(&dir).expect("prepare render files");
+
+        assert!(!dir.join("libGLESv2.dll").exists());
+        assert!(dir.join("libGLESv2.dll.metalsharp-disabled").exists());
+        assert!(dir.join("libEGL.dll").exists());
+        assert!(!dir.join("libEGL.dll.metalsharp-disabled").exists());
+        assert!(dir.join("d3dcompiler_47.dll").exists());
+        assert!(!dir.join("d3dcompiler_47.dll.metalsharp-disabled").exists());
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn gog_galaxy_process_matching_separates_running_client_from_installer() {
+        assert!(is_gog_galaxy_process_command(
+            0,
+            "C:\\Program Files (x86)\\GOG Galaxy\\GalaxyClient.exe /runWithoutUpdating",
+            None,
+            false
+        ));
+        assert!(is_gog_galaxy_process_command(
+            0,
+            "C:\\Program Files (x86)\\GOG Galaxy\\GalaxyClient Helper.exe --type=renderer",
+            None,
+            false
+        ));
+        assert!(!is_gog_galaxy_process_command(
+            0,
+            "GalaxySetup.exe /DIR=C:\\Program Files (x86)\\GOG Galaxy",
+            None,
+            false
+        ));
+        assert!(is_gog_galaxy_process_command(
+            0,
+            "GalaxySetup.exe /DIR=C:\\Program Files (x86)\\GOG Galaxy",
+            None,
+            true
+        ));
+        assert!(!is_gog_galaxy_process_command(
+            0,
+            "C:\\Program Files (x86)\\GOG Galaxy\\GalaxyClient.exe",
+            Some("/tmp/other-prefix"),
+            false
+        ));
+    }
+
+    #[test]
+    fn gog_galaxy_vcredist_check_requires_mfc_x86() {
+        let prefix = test_dir("gog-vcredist-x86");
+        let syswow64 = prefix.join("drive_c").join("windows").join("syswow64");
+        fs::create_dir_all(&syswow64).expect("create syswow64");
+        fs::write(syswow64.join("msvcp140.dll"), vec![1u8; 16 * 1024]).expect("write msvcp");
+        fs::write(syswow64.join("vcruntime140.dll"), vec![1u8; 16 * 1024]).expect("write vcruntime");
+        assert!(!gog_galaxy_has_vcredist_x86(&prefix));
+        fs::write(syswow64.join("mfc140u.dll"), vec![1u8; 16 * 1024]).expect("write mfc");
+        assert!(gog_galaxy_has_vcredist_x86(&prefix));
+        let _ = fs::remove_dir_all(prefix);
     }
 
     #[test]

--- a/app/src-rust/src/sharp_library.rs
+++ b/app/src-rust/src/sharp_library.rs
@@ -391,6 +391,9 @@ fn is_hidden_sharp_library_app(app: &SharpApp) -> bool {
     if matches!(exe.as_str(), "lobby_connect.exe" | "experimental_steamclient.exe" | "tools.exe") {
         return true;
     }
+    if store_launcher_kind_for_app(app) == Some(StoreLauncherKind::Gog) && exe != "galaxyclient.exe" {
+        return true;
+    }
 
     path_has_component(&app.install_dir, "lobby_connect")
         || path_has_component(&app.install_dir, "experimental_steamclient")
@@ -467,7 +470,8 @@ fn default_launcher_launch_args(kind: StoreLauncherKind) -> &'static [&'static s
         StoreLauncherKind::Epic => {
             &["-SkipBuildPatchPrereq", "-OpenGL", "--disable-gpu-sandbox", "--disable-direct-composition"]
         },
-        StoreLauncherKind::Gog | StoreLauncherKind::Rockstar | StoreLauncherKind::Ubisoft => {
+        StoreLauncherKind::Gog => &["/runWithoutUpdating", "/deelevated"],
+        StoreLauncherKind::Rockstar | StoreLauncherKind::Ubisoft => {
             &["--disable-gpu", "--disable-gpu-compositing", "--disable-direct-composition", "--disable-gpu-sandbox"]
         },
     }
@@ -938,7 +942,9 @@ pub fn import_bottle_app(
     if let Some(existing) =
         library.iter_mut().find(|existing| existing.id == app.id || app_absolute_exe_path(existing) == absolute)
     {
-        existing.name = app.name.clone();
+        if !should_preserve_imported_bottle_app_name(existing, &app) {
+            existing.name = app.name.clone();
+        }
         existing.exe_path = app.exe_path.clone();
         existing.install_dir = app.install_dir.clone();
         existing.bottle_id = app.bottle_id.clone();
@@ -952,6 +958,14 @@ pub fn import_bottle_app(
     library.push(app.clone());
     save_library(&library)?;
     Ok(app)
+}
+
+fn should_preserve_imported_bottle_app_name(existing: &SharpApp, incoming: &SharpApp) -> bool {
+    existing.bottle_id.is_some()
+        && existing.bottle_id == incoming.bottle_id
+        && app_absolute_exe_path(existing) == app_absolute_exe_path(incoming)
+        && !existing.name.trim().is_empty()
+        && existing.name != incoming.name
 }
 
 pub fn uninstall_app(id: &str) -> Result<(), Box<dyn std::error::Error>> {
@@ -1542,6 +1556,7 @@ fn is_setup_exe(name: &str) -> bool {
 fn is_valid_app_exe(name: &str) -> bool {
     let lower = name.to_lowercase();
     lower.ends_with(".exe")
+        && !is_ignored_gog_galaxy_exe_name(&lower)
         && !lower.contains("setup")
         && !lower.contains("redist")
         && !lower.contains("dotnet")
@@ -1600,10 +1615,24 @@ fn find_real_exe(dir: &PathBuf) -> Option<PathBuf> {
 fn known_launcher_exe_score(lower_name: &str) -> i32 {
     match lower_name {
         "epicgameslauncher.exe" | "epicgameslauncher_real.exe" => 90,
+        "galaxyclient.exe" => 150,
         "ubisoftconnect.exe" | "ubisoftconnect_real.exe" => 140,
         "ubisoftgamelauncher.exe" | "ubisoftgamelauncher_real.exe" => 40,
         _ => 0,
     }
+}
+
+fn is_ignored_gog_galaxy_exe_name(lower_name: &str) -> bool {
+    matches!(
+        lower_name,
+        "gog_galaxy_2.0.exe"
+            | "galaxyinstaller.exe"
+            | "galaxysetup.exe"
+            | "galaxyclientservice.exe"
+            | "galaxyoverlay.exe"
+            | "galaxyclient_helper.exe"
+            | "galaxyclient_real.exe"
+    ) || lower_name.ends_with("_real.exe") && lower_name.contains("galaxy")
 }
 
 fn dir_size(dir: &PathBuf) -> u64 {
@@ -2004,13 +2033,16 @@ mod tests {
         for app in [
             test_app("Ubisoft Connect", "UbisoftConnect.exe", "/tmp/Ubisoft/Ubisoft Game Launcher"),
             test_app("Rockstar Games Launcher", "Launcher.exe", "/tmp/Rockstar Games/Launcher"),
-            test_app("GOG Galaxy", "GalaxyClient.exe", "/tmp/GOG Galaxy"),
         ] {
             assert_eq!(
                 default_launcher_launch_args_for_app(&app),
                 ["--disable-gpu", "--disable-gpu-compositing", "--disable-direct-composition", "--disable-gpu-sandbox"]
             );
         }
+        assert_eq!(
+            default_launcher_launch_args_for_app(&test_app("GOG Galaxy", "GalaxyClient.exe", "/tmp/GOG Galaxy")),
+            ["/runWithoutUpdating", "/deelevated"]
+        );
     }
 
     #[test]
@@ -2040,15 +2072,7 @@ mod tests {
                     "--disable-gpu-sandbox",
                 ],
             ),
-            (
-                "GOG_Galaxy_2.0.exe",
-                vec![
-                    "--disable-gpu",
-                    "--disable-gpu-compositing",
-                    "--disable-direct-composition",
-                    "--disable-gpu-sandbox",
-                ],
-            ),
+            ("GOG_Galaxy_2.0.exe", vec!["/runWithoutUpdating", "/deelevated"]),
         ];
 
         for (filename, expected) in cases {
@@ -2079,6 +2103,38 @@ mod tests {
             "UbisoftConnect.exe",
             "/tmp/prefix/drive_c/Program Files/Ubisoft"
         )));
+    }
+
+    #[test]
+    fn gog_galaxy_hides_installers_and_internal_helpers() {
+        assert!(!is_hidden_sharp_library_app(&test_app(
+            "GOG Galaxy",
+            "GalaxyClient.exe",
+            "/tmp/prefix/drive_c/Program Files (x86)/GOG Galaxy"
+        )));
+        for exe in [
+            "GOG_Galaxy_2.0.exe",
+            "GalaxyInstaller.exe",
+            "GalaxySetup.exe",
+            "GalaxyClientService.exe",
+            "GalaxyOverlay.exe",
+            "GalaxyClient_real.exe",
+        ] {
+            assert!(is_hidden_sharp_library_app(&test_app(
+                "GOG Galaxy",
+                exe,
+                "/tmp/prefix/drive_c/Program Files (x86)/GOG Galaxy"
+            )));
+            assert!(!is_valid_app_exe(exe));
+        }
+    }
+
+    #[test]
+    fn gog_galaxy_client_gets_play_launch_args() {
+        let mut app = test_app("GOG Galaxy", "GalaxyClient.exe", "/tmp/prefix/drive_c/Program Files (x86)/GOG Galaxy");
+        assert!(apply_default_launcher_launch_args_to_app(&mut app));
+        assert_eq!(app.launch_args, vec!["/runWithoutUpdating", "/deelevated"]);
+        assert!(!apply_default_launcher_launch_args_to_app(&mut app));
     }
 
     #[test]

--- a/app/src-rust/src/sharp_library.rs
+++ b/app/src-rust/src/sharp_library.rs
@@ -465,7 +465,12 @@ fn default_installer_launch_args(src: &Path, classification: &crate::bottles::In
     if kind == StoreLauncherKind::Gog {
         // GOG's /runWithoutUpdating /deelevated flags are client launch flags;
         // passing them to GOG_Galaxy_2.0.exe or GalaxySetup.exe can perturb the
-        // bootstrapper/setup flow.
+        // bootstrapper/setup flow. GalaxySetup.exe is an Inno installer; give
+        // it an explicit install dir so its previous-install detection never
+        // falls back to the Wine drive root ("Found GalaxyClientExePath under \\").
+        if is_gog_galaxy_setup_installer(src) {
+            return vec!["/DIR=C:\\Program Files (x86)\\GOG Galaxy".to_string()];
+        }
         return Vec::new();
     }
     default_launcher_launch_args(kind).iter().map(|arg| arg.to_string()).collect()
@@ -2365,6 +2370,7 @@ mod tests {
                 ],
             ),
             ("GOG_Galaxy_2.0.exe", vec![]),
+            ("GalaxySetup.exe", vec!["/DIR=C:\\Program Files (x86)\\GOG Galaxy"]),
         ];
 
         for (filename, expected) in cases {

--- a/app/src-rust/src/sharp_library.rs
+++ b/app/src-rust/src/sharp_library.rs
@@ -831,8 +831,21 @@ fn start_gog_galaxy_installer(
     Ok(outcome)
 }
 
+const GOG_GALAXY_SETUP_MIN_BYTES: u64 = 240 * 1024 * 1024;
+
 fn gog_galaxy_setup_cache_path() -> PathBuf {
     crate::platform::metalsharp_home_dir().join("cache").join("gog-galaxy").join("GalaxySetup.exe")
+}
+
+fn valid_gog_galaxy_setup(path: &Path) -> bool {
+    path.is_file() && path.metadata().map(|meta| meta.len() >= GOG_GALAXY_SETUP_MIN_BYTES).unwrap_or(false)
+}
+
+fn remove_invalid_gog_galaxy_setup_cache() {
+    let cache = gog_galaxy_setup_cache_path();
+    if cache.exists() && !valid_gog_galaxy_setup(&cache) {
+        let _ = fs::remove_file(cache);
+    }
 }
 
 fn spawn_gog_galaxy_install_watcher(bottle_id: String, mut watched_pid: u32, source_installer: PathBuf) {
@@ -852,7 +865,7 @@ fn spawn_gog_galaxy_install_watcher(bottle_id: String, mut watched_pid: u32, sou
             let running = crate::launch::is_process_active(watched_pid as i32);
             if !running && !retried_cached_setup && !is_gog_galaxy_setup_installer(&source_installer) {
                 let cached_setup = gog_galaxy_setup_cache_path();
-                if cached_setup.exists() {
+                if valid_gog_galaxy_setup(&cached_setup) {
                     let classification = crate::bottles::classify_installer(&cached_setup);
                     kill_stale_gog_galaxy_processes(&prefix);
                     if let Ok(SharpInstallOutcome::InstallerStarted { pid, .. }) =
@@ -916,10 +929,18 @@ fn gog_galaxy_setup_candidates(prefix: &Path) -> Vec<PathBuf> {
 }
 
 fn cache_downloaded_gog_galaxy_setup(prefix: &Path) {
-    let Some(candidate) = gog_galaxy_setup_candidates(prefix)
-        .into_iter()
-        .find(|path| path.metadata().map(|meta| meta.len() > 1_000_000).unwrap_or(false))
-    else {
+    let Some(candidate) = gog_galaxy_setup_candidates(prefix).into_iter().find(|path| {
+        let Ok(before) = path.metadata() else {
+            return false;
+        };
+        if before.len() < GOG_GALAXY_SETUP_MIN_BYTES {
+            return false;
+        }
+        std::thread::sleep(std::time::Duration::from_secs(2));
+        path.metadata()
+            .map(|after| after.len() == before.len() && after.len() >= GOG_GALAXY_SETUP_MIN_BYTES)
+            .unwrap_or(false)
+    }) else {
         return;
     };
     let cache = gog_galaxy_setup_cache_path();
@@ -1927,6 +1948,7 @@ fn handle_install_gog_galaxy_fresh() -> Value {
 }
 
 fn handle_install_gog_galaxy_with_fresh(fresh_bottle: bool) -> Value {
+    remove_invalid_gog_galaxy_setup_cache();
     match ensure_gog_galaxy_installer_cached()
         .and_then(|path| install_exe_with_options(path.to_string_lossy().as_ref(), Some("GOG Galaxy"), fresh_bottle))
     {
@@ -2011,6 +2033,12 @@ fn gog_galaxy_diagnostics_value() -> Value {
         if lower.contains("client setup finished with return code: 1") || lower.contains("return code: 1") {
             issues.push(json!({"id": "setup_return_code_1", "severity": "error", "detail": "GOG Galaxy setup exited with return code 1"}));
         }
+        if lower.contains("setup files are corrupted")
+            || lower.contains("obtain a new copy")
+            || lower.contains("corrupt")
+        {
+            issues.push(json!({"id": "corrupt_setup_payload", "severity": "error", "detail": "GOG setup reported a corrupt installer payload"}));
+        }
         if lower.contains("already running") || lower.contains("galaxy already running") {
             issues.push(json!({"id": "stale_galaxy_process", "severity": "error", "detail": "Installer reported that GOG Galaxy is already running"}));
         }
@@ -2039,7 +2067,7 @@ fn gog_galaxy_diagnostics_value() -> Value {
         }
     }
 
-    if cached_setup.exists() {
+    if valid_gog_galaxy_setup(&cached_setup) {
         actions.push(gog_repair_action("retry_cached_setup", "Retry with cached GalaxySetup.exe"));
     }
     actions.push(gog_repair_action("recreate_clean_bottle", "Recreate clean GOG bottle"));
@@ -2053,7 +2081,7 @@ fn gog_galaxy_diagnostics_value() -> Value {
         "status": if client.is_some() { "installed" } else { "needs_repair" },
         "bottleId": bottle.id,
         "clientPath": client.map(|path| path.to_string_lossy().to_string()),
-        "cachedSetupPath": if cached_setup.exists() { Some(cached_setup.to_string_lossy().to_string()) } else { None },
+        "cachedSetupPath": if valid_gog_galaxy_setup(&cached_setup) { Some(cached_setup.to_string_lossy().to_string()) } else { None },
         "setupCandidates": setup_candidates.iter().map(|path| path.to_string_lossy().to_string()).collect::<Vec<_>>(),
         "issues": dedupe_json_issues(issues),
         "actions": actions,
@@ -2452,6 +2480,17 @@ mod tests {
 
         assert_eq!(gog_galaxy_setup_candidates(&prefix), vec![setup]);
         let _ = fs::remove_dir_all(prefix);
+    }
+
+    #[test]
+    fn gog_galaxy_setup_cache_rejects_partial_payloads() {
+        let dir = test_dir("gog-partial-cache");
+        fs::create_dir_all(&dir).expect("create cache dir");
+        let partial = dir.join("GalaxySetup.exe");
+        fs::write(&partial, vec![0u8; 1024]).expect("write partial setup");
+
+        assert!(!valid_gog_galaxy_setup(&partial));
+        let _ = fs::remove_dir_all(dir);
     }
 
     #[test]

--- a/app/src-rust/src/sharp_library.rs
+++ b/app/src-rust/src/sharp_library.rs
@@ -775,6 +775,8 @@ fn should_run_as_wine_installer(src: &Path) -> bool {
         || name.contains("launcher")
         || name.contains("bootstrap")
         || name.contains("update")
+        || name.contains("gog_galaxy")
+        || name == "galaxysetup.exe"
 }
 
 fn is_supported_windows_program(src: &Path) -> bool {
@@ -1812,14 +1814,24 @@ fn find_gog_galaxy_app(apps: &[SharpApp]) -> Option<&SharpApp> {
 
 fn find_gog_galaxy_bottle() -> Option<crate::bottles::BottleManifest> {
     let cache_path = gog_galaxy_cache_path().to_string_lossy().to_string();
-    crate::bottles::list_bottles().ok()?.into_iter().find(|bottle| {
-        bottle
-            .source_installer_path
-            .as_deref()
-            .map(|path| path == cache_path || path.to_ascii_lowercase().contains("gog_galaxy"))
-            .unwrap_or(false)
-            || bottle.name.to_ascii_lowercase().contains("gog galaxy")
-    })
+    let mut candidates = crate::bottles::list_bottles()
+        .ok()?
+        .into_iter()
+        .filter(|bottle| {
+            bottle
+                .source_installer_path
+                .as_deref()
+                .map(|path| path == cache_path || path.to_ascii_lowercase().contains("gog_galaxy"))
+                .unwrap_or(false)
+                || bottle.name.to_ascii_lowercase().contains("gog galaxy")
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by(|a, b| b.updated_at.cmp(&a.updated_at).then_with(|| b.id.cmp(&a.id)));
+    candidates
+        .iter()
+        .find(|bottle| gog_galaxy_client_in_bottle(bottle).is_some())
+        .cloned()
+        .or_else(|| candidates.into_iter().next())
 }
 
 fn gog_galaxy_client_in_bottle(bottle: &crate::bottles::BottleManifest) -> Option<PathBuf> {
@@ -1896,8 +1908,16 @@ fn ensure_gog_galaxy_installer_cached() -> Result<PathBuf, Box<dyn std::error::E
 }
 
 pub fn handle_install_gog_galaxy() -> Value {
+    handle_install_gog_galaxy_with_fresh(false)
+}
+
+fn handle_install_gog_galaxy_fresh() -> Value {
+    handle_install_gog_galaxy_with_fresh(true)
+}
+
+fn handle_install_gog_galaxy_with_fresh(fresh_bottle: bool) -> Value {
     match ensure_gog_galaxy_installer_cached()
-        .and_then(|path| install_exe_with_options(path.to_string_lossy().as_ref(), Some("GOG Galaxy"), false))
+        .and_then(|path| install_exe_with_options(path.to_string_lossy().as_ref(), Some("GOG Galaxy"), fresh_bottle))
     {
         Ok(SharpInstallOutcome::Imported(app)) => {
             json!({"ok": true, "app": *app, "launcher": gog_launcher_status_value()})
@@ -1942,7 +1962,7 @@ pub fn handle_repair_gog_galaxy() -> Value {
             return json!({"ok": true, "launcher": gog_launcher_status_value()});
         }
     }
-    handle_install_gog_galaxy()
+    handle_install_gog_galaxy_fresh()
 }
 
 pub fn handle_gog_galaxy_diagnostics() -> Value {
@@ -2734,6 +2754,8 @@ mod tests {
         assert!(should_run_as_wine_installer(Path::new("/tmp/MinecraftInstaller.exe")));
         assert!(should_run_as_wine_installer(Path::new("/tmp/MinecraftLauncher.exe")));
         assert!(should_run_as_wine_installer(Path::new("/tmp/DemoSetup.msi")));
+        assert!(should_run_as_wine_installer(Path::new("/tmp/GOG_Galaxy_2.0.exe")));
+        assert!(should_run_as_wine_installer(Path::new("/tmp/GalaxySetup.exe")));
         assert!(!should_run_as_wine_installer(Path::new("/tmp/TJoC_SM.exe")));
     }
 

--- a/app/src-rust/src/sharp_library.rs
+++ b/app/src-rust/src/sharp_library.rs
@@ -2146,6 +2146,7 @@ pub fn handle_get_library() -> Value {
 }
 
 const GOG_GALAXY_INSTALLER_URL: &str = "https://webinstallers.gog-statics.com/download/GOG_Galaxy_2.0.exe";
+const GOGDL_AUTH_URL: &str = "https://auth.gog.com/auth?client_id=46899977096215655&redirect_uri=https%3A%2F%2Fembed.gog.com%2Fon_login_success%3Forigin%3Dclient&response_type=code&layout=galaxy";
 
 fn gog_galaxy_cache_path() -> PathBuf {
     crate::platform::metalsharp_home_dir().join("cache").join("gog-galaxy").join("GOG_Galaxy_2.0.exe")
@@ -2250,8 +2251,81 @@ fn gog_launcher_status_value() -> Value {
     })
 }
 
+fn gogdl_config_dir() -> PathBuf {
+    crate::platform::metalsharp_home_dir().join("gogdl")
+}
+
+fn gogdl_auth_config_path() -> PathBuf {
+    crate::platform::metalsharp_home_dir().join("gog_store").join("auth.json")
+}
+
+fn gogdl_candidate_paths_from_path_env(path_env: Option<&str>) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Ok(explicit) = std::env::var("METALSHARP_GOGDL_BIN") {
+        let explicit = explicit.trim();
+        if !explicit.is_empty() {
+            candidates.push(PathBuf::from(explicit));
+        }
+    }
+
+    let home = crate::platform::metalsharp_home_dir();
+    candidates.push(home.join("tools").join("gogdl"));
+    candidates.push(home.join("runtime").join("gogdl"));
+
+    if let Some(path_env) = path_env {
+        for path in std::env::split_paths(path_env) {
+            candidates.push(path.join("gogdl"));
+        }
+    }
+    candidates
+}
+
+fn find_gogdl_binary() -> Option<PathBuf> {
+    gogdl_candidate_paths_from_path_env(std::env::var("PATH").ok().as_deref()).into_iter().find(|path| path.is_file())
+}
+
+fn gogdl_status_value() -> Value {
+    let binary = find_gogdl_binary();
+    let auth_config = gogdl_auth_config_path();
+    let authenticated = auth_config.is_file();
+    let status = if binary.is_some() {
+        if authenticated {
+            "ready"
+        } else {
+            "needs_login"
+        }
+    } else {
+        "not_configured"
+    };
+    let status_label = match status {
+        "ready" => "Ready",
+        "needs_login" => "Needs login",
+        _ => "gogdl not found",
+    };
+
+    json!({
+        "id": "gogdl",
+        "name": "GOG",
+        "backend": "gogdl",
+        "status": status,
+        "statusLabel": status_label,
+        "available": binary.is_some(),
+        "authenticated": authenticated,
+        "binaryPath": binary.map(|path| path.to_string_lossy().to_string()),
+        "configPath": gogdl_config_dir().to_string_lossy().to_string(),
+        "authConfigPath": auth_config.to_string_lossy().to_string(),
+        "authUrl": GOGDL_AUTH_URL,
+        "galaxyFallbackId": "gog_galaxy",
+        "capabilities": ["auth", "metadata", "download", "launch", "cloud_saves", "redists"],
+    })
+}
+
+pub fn handle_gogdl_diagnostics() -> Value {
+    json!({"ok": true, "launcher": gogdl_status_value(), "galaxyFallback": gog_launcher_status_value()})
+}
+
 pub fn handle_launchers() -> Value {
-    json!({"ok": true, "launchers": [gog_launcher_status_value()]})
+    json!({"ok": true, "launchers": [gogdl_status_value(), gog_launcher_status_value()]})
 }
 
 fn ensure_gog_galaxy_installer_cached() -> Result<PathBuf, Box<dyn std::error::Error>> {
@@ -2753,6 +2827,38 @@ mod tests {
                 "--disable-crash-reporter",
             ]
         );
+    }
+
+    #[test]
+    fn launchers_include_gogdl_backend_before_galaxy_fallback() {
+        let value = handle_launchers();
+        let launchers = value.get("launchers").and_then(|value| value.as_array()).expect("launchers array");
+
+        assert_eq!(launchers.first().and_then(|launcher| launcher.get("id")).and_then(|id| id.as_str()), Some("gogdl"));
+        assert_eq!(
+            launchers.get(1).and_then(|launcher| launcher.get("id")).and_then(|id| id.as_str()),
+            Some("gog_galaxy")
+        );
+        assert_eq!(
+            launchers.first().and_then(|launcher| launcher.get("backend")).and_then(|backend| backend.as_str()),
+            Some("gogdl")
+        );
+        assert_eq!(
+            launchers.first().and_then(|launcher| launcher.get("galaxyFallbackId")).and_then(|id| id.as_str()),
+            Some("gog_galaxy")
+        );
+    }
+
+    #[test]
+    fn gogdl_path_candidates_prefer_explicit_env_then_metalsharp_and_path() {
+        std::env::set_var("METALSHARP_GOGDL_BIN", "/tmp/custom-gogdl");
+        let candidates = gogdl_candidate_paths_from_path_env(Some("/bin:/usr/local/bin"));
+        std::env::remove_var("METALSHARP_GOGDL_BIN");
+
+        assert_eq!(candidates.first(), Some(&PathBuf::from("/tmp/custom-gogdl")));
+        assert!(candidates.iter().any(|path| path.ends_with("tools/gogdl")));
+        assert!(candidates.iter().any(|path| path.ends_with("runtime/gogdl")));
+        assert!(candidates.iter().any(|path| path == &PathBuf::from("/usr/local/bin/gogdl")));
     }
 
     #[test]

--- a/app/src-rust/src/sharp_library.rs
+++ b/app/src-rust/src/sharp_library.rs
@@ -1625,6 +1625,157 @@ pub fn handle_get_library() -> Value {
     }
 }
 
+const GOG_GALAXY_INSTALLER_URL: &str = "https://webinstallers.gog-statics.com/download/GOG_Galaxy_2.0.exe";
+
+fn gog_galaxy_cache_path() -> PathBuf {
+    crate::platform::metalsharp_home_dir().join("cache").join("gog-galaxy").join("GOG_Galaxy_2.0.exe")
+}
+
+fn find_gog_galaxy_app(apps: &[SharpApp]) -> Option<&SharpApp> {
+    apps.iter().find(|app| {
+        store_launcher_kind_for_app(app) == Some(StoreLauncherKind::Gog)
+            && Path::new(&app.exe_path)
+                .file_name()
+                .map(|name| name.to_string_lossy().eq_ignore_ascii_case("GalaxyClient.exe"))
+                .unwrap_or(false)
+    })
+}
+
+fn find_gog_galaxy_bottle() -> Option<crate::bottles::BottleManifest> {
+    let cache_path = gog_galaxy_cache_path().to_string_lossy().to_string();
+    crate::bottles::list_bottles().ok()?.into_iter().find(|bottle| {
+        bottle
+            .source_installer_path
+            .as_deref()
+            .map(|path| path == cache_path || path.to_ascii_lowercase().contains("gog_galaxy"))
+            .unwrap_or(false)
+            || bottle.name.to_ascii_lowercase().contains("gog galaxy")
+    })
+}
+
+fn gog_galaxy_client_in_bottle(bottle: &crate::bottles::BottleManifest) -> Option<PathBuf> {
+    let prefix = Path::new(&bottle.prefix_path);
+    [
+        prefix.join("drive_c").join("Program Files (x86)").join("GOG Galaxy").join("GalaxyClient.exe"),
+        prefix.join("drive_c").join("Program Files").join("GOG Galaxy").join("GalaxyClient.exe"),
+    ]
+    .into_iter()
+    .find(|path| path.exists())
+}
+
+fn gog_launcher_status_value() -> Value {
+    let apps = load_library().unwrap_or_default();
+    let app = find_gog_galaxy_app(&apps);
+    let bottle = find_gog_galaxy_bottle();
+    let installing = bottle
+        .as_ref()
+        .and_then(|bottle| bottle.last_launch_pid)
+        .map(|pid| crate::launch::is_process_active(pid as i32))
+        .unwrap_or(false);
+    let client_exists = app.map(|app| app_absolute_exe_path(app).exists()).unwrap_or(false)
+        || bottle.as_ref().and_then(gog_galaxy_client_in_bottle).is_some();
+    let (status, detail) = if installing {
+        ("installing", "Installing…")
+    } else if client_exists {
+        ("installed", "Installed")
+    } else if bottle.is_some() {
+        ("needs_repair", "Needs repair")
+    } else {
+        ("not_installed", "Not installed")
+    };
+
+    json!({
+        "id": "gog_galaxy",
+        "name": "GOG Galaxy",
+        "status": status,
+        "statusLabel": detail,
+        "appId": app.map(|app| app.id.clone()),
+        "bottleId": bottle.as_ref().map(|bottle| bottle.id.clone()),
+        "installerUrl": GOG_GALAXY_INSTALLER_URL,
+    })
+}
+
+pub fn handle_launchers() -> Value {
+    json!({"ok": true, "launchers": [gog_launcher_status_value()]})
+}
+
+fn ensure_gog_galaxy_installer_cached() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let path = gog_galaxy_cache_path();
+    if path.exists() && path.metadata().map(|meta| meta.len() > 1_000_000).unwrap_or(false) {
+        return Ok(path);
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let tmp = path.with_extension("exe.download");
+    let _ = fs::remove_file(&tmp);
+    let status = Command::new("/usr/bin/curl")
+        .arg("--fail")
+        .arg("--location")
+        .arg("--silent")
+        .arg("--show-error")
+        .arg("--output")
+        .arg(&tmp)
+        .arg(GOG_GALAXY_INSTALLER_URL)
+        .status()?;
+    if !status.success() {
+        let _ = fs::remove_file(&tmp);
+        return Err(format!("failed to download GOG Galaxy installer from {}", GOG_GALAXY_INSTALLER_URL).into());
+    }
+    fs::rename(&tmp, &path)?;
+    Ok(path)
+}
+
+pub fn handle_install_gog_galaxy() -> Value {
+    match ensure_gog_galaxy_installer_cached()
+        .and_then(|path| install_exe_with_options(path.to_string_lossy().as_ref(), Some("GOG Galaxy"), false))
+    {
+        Ok(SharpInstallOutcome::Imported(app)) => {
+            json!({"ok": true, "app": *app, "launcher": gog_launcher_status_value()})
+        },
+        Ok(SharpInstallOutcome::InstallerStarted { pid, message }) => {
+            json!({"ok": true, "installing": true, "pid": pid, "message": message, "launcher": gog_launcher_status_value()})
+        },
+        Err(e) => json!({"ok": false, "error": e.to_string(), "launcher": gog_launcher_status_value()}),
+    }
+}
+
+fn import_installed_gog_galaxy_card() -> Result<SharpApp, Box<dyn std::error::Error>> {
+    let apps = load_library()?;
+    if let Some(app) = find_gog_galaxy_app(&apps) {
+        return Ok(app.clone());
+    }
+    let bottle = find_gog_galaxy_bottle().ok_or("GOG Galaxy bottle not found")?;
+    let client = gog_galaxy_client_in_bottle(&bottle).ok_or("GalaxyClient.exe not found in GOG Galaxy bottle")?;
+    import_bottle_app(&bottle.id, &client.to_string_lossy(), Some("GOG Galaxy"))
+}
+
+pub fn handle_show_gog_galaxy_card() -> Value {
+    match import_installed_gog_galaxy_card() {
+        Ok(app) => json!({"ok": true, "app": app, "launcher": gog_launcher_status_value()}),
+        Err(e) => json!({"ok": false, "error": e.to_string(), "launcher": gog_launcher_status_value()}),
+    }
+}
+
+pub fn handle_open_gog_galaxy() -> Value {
+    match import_installed_gog_galaxy_card().and_then(|app| launch_app(&app.id, &app.engine)) {
+        Ok(result) => {
+            json!({"ok": true, "pid": result.pid, "pipeline": result.pipeline, "exePath": result.exe_path, "launcher": gog_launcher_status_value()})
+        },
+        Err(e) => json!({"ok": false, "error": e.to_string(), "launcher": gog_launcher_status_value()}),
+    }
+}
+
+pub fn handle_repair_gog_galaxy() -> Value {
+    if let Some(bottle) = find_gog_galaxy_bottle() {
+        let _ = crate::bottles::refresh_app_detections(&bottle.id);
+        if import_installed_gog_galaxy_card().is_ok() {
+            return json!({"ok": true, "launcher": gog_launcher_status_value()});
+        }
+    }
+    handle_install_gog_galaxy()
+}
+
 pub fn handle_install(body: &serde_json::Map<String, Value>) -> Value {
     let src_path = body.get("srcPath").and_then(|v| v.as_str()).unwrap_or("");
     let custom_name = body.get("name").and_then(|v| v.as_str());

--- a/app/src/renderer/views/SharpView.vue
+++ b/app/src/renderer/views/SharpView.vue
@@ -4,6 +4,7 @@ import { useToast } from "../composables/useToast";
 import { api, getAPI } from "../composables/useApi";
 import type { SharpApp } from "../api-types";
 import IconDownload from "~icons/lucide/download";
+import IconRocket from "~icons/lucide/rocket";
 import IconUpload from "~icons/lucide/upload";
 import IconRefreshCcw from "~icons/lucide/refresh-ccw";
 import IconMonitor from "~icons/lucide/monitor";
@@ -142,6 +143,16 @@ interface RedistSourceGuide {
   notes: string;
 }
 
+interface LauncherState {
+  id: string;
+  name: string;
+  status: "not_installed" | "installing" | "installed" | "needs_repair";
+  statusLabel: string;
+  appId?: string | null;
+  bottleId?: string | null;
+  installerUrl?: string;
+}
+
 const toast = useToast();
 const apps = ref<SharpApp[]>([]);
 const dropdownOpen = ref<string | null>(null);
@@ -163,6 +174,8 @@ function openDropdown(name: string, event: MouseEvent) {
 const bottles = ref<BottleManifest[]>([]);
 const runtimeProfiles = ref<RuntimeProfileDefinition[]>([]);
 const redistSources = ref<RedistSourceGuide[]>([]);
+const launchers = ref<LauncherState[]>([]);
+const launcherActionLoading = ref<Record<string, boolean>>({});
 const bottleReports = ref<Record<string, BottleDiagnostic | null>>({});
 const d3dmetalStates = ref<Record<string, D3DMetalGptkState | null>>({});
 const d3dmetalActions = ref<Record<string, D3DMetalGptkAction[]>>({});
@@ -261,11 +274,12 @@ function sharpAppNameSort(a: SharpApp, b: SharpApp) {
 }
 
 async function load() {
-  const [result, bottleResult, profileResult, redistResult] = await Promise.all([
+  const [result, bottleResult, profileResult, redistResult, launcherResult] = await Promise.all([
     api<{ ok: boolean; apps: SharpApp[] }>("GET", "/sharp-library"),
     api<{ ok: boolean; bottles: BottleManifest[] }>("GET", "/bottles"),
     api<{ ok: boolean; profiles: RuntimeProfileDefinition[] }>("GET", "/bottles/profiles"),
     api<{ ok: boolean; sources: RedistSourceGuide[] }>("GET", "/bottles/redist-sources"),
+    api<{ ok: boolean; launchers: LauncherState[] }>("GET", "/sharp-library/launchers"),
   ]);
   if (result?.ok) {
     apps.value = [...result.apps].sort(sharpAppNameSort);
@@ -280,6 +294,46 @@ async function load() {
   }
   if (profileResult?.ok) runtimeProfiles.value = profileResult.profiles;
   if (redistResult?.ok) redistSources.value = redistResult.sources;
+  if (launcherResult?.ok) launchers.value = launcherResult.launchers;
+}
+
+function launcherBadgeClass(status: LauncherState["status"]): string {
+  if (status === "installed") return "badge-ok";
+  if (status === "installing") return "badge-warn";
+  if (status === "needs_repair") return "badge-warn";
+  return "badge-muted";
+}
+
+function isGogGalaxyApp(app: SharpApp): boolean {
+  const exe = app.exe_path.split(/[\\/]/).pop()?.toLowerCase() ?? "";
+  return exe === "galaxyclient.exe" || app.name.toLowerCase().includes("gog galaxy");
+}
+
+async function runLauncherAction(launcher: LauncherState, action: "install" | "open" | "repair" | "show-card") {
+  launcherActionLoading.value[`${launcher.id}:${action}`] = true;
+  const result = await api<{ ok: boolean; app?: SharpApp; installing?: boolean; pid?: number; message?: string; error?: string; launcher?: LauncherState }>(
+    "POST",
+    `/sharp-library/launchers/gog/${action}`,
+  );
+  launcherActionLoading.value[`${launcher.id}:${action}`] = false;
+  if (result?.launcher) {
+    const idx = launchers.value.findIndex((item) => item.id === result.launcher?.id);
+    if (idx >= 0) launchers.value[idx] = result.launcher;
+  }
+  if (result?.ok) {
+    if (result.pid && result.app?.id) runningSharpPids.value[result.app.id] = result.pid;
+    const msg = result.installing
+      ? (result.message ?? `${launcher.name} installer started`)
+      : action === "open"
+        ? `${launcher.name} launched`
+        : action === "show-card"
+          ? `${launcher.name} card is visible`
+          : `${launcher.name} action complete`;
+    toast.show(msg, "success");
+    await load();
+  } else {
+    toast.show(result?.error ?? `Failed to ${action.replace("-", " ")} ${launcher.name}`, "error");
+  }
 }
 
 async function refreshSharpLibrary() {
@@ -867,6 +921,59 @@ onUnmounted(() => { document.removeEventListener('click', closeDropdowns); });
     <div class="sharp-header">
       <h1>Sharp Library</h1>
       <div class="sharp-header-controls">
+        <div v-if="launchers.length" class="dropdown-wrap">
+          <button class="btn btn-secondary" @click="openDropdown('launchers', $event)">
+            <IconRocket class="btn-icon" width="14" height="14" />
+            <span class="btn-label-long">Launchers</span><span class="btn-label-short">Launchers</span>
+            <span class="dropdown-count">{{ launchers.length }}</span>
+          </button>
+          <div v-if="dropdownOpen === 'launchers'" class="dropdown-panel" :style="dropdownStyle" @click.stop>
+            <div class="dropdown-scroll launcher-list">
+              <article v-for="launcher in launchers" :key="launcher.id" class="launcher-card-compact">
+                <div class="launcher-card-header">
+                  <div>
+                    <strong>{{ launcher.name }}</strong>
+                    <small>{{ launcher.installerUrl }}</small>
+                  </div>
+                  <span class="badge" :class="launcherBadgeClass(launcher.status)">{{ launcher.statusLabel }}</span>
+                </div>
+                <div class="launcher-actions">
+                  <button
+                    v-if="launcher.status === 'not_installed'"
+                    class="btn btn-primary btn-sm"
+                    :disabled="launcherActionLoading[`${launcher.id}:install`]"
+                    @click="runLauncherAction(launcher, 'install')"
+                  >
+                    {{ launcherActionLoading[`${launcher.id}:install`] ? "Installing…" : "Install GOG Galaxy" }}
+                  </button>
+                  <button
+                    v-if="launcher.status === 'installed'"
+                    class="btn btn-primary btn-sm"
+                    :disabled="launcherActionLoading[`${launcher.id}:open`]"
+                    @click="runLauncherAction(launcher, 'open')"
+                  >
+                    Open GOG Galaxy
+                  </button>
+                  <button
+                    v-if="launcher.status === 'needs_repair'"
+                    class="btn btn-secondary btn-sm"
+                    :disabled="launcherActionLoading[`${launcher.id}:repair`]"
+                    @click="runLauncherAction(launcher, 'repair')"
+                  >
+                    Repair GOG Galaxy
+                  </button>
+                  <button
+                    class="btn btn-secondary btn-sm"
+                    :disabled="launcher.status === 'not_installed' || launcherActionLoading[`${launcher.id}:show-card`]"
+                    @click="runLauncherAction(launcher, 'show-card')"
+                  >
+                    Show launcher card
+                  </button>
+                </div>
+              </article>
+            </div>
+          </div>
+        </div>
         <div v-if="redistSources.length" class="dropdown-wrap">
           <button class="btn btn-secondary" @click="openDropdown('redist', $event)">
             <IconDownload class="btn-icon" width="14" height="14" />
@@ -930,7 +1037,7 @@ onUnmounted(() => { document.removeEventListener('click', closeDropdowns); });
           <div class="sharp-card-actions">
             <div class="sharp-card-actions-row">
               <button v-if="runningSharpPids[app.id]" class="btn btn-stop" @click="stopSharpApp(app)">Stop</button>
-              <button v-else class="btn btn-play" @click="launchApp(app.id, app.engine)">Play</button>
+              <button v-else class="btn btn-play" @click="launchApp(app.id, app.engine)">{{ isGogGalaxyApp(app) ? "Play GOG Galaxy" : "Play" }}</button>
               <select
                 class="control-input"
                 :value="app.engine"
@@ -1194,6 +1301,42 @@ onUnmounted(() => { document.removeEventListener('click', closeDropdowns); });
 }
 .redist-source-compact:last-child {
   margin-bottom: 0;
+}
+.launcher-card-compact {
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  margin-bottom: 6px;
+  background: var(--bg-surface);
+  font-size: 12px;
+}
+.launcher-card-compact:last-child {
+  margin-bottom: 0;
+}
+.launcher-card-header,
+.launcher-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.launcher-card-header small {
+  display: block;
+  margin-top: 2px;
+  color: var(--text-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 260px;
+}
+.launcher-actions {
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+.badge-muted {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-dim);
 }
 .bottle-list {
   display: flex;

--- a/app/src/renderer/views/SharpView.vue
+++ b/app/src/renderer/views/SharpView.vue
@@ -146,11 +146,16 @@ interface RedistSourceGuide {
 interface LauncherState {
   id: string;
   name: string;
-  status: "not_installed" | "installing" | "installed" | "running" | "needs_repair";
+  backend?: "gogdl" | string;
+  status: "not_installed" | "installing" | "installed" | "running" | "needs_repair" | "not_configured" | "needs_login" | "ready";
   statusLabel: string;
   appId?: string | null;
   bottleId?: string | null;
   installerUrl?: string;
+  authUrl?: string;
+  binaryPath?: string | null;
+  authConfigPath?: string | null;
+  capabilities?: string[];
 }
 
 interface LauncherDiagnostics {
@@ -307,10 +312,13 @@ async function load() {
 }
 
 function launcherBadgeClass(status: LauncherState["status"]): string {
-  if (status === "installed" || status === "running") return "badge-ok";
-  if (status === "installing") return "badge-warn";
-  if (status === "needs_repair") return "badge-warn";
+  if (status === "installed" || status === "running" || status === "ready") return "badge-ok";
+  if (status === "installing" || status === "needs_repair" || status === "needs_login") return "badge-warn";
   return "badge-muted";
+}
+
+function isGogdlLauncher(launcher: LauncherState): boolean {
+  return launcher.id === "gogdl" || launcher.backend === "gogdl";
 }
 
 function isGogGalaxyApp(app: SharpApp): boolean {
@@ -320,9 +328,10 @@ function isGogGalaxyApp(app: SharpApp): boolean {
 
 async function loadLauncherDiagnostics(launcher: LauncherState) {
   launcherActionLoading.value[`${launcher.id}:diagnostics`] = true;
+  const diagnosticsUrl = isGogdlLauncher(launcher) ? "/sharp-library/launchers/gogdl/diagnostics" : "/sharp-library/launchers/gog/diagnostics";
   const result = await api<{ ok: boolean; diagnostics?: LauncherDiagnostics; error?: string; launcher?: LauncherState }>(
     "GET",
-    "/sharp-library/launchers/gog/diagnostics",
+    diagnosticsUrl,
   );
   launcherActionLoading.value[`${launcher.id}:diagnostics`] = false;
   if (result?.launcher) {
@@ -332,9 +341,17 @@ async function loadLauncherDiagnostics(launcher: LauncherState) {
   if (result?.ok && result.diagnostics) {
     launcherDiagnostics.value[launcher.id] = result.diagnostics;
     toast.show(`${launcher.name} diagnostics refreshed`, "success");
+  } else if (result?.ok) {
+    toast.show(`${launcher.name} status refreshed`, "success");
   } else {
     toast.show(result?.error ?? `Failed to inspect ${launcher.name}`, "error");
   }
+}
+
+async function copyLauncherAuthUrl(launcher: LauncherState) {
+  if (!launcher.authUrl) return;
+  const result = await getAPI().copyText(launcher.authUrl);
+  toast.show(result?.ok ? `${launcher.name} login URL copied` : (result?.error ?? `Failed to copy ${launcher.name} login URL`), result?.ok ? "success" : "error");
 }
 
 async function runLauncherAction(launcher: LauncherState, action: "install" | "open" | "stop" | "repair" | "show-card") {
@@ -963,13 +980,13 @@ onUnmounted(() => { document.removeEventListener('click', closeDropdowns); });
                 <div class="launcher-card-header">
                   <div>
                     <strong>{{ launcher.name }}</strong>
-                    <small>{{ launcher.installerUrl }}</small>
+                    <small>{{ launcher.backend === "gogdl" ? "Heroic-style gogdl backend" : launcher.installerUrl }}</small>
                   </div>
                   <span class="badge" :class="launcherBadgeClass(launcher.status)">{{ launcher.statusLabel }}</span>
                 </div>
                 <div class="launcher-actions">
                   <button
-                    v-if="launcher.status === 'not_installed'"
+                    v-if="!isGogdlLauncher(launcher) && launcher.status === 'not_installed'"
                     class="btn btn-primary btn-sm"
                     :disabled="launcherActionLoading[`${launcher.id}:install`]"
                     @click="runLauncherAction(launcher, 'install')"
@@ -977,7 +994,7 @@ onUnmounted(() => { document.removeEventListener('click', closeDropdowns); });
                     {{ launcherActionLoading[`${launcher.id}:install`] ? "Installing…" : "Install GOG Galaxy" }}
                   </button>
                   <button
-                    v-if="launcher.status === 'installed'"
+                    v-if="!isGogdlLauncher(launcher) && launcher.status === 'installed'"
                     class="btn btn-primary btn-sm"
                     :disabled="launcherActionLoading[`${launcher.id}:open`]"
                     @click="runLauncherAction(launcher, 'open')"
@@ -985,7 +1002,7 @@ onUnmounted(() => { document.removeEventListener('click', closeDropdowns); });
                     {{ launcherActionLoading[`${launcher.id}:open`] ? "Starting…" : "Start GOG" }}
                   </button>
                   <button
-                    v-if="launcher.status === 'running'"
+                    v-if="!isGogdlLauncher(launcher) && launcher.status === 'running'"
                     class="btn btn-stop btn-sm"
                     :disabled="launcherActionLoading[`${launcher.id}:stop`]"
                     @click="runLauncherAction(launcher, 'stop')"
@@ -993,7 +1010,7 @@ onUnmounted(() => { document.removeEventListener('click', closeDropdowns); });
                     {{ launcherActionLoading[`${launcher.id}:stop`] ? "Stopping…" : "Stop GOG" }}
                   </button>
                   <button
-                    v-if="launcher.status === 'needs_repair'"
+                    v-if="!isGogdlLauncher(launcher) && launcher.status === 'needs_repair'"
                     class="btn btn-secondary btn-sm"
                     :disabled="launcherActionLoading[`${launcher.id}:repair`]"
                     @click="runLauncherAction(launcher, 'repair')"
@@ -1008,12 +1025,25 @@ onUnmounted(() => { document.removeEventListener('click', closeDropdowns); });
                     Diagnostics
                   </button>
                   <button
+                    v-if="isGogdlLauncher(launcher) && launcher.authUrl"
+                    class="btn btn-secondary btn-sm"
+                    @click="copyLauncherAuthUrl(launcher)"
+                  >
+                    Copy login URL
+                  </button>
+                  <button
+                    v-if="!isGogdlLauncher(launcher)"
                     class="btn btn-secondary btn-sm"
                     :disabled="launcher.status === 'not_installed' || launcherActionLoading[`${launcher.id}:show-card`]"
                     @click="runLauncherAction(launcher, 'show-card')"
                   >
                     Show launcher card
                   </button>
+                  <div v-if="isGogdlLauncher(launcher)" class="launcher-diagnostic-section">
+                    <small>Binary: {{ launcher.binaryPath || "Set METALSHARP_GOGDL_BIN or install gogdl" }}</small>
+                    <small>Auth: {{ launcher.authConfigPath }}</small>
+                    <small v-if="launcher.capabilities?.length">Capabilities: {{ launcher.capabilities.join(' · ') }}</small>
+                  </div>
                 </div>
                 <div v-if="launcherDiagnostics[launcher.id]" class="launcher-diagnostics">
                   <strong>Diagnostics: {{ launcherDiagnostics[launcher.id]?.status }}</strong>

--- a/app/src/renderer/views/SharpView.vue
+++ b/app/src/renderer/views/SharpView.vue
@@ -153,6 +153,14 @@ interface LauncherState {
   installerUrl?: string;
 }
 
+interface LauncherDiagnostics {
+  status: string;
+  issues: { id: string; severity: string; detail: string }[];
+  actions: { id: string; label: string }[];
+  logs: { path: string; size: number }[];
+  cachedSetupPath?: string | null;
+}
+
 const toast = useToast();
 const apps = ref<SharpApp[]>([]);
 const dropdownOpen = ref<string | null>(null);
@@ -176,6 +184,7 @@ const runtimeProfiles = ref<RuntimeProfileDefinition[]>([]);
 const redistSources = ref<RedistSourceGuide[]>([]);
 const launchers = ref<LauncherState[]>([]);
 const launcherActionLoading = ref<Record<string, boolean>>({});
+const launcherDiagnostics = ref<Record<string, LauncherDiagnostics | null>>({});
 const bottleReports = ref<Record<string, BottleDiagnostic | null>>({});
 const d3dmetalStates = ref<Record<string, D3DMetalGptkState | null>>({});
 const d3dmetalActions = ref<Record<string, D3DMetalGptkAction[]>>({});
@@ -307,6 +316,25 @@ function launcherBadgeClass(status: LauncherState["status"]): string {
 function isGogGalaxyApp(app: SharpApp): boolean {
   const exe = app.exe_path.split(/[\\/]/).pop()?.toLowerCase() ?? "";
   return exe === "galaxyclient.exe" || app.name.toLowerCase().includes("gog galaxy");
+}
+
+async function loadLauncherDiagnostics(launcher: LauncherState) {
+  launcherActionLoading.value[`${launcher.id}:diagnostics`] = true;
+  const result = await api<{ ok: boolean; diagnostics?: LauncherDiagnostics; error?: string; launcher?: LauncherState }>(
+    "GET",
+    "/sharp-library/launchers/gog/diagnostics",
+  );
+  launcherActionLoading.value[`${launcher.id}:diagnostics`] = false;
+  if (result?.launcher) {
+    const idx = launchers.value.findIndex((item) => item.id === result.launcher?.id);
+    if (idx >= 0) launchers.value[idx] = result.launcher;
+  }
+  if (result?.ok && result.diagnostics) {
+    launcherDiagnostics.value[launcher.id] = result.diagnostics;
+    toast.show(`${launcher.name} diagnostics refreshed`, "success");
+  } else {
+    toast.show(result?.error ?? `Failed to inspect ${launcher.name}`, "error");
+  }
 }
 
 async function runLauncherAction(launcher: LauncherState, action: "install" | "open" | "repair" | "show-card") {
@@ -964,11 +992,30 @@ onUnmounted(() => { document.removeEventListener('click', closeDropdowns); });
                   </button>
                   <button
                     class="btn btn-secondary btn-sm"
+                    :disabled="launcherActionLoading[`${launcher.id}:diagnostics`]"
+                    @click="loadLauncherDiagnostics(launcher)"
+                  >
+                    Diagnostics
+                  </button>
+                  <button
+                    class="btn btn-secondary btn-sm"
                     :disabled="launcher.status === 'not_installed' || launcherActionLoading[`${launcher.id}:show-card`]"
                     @click="runLauncherAction(launcher, 'show-card')"
                   >
                     Show launcher card
                   </button>
+                </div>
+                <div v-if="launcherDiagnostics[launcher.id]" class="launcher-diagnostics">
+                  <strong>Diagnostics: {{ launcherDiagnostics[launcher.id]?.status }}</strong>
+                  <div v-if="launcherDiagnostics[launcher.id]?.issues.length" class="launcher-diagnostic-section">
+                    <span v-for="issue in launcherDiagnostics[launcher.id]?.issues" :key="issue.id" class="component-pill" :class="issue.severity === 'error' ? 'pill-missing' : 'pill-warn'">{{ issue.detail }}</span>
+                  </div>
+                  <div v-if="launcherDiagnostics[launcher.id]?.actions.length" class="launcher-diagnostic-section">
+                    <small>Repair actions: {{ launcherDiagnostics[launcher.id]?.actions.map(action => action.label).join(' · ') }}</small>
+                  </div>
+                  <div v-if="launcherDiagnostics[launcher.id]?.cachedSetupPath" class="launcher-diagnostic-section">
+                    <small>Cached setup: {{ launcherDiagnostics[launcher.id]?.cachedSetupPath }}</small>
+                  </div>
                 </div>
               </article>
             </div>
@@ -1333,6 +1380,18 @@ onUnmounted(() => { document.removeEventListener('click', closeDropdowns); });
   justify-content: flex-start;
   flex-wrap: wrap;
   margin-top: 10px;
+}
+.launcher-diagnostics {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+}
+.launcher-diagnostic-section {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+  color: var(--text-dim);
 }
 .badge-muted {
   background: rgba(255, 255, 255, 0.08);

--- a/app/src/renderer/views/SharpView.vue
+++ b/app/src/renderer/views/SharpView.vue
@@ -146,7 +146,7 @@ interface RedistSourceGuide {
 interface LauncherState {
   id: string;
   name: string;
-  status: "not_installed" | "installing" | "installed" | "needs_repair";
+  status: "not_installed" | "installing" | "installed" | "running" | "needs_repair";
   statusLabel: string;
   appId?: string | null;
   bottleId?: string | null;
@@ -307,7 +307,7 @@ async function load() {
 }
 
 function launcherBadgeClass(status: LauncherState["status"]): string {
-  if (status === "installed") return "badge-ok";
+  if (status === "installed" || status === "running") return "badge-ok";
   if (status === "installing") return "badge-warn";
   if (status === "needs_repair") return "badge-warn";
   return "badge-muted";
@@ -337,7 +337,7 @@ async function loadLauncherDiagnostics(launcher: LauncherState) {
   }
 }
 
-async function runLauncherAction(launcher: LauncherState, action: "install" | "open" | "repair" | "show-card") {
+async function runLauncherAction(launcher: LauncherState, action: "install" | "open" | "stop" | "repair" | "show-card") {
   launcherActionLoading.value[`${launcher.id}:${action}`] = true;
   const result = await api<{ ok: boolean; app?: SharpApp; installing?: boolean; pid?: number; message?: string; error?: string; launcher?: LauncherState }>(
     "POST",
@@ -354,9 +354,11 @@ async function runLauncherAction(launcher: LauncherState, action: "install" | "o
       ? (result.message ?? `${launcher.name} installer started`)
       : action === "open"
         ? `${launcher.name} launched`
-        : action === "show-card"
-          ? `${launcher.name} card is visible`
-          : `${launcher.name} action complete`;
+        : action === "stop"
+          ? `${launcher.name} stopped`
+          : action === "show-card"
+            ? `${launcher.name} card is visible`
+            : `${launcher.name} action complete`;
     toast.show(msg, "success");
     await load();
   } else {
@@ -980,7 +982,15 @@ onUnmounted(() => { document.removeEventListener('click', closeDropdowns); });
                     :disabled="launcherActionLoading[`${launcher.id}:open`]"
                     @click="runLauncherAction(launcher, 'open')"
                   >
-                    Open GOG Galaxy
+                    {{ launcherActionLoading[`${launcher.id}:open`] ? "Starting…" : "Start GOG" }}
+                  </button>
+                  <button
+                    v-if="launcher.status === 'running'"
+                    class="btn btn-stop btn-sm"
+                    :disabled="launcherActionLoading[`${launcher.id}:stop`]"
+                    @click="runLauncherAction(launcher, 'stop')"
+                  >
+                    {{ launcherActionLoading[`${launcher.id}:stop`] ? "Stopping…" : "Stop GOG" }}
                   </button>
                   <button
                     v-if="launcher.status === 'needs_repair'"

--- a/app/src/renderer/views/SharpView.vue
+++ b/app/src/renderer/views/SharpView.vue
@@ -155,6 +155,8 @@ interface LauncherState {
   authUrl?: string;
   binaryPath?: string | null;
   authConfigPath?: string | null;
+  winePrefix?: string | null;
+  prefixInitialized?: boolean;
   capabilities?: string[];
 }
 
@@ -1041,6 +1043,7 @@ onUnmounted(() => { document.removeEventListener('click', closeDropdowns); });
                   </button>
                   <div v-if="isGogdlLauncher(launcher)" class="launcher-diagnostic-section">
                     <small>Binary: {{ launcher.binaryPath || "Set METALSHARP_GOGDL_BIN or install gogdl" }}</small>
+                    <small>Prefix: {{ launcher.winePrefix }}{{ launcher.prefixInitialized ? "" : " (will initialize)" }}</small>
                     <small>Auth: {{ launcher.authConfigPath }}</small>
                     <small v-if="launcher.capabilities?.length">Capabilities: {{ launcher.capabilities.join(' · ') }}</small>
                   </div>


### PR DESCRIPTION
## Summary
- Phase 0: add a Sharp Library **Launchers** dropdown with GOG Galaxy as the first launcher.
- Add backend launcher status/actions for GOG Galaxy: install, open, repair, and show launcher card.
- Cache the GOG Galaxy web installer under `~/.metalsharp/cache/gog-galaxy/` and route installation through the existing Sharp Library bottle installer flow.
- Make GOG Galaxy cards show a specific `Play GOG Galaxy` button.
- Phase 1: only import the installed `GalaxyClient.exe` as GOG Galaxy, hide legacy installer/helper/overlay entries, preserve imported bottle app custom names, and apply `/runWithoutUpdating /deelevated` to the GOG client.
- Phase 2: add a dedicated `gog_galaxy` runtime profile with WoW64/win10, VC++ x86+x64, corefonts, and d3dcompiler_47 tracking, and classify the GOG installer into that profile without defaulting to .NET.
- Phase 3: watch the GOG web bootstrapper for `GalaxyInstaller_*/GalaxySetup.exe`, cache only stable/full-size second-stage installers, retry cached setup if the web bootstrapper exits before `GalaxyClient.exe` appears, and auto-import the final client card on success.
- Phase 4: add GOG install diagnostics that parse bootstrapper/webinstaller/Inno logs, surface known failure causes including corrupt setup payloads, expose cached setup state, and list repair actions in the Launchers dropdown.

## Validation
- `cargo fmt --all`
- `cargo test default_launcher_launch_args_match_known_store_launchers -- --nocapture`
- `cargo test gog_galaxy -- --nocapture`
- `cargo test runtime_profile_definitions_are_declarative -- --nocapture`
- `npm ci`
- `npm run build`

## Roadmap progress
- [x] Phase 0 — Sharp Library Launchers UX
- [x] Phase 1 — Stabilize Detection and Import Behavior
- [x] Phase 2 — Add a GOG-Specific Runtime Profile
- [x] Phase 3 — Implement GOG Installer Orchestration
- [x] Phase 4 — Failure Diagnostics and Repair Actions
- [ ] Phase 5 — Launch Validation
- [ ] Phase 6 — Optional GOG Game Detection
