### PR TITLE
Fix 0.56.1 migration to update prefixes only

### DIFF
--- a/app/src-c/Makefile
+++ b/app/src-c/Makefile
@@ -43,7 +43,9 @@ integrity:
 	@while IFS= read -r source; do test -f "$$source"; done < manifests/maintained-test-sources.txt
 	@grep -q 'metalsharp_launcher_preflight(_arg0' "$(LAUNCH_ADAPTER_SRC)"
 	@grep -q 'metalsharp_launcher_prepare_eac(_arg0' "$(LAUNCH_ADAPTER_SRC)"
-	@grep -q 'metalsharp_migration_refresh_saved_bottles()' "$(MIGRATION_ADAPTER_SRC)"
+	@grep -q 'extern bool metalsharp_migration_refresh_saved_bottles(void);' "$(MIGRATION_ADAPTER_SRC)"
+	@grep -q 'Required Wine prefix updates complete; saved bottle DLLs unchanged.' "$(MIGRATION_ADAPTER_SRC)"
+	@! grep -q 'if (!metalsharp_migration_refresh_saved_bottles())' "$(MIGRATION_ADAPTER_SRC)"
 	@grep -q 'metalsharp_game_requires_agility(_arg1, _arg2)' "$(AGILITY_ADAPTER_SRC)"
 	@grep -q 'metalsharp_find_bytes(_arg0, _arg1, _arg2, _arg3' "$(AGILITY_ADAPTER_SRC)"
 	@grep -q '_metalsharp_m12_components' "$(BOTTLE_ADAPTER_SRC)"

--- a/app/src/renderer/components/MigrationView.vue
+++ b/app/src/renderer/components/MigrationView.vue
@@ -30,7 +30,7 @@ const percent = computed(() => {
 const stages = computed(() => [
   { name: restoringData.value ? "Restore Data" : "Preserve Data", detail: "Settings, bottles, prefixes" },
   { name: "Install Runtime", detail: "Matched graphics components" },
-  { name: "Refresh Bottles", detail: "Update profile-owned DLLs" },
+  { name: "Update Prefixes", detail: "Required Wine prefix changes" },
   { name: "Verify", detail: "Runtime and saved routes" },
 ]);
 
@@ -41,6 +41,8 @@ function stageFromMessage(value: string): MigrationStageIndex | null {
   // Check it before bottle/prefix terms because restore messages can contain both.
   if (detail.includes("restor")) return 0;
   if (
+    detail.includes("prefix updates complete") ||
+    detail.includes("updating wine prefix") ||
     detail.includes("refreshing saved bottle") ||
     detail.includes("refreshing bottle") ||
     detail.includes("bottle refresh")
@@ -255,7 +257,7 @@ onUnmounted(() => {
         <div :key="spinnerEpoch" class="loading-icon" :class="{ complete, error: !!error }" aria-hidden="true" />
         <h1 class="migration-title">{{ title }}</h1>
         <p class="migration-subtitle">
-          Your game files, settings, bottles, and prefixes stay in place while runtime components are refreshed.
+          Your game files, settings, and bottles stay unchanged while required runtime and prefix updates are applied.
         </p>
       </div>
 

--- a/tools/c-backend/verify-module-alignment.py
+++ b/tools/c-backend/verify-module-alignment.py
@@ -83,8 +83,8 @@ def main() -> int:
         ("metalsharp_m12_runtime_complete" in generated, "generated-to-native installer bridge"),
         ("metalsharp_launcher_runtime_ready" in (ROOT / "app/src-c/installer.c").read_text(),
          "generated bottle/launch readiness to maintained C policy bridge"),
-        ("metalsharp_migration_refresh_saved_bottles" in generated,
-         "generated migration to maintained bottle refresh bridge"),
+        ("extern bool metalsharp_migration_refresh_saved_bottles(void);" in generated,
+         "legacy migration bottle-refresh bridge declaration"),
     ]
     for present, label in requirements:
         if not present:

--- a/tools/ci/verify-dmg-workflow.py
+++ b/tools/ci/verify-dmg-workflow.py
@@ -117,9 +117,23 @@ def check_updater_handoff() -> None:
             fail(f"Electron migration handoff is missing: {needle}")
 
     migration_view = read("app/src/renderer/components/MigrationView.vue")
-    for needle in ["pollInFlight", "Retry Migration", "Reconnecting to the migration backend"]:
+    for needle in [
+        "pollInFlight",
+        "Retry Migration",
+        "Reconnecting to the migration backend",
+        "Update Prefixes",
+        "Required Wine prefix changes",
+    ]:
         if needle not in migration_view:
             fail(f"migration wizard recovery is missing: {needle}")
+
+    migration_runtime = read(
+        "app/src-c/runtime/c/metalsharp_backend-be5c1ce78fdf154a.metalsharp_backend.821b1f24846112cc-cgu.08.rcgu.c"
+    )
+    if "Required Wine prefix updates complete; saved bottle DLLs unchanged." not in migration_runtime:
+        fail("migration does not report the prefix-only update contract")
+    if "if (!metalsharp_migration_refresh_saved_bottles())" in migration_runtime:
+        fail("migration still rewrites saved bottle DLLs")
 
     native_migrator = read("tools/migrator/main.m")
     if "METALSHARP_PORT" not in native_migrator or "127.0.0.1:9274" in native_migrator:


### PR DESCRIPTION
## Summary
- remove the saved-bottle graphics DLL reconciliation from release migration part 6
- keep required Wine prefix updates and final runtime verification authoritative
- leave preserved bottle DLLs and game files unchanged
- update the migration UI to describe the prefix-only contract
- add build and DMG workflow guards preventing the bottle-refresh call from returning

## Validation
- `make -C app/src-c verify`
- `cd app && npm run build`
- `cd app && npx biome check src/`
- `python3 tools/ci/verify-dmg-workflow.py`
- compiled backend contains the prefix-only message and no bottle-refresh failure path