### PR TITLE
Refresh stale locked release bundles

### DIFF
--- a/tools/bundles/verify-release-inputs.py
+++ b/tools/bundles/verify-release-inputs.py
@@ -21,13 +21,19 @@ def main() -> int:
     parser.add_argument("--bundle-dir", type=Path, required=True)
     parser.add_argument("--lock", type=Path, default=Path(__file__).with_name("release-inputs.lock.tsv"))
     parser.add_argument("--require-all", action="store_true")
+    parser.add_argument("--asset", action="append", default=[])
     args = parser.parse_args()
     failures: list[str] = []
     checked = 0
+    requested = set(args.asset)
+    found: set[str] = set()
     for line in args.lock.read_text(encoding="utf-8").splitlines():
         if not line or line.startswith("#"):
             continue
         source, name, expected_hash, expected_size, _provenance = line.split(r"\t", 4)
+        if requested and name not in requested:
+            continue
+        found.add(name)
         path = args.bundle_dir / name
         if not path.is_file():
             if args.require_all:
@@ -40,6 +46,9 @@ def main() -> int:
             failures.append(f"SHA-256 mismatch for {name}")
             continue
         checked += 1
+    missing_lock_entries = requested - found
+    if missing_lock_entries:
+        failures.extend(f"asset is not locked: {name}" for name in sorted(missing_lock_entries))
     if failures:
         print("release input verification failed:\n- " + "\n- ".join(failures), file=sys.stderr)
         return 1

--- a/tools/ci/verify-dmg-workflow.py
+++ b/tools/ci/verify-dmg-workflow.py
@@ -106,7 +106,9 @@ def check_bundle_scripts() -> None:
         "repair_assets_fnalibs_bundle",
         "tools/bundles/verify-bundles.sh",
         "--bundle-dir \"$BUNDLE_DIR\" \"$asset\"",
-        "Refreshing stale bundle",
+        "verify-release-inputs.py",
+        "--asset \"$asset\"",
+        "Refreshing stale or unlocked bundle",
         "metalsharp-bundle-manifest.tsv",
     ]:
         if needle not in create_bundles:

--- a/tools/dmg/create-bundles.sh
+++ b/tools/dmg/create-bundles.sh
@@ -19,10 +19,13 @@ download_asset() {
   local dest="$2"
   if [ -s "$dest" ]; then
     if "$PROJECT_ROOT/tools/bundles/verify-bundles.sh" --bundle-dir "$BUNDLE_DIR" "$asset" >/dev/null 2>&1; then
-      echo "SKIP bundle: $asset"
-      return 0
+      if python3 "$PROJECT_ROOT/tools/bundles/verify-release-inputs.py" \
+        --bundle-dir "$BUNDLE_DIR" --lock "$INPUT_LOCK" --asset "$asset" >/dev/null 2>&1; then
+        echo "SKIP bundle: $asset"
+        return 0
+      fi
     fi
-    echo "Refreshing stale bundle: $asset"
+    echo "Refreshing stale or unlocked bundle: $asset"
     rm -f "$dest"
   fi
   echo "Downloading bundle: $asset"


### PR DESCRIPTION
## Summary
- require cached release bundles to match the immutable lock before skipping a download
- refresh structurally valid but stale cached archives, then keep the final lock verification as the upstream-integrity gate
- cover the cache-lock behavior in the DMG workflow contract check

## Validation
- stale `metalsharp-graphics-dll.tar.zst` correctly fails the single-asset lock check
- locked `fnalibs.tar.zst` passes the single-asset lock check
- `bash -n tools/dmg/create-bundles.sh`
- `python3 tools/ci/verify-dmg-workflow.py`

Fixes the failed Release CI Developer SDK bundle download.