### PR TITLE
ci: restore CodeQL C++ and TypeScript analysis

### DIFF
--- a/.github/codeql/codeql-cpp.yml
+++ b/.github/codeql/codeql-cpp.yml
@@ -1,5 +1,0 @@
-paths:
-  - include
-  - src
-  - tests
-  - tools

--- a/.github/codeql/codeql-js.yml
+++ b/.github/codeql/codeql-js.yml
@@ -1,4 +1,0 @@
-paths:
-  - app/src/main
-  - app/src/shared
-  - app/vite.config.ts

--- a/.github/codeql/codeql-typescript.yml
+++ b/.github/codeql/codeql-typescript.yml
@@ -1,0 +1,3 @@
+paths:
+  - app/src
+  - app/vite.config.ts

--- a/.github/codeql/codeql-vue.yml
+++ b/.github/codeql/codeql-vue.yml
@@ -1,2 +1,0 @@
-paths:
-  - app/src/renderer

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,8 +26,8 @@ permissions:
   security-events: write
 
 jobs:
-  vue:
-    name: CodeQL Vue
+  typescript:
+    name: CodeQL TypeScript
     runs-on: macos-14
     timeout-minutes: 15
     steps:
@@ -45,33 +45,29 @@ jobs:
       - uses: github/codeql-action/init@v4
         with:
           languages: javascript-typescript
-          config-file: .github/codeql/codeql-vue.yml
+          config-file: .github/codeql/codeql-typescript.yml
 
       - uses: github/codeql-action/analyze@v4
         with:
-          category: '/language:vue'
+          category: '/language:javascript-typescript'
 
-  js:
-    name: CodeQL JS
+  c-cpp-objc:
+    name: CodeQL C/C++/Objective-C
     runs-on: macos-14
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: app/package-lock.json
-
-      - run: npm ci
-        working-directory: app
-
       - uses: github/codeql-action/init@v4
         with:
-          languages: javascript-typescript
-          config-file: .github/codeql/codeql-js.yml
+          languages: c-cpp
+          build-mode: manual
+
+      - name: Build C/C++/Objective-C targets for CodeQL
+        run: |
+          cmake -S . -B build-codeql -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=OFF
+          cmake --build build-codeql --parallel $(sysctl -n hw.ncpu)
 
       - uses: github/codeql-action/analyze@v4
         with:
-          category: '/language:javascript'
+          category: '/language:c-cpp'


### PR DESCRIPTION
## Summary

- Replace the overlapping Vue and JavaScript jobs with one CodeQL TypeScript runner for all Electron sources.
- Restore traced CodeQL analysis for C, C++, Objective-C, and Objective-C++ using the repository native CMake build.
- Remove obsolete split CodeQL path configurations.

## Why

The security workflow no longer had a C/C++ runner, and its two JavaScript/TypeScript jobs split the Electron source tree. The restored manual build capture gives CodeQL the actual native compiler invocations, while the unified TypeScript job emits the correct language category.

## Validation

- CodeQL workflow YAML parsing
- npx tsc --noEmit
- cmake -S . -B build-codeql -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=OFF
- cmake --build build-codeql --parallel $(sysctl -n hw.ncpu)