### PR TITLE
Detach DMG release from optional Developer SDK

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,11 +146,6 @@ jobs:
 
   build:
     name: Build DMG
-    needs: [developer-sdk]
-    # A skipped optional SDK job must not suppress the normal DMG release.
-    # When explicitly enabled, an SDK failure still blocks the release so a
-    # stale or partial SDK bundle cannot be published as current.
-    if: ${{ always() && (needs.developer-sdk.result == 'success' || needs.developer-sdk.result == 'skipped') }}
     runs-on: macos-14
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/tools/ci/verify-dmg-workflow.py
+++ b/tools/ci/verify-dmg-workflow.py
@@ -211,10 +211,9 @@ def check_workflows(assets: list[str]) -> None:
             fail(f"release workflow missing publish step: {required}")
     if "vars.METALSHARP_DEVELOPER_SDK_CI == '1'" not in release:
         fail("release Developer SDK job must be opt-in with METALSHARP_DEVELOPER_SDK_CI=1")
-    if "needs.developer-sdk.result == 'skipped'" not in release:
-        fail("a skipped optional Developer SDK job must not suppress the DMG release")
-    if "needs.developer-sdk.result == 'success'" not in release:
-        fail("an enabled Developer SDK job must succeed before the DMG release")
+    build_job = release.split("\n  build:\n", 1)[1].split("\n  release:\n", 1)[0]
+    if "needs: [developer-sdk]" in build_job or "needs.developer-sdk" in build_job:
+        fail("the optional Developer SDK job must not be in the DMG dependency graph")
     for asset in assets:
         publish_path = (
             f"dist/developer-sdk/{asset}"


### PR DESCRIPTION
## What changed

- remove the optional Developer SDK job from the DMG dependency graph
- keep the Developer SDK job opt-in with `METALSHARP_DEVELOPER_SDK_CI=1`
- add a workflow contract that rejects any future SDK dependency from the DMG job

## Root cause

GitHub propagated the skipped Developer SDK dependency through the successful DMG build and skipped the downstream Release job. The SDK job must be fully independent, not a skipped dependency accepted by an intermediate condition.

## Validation

- `python3 tools/ci/verify-dmg-workflow.py`
- parsed `.github/workflows/release.yml` and asserted SDK gating, independent DMG execution, and Release depending only on DMG
- `git diff --check`