### PR TITLE
Fix M12 graphics archive contract in release installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,6 +233,9 @@ jobs:
       - name: Verify DMG runtime assets
         run: tools/dmg/verify-dmg-runtime-assets.sh dist/electron/MetalSharp-*-arm64.dmg
 
+      - name: Verify clean DMG setup wizard
+        run: tools/dmg/verify-dmg-clean-setup.sh dist/electron/MetalSharp-*-arm64.dmg
+
       - name: Verify Apple notarization
         if: steps.apple-signing.outputs.ready == 'true'
         run: |

--- a/app/src-c/Makefile
+++ b/app/src-c/Makefile
@@ -29,7 +29,7 @@ LDFLAGS := -arch arm64 -mmacosx-version-min=$(DEPLOYMENT_TARGET) -isysroot $(SDK
 BACKEND := $(OUT_DIR)/metalsharp-backend
 TEST_BIN := $(OUT_DIR)/metalsharp-backend-tests
 
-.PHONY: integrity backend test-binary installer-test surface-test policy-test bottle-deployment-test test smoke contract verify clean
+.PHONY: integrity backend graphics-archive-contract test-binary installer-test surface-test policy-test bottle-deployment-test test smoke contract verify clean
 integrity:
 	@test "$$(wc -l < manifests/runtime-sources.txt | tr -d ' ')" = 374
 	@test "$$(wc -l < manifests/test-sources.txt | tr -d ' ')" = 394
@@ -57,6 +57,13 @@ integrity:
 	@echo "C source manifests are complete (374 converted runtime, 394 converted test, 5 maintained runtime, 4 maintained test units)."
 
 backend: $(BACKEND)
+
+graphics-archive-contract: $(BACKEND)
+	@strings "$(BACKEND)" | grep -q 'Graphics/dll/dxmt_m12/x86_64-windows/d3d12.dll'
+	@strings "$(BACKEND)" | grep -q 'Graphics/dll/dxmt_m12/x86_64-unix/winemetal.so'
+	@! strings "$(BACKEND)" | grep -q 'Graphics/dll/dxmt-m12/'
+	@echo "Backend graphics archive contract uses the canonical Graphics/dll/dxmt_m12 lane."
+
 test-binary: $(TEST_BIN)
 
 $(BACKEND): $(RUNTIME_OBJS) $(NATIVE_OBJS) $(MAINTAINED_OBJS)
@@ -117,7 +124,7 @@ contract: $(BACKEND)
 	python3 "$(CURDIR)/../../tools/contracts/validate-electron-backend-contract.py"
 	python3 "$(CURDIR)/../../tools/contracts/run-electron-backend-conformance.py" "$(CURDIR)/$(BACKEND)"
 
-verify: integrity backend installer-test surface-test policy-test bottle-deployment-test test smoke contract
+verify: integrity backend graphics-archive-contract installer-test surface-test policy-test bottle-deployment-test test smoke contract
 
 clean:
 	rm -rf build $(OUT_DIR)

--- a/tools/ci/verify-dmg-workflow.py
+++ b/tools/ci/verify-dmg-workflow.py
@@ -194,13 +194,16 @@ def check_workflows(assets: list[str]) -> None:
     for needle in [
         "Graphics/dll/dxmt_m12",
         "Graphics/dll/dxmt",
-        "runtime/wine/lib/wine/x86_64-unix/winemetal.so",
         "drive_c/windows/system32",
-        "clean-dmg-game-m12",
-        "clean-dmg-game-m11",
+        "bottles/steam_1245620/prefix",
+        "bottles/steam_312520/prefix",
+        "games/1245620",
+        "games/312520",
     ]:
         if needle not in clean_setup:
             fail(f"clean-DMG verifier no longer byte-checks {needle}")
+    if "tools/dmg/verify-dmg-clean-setup.sh dist/electron/MetalSharp-*-arm64.dmg" not in release:
+        fail("release workflow must complete the clean DMG setup wizard before publishing")
 
     if "DMG Workflow CI" not in pr:
         fail("PR CI must keep a lightweight DMG Workflow CI job")

--- a/tools/dmg/verify-dmg-clean-setup.sh
+++ b/tools/dmg/verify-dmg-clean-setup.sh
@@ -44,7 +44,7 @@ curl -fsS -X POST "http://127.0.0.1:$PORT/setup/install-all" >/dev/null
 for _ in $(seq 1 300); do
   status="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("status", ""))' "$HOME_DIR/install_progress.json" 2>/dev/null || true)"
   [ "$status" = complete ] && break
-  if [ "$status" = failed ]; then
+  if [ "$status" = failed ] || [ "$status" = error ]; then
     cat "$HOME_DIR/install_progress.json" >&2
     exit 1
   fi
@@ -88,19 +88,16 @@ compare_tree() {
 compare_tree "$EXTRACT_DIR/Graphics/dll/dxmt" "$HOME_DIR/runtime/wine/lib/dxmt"
 compare_tree "$EXTRACT_DIR/Graphics/dll/dxmt_m12" "$HOME_DIR/runtime/wine/lib/dxmt_m12"
 
-# Wine's active loader mirrors must use the promoted M12 bridge, not a stale runtime copy.
-cmp "$EXTRACT_DIR/Graphics/dll/dxmt_m12/x86_64-unix/winemetal.so" \
-  "$HOME_DIR/runtime/wine/lib/wine/x86_64-unix/winemetal.so"
-cmp "$EXTRACT_DIR/Graphics/dll/dxmt_m12/x86_64-windows/winemetal.dll" \
-  "$HOME_DIR/runtime/wine/lib/wine/x86_64-windows/winemetal.dll"
+# M12 is intentionally isolated from lib/wine. Validate its active copies through
+# the bottle prefix and game-local route surfaces below.
 
 stage_test_bottle() {
   local appid="$1"
   local profile="$2"
   local executable="$3"
-  local prefix="$HOME_DIR/clean-dmg-prefix-$profile"
-  local game="$HOME_DIR/clean-dmg-game-$profile"
   local bottle="$HOME_DIR/bottles/steam_$appid"
+  local prefix="$bottle/prefix"
+  local game="$HOME_DIR/games/$appid"
   mkdir -p "$prefix" "$game" "$bottle"
   printf 'clean DMG direct launch probe\n' >"$game/$executable"
   python3 - "$bottle/bottle.json" "$appid" "$profile" "$prefix" "$game" <<'PY'
@@ -151,17 +148,17 @@ for entry in \
   d3d12.dll d3d11.dll d3d10core.dll dxgi.dll dxgi_dxmt.dll winemetal.dll nvapi64.dll nvngx.dll
 do
   cmp "$EXTRACT_DIR/Graphics/dll/dxmt_m12/x86_64-windows/$entry" \
-    "$HOME_DIR/clean-dmg-prefix-m12/drive_c/windows/system32/$entry"
+    "$HOME_DIR/bottles/steam_1245620/prefix/drive_c/windows/system32/$entry"
   cmp "$EXTRACT_DIR/Graphics/dll/dxmt_m12/x86_64-windows/$entry" \
-    "$HOME_DIR/clean-dmg-game-m12/$entry"
+    "$HOME_DIR/games/1245620/$entry"
 done
 for entry in d3d11.dll d3d10core.dll dxgi.dll dxgi_dxmt.dll winemetal.dll; do
   cmp "$EXTRACT_DIR/Graphics/dll/dxmt/x86_64-windows/$entry" \
-    "$HOME_DIR/clean-dmg-prefix-m11/drive_c/windows/system32/$entry"
+    "$HOME_DIR/bottles/steam_312520/prefix/drive_c/windows/system32/$entry"
   cmp "$EXTRACT_DIR/Graphics/dll/dxmt/x86_64-windows/$entry" \
-    "$HOME_DIR/clean-dmg-game-m11/$entry"
+    "$HOME_DIR/games/312520/$entry"
 done
-test ! -e "$HOME_DIR/clean-dmg-prefix-m11/drive_c/windows/system32/d3d12.dll"
-test ! -e "$HOME_DIR/clean-dmg-game-m11/d3d12.dll"
+test ! -e "$HOME_DIR/bottles/steam_312520/prefix/drive_c/windows/system32/d3d12.dll"
+test ! -e "$HOME_DIR/games/312520/d3d12.dll"
 
-echo "DMG clean setup verified: 15/15 steps, no fallback downloads, exact canonical, Wine-mirror, prefix, and game payloads."
+echo "DMG clean setup verified: 15/15 steps, no fallback downloads, exact canonical, prefix, and game payloads."


### PR DESCRIPTION
## Summary

- align the committed C backend installer with the packaged `Graphics/dll/dxmt_m12` archive lane instead of the removed `dxmt-m12` spelling
- add a binary-level backend contract gate so the old packaged path cannot return unnoticed
- restore the full clean-DMG setup wizard verifier to the release workflow before publication
- update that verifier for the isolated M12 bottle/game layout and fail immediately on both `failed` and `error` installer states

## Root cause

The 0.56.0 DMG did contain `metalsharp-graphics-dll.tar.zst`, and that archive contained the correct `Graphics/dll/dxmt_m12` payload. The packaged backend still validated `Graphics/dll/dxmt-m12`, rejected the existing archive, and then surfaced the misleading missing-bundle error.

## Verification

- `make -C app/src-c verify` — 629 tests passed, plus soak and Electron/backend conformance
- `make -C app/src-c graphics-archive-contract`
- `python3 tools/ci/verify-dmg-workflow.py`
- staged the rebuilt dev backend into a disposable copy of the installed 0.56.0 app, packaged it as a DMG, and ran `tools/dmg/verify-dmg-clean-setup.sh`
  - setup completed 15/15 steps
  - no fallback downloads
  - canonical DXMT and `dxmt_m12` payloads matched the embedded archive byte-for-byte
  - M11 and M12 bottle-prefix and game-local DLL deployments matched the archive byte-for-byte
