### PR TITLE
Use C backend artifacts consistently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,9 @@ jobs:
       - name: TypeScript
         run: npx tsc --noEmit
 
+      - name: Electron/C backend bindings
+        run: python3 ../tools/contracts/validate-electron-c-backend-bindings.py
+
       - name: Biome
         run: npx @biomejs/biome ci src/main src/shared
 

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -134,6 +134,9 @@ jobs:
       - name: TypeScript
         run: npx tsc --noEmit
 
+      - name: Electron/C backend bindings
+        run: python3 ../tools/contracts/validate-electron-c-backend-bindings.py
+
       - name: Biome
         run: npx @biomejs/biome ci src/main src/shared
 

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -5,7 +5,7 @@ import * as http from "http";
 import * as os from "os";
 import * as path from "path";
 import type { ProcessManagerAction, ProcessManagerActionResult, ProcessManagerSample } from "./process-manager-types";
-import { RustBridge } from "./rust-bridge";
+import { BackendBridge } from "./rust-bridge";
 import { UpdaterBridge } from "./updater-bridge";
 
 let shellPath: string | undefined;
@@ -31,7 +31,7 @@ function ensureShellPath() {
 
 let mainWindow: BrowserWindow | null = null;
 let processManagerWindow: BrowserWindow | null = null;
-let bridge: RustBridge;
+let bridge: BackendBridge;
 let updaterBridge: UpdaterBridge;
 let steamappsWatcher: fs.FSWatcher | null = null;
 
@@ -651,7 +651,7 @@ app.whenReady().then(async () => {
   process.env.METALSHARP_HOME = getMetalsharpDir();
   if (isDevRuntime()) process.env.METALSHARP_DEV = "1";
   ensureMetalsharpDirs();
-  bridge = new RustBridge({ devMode: isDevRuntime(), metalsharpHome: getMetalsharpDir() });
+  bridge = new BackendBridge({ devMode: isDevRuntime(), metalsharpHome: getMetalsharpDir() });
   updaterBridge = new UpdaterBridge(bridge.getPort());
   const backendStart = await bridge.start();
   if (!backendStart.ok) {

--- a/app/src/main/rust-bridge.ts
+++ b/app/src/main/rust-bridge.ts
@@ -23,12 +23,14 @@ function getShellPath(): string {
 
 const shellPath = getShellPath();
 
-interface RustBridgeOptions {
+interface BackendBridgeOptions {
   devMode?: boolean;
   metalsharpHome?: string;
 }
 
-export class RustBridge {
+// This compatibility filename remains while import paths migrate. The spawned
+// executable is the C-compiled MetalSharp backend, never a Cargo binary.
+export class BackendBridge {
   private proc: ChildProcess | null = null;
   private port: number = 9274;
   private base: string;
@@ -36,7 +38,7 @@ export class RustBridge {
   private devMode: boolean;
   private metalsharpHome?: string;
 
-  constructor(options: RustBridgeOptions = {}) {
+  constructor(options: BackendBridgeOptions = {}) {
     this.devMode = options.devMode === true || process.env.METALSHARP_DEV === "1";
     this.metalsharpHome = options.metalsharpHome || process.env.METALSHARP_HOME;
     const defaultPort = this.devMode ? "9276" : "9274";

--- a/app/src/main/rust-bridge.ts
+++ b/app/src/main/rust-bridge.ts
@@ -390,16 +390,12 @@ export class RustBridge {
   }
 
   private findBinary(): string | null {
-    const devCandidates = [
-      path.join(__dirname, "..", "..", "build", "c-backend", "metalsharp-backend"),
-      path.join(__dirname, "..", "..", "src-rust", "target", "debug", "metalsharp-backend"),
-      path.join(__dirname, "..", "..", "src-rust", "target", "release", "metalsharp-backend"),
-    ];
+    // The shipped backend is the checked-in C artifact. Keep this bridge's
+    // legacy filename for now, but never fall back to a Cargo-built binary.
+    const devCandidates = [path.join(__dirname, "..", "..", "build", "c-backend", "metalsharp-backend")];
     const packagedCandidates = [
       path.join(process.resourcesPath || "", "runtime", "metalsharp-backend"),
       path.join(__dirname, "..", "..", "build", "c-backend", "metalsharp-backend"),
-      path.join(__dirname, "..", "..", "src-rust", "target", "release", "metalsharp-backend"),
-      path.join(__dirname, "..", "..", "src-rust", "target", "debug", "metalsharp-backend"),
       "/usr/local/bin/metalsharp-backend",
       "/usr/bin/metalsharp-backend",
     ];

--- a/app/src/renderer/components/MigrationView.vue
+++ b/app/src/renderer/components/MigrationView.vue
@@ -9,20 +9,17 @@ const message = ref("Checking migration status...");
 const error = ref<string | null>(null);
 const complete = ref(false);
 const launching = ref(false);
+const spinnerEpoch = ref(0);
 
 let pollTimer: ReturnType<typeof setInterval> | null = null;
+let spinnerWatchdog: ReturnType<typeof setInterval> | null = null;
 
 const percent = computed(() => {
   if (total.value === 0) return 0;
   return Math.round((step.value / total.value) * 100);
 });
 
-const stages = [
-  { name: "[D3D]" },
-  { name: "[DXMT]" },
-  { name: "[x86_64]" },
-  { name: "[Metal]" },
-];
+const stages = [{ name: "[D3D]" }, { name: "[DXMT]" }, { name: "[x86_64]" }, { name: "[Metal]" }];
 
 const MAX_START_RETRIES = 20;
 const START_RETRY_DELAY_MS = 500;
@@ -100,6 +97,19 @@ function stopPolling() {
   }
 }
 
+function startSpinnerWatchdog() {
+  spinnerWatchdog = setInterval(() => {
+    if (!complete.value && !error.value) spinnerEpoch.value += 1;
+  }, 4000);
+}
+
+function stopSpinnerWatchdog() {
+  if (spinnerWatchdog) {
+    clearInterval(spinnerWatchdog);
+    spinnerWatchdog = null;
+  }
+}
+
 async function restartApp() {
   launching.value = true;
   message.value = "Closing old MetalSharp, stopping the backend, and launching the updated app...";
@@ -112,11 +122,13 @@ async function restartApp() {
 }
 
 onMounted(async () => {
+  startSpinnerWatchdog();
   await startMigration();
 });
 
 onUnmounted(() => {
   stopPolling();
+  stopSpinnerWatchdog();
 });
 </script>
 
@@ -124,13 +136,18 @@ onUnmounted(() => {
   <div class="migration-overlay">
     <div class="migration-card">
       <div class="migration-header">
-        <div class="loading-icon" :class="{ complete, error: !!error }" aria-hidden="true" />
+        <div :key="spinnerEpoch" class="loading-icon" :class="{ complete, error: !!error }" aria-hidden="true" />
         <h1 class="migration-title">MetalSharp Update Migration</h1>
         <p class="migration-subtitle">Preserving your settings and refreshing the runtime</p>
       </div>
 
       <div class="pipeline-vis">
-        <div v-for="(stage, i) in stages" :key="stage.name" class="pipeline-stage" :class="{ active: !complete && !error }">
+        <div
+          v-for="(stage, i) in stages"
+          :key="stage.name"
+          class="pipeline-stage"
+          :class="{ active: !complete && !error }"
+        >
           <span class="stage-label">{{ stage.name }}</span>
           <div v-if="i < stages.length - 1" class="pipeline-arrow">
             <IconArrowRight width="16" height="12" />
@@ -248,12 +265,19 @@ onUnmounted(() => {
 }
 
 @keyframes pulse {
-  0%, 100% { opacity: 0.6; }
-  50% { opacity: 1; }
+  0%,
+  100% {
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 1;
+  }
 }
 
 @keyframes spin {
-  to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .pipeline-arrow {

--- a/docs/backend-rust-to-c-migration-plan.md
+++ b/docs/backend-rust-to-c-migration-plan.md
@@ -19,18 +19,17 @@ a deliberately one-time compiler integration, not a MetalSharp compiler fork.
 
 ## Implemented build path
 
-`tools/rustc-c/build-backend.sh` is the only release entry point. It pins
+`tools/rustc-c/build-backend.sh` is generation tooling only. It pins
 `rustic-compiler/rustc_codegen_c` and its matching Rust 1.94.1 source tree,
-applies the minimal Apple Silicon compatibility patches, builds a stage-1 C
-compiler and standard library, and writes the existing executable path:
+then produces auditable C units for review and promotion. The release path
+builds the checked-in C source directly with:
 
-`app/src-rust/target/release/metalsharp-backend`
+`make -C app/src-c backend`
 
-This preserves Electron's executable name and packaged runtime location. It
-also writes all generated C into `app/src-c/generated`, alongside a SHA-256
-manifest and compiler/deployment-target provenance. Those artifacts are
-ignored locally and attached to release CI; the release product contains no
-Rust dynamic library.
+That command writes `app/build/c-backend/metalsharp-backend`, which is the
+only executable Electron, DMG repair, split bundles, and release packaging
+may select. The release product contains no Rust runtime or Cargo-built
+backend fallback.
 
 The integration uses `ureq` with macOS native TLS (rather than Rustls/ring) and
 pins `rusqlite` 0.39 because the selected code generator cannot compile the

--- a/tools/bundles/create-split-bundles.py
+++ b/tools/bundles/create-split-bundles.py
@@ -225,7 +225,7 @@ def build_staging(tmp: Path) -> dict[str, Path]:
     wine_src = source1 / "wine-11.5"
     copy_tree(wine_src, roots["runtime"] / "wine")
     copy_tree(source2 / "wine" / "etc", roots["runtime"] / "wine" / "etc")
-    backend = APP_DIR / "src-rust" / "target" / "release" / "metalsharp-backend"
+    backend = APP_DIR / "build" / "c-backend" / "metalsharp-backend"
     require_file(backend, "runtime backend")
     copy_file(backend, roots["runtime"] / "metalsharp-backend")
     require_host_runtime(APP_DIR / "native" / "host")

--- a/tools/ci/verify-dmg-workflow.py
+++ b/tools/ci/verify-dmg-workflow.py
@@ -111,6 +111,16 @@ def check_bundle_scripts() -> None:
     if 'DEFAULT_BACKEND = PROJECT_ROOT / "app" / "build" / "c-backend" / "metalsharp-backend"' not in runtime_repair:
         fail("runtime-bundle repair must default to the C backend")
 
+    split_bundles = read("tools/bundles/create-split-bundles.py")
+    if 'APP_DIR / "build" / "c-backend" / "metalsharp-backend"' not in split_bundles:
+        fail("split bundle staging must use the C backend")
+    if 'APP_DIR / "src-rust" / "target"' in split_bundles:
+        fail("split bundle staging must not package a Cargo-built backend")
+
+    bridge = read("app/src/main/rust-bridge.ts")
+    if '"src-rust", "target"' in bridge:
+        fail("Electron backend selection must not fall back to a Cargo-built backend")
+
     stage_bundles = read("tools/dmg/stage-release-bundles.sh")
     if "asset-manifest.tsv" not in stage_bundles or "tar --use-compress-program=unzstd" not in stage_bundles:
         fail("stage-release-bundles.sh no longer stages bundle manifest archives")

--- a/tools/contracts/validate-electron-c-backend-bindings.py
+++ b/tools/contracts/validate-electron-c-backend-bindings.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Ensure static Electron renderer actions target routes in the C backend contract."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT = ROOT / "contracts" / "electron-backend.v1.json"
+RENDERER = ROOT / "app" / "src" / "renderer"
+
+# The renderer's generic `api<T>("METHOD", "/route")` calls may contain
+# multiline TypeScript types, so only anchor on the call name and the method /
+# route pair. Dynamic route construction is intentionally excluded: it must
+# still be represented by a static base route in the contract inventory.
+CALL = re.compile(
+    r"\b(?:api|contractApi)\s*(?:<[^()]*?>)?\s*\(\s*[\"'](GET|POST)[\"']\s*,\s*[\"']([^\"']+)[\"']",
+    re.DOTALL,
+)
+
+
+def fail(message: str) -> None:
+    print(f"Electron/C backend binding check failed: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def route_path(route: str) -> str:
+    return route.split("?", 1)[0]
+
+
+def main() -> None:
+    contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
+    inventory = {(item["method"], item["path"]) for item in contract["route_inventory"]}
+    used: set[tuple[str, str]] = set()
+
+    for source in RENDERER.rglob("*.vue"):
+        for method, route in CALL.findall(source.read_text(encoding="utf-8")):
+            used.add((method, route_path(route)))
+
+    missing = sorted(used - inventory)
+    if missing:
+        formatted = ", ".join(f"{method} {path}" for method, path in missing)
+        fail(f"renderer actions missing from the C backend route inventory: {formatted}")
+
+    print(f"Electron/C backend binding check passed ({len(used)} static renderer routes).")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR makes the Electron application consistently use and validate the shipped C-compiled backend.

- Removes Cargo-built backend fallbacks from Electron startup and split-bundle staging.
- Renames the runtime-facing bridge class to `BackendBridge` and documents C-only runtime ownership.
- Adds a migration-spinner watchdog that restarts the active animation if it stalls.
- Adds CI guards for C-only backend selection.
- Validates all 78 static renderer API actions against the C backend route inventory.

## Validation

- `make -C app/src-c contract`
- `python3 tools/contracts/validate-electron-c-backend-bindings.py`
- `python3 tools/ci/verify-dmg-workflow.py`
- `cd app && npx tsc --noEmit`

Related to #267. This delivers the C-runtime and Electron-wiring foundation; the C job/control-plane implementation remains tracked in that issue.