### PR TITLE
Fix Discord link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <a href="https://github.com/aaf2tbz/metalsharp/releases"><img src="https://img.shields.io/github/v/release/aaf2tbz/metalsharp?style=for-the-badge" alt="Release"></a>
 <a href="https://github.com/aaf2tbz/metalsharp/discussions"><img src="https://img.shields.io/github/discussions/aaf2tbz/metalsharp?style=for-the-badge" alt="Discussions"></a>
 <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="MIT"></a>
-<a href="DISCORD"><img alt="Discord" src="https://img.shields.io/discord/:1513705401374343259"></a>
+<a href="https://discord.gg/qW5rUr4dH"><img src="https://img.shields.io/discord/:1513705401374343259" alt="DISCORD"></a>
 
 </div>
 


### PR DESCRIPTION
Updated Discord link to point to the correct invite.

## Summary

<!-- Brief description of what this PR does and why -->

## Changes

<!-- List the key changes -->

-

## Checklist

- [ ] `cargo build --release` passes (Rust backend)
- [ ] `cargo clippy --all-targets` passes
- [ ] `cargo fmt --all -- --check` passes
- [ ] C++ compiles if changed: `cmake -B build && cmake --build build`
- [ ] TypeScript compiles if changed: `cd app && npx tsc --noEmit`
- [ ] Tested with at least one game
- [ ] No hardcoded paths or secrets

## Test notes

<!-- What did you test? Which game, which launch method, which drive? -->
