### PR TITLE
feat: add versioned Electron/backend contract suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,15 @@ jobs:
       - name: Check doc freshness (warn-only)
         run: python3 tools/ci/check-doc-freshness.py
 
+  backend-contract:
+    name: Backend Contract CI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Validate versioned Electron/backend contract
+        run: python3 tools/contracts/validate-electron-backend-contract.py
+
   metal:
     name: Metal CI
     runs-on: macos-14

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -47,6 +47,15 @@ jobs:
       - name: Check doc freshness (warn-only)
         run: python3 tools/ci/check-doc-freshness.py
 
+  backend-contract:
+    name: Backend Contract CI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Validate versioned Electron/backend contract
+        run: python3 tools/contracts/validate-electron-backend-contract.py
+
   metal:
     name: Metal CI
     runs-on: macos-14

--- a/app/src-c/Makefile
+++ b/app/src-c/Makefile
@@ -18,7 +18,7 @@ LDFLAGS := -arch arm64 -mmacosx-version-min=$(DEPLOYMENT_TARGET) -isysroot $(SDK
 BACKEND := $(OUT_DIR)/metalsharp-backend
 TEST_BIN := $(OUT_DIR)/metalsharp-backend-tests
 
-.PHONY: integrity backend test-binary test smoke verify clean
+.PHONY: integrity backend test-binary test smoke contract verify clean
 integrity:
 	@test "$$(wc -l < manifests/runtime-sources.txt | tr -d ' ')" = 374
 	@test "$$(wc -l < manifests/test-sources.txt | tr -d ' ')" = 394
@@ -53,7 +53,11 @@ test: $(TEST_BIN)
 smoke: $(BACKEND)
 	"$(CURDIR)/../../tools/c-backend/soak.sh" "$(CURDIR)/$(BACKEND)"
 
-verify: integrity backend test smoke
+contract: $(BACKEND)
+	python3 "$(CURDIR)/../../tools/contracts/validate-electron-backend-contract.py"
+	python3 "$(CURDIR)/../../tools/contracts/run-electron-backend-conformance.py" "$(CURDIR)/$(BACKEND)"
+
+verify: integrity backend test smoke contract
 
 clean:
 	rm -rf build $(OUT_DIR)

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -165,6 +165,7 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
                 json!({
                     "ok": true,
                     "version": env!("CARGO_PKG_VERSION"),
+                    "contract_version": "1",
                     "pid": std::process::id(),
                     "dev_mode": std::env::var("METALSHARP_DEV").map(|v| v == "1").unwrap_or(false),
                     "metalsharp_home": crate::platform::metalsharp_home_dir().to_string_lossy().to_string(),

--- a/app/src/main/rust-bridge.ts
+++ b/app/src/main/rust-bridge.ts
@@ -2,6 +2,7 @@ import { type ChildProcess, spawn } from "child_process";
 import * as fs from "fs";
 import * as http from "http";
 import * as path from "path";
+import { BACKEND_CONTRACT_VERSION, type BackendStatus, compatibleContractVersion } from "../shared/backend-contract";
 
 function getShellPath(): string {
   const home = process.env.HOME || "";
@@ -58,7 +59,7 @@ export class RustBridge {
   }
 
   async ensureRunning(maxMs = 15000): Promise<{ ok: boolean; error?: string }> {
-    if (await this.isAlive()) return { ok: true };
+    if (await this.isAlive()) return this.ensureCompatibleContract();
 
     // In dev mode, auto-restart the backend so binary swaps "just work".
     // In production, the app owns the lifecycle — only start() spawns.
@@ -67,7 +68,7 @@ export class RustBridge {
       if (!started.ok) return started;
       try {
         await this.waitForReady(maxMs);
-        return { ok: true };
+        return this.ensureCompatibleContract();
       } catch (e) {
         return { ok: false, error: (e as Error).message };
       }
@@ -89,13 +90,13 @@ export class RustBridge {
       await this.killProcess();
     } else if (await this.isAlive()) {
       console.log("Backend already running and up to date");
-      return { ok: true };
+      return this.ensureCompatibleContract();
     }
 
     this.spawnBackend(binPath);
     try {
       await this.waitForReady();
-      return { ok: true };
+      return this.ensureCompatibleContract();
     } catch (e) {
       return { ok: false, error: (e as Error).message };
     }
@@ -113,7 +114,7 @@ export class RustBridge {
     try {
       this.spawnBackend(binPath);
       await this.waitForReady(10000);
-      return { ok: true };
+      return this.ensureCompatibleContract();
     } catch (e) {
       return { ok: false, error: (e as Error).message };
     }
@@ -338,6 +339,42 @@ export class RustBridge {
     });
   }
 
+  private async getBackendStatus(): Promise<BackendStatus | null> {
+    return new Promise((resolve) => {
+      const req = http.get(`http://127.0.0.1:${this.port}/status`, (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk) => chunks.push(chunk));
+        res.on("end", () => {
+          try {
+            resolve(JSON.parse(Buffer.concat(chunks).toString()) as BackendStatus);
+          } catch {
+            resolve(null);
+          }
+        });
+      });
+      req.on("error", () => resolve(null));
+      req.setTimeout(1500, () => {
+        req.destroy();
+        resolve(null);
+      });
+    });
+  }
+
+  private async ensureCompatibleContract(): Promise<{ ok: boolean; error?: string }> {
+    const status = await this.getBackendStatus();
+    if (!status?.ok || !status.version) {
+      return { ok: false, error: "Backend returned an invalid /status response" };
+    }
+    const actual = compatibleContractVersion(status);
+    if (actual !== BACKEND_CONTRACT_VERSION) {
+      return {
+        ok: false,
+        error: `Backend contract mismatch: Electron requires v${BACKEND_CONTRACT_VERSION}, backend ${status.version} provides ${actual ? `v${actual}` : "no supported contract"}. Update MetalSharp so the app and backend match.`,
+      };
+    }
+    return { ok: true };
+  }
+
   private async getProcessPath(pid: number): Promise<string | null> {
     if (!Number.isInteger(pid) || pid <= 0) return null;
     return new Promise((resolve) => {
@@ -354,11 +391,13 @@ export class RustBridge {
 
   private findBinary(): string | null {
     const devCandidates = [
+      path.join(__dirname, "..", "..", "build", "c-backend", "metalsharp-backend"),
       path.join(__dirname, "..", "..", "src-rust", "target", "debug", "metalsharp-backend"),
       path.join(__dirname, "..", "..", "src-rust", "target", "release", "metalsharp-backend"),
     ];
     const packagedCandidates = [
       path.join(process.resourcesPath || "", "runtime", "metalsharp-backend"),
+      path.join(__dirname, "..", "..", "build", "c-backend", "metalsharp-backend"),
       path.join(__dirname, "..", "..", "src-rust", "target", "release", "metalsharp-backend"),
       path.join(__dirname, "..", "..", "src-rust", "target", "debug", "metalsharp-backend"),
       "/usr/local/bin/metalsharp-backend",

--- a/app/src/renderer/composables/useApi.ts
+++ b/app/src/renderer/composables/useApi.ts
@@ -1,4 +1,5 @@
 /// <reference path="../api-types.ts" />
+import type { ContractResponses, ContractRoute } from "../../shared/backend-contract";
 
 function getAPI(): MetalsharpAPI {
   return (window as unknown as { metalsharp: MetalsharpAPI }).metalsharp;
@@ -17,6 +18,17 @@ export async function api<T = unknown>(
     console.error(`API ${method} ${url}:`, e);
     return null;
   }
+}
+
+// Prefer this for contract-covered routes. The generic api() remains available
+// while the large existing renderer surface is migrated incrementally.
+export async function contractApi<Route extends ContractRoute>(
+  method: Route extends `${infer Method} ${string}` ? Method : never,
+  url: Route extends `${string} ${infer Path}` ? Path | `${Path}?${string}` : never,
+  body?: Record<string, unknown>,
+  timeoutMs?: number,
+): Promise<ContractResponses[Route] | null> {
+  return api<ContractResponses[Route]>(method, url, body, timeoutMs);
 }
 
 export { getAPI };

--- a/app/src/shared/backend-contract.ts
+++ b/app/src/shared/backend-contract.ts
@@ -1,0 +1,92 @@
+// Generated-facing types for contracts/electron-backend.v1.json. Keep this
+// module implementation-independent: it describes the Electron/backend wire
+// protocol, not Rust or generated-C internals.
+
+export const BACKEND_CONTRACT_VERSION = "1" as const;
+
+export interface BackendStatus {
+  ok: boolean;
+  version: string;
+  contract_version?: string;
+  pid: number;
+  dev_mode?: boolean;
+  metalsharp_home: string;
+}
+
+export interface SetupStateContract {
+  ok: boolean;
+  completed: boolean;
+  step: number;
+  steamApiKeySet: boolean;
+}
+
+export interface SteamStatusContract {
+  installed: boolean;
+  running: boolean;
+}
+
+export interface SteamLibraryContract {
+  ok: boolean;
+  games: unknown[];
+  total: number;
+}
+
+export interface BottleListContract {
+  ok: boolean;
+  bottles: unknown[];
+}
+
+export interface LogListContract {
+  ok: boolean;
+  logs: unknown[];
+}
+
+export interface LogStreamContract {
+  ok: boolean;
+  lines: string[];
+  total: number;
+}
+
+export interface PipelineDryRunContract {
+  appid: number;
+  dry_run: boolean;
+  env_pairs: Array<{ key: string; value: string }>;
+}
+
+export interface LaunchAutoRequest {
+  appid: number;
+  pipeline?: string;
+}
+
+export interface LaunchResult {
+  ok: boolean;
+  error?: string;
+  pid?: number;
+}
+
+export type ContractMethod = "GET" | "POST";
+
+export interface ContractResponses {
+  "GET /status": BackendStatus;
+  "GET /setup/state": SetupStateContract;
+  "GET /steam/status": SteamStatusContract;
+  "GET /steam/library": SteamLibraryContract;
+  "GET /bottles": BottleListContract;
+  "GET /logs": LogListContract;
+  "GET /logs/stream": LogStreamContract;
+  "GET /diagnostics/pipeline/dry-run": PipelineDryRunContract;
+  "GET /diagnostics/m12/dry-run": PipelineDryRunContract;
+  "POST /game/launch-auto": LaunchResult;
+}
+
+export type ContractRoute = keyof ContractResponses;
+
+export const LEGACY_CONTRACT_BY_BACKEND_VERSION: Readonly<Record<string, string>> = {
+  "0.54.5": BACKEND_CONTRACT_VERSION,
+};
+
+export function compatibleContractVersion(
+  status: Pick<BackendStatus, "version" | "contract_version">,
+): string | undefined {
+  return status.contract_version ?? LEGACY_CONTRACT_BY_BACKEND_VERSION[status.version];
+}

--- a/contracts/electron-backend.v1.json
+++ b/contracts/electron-backend.v1.json
@@ -1,0 +1,1200 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "MetalSharp Electron to backend contract",
+  "contract_version": "1",
+  "description": "The implementation-independent HTTP boundary used by Electron and the shipped backend. A breaking change requires a new contract version and fixtures before it can be packaged.",
+  "status": {
+    "path": "/status",
+    "method": "GET",
+    "required": [
+      "ok",
+      "version",
+      "pid",
+      "metalsharp_home"
+    ],
+    "contract_version_field": "contract_version",
+    "legacy_versions": {
+      "0.54.5": "1"
+    }
+  },
+  "conformance_routes": [
+    {
+      "name": "setup",
+      "method": "GET",
+      "path": "/setup/state",
+      "status": 200,
+      "required": [
+        "ok",
+        "completed",
+        "step",
+        "steamApiKeySet"
+      ]
+    },
+    {
+      "name": "steam-status",
+      "method": "GET",
+      "path": "/steam/status",
+      "status": 200,
+      "required": [
+        "installed",
+        "running"
+      ]
+    },
+    {
+      "name": "steam-library",
+      "method": "GET",
+      "path": "/steam/library",
+      "status": 200,
+      "required": [
+        "ok",
+        "games",
+        "total"
+      ]
+    },
+    {
+      "name": "bottles",
+      "method": "GET",
+      "path": "/bottles",
+      "status": 200,
+      "required": [
+        "ok",
+        "bottles"
+      ]
+    },
+    {
+      "name": "logs",
+      "method": "GET",
+      "path": "/logs",
+      "status": 200,
+      "required": [
+        "ok",
+        "logs"
+      ]
+    },
+    {
+      "name": "log-stream",
+      "method": "GET",
+      "path": "/logs/stream?after=0",
+      "status": 200,
+      "required": [
+        "ok",
+        "lines",
+        "total"
+      ]
+    },
+    {
+      "name": "pipeline-dry-run",
+      "method": "GET",
+      "path": "/diagnostics/pipeline/dry-run?appid=0",
+      "status": 200,
+      "required": [
+        "appid",
+        "dry_run",
+        "env_pairs"
+      ]
+    },
+    {
+      "name": "m12-dry-run",
+      "method": "GET",
+      "path": "/diagnostics/m12/dry-run?appid=0",
+      "status": 200,
+      "required": [
+        "appid",
+        "dry_run",
+        "env_pairs"
+      ]
+    }
+  ],
+  "typed_routes": {
+    "GET /status": {
+      "response": "BackendStatus"
+    },
+    "GET /setup/state": {
+      "response": "SetupState"
+    },
+    "GET /steam/status": {
+      "response": "SteamStatus"
+    },
+    "GET /steam/library": {
+      "response": "SteamLibrary"
+    },
+    "GET /bottles": {
+      "response": "BottleList"
+    },
+    "GET /logs": {
+      "response": "LogList"
+    },
+    "GET /logs/stream": {
+      "response": "LogStream"
+    },
+    "GET /diagnostics/pipeline/dry-run": {
+      "response": "PipelineDryRun"
+    },
+    "GET /diagnostics/m12/dry-run": {
+      "response": "PipelineDryRun"
+    },
+    "POST /game/launch-auto": {
+      "request": "LaunchAutoRequest",
+      "response": "LaunchResult",
+      "process_launch": true
+    }
+  },
+  "route_inventory": [
+    {
+      "method": "GET",
+      "path": "/bottles"
+    },
+    {
+      "method": "POST",
+      "path": "/bottles/apply-font-subs"
+    },
+    {
+      "method": "GET",
+      "path": "/bottles/compatibility-matrix"
+    },
+    {
+      "method": "POST",
+      "path": "/bottles/doctor"
+    },
+    {
+      "method": "POST",
+      "path": "/bottles/edit"
+    },
+    {
+      "method": "POST",
+      "path": "/bottles/get"
+    },
+    {
+      "method": "POST",
+      "path": "/bottles/prepare"
+    },
+    {
+      "method": "GET",
+      "path": "/bottles/profiles"
+    },
+    {
+      "method": "POST",
+      "path": "/bottles/record-compatibility"
+    },
+    {
+      "method": "GET",
+      "path": "/bottles/redist-sources"
+    },
+    {
+      "method": "POST",
+      "path": "/bottles/refresh"
+    },
+    {
+      "method": "POST",
+      "path": "/bottles/relaunch-installer"
+    },
+    {
+      "method": "POST",
+      "path": "/bottles/repair-component"
+    },
+    {
+      "method": "GET",
+      "path": "/bottles/route-contracts"
+    },
+    {
+      "method": "POST",
+      "path": "/bottles/seed-post-wineboot"
+    },
+    {
+      "method": "POST",
+      "path": "/bottles/set-runtime-profile"
+    },
+    {
+      "method": "POST",
+      "path": "/bottles/set-windows-version"
+    },
+    {
+      "method": "POST",
+      "path": "/bottles/sync-steam"
+    },
+    {
+      "method": "POST",
+      "path": "/bottles/verify-directx"
+    },
+    {
+      "method": "POST",
+      "path": "/cache/clear"
+    },
+    {
+      "method": "GET",
+      "path": "/cache/size"
+    },
+    {
+      "method": "GET",
+      "path": "/config"
+    },
+    {
+      "method": "POST",
+      "path": "/config"
+    },
+    {
+      "method": "POST",
+      "path": "/d3dmetal/bottles/install-homebrew-gptk"
+    },
+    {
+      "method": "POST",
+      "path": "/d3dmetal/bottles/install-rosetta"
+    },
+    {
+      "method": "POST",
+      "path": "/d3dmetal/bottles/install-x64-redist"
+    },
+    {
+      "method": "POST",
+      "path": "/d3dmetal/bottles/play"
+    },
+    {
+      "method": "POST",
+      "path": "/d3dmetal/bottles/repair-gptk-payload"
+    },
+    {
+      "method": "POST",
+      "path": "/d3dmetal/bottles/save"
+    },
+    {
+      "method": "POST",
+      "path": "/d3dmetal/bottles/seed-prefix"
+    },
+    {
+      "method": "POST",
+      "path": "/d3dmetal/bottles/status"
+    },
+    {
+      "method": "POST",
+      "path": "/diagnostics/binding-contract/validate"
+    },
+    {
+      "method": "GET",
+      "path": "/diagnostics/cache-doctor"
+    },
+    {
+      "method": "POST",
+      "path": "/diagnostics/command-replay/validate"
+    },
+    {
+      "method": "GET",
+      "path": "/diagnostics/fna/classify"
+    },
+    {
+      "method": "GET",
+      "path": "/diagnostics/fna/explain"
+    },
+    {
+      "method": "GET",
+      "path": "/diagnostics/fna/signals"
+    },
+    {
+      "method": "GET",
+      "path": "/diagnostics/launch"
+    },
+    {
+      "method": "GET",
+      "path": "/diagnostics/launch/timing"
+    },
+    {
+      "method": "GET",
+      "path": "/diagnostics/m12/dry-run"
+    },
+    {
+      "method": "GET",
+      "path": "/diagnostics/pipeline/dry-run"
+    },
+    {
+      "method": "GET",
+      "path": "/diagnostics/pso-manifests"
+    },
+    {
+      "method": "GET",
+      "path": "/diagnostics/runtime-artifacts"
+    },
+    {
+      "method": "GET",
+      "path": "/diagnostics/wineboot-state"
+    },
+    {
+      "method": "GET",
+      "path": "/game/dual-info"
+    },
+    {
+      "method": "POST",
+      "path": "/game/launch-auto"
+    },
+    {
+      "method": "POST",
+      "path": "/game/prepare"
+    },
+    {
+      "method": "POST",
+      "path": "/game/resolve-routing"
+    },
+    {
+      "method": "GET",
+      "path": "/game/running"
+    },
+    {
+      "method": "GET",
+      "path": "/goldberg/status"
+    },
+    {
+      "method": "POST",
+      "path": "/goldberg/toggle"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/anti-debug/add-sanitize-rule"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/anti-debug/check-results"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/anti-debug/filesystem-check"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/anti-debug/full-breakpoint-map"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/anti-debug/hw-breakpoint-map"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/anti-debug/module-sanitize"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/anti-debug/run-all-checks"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/anti-debug/seed-demo"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/anti-debug/simulate-check"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/anti-debug/status-survey"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/anti-debug/timing-analysis"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/apc/allocate-trampoline"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/apc/get-thread-context"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/apc/inject-sequence"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/apc/queue"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/apc/queue-status"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/apc/set-thread-context"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/apc/suspend-thread"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/apc/test-alert"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/apc/trampoline-status"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/apc/wait-alertable"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/driver/create-device"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/driver/decode-ioctl"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/driver/dispatch-irp"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/driver/extension-template"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/driver/list"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/driver/list-devices"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/driver/list-ioctls"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/driver/list-irps"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/driver/load"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/driver/register-ioctl"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/driver/seed-demo"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/driver/type-mapping-survey"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/driver/unload"
+    },
+    {
+      "method": "GET",
+      "path": "/kernel-translation/es-live/events"
+    },
+    {
+      "method": "GET",
+      "path": "/kernel-translation/es-live/processes"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/es-live/start"
+    },
+    {
+      "method": "GET",
+      "path": "/kernel-translation/es-live/status"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/es-live/stop"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/es/create-ipc-channel"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/es/detect-events"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/es/fire-image-event"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/es/fire-process-event"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/es/fire-thread-event"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/es/image-events"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/es/ipc-channels"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/es/list-callbacks"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/es/nt-callback-bridge"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/es/process-events"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/es/register-callback"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/es/seed-demo"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/es/status"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/es/thread-events"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/es/unregister-callback"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/handle/close"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/handle/create"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/handle/duplicate"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/handle/enumerate"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/handle/enumerate-fds"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/handle/enumerate-ports"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/handle/query"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/handle/seed-demo"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/handle/snapshot-all"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/handle/system-info"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/handle/table-status"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/handle/unified-snapshot"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/host-probe"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/integration/bottle-configure"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/integration/bottle-get-config"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/integration/bottle-list-configs"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/integration/extension-activate"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/integration/extension-crash"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/integration/extension-deactivate"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/integration/extension-install"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/integration/extension-status"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/integration/fallback-mode"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/integration/full-stack-status"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/integration/list-multi-ac"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/integration/list-performance"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/integration/log-translation"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/integration/performance-profile"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/integration/query-translation-log"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/integration/register-multi-ac"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/integration/runtime-doctor"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/integration/seed-demo"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/integration/simulate-conflict"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/integration/simulate-pipeline"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/integrity/list-modules"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/integrity/query-process-signing"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/integrity/query-signing-level"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/integrity/register-macho-module"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/integrity/register-pe-module"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/integrity/seed-demo"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/integrity/set-cached-signing-level"
+    },
+    {
+      "method": "GET",
+      "path": "/kernel-translation/ipc/handles"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/ipc/start"
+    },
+    {
+      "method": "GET",
+      "path": "/kernel-translation/ipc/status"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/ipc/stop"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/ob/access-log"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/ob/capability-survey"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/ob/list-protected"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/ob/list-registrations"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/ob/post-operations"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/ob/pre-operations"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/ob/protect-process"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/ob/register-callback"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/ob/seed-demo"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/ob/simulate-operation"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/ob/unprotect-process"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/ob/unregister-callback"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/probe"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/thread/compute-delta"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/thread/configure-notifications"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/thread/create-watcher"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/thread/destroy-watcher"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/thread/info"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/thread/list-deltas"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/thread/list-watchers"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/thread/mechanism-survey"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/thread/poll-watcher"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/thread/seed-demo"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/thread/snapshot"
+    },
+    {
+      "method": "POST",
+      "path": "/kernel-translation/thread/watcher-status"
+    },
+    {
+      "method": "POST",
+      "path": "/kill"
+    },
+    {
+      "method": "POST",
+      "path": "/launch"
+    },
+    {
+      "method": "POST",
+      "path": "/launcher/evidence"
+    },
+    {
+      "method": "GET",
+      "path": "/logs"
+    },
+    {
+      "method": "GET",
+      "path": "/logs/crash-reports"
+    },
+    {
+      "method": "GET",
+      "path": "/logs/stream"
+    },
+    {
+      "method": "GET",
+      "path": "/metalfx/state"
+    },
+    {
+      "method": "POST",
+      "path": "/metalfx/toggle"
+    },
+    {
+      "method": "GET",
+      "path": "/mtsp/default-rules"
+    },
+    {
+      "method": "POST",
+      "path": "/mtsp/doctor"
+    },
+    {
+      "method": "GET",
+      "path": "/mtsp/launch-shape"
+    },
+    {
+      "method": "GET",
+      "path": "/mtsp/pipelines"
+    },
+    {
+      "method": "POST",
+      "path": "/mtsp/prepare"
+    },
+    {
+      "method": "POST",
+      "path": "/mtsp/recipe"
+    },
+    {
+      "method": "POST",
+      "path": "/processes/force-kill"
+    },
+    {
+      "method": "GET",
+      "path": "/runtime/host-abi"
+    },
+    {
+      "method": "GET",
+      "path": "/scan"
+    },
+    {
+      "method": "GET",
+      "path": "/setup/agility-versions"
+    },
+    {
+      "method": "GET",
+      "path": "/setup/dependencies"
+    },
+    {
+      "method": "GET",
+      "path": "/setup/device-name"
+    },
+    {
+      "method": "POST",
+      "path": "/setup/install-all"
+    },
+    {
+      "method": "POST",
+      "path": "/setup/install-deps"
+    },
+    {
+      "method": "GET",
+      "path": "/setup/install-progress"
+    },
+    {
+      "method": "POST",
+      "path": "/setup/install-vcpp-x64"
+    },
+    {
+      "method": "POST",
+      "path": "/setup/install-vcpp-x86"
+    },
+    {
+      "method": "GET",
+      "path": "/setup/installing"
+    },
+    {
+      "method": "POST",
+      "path": "/setup/save"
+    },
+    {
+      "method": "GET",
+      "path": "/setup/state"
+    },
+    {
+      "method": "GET",
+      "path": "/sharp-library"
+    },
+    {
+      "method": "GET",
+      "path": "/sharp-library/cover"
+    },
+    {
+      "method": "POST",
+      "path": "/sharp-library/doctor"
+    },
+    {
+      "method": "POST",
+      "path": "/sharp-library/gog/auth-code"
+    },
+    {
+      "method": "GET",
+      "path": "/sharp-library/gog/games"
+    },
+    {
+      "method": "POST",
+      "path": "/sharp-library/gog/import"
+    },
+    {
+      "method": "POST",
+      "path": "/sharp-library/gog/initialize-prefix"
+    },
+    {
+      "method": "POST",
+      "path": "/sharp-library/gog/install"
+    },
+    {
+      "method": "POST",
+      "path": "/sharp-library/gog/logout"
+    },
+    {
+      "method": "POST",
+      "path": "/sharp-library/gog/play"
+    },
+    {
+      "method": "POST",
+      "path": "/sharp-library/gog/progress"
+    },
+    {
+      "method": "POST",
+      "path": "/sharp-library/gog/remove-prefix"
+    },
+    {
+      "method": "GET",
+      "path": "/sharp-library/gog/status"
+    },
+    {
+      "method": "POST",
+      "path": "/sharp-library/gog/stop"
+    },
+    {
+      "method": "POST",
+      "path": "/sharp-library/gog/sync"
+    },
+    {
+      "method": "POST",
+      "path": "/sharp-library/gog/uninstall"
+    },
+    {
+      "method": "POST",
+      "path": "/sharp-library/import-bottle-app"
+    },
+    {
+      "method": "POST",
+      "path": "/sharp-library/install"
+    },
+    {
+      "method": "POST",
+      "path": "/sharp-library/launch"
+    },
+    {
+      "method": "POST",
+      "path": "/sharp-library/set-cover"
+    },
+    {
+      "method": "POST",
+      "path": "/sharp-library/set-cover-position"
+    },
+    {
+      "method": "POST",
+      "path": "/sharp-library/set-engine"
+    },
+    {
+      "method": "POST",
+      "path": "/sharp-library/set-launch-args"
+    },
+    {
+      "method": "POST",
+      "path": "/sharp-library/uninstall"
+    },
+    {
+      "method": "GET",
+      "path": "/status"
+    },
+    {
+      "method": "GET",
+      "path": "/steam/api-key"
+    },
+    {
+      "method": "POST",
+      "path": "/steam/bridge-start"
+    },
+    {
+      "method": "GET",
+      "path": "/steam/bridge-status"
+    },
+    {
+      "method": "POST",
+      "path": "/steam/compatdata"
+    },
+    {
+      "method": "POST",
+      "path": "/steam/d3d12-runtime-doctor"
+    },
+    {
+      "method": "POST",
+      "path": "/steam/install"
+    },
+    {
+      "method": "POST",
+      "path": "/steam/install-game"
+    },
+    {
+      "method": "POST",
+      "path": "/steam/install-recipe-deps"
+    },
+    {
+      "method": "GET",
+      "path": "/steam/is-running"
+    },
+    {
+      "method": "POST",
+      "path": "/steam/launch"
+    },
+    {
+      "method": "POST",
+      "path": "/steam/launch-game"
+    },
+    {
+      "method": "POST",
+      "path": "/steam/launch-offline"
+    },
+    {
+      "method": "GET",
+      "path": "/steam/library"
+    },
+    {
+      "method": "POST",
+      "path": "/steam/mac-install"
+    },
+    {
+      "method": "POST",
+      "path": "/steam/mac-launch"
+    },
+    {
+      "method": "POST",
+      "path": "/steam/mac-launch-game"
+    },
+    {
+      "method": "POST",
+      "path": "/steam/mac-stop"
+    },
+    {
+      "method": "POST",
+      "path": "/steam/runtime-doctor"
+    },
+    {
+      "method": "POST",
+      "path": "/steam/save-api-key"
+    },
+    {
+      "method": "GET",
+      "path": "/steam/status"
+    },
+    {
+      "method": "POST",
+      "path": "/steam/stop"
+    },
+    {
+      "method": "GET",
+      "path": "/steam/stop-targets"
+    },
+    {
+      "method": "POST",
+      "path": "/steam/uninstall-game"
+    },
+    {
+      "method": "POST",
+      "path": "/steam/view-game"
+    },
+    {
+      "method": "GET",
+      "path": "/steam/watch-steamapps"
+    },
+    {
+      "method": "GET",
+      "path": "/update/check"
+    },
+    {
+      "method": "POST",
+      "path": "/update/cleanup"
+    },
+    {
+      "method": "GET",
+      "path": "/update/dmg-path"
+    },
+    {
+      "method": "GET",
+      "path": "/update/migrate/check"
+    },
+    {
+      "method": "GET",
+      "path": "/update/migrate/progress"
+    },
+    {
+      "method": "GET",
+      "path": "/update/migrate/report"
+    },
+    {
+      "method": "POST",
+      "path": "/update/migrate/start"
+    },
+    {
+      "method": "GET",
+      "path": "/update/progress"
+    },
+    {
+      "method": "POST",
+      "path": "/update/start"
+    },
+    {
+      "method": "POST",
+      "path": "/wine-mono/install"
+    },
+    {
+      "method": "POST",
+      "path": "/wine-mono/reset"
+    },
+    {
+      "method": "GET",
+      "path": "/wine-mono/status"
+    }
+  ]
+}

--- a/docs/electron-backend-contract.md
+++ b/docs/electron-backend-contract.md
@@ -1,0 +1,16 @@
+# Electron ↔ backend contract
+
+[`contracts/electron-backend.v1.json`](../contracts/electron-backend.v1.json) is the authoritative, implementation-independent boundary between Electron and the MetalSharp backend. It defines the compatibility version, status handshake, typed high-value routes, and the isolated conformance fixtures that every shipped backend must pass.
+
+Electron requires contract v1. New backends report it as `contract_version` in `GET /status`; the initial direct-C backend (`0.54.5`) is explicitly mapped as the v1 baseline because it was shipped immediately before the field existed. Any backend without that field or an approved legacy mapping is rejected before renderer requests are forwarded.
+
+Run the suite against an executable with:
+
+```sh
+python3 tools/contracts/validate-electron-backend-contract.py
+python3 tools/contracts/run-electron-backend-conformance.py app/build/c-backend/metalsharp-backend
+```
+
+The runner creates a fresh `METALSHARP_HOME`, starts one backend artifact, and exercises status, setup, Steam, bottles, logs/streaming, and dry-run diagnostic flows without Steam credentials, a Wine prefix, or a game installation. `make -C app/src-c verify` runs it for the committed C backend in CI.
+
+Add a new contract version for breaking wire changes. First add its fixtures and Electron types, then update the backend and packaging together; do not silently extend the legacy-version map.

--- a/tools/contracts/generate-electron-backend-route-inventory.py
+++ b/tools/contracts/generate-electron-backend-route-inventory.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Refresh the checked-in route inventory from the backend router source."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT = ROOT / "contracts" / "electron-backend.v1.json"
+ROUTER = ROOT / "app" / "src-rust" / "src" / "main.rs"
+ROUTE = re.compile(r'\(Method::(Get|Post),\s*"([^"?]+)"\)')
+
+
+def inventory() -> list[dict[str, str]]:
+    return [
+        {"method": method.upper(), "path": path}
+        for method, path in sorted(set(ROUTE.findall(ROUTER.read_text())), key=lambda value: (value[1], value[0]))
+    ]
+
+
+def main() -> None:
+    contract = json.loads(CONTRACT.read_text())
+    contract["route_inventory"] = inventory()
+    CONTRACT.write_text(json.dumps(contract, indent=2) + "\n")
+    print(f"Wrote {len(contract['route_inventory'])} Electron/backend routes.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/contracts/run-electron-backend-conformance.py
+++ b/tools/contracts/run-electron-backend-conformance.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Run the language-neutral HTTP compatibility suite against a backend artifact."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT = ROOT / "contracts" / "electron-backend.v1.json"
+
+
+def fail(message: str) -> None:
+    print(f"conformance failed: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def request(port: int, method: str, path: str) -> tuple[int, dict]:
+    req = Request(f"http://127.0.0.1:{port}{path}", method=method)
+    with urlopen(req, timeout=3) as response:
+        body = json.loads(response.read().decode("utf-8"))
+        if not isinstance(body, dict):
+            fail(f"{method} {path} returned a non-object JSON response")
+        return response.status, body
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("backend", type=Path)
+    args = parser.parse_args()
+    backend = args.backend.resolve()
+    if not backend.is_file() or not os.access(backend, os.X_OK):
+        fail(f"backend is not executable: {backend}")
+
+    contract = json.loads(CONTRACT.read_text())
+    port = free_port()
+    home = Path(tempfile.mkdtemp(prefix="metalsharp-contract-"))
+    env = {**os.environ, "METALSHARP_HOME": str(home), "METALSHARP_PORT": str(port)}
+    process = subprocess.Popen([str(backend)], env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    try:
+        deadline = time.monotonic() + 12
+        status_body: dict | None = None
+        while time.monotonic() < deadline:
+            try:
+                _, status_body = request(port, "GET", "/status")
+                break
+            except (URLError, ConnectionError, TimeoutError):
+                time.sleep(0.15)
+        if status_body is None:
+            output = process.stdout.read() if process.stdout else ""
+            fail(f"backend did not become ready: {output}")
+
+        status_spec = contract["status"]
+        missing = [key for key in status_spec["required"] if key not in status_body]
+        if missing:
+            fail(f"/status missing required keys: {missing}")
+        reported_contract = status_body.get(status_spec["contract_version_field"])
+        expected = contract["contract_version"]
+        if reported_contract is None:
+            reported_contract = status_spec.get("legacy_versions", {}).get(status_body.get("version"))
+        if reported_contract != expected:
+            fail(f"/status reported incompatible contract {reported_contract!r}; expected {expected!r}")
+
+        for route in contract["conformance_routes"]:
+            code, body = request(port, route["method"], route["path"])
+            if code != route["status"]:
+                fail(f"{route['name']} returned HTTP {code}, expected {route['status']}")
+            missing = [key for key in route["required"] if key not in body]
+            if missing:
+                fail(f"{route['name']} missing required keys: {missing}")
+        print(f"Electron/backend contract v{expected} passed against {backend.name} in isolated METALSHARP_HOME.")
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+        shutil.rmtree(home, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/contracts/validate-electron-backend-contract.py
+++ b/tools/contracts/validate-electron-backend-contract.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Validate the versioned Electron/backend contract without a language runtime."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT = ROOT / "contracts" / "electron-backend.v1.json"
+ROUTER = ROOT / "app" / "src-rust" / "src" / "main.rs"
+
+
+def fail(message: str) -> None:
+    print(f"contract validation failed: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def main() -> None:
+    try:
+        contract = json.loads(CONTRACT.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        fail(str(exc))
+
+    if contract.get("contract_version") != "1":
+        fail("contract_version must be the string '1'")
+    status = contract.get("status")
+    if not isinstance(status, dict) or status.get("path") != "/status" or status.get("method") != "GET":
+        fail("status must describe GET /status")
+    if not status.get("legacy_versions", {}).get("0.54.5") == "1":
+        fail("the shipped 0.54.5 C backend must remain explicitly mapped to contract v1")
+
+    names: set[str] = set()
+    for route in contract.get("conformance_routes", []):
+        if not isinstance(route, dict):
+            fail("conformance route must be an object")
+        name = route.get("name")
+        if not isinstance(name, str) or name in names:
+            fail(f"conformance route has missing or duplicate name: {name!r}")
+        names.add(name)
+        if route.get("method") not in {"GET", "POST"} or not str(route.get("path", "")).startswith("/"):
+            fail(f"invalid method or path for {name}")
+        if route.get("status") != 200 or not route.get("required"):
+            fail(f"{name} needs an explicit successful status and response shape")
+
+    required = {"setup", "steam-status", "steam-library", "bottles", "logs", "log-stream", "pipeline-dry-run", "m12-dry-run"}
+    if names != required:
+        fail(f"conformance coverage mismatch: expected {sorted(required)}, got {sorted(names)}")
+
+    typed = contract.get("typed_routes", {})
+    if "POST /game/launch-auto" not in typed or not typed["POST /game/launch-auto"].get("process_launch"):
+        fail("launch-auto must remain a typed process-launch route")
+
+    expected_inventory = [
+        {"method": method.upper(), "path": path}
+        for method, path in sorted(
+            set(re.findall(r'\(Method::(Get|Post),\s*"([^"?]+)"\)', ROUTER.read_text())),
+            key=lambda value: (value[1], value[0]),
+        )
+    ]
+    if contract.get("route_inventory") != expected_inventory:
+        fail("route_inventory is stale; run tools/contracts/generate-electron-backend-route-inventory.py")
+    print("Electron/backend contract v1 is valid.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #265

## Summary

- Add the authoritative versioned Electron/backend contract with a checked-in inventory of all 264 static backend routes.
- Enforce the backend contract handshake in Electron and add the direct-C backend as the development artifact.
- Add isolated fixture-based conformance coverage for status, setup, Steam, bottles, logs/streaming, and dry-run diagnostics.
- Run contract validation in CI and conformance against the direct-Clang C backend in make -C app/src-c verify.

## Compatibility

Newly generated backends expose contract_version 1 through GET /status. The just-merged 0.54.5 C artifact is explicitly mapped as the contract-v1 baseline so it remains compatible.

## Validation

- npx tsc --noEmit
- Biome and Prettier checks
- make -C app/src-c contract
- C backend conformance runner with an isolated METALSHARP_HOME
- C backend test executable: 629 passed, 0 failed