### PR TITLE
Add Ubisoft Connect support to Sharp Library

### DIFF
--- a/docs/plans/ubisoft-connect-phase-0-1-evidence.md
+++ b/docs/plans/ubisoft-connect-phase-0-1-evidence.md
@@ -1,0 +1,161 @@
+# Ubisoft Connect phases 0–1 evidence
+
+This record covers the runtime preservation and incremental Unix ntdll work required before the Ubisoft Connect application integration.
+
+## Phase 0: installed runtime preservation
+
+MetalSharp runtime inspected:
+
+```text
+/Users/averyfelts/.metalsharp/runtime/wine
+```
+
+Active module:
+
+```text
+/Users/averyfelts/.metalsharp/runtime/wine/lib/wine/x86_64-unix/ntdll.so
+```
+
+Baseline facts:
+
+| Property | Value |
+| --- | --- |
+| Wine version | `wine-11.5` |
+| Architecture | thin Mach-O `x86_64` |
+| SHA-256 | `2c65c0aec607ea64abcae733b30b730689a75ba9463b5b676b4dd7f10b792fb3` |
+| Size | `741840` bytes |
+| Install name | `@rpath/ntdll.so` |
+| Rpath | `@loader_path/` |
+| Minimum macOS | `26.0` |
+| Build SDK | `26.4` |
+| Exported symbols | `288` |
+| Signature | ad-hoc |
+
+The baseline module, metadata, exported symbols, complete runtime hash manifest, disposable runtime, and smoke-test logs are retained outside the runtime at:
+
+```text
+/Volumes/AverySSD/MetalSharp PR Work/runtime-safety/ubisoft-phase0-2c65c0aec607
+```
+
+The preserved module is:
+
+```text
+/Volumes/AverySSD/MetalSharp PR Work/runtime-safety/ubisoft-phase0-2c65c0aec607/original/ntdll.so
+```
+
+Its saved hash matches the installed baseline. A byte-level hash manifest confirmed that the disposable runtime initially matched all regular files in the installed runtime.
+
+The disposable baseline passed:
+
+- `metalsharp-wine --version`;
+- `wineboot -u` in a new isolated prefix; and
+- `cmd /c echo METALSHARP_DISPOSABLE_BASELINE_OK`.
+
+The baseline write-copy probe returned `PAGE_WRITECOPY` (`0x8`) with the environment unset, with `WINE_SIMULATE_WRITECOPY=1`, and when named `UplayWebCore.exe`. This proves the original runtime did not implement either requested behavior.
+
+Atomic installation and restoration are provided by `tools/wine/swap-metalsharp-ntdll.sh`. Its install/functional-test/restore cycle passed against the disposable runtime, including restoration to the exact baseline hash. Safety tests also confirmed that it rejects backup-directory symlinks resolving inside the runtime, while the build script rejects output paths resolving inside the installed runtime. The retained manual backup can also be restored atomically with:
+
+```bash
+cp -p '/Volumes/AverySSD/MetalSharp PR Work/runtime-safety/ubisoft-phase0-2c65c0aec607/original/ntdll.so' \
+  "$HOME/.metalsharp/runtime/wine/lib/wine/x86_64-unix/ntdll.so.restore"
+mv -f "$HOME/.metalsharp/runtime/wine/lib/wine/x86_64-unix/ntdll.so.restore" \
+  "$HOME/.metalsharp/runtime/wine/lib/wine/x86_64-unix/ntdll.so"
+```
+
+## Phase 1: incremental x86_64 Unix ntdll
+
+Wine source:
+
+```text
+Wine 11.5 commit 1dbc94083d1b508c3708c857b1715f9d379aa78a
+```
+
+The existing `/Volumes/AverySSD/Arm64WINE_Build/wine-11.5` configuration was not used as a binary donor because it produces an arm64 Unix ntdll. A separate clean worktree was configured for x86_64.
+
+Only the following Wine sources were changed:
+
+```text
+dlls/ntdll/unix/loader.c
+dlls/ntdll/unix/unix_private.h
+dlls/ntdll/unix/virtual.c
+```
+
+The source adaptation is stored at:
+
+```text
+tools/wine/patches/ubisoft-writecopy/0001-wine-11.5-ubisoft-writecopy.patch
+```
+
+The incremental build invoked:
+
+```bash
+make dlls/ntdll/ntdll.so
+```
+
+Wine's generated-header tools were built as target prerequisites, but no complete Wine build or installation was performed. `tools/wine/build-ubisoft-ntdll.sh` subsequently completed an independent end-to-end build from a second clean worktree, and its output passed the baseline ABI verifier.
+
+Final candidate:
+
+| Property | Value |
+| --- | --- |
+| Architecture | thin Mach-O `x86_64` |
+| SHA-256 | `223439a2c334b6532bb4235dd0ec91aadbd07923d7c6959c6c71585d9f6319bd` |
+| Size | `669120` bytes |
+| Install name | `@rpath/ntdll.so` |
+| Rpath | `@loader_path/` |
+| Minimum macOS | `26.0` |
+| Build SDK | `26.5` |
+| Exported symbols | same `288`-symbol set as baseline |
+| Signature | ad-hoc, strict verification passed |
+
+The candidate has the same dependency identities as the baseline:
+
+```text
+@rpath/ntdll.so
+IOKit.framework
+CoreFoundation.framework
+CoreServices.framework
+/usr/lib/libSystem.B.dylib
+```
+
+The SDK patch level is `26.5` rather than the unavailable baseline SDK `26.4`. The minimum OS, dependency identities, exports, install name, and rpath match; isolated-prefix execution validates the resulting module on the current runtime.
+
+The candidate preserves the installed runtime's `MS_ROOT`/`mscompatdb.so` autoload path and corrects its non-`MS_ROOT` fallback to resolve from the architecture-specific ntdll directory. The existing mscompatdb module continues to report its pre-existing missing `KeServiceDescriptorTable`; that deprecated subsystem was not expanded as part of the Ubisoft fix. The baseline's unconsumed `MS_APPLEGPTK_LIBD3DSHARED_PATH` marker was not treated as a functional compatibility surface.
+
+### Functional results
+
+The disposable patched runtime passed:
+
+- Wine 11.5 version check;
+- new-prefix `wineboot -u`;
+- Windows command execution; and
+- strict code-signature verification.
+
+The write-copy probe produced:
+
+| Invocation | Initial protection | Returned old protection | Result |
+| --- | --- | --- | --- |
+| ordinary executable, env unset | `0x8` | `0x8` | unchanged baseline behavior |
+| ordinary executable, `WINE_SIMULATE_WRITECOPY=1` | `0x8` | `0x4` | explicit simulation passed |
+| executable named `UplayWebCore.exe`, env unset | `0x8` | `0x4` | automatic Ubisoft behavior passed |
+
+The same startup and functional probes passed after the atomic swap into the installed MetalSharp runtime.
+
+A complete post-swap runtime hash manifest differs from the Phase 0 manifest at exactly one path:
+
+```text
+lib/wine/x86_64-unix/ntdll.so
+```
+
+No PE ntdll, Wine loader, Wine server, graphics library, or other runtime file changed.
+
+## Result
+
+Phases 0 and 1 are complete:
+
+- the original installed ntdll is preserved and immediately restorable;
+- a disposable baseline was captured and tested;
+- the Valve write-copy behavior was adapted to Wine 11.5;
+- only x86_64 Unix ntdll was incrementally built;
+- explicit and automatic Ubisoft write-copy behavior passed functional probes; and
+- only the installed x86_64 Unix ntdll was atomically replaced.

--- a/docs/plans/ubisoft-connect-sharp-library.md
+++ b/docs/plans/ubisoft-connect-sharp-library.md
@@ -1,0 +1,283 @@
+# Ubisoft Connect Sharp Library Integration Plan
+
+## Objective
+
+Add a dedicated Ubisoft Connect source to Sharp Library, modeled after the GOG experience, with:
+
+- an isolated Ubisoft Wine prefix;
+- official Ubisoft Connect installation and Start/Stop controls;
+- local discovery and synchronization of downloaded Ubisoft games;
+- game launching through Ubisoft's `uplay://` protocol;
+- launcher and game process lifecycle management;
+- suppression of recurring `winedbg` crash windows; and
+- no Ubisoft Connect launcher card in the game library.
+
+The integration must use MetalSharp's installed Wine 11.5 runtime and must not depend on CrossOver-specific fixes.
+
+## Research basis
+
+The proposed design combines proven patterns from several open-source projects:
+
+- [Heroic Games Launcher](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher) installs the official launcher, launches Ubisoft-managed titles through `uplay://launch/<id>`, and demonstrates why shutdown must be scoped to the title's Wine prefix.
+- [Bottles](https://github.com/bottlesdevs/Bottles) discovers Ubisoft configuration data, launches games through Ubisoft Connect, disables overlay behavior, and configures launcher close behavior.
+- [Lutris](https://github.com/lutris/lutris) parses Ubisoft configuration and ownership records, Wine registry install records, and `uplay_install.state`.
+- [gcenx/Wineskin](https://github.com/Gcenx/WineskinServer) provides the Wine registry settings used to disable Wine debugger dialogs.
+- Valve Wine commits [334f7a7](https://github.com/ValveSoftware/wine/commit/334f7a78190a0a0a4abede0d598b28a2743f468a) and [10a46db](https://github.com/ValveSoftware/wine/commit/10a46db3c80835d7a6038dbbac5163531dab6158) implement the write-copy behavior required by `UplayWebCore.exe`.
+
+Heroic and Wineskin are useful implementation references, but neither can substitute for fixing MetalSharp's own Wine runtime. Heroic still depends on the selected Wine runtime, and the current upstream-style gcenx Wine tree does not contain Valve's `WINE_SIMULATE_WRITECOPY` implementation.
+
+## Runtime constraint
+
+MetalSharp uses:
+
+```text
+~/.metalsharp/runtime/wine/bin/metalsharp-wine
+~/.metalsharp/runtime/wine/bin/wine
+~/.metalsharp/runtime/wine/lib/wine/x86_64-unix/ntdll.so
+```
+
+The active runtime reports Wine 11.5 and its Unix ntdll is x86_64. The existing `/Volumes/AverySSD/Arm64WINE_Build/wine-11.5` configuration produces an arm64 Unix ntdll, so its current build artifact cannot be copied into the installed runtime.
+
+This work will **not rebuild all of Wine**. It will create a separate x86_64 Wine 11.5 configuration, compile only Unix ntdll, and replace only:
+
+```text
+runtime/wine/lib/wine/x86_64-unix/ntdll.so
+```
+
+The PE ntdll modules, Wine loader, Wine server, graphics libraries, and all unrelated runtime files remain unchanged.
+
+## Phased implementation
+
+### Phase 0: Preserve and characterize the installed runtime
+
+1. Record hashes, architecture, Mach-O load commands, exported symbols, deployment target, and version for the installed ntdll.
+2. Back up the installed ntdll outside the runtime directory.
+3. Create a disposable copy of the MetalSharp runtime for initial testing.
+4. Provide an atomic rollback procedure.
+5. Confirm that the disposable runtime behaves identically before patching.
+
+**Completion gate:** The original ntdll can be restored immediately and the baseline disposable runtime passes Wine startup tests.
+
+### Phase 1: Incrementally rebuild only x86_64 Unix ntdll
+
+1. Create a separate x86_64 Wine 11.5 build configuration compatible with the installed runtime.
+2. Use installed MetalSharp build tools where appropriate, including `~/.metalsharp/runtime/wine/bin/winebuild`.
+3. Adapt Valve's write-copy changes to Wine 11.5 in:
+   - `dlls/ntdll/unix/loader.c`
+   - `dlls/ntdll/unix/unix_private.h`
+   - `dlls/ntdll/unix/virtual.c`
+4. Build only:
+
+   ```bash
+   make dlls/ntdll/ntdll.so
+   ```
+
+5. Validate architecture, exports, load commands, rpaths, version, and isolated-prefix startup.
+6. Functionally verify `WINE_SIMULATE_WRITECOPY=1` and automatic `UplayWebCore.exe` handling.
+7. Swap the patched ntdll into the disposable runtime first, then atomically replace the installed ntdll only after validation.
+
+**Completion gate:** The patched x86_64 ntdll passes startup and write-copy tests without changing any other Wine component.
+
+### Phase 2: Prove Ubisoft Connect manually
+
+1. Create a temporary isolated prefix.
+2. Run `wineboot -u`.
+3. Configure Wine debugger suppression:
+
+   ```text
+   HKLM\Software\Microsoft\Windows NT\CurrentVersion\AeDebug\Debugger = false
+   HKCU\Software\Wine\WineDbg\ShowCrashDialog = 0
+   ```
+
+4. Download and run the official `UbisoftConnectInstaller.exe`.
+5. Start Ubisoft Connect with `WINEDEBUGGER=none` and `WINE_SIMULATE_WRITECOPY=1`.
+6. Verify that WebCore remains alive, login renders, the launcher restarts, and no recurring debugger windows appear.
+7. Verify prefix-scoped shutdown with the matching Wine server.
+
+**Completion gate:** Ubisoft Connect is usable with MetalSharp Wine before application UI work begins.
+
+### Phase 3: Add the dedicated Ubisoft backend
+
+Create `app/src-rust/src/ubisoft.rs` and register its routes in `app/src-rust/src/main.rs`.
+
+Use isolated storage:
+
+```text
+~/.metalsharp/bottles/ubisoft-prefix/prefix/
+~/.metalsharp/ubisoft/installers/
+~/.metalsharp/ubisoft/library.json
+~/.metalsharp/ubisoft/logs/
+```
+
+Initial endpoints:
+
+```text
+GET  /sharp-library/ubisoft/status
+POST /sharp-library/ubisoft/initialize-prefix
+POST /sharp-library/ubisoft/remove-prefix
+POST /sharp-library/ubisoft/install
+POST /sharp-library/ubisoft/start
+POST /sharp-library/ubisoft/stop
+```
+
+Backend responsibilities:
+
+- verify runtime write-copy capability;
+- initialize and configure the dedicated prefix;
+- apply debugger suppression;
+- download and validate the official installer transactionally;
+- install and start Ubisoft Connect with the required environment;
+- update supported launcher settings without discarding unrelated settings;
+- log launcher activity separately; and
+- stop only the Ubisoft prefix using its exact `WINEPREFIX` and Wine server.
+
+**Completion gate:** Every manual operation from Phase 2 works through a backend endpoint.
+
+### Phase 4: Synchronize locally installed games
+
+Add:
+
+```text
+POST /sharp-library/ubisoft/sync
+GET  /sharp-library/ubisoft/games
+GET  /sharp-library/ubisoft/cover?id=...
+```
+
+Discovery sources:
+
+```text
+cache/configuration/configurations
+HKLM\Software\Ubisoft\Launcher\Installs\<id>\InstallDir
+uplay_install.state
+known executable paths
+```
+
+Synchronization will:
+
+1. locate supported Ubisoft configuration paths;
+2. parse framed YAML configuration records;
+3. extract stable install and launch IDs, localized titles, artwork, install paths, and executable information;
+4. verify local installation through registry and filesystem evidence;
+5. deduplicate records by Ubisoft identifier;
+6. write `library.json` transactionally; and
+7. preserve the previous valid cache if fresh parsing fails.
+
+MetalSharp will not handle Ubisoft passwords, authentication tokens, or unofficial account APIs. Authentication stays inside the official launcher.
+
+**Completion gate:** A game downloaded through Ubisoft Connect appears exactly once after synchronization.
+
+### Phase 5: Add game launch and process lifecycle
+
+Add:
+
+```text
+POST /sharp-library/ubisoft/play
+POST /sharp-library/ubisoft/stop-game
+```
+
+Launch games through:
+
+```text
+UbisoftConnect.exe uplay://launch/<launch-id>/0
+```
+
+Lifecycle requirements:
+
+- start Ubisoft Connect automatically when required;
+- identify games using exact launch IDs, including `-upc_uplay_id <id>` where available;
+- do not mistake the persistent launcher for the running game;
+- stop an individual game only when its process is identified safely;
+- reserve prefix-wide termination for the explicit Stop Ubisoft action; and
+- never use unscoped `killall wine` behavior.
+
+**Completion gate:** A game launches by stable Ubisoft ID and its running state clears after exit even when Ubisoft Connect remains open.
+
+### Phase 6: Guarantee launcher hiding
+
+Update `app/src-rust/src/sharp_library.rs` so exact Ubisoft launcher executables are excluded from game discovery:
+
+```text
+UbisoftConnect.exe
+upc.exe
+UbisoftGameLauncher.exe
+UbisoftGameLauncher64.exe
+Uplay.exe
+```
+
+Avoid broad substring matching that could hide real games. The dedicated Ubisoft prefix will also remain outside ordinary installer-bottle scanning.
+
+**Completion gate:** Ubisoft Connect never appears as a game card, while installed Ubisoft games remain visible.
+
+### Phase 7: Add the Ubisoft Sharp Library tab
+
+Update `app/src/renderer/views/SharpView.vue` to support explicit source modes:
+
+```ts
+"installers" | "gog" | "ubisoft"
+```
+
+Add header controls for:
+
+- Initialize/Remove Prefix
+- Install Ubisoft Connect
+- Start Ubisoft
+- Stop Ubisoft
+- Sync Games
+
+Render explicit states for runtime incompatibility, missing prefix, missing launcher, sign-in instructions, empty installed library, synchronization errors, and installed games. Ubisoft Connect itself remains a header-level service and is never rendered as a card.
+
+**Completion gate:** The full flow works through Sharp Library without terminal commands.
+
+### Phase 8: Automated and manual validation
+
+Automated coverage will include:
+
+- runtime capability detection;
+- safe prefix initialization and removal;
+- installer validation and atomic writes;
+- debugger registry generation;
+- required launch environment;
+- framed configuration parsing, including malformed input;
+- localized title fallback;
+- Wine registry and `uplay_install.state` parsing;
+- stable deduplication;
+- exact launcher filtering; and
+- exact process/launch-ID matching.
+
+Project validation:
+
+```bash
+cargo fmt --check
+cargo test
+npm run build
+git diff --check
+```
+
+Manual acceptance will cover ntdll rollback, existing Steam/GOG startup, clean Ubisoft installation, absence of recurring `winedbg`, login persistence, prefix-scoped Start/Stop, downloaded-game synchronization, launcher hiding, URI game launch, and game-state cleanup.
+
+### Phase 9: Package the one-file runtime update
+
+1. Store the adapted Valve patches and attribution under `tools/wine/patches/`.
+2. Document or script the reproducible x86_64 incremental ntdll build.
+3. Add verification for ntdll architecture and write-copy capability.
+4. Replace only `runtime/wine/lib/wine/x86_64-unix/ntdll.so` in a candidate runtime bundle.
+5. Verify that all unrelated Wine files retain their previous hashes.
+6. Test the candidate bundle in a clean MetalSharp installation before promotion.
+
+**Completion gate:** The distributed runtime includes the patched ntdll without rebuilding or replacing the rest of Wine.
+
+## Pull request boundaries
+
+The draft PR should remain reviewable in two logical sections:
+
+1. **Runtime prerequisite:** adapted Valve patches, incremental x86_64 ntdll tooling, capability checks, rollback instructions, and the one-file candidate runtime update.
+2. **Ubisoft integration:** backend, discovery, lifecycle, launcher hiding, Sharp Library UI, tests, and documentation.
+
+## Out of scope
+
+- Full Wine rebuilds.
+- CrossOver-only fixes or runtime dependencies.
+- Unofficial Ubisoft account authentication or credential handling.
+- Synchronizing uninstalled account-owned games in the initial implementation.
+- Guarantees for anti-cheat-protected multiplayer titles.
+- Global Wine process termination.

--- a/docs/plans/ubisoft-connect-sharp-library.md
+++ b/docs/plans/ubisoft-connect-sharp-library.md
@@ -48,7 +48,7 @@ The PE ntdll modules, Wine loader, Wine server, graphics libraries, and all unre
 
 ## Phased implementation
 
-### Phase 0: Preserve and characterize the installed runtime
+### Phase 0: Preserve and characterize the installed runtime — Complete
 
 1. Record hashes, architecture, Mach-O load commands, exported symbols, deployment target, and version for the installed ntdll.
 2. Back up the installed ntdll outside the runtime directory.
@@ -58,7 +58,9 @@ The PE ntdll modules, Wine loader, Wine server, graphics libraries, and all unre
 
 **Completion gate:** The original ntdll can be restored immediately and the baseline disposable runtime passes Wine startup tests.
 
-### Phase 1: Incrementally rebuild only x86_64 Unix ntdll
+**Evidence:** [`ubisoft-connect-phase-0-1-evidence.md`](ubisoft-connect-phase-0-1-evidence.md)
+
+### Phase 1: Incrementally rebuild only x86_64 Unix ntdll — Complete
 
 1. Create a separate x86_64 Wine 11.5 build configuration compatible with the installed runtime.
 2. Use installed MetalSharp build tools where appropriate, including `~/.metalsharp/runtime/wine/bin/winebuild`.
@@ -77,6 +79,8 @@ The PE ntdll modules, Wine loader, Wine server, graphics libraries, and all unre
 7. Swap the patched ntdll into the disposable runtime first, then atomically replace the installed ntdll only after validation.
 
 **Completion gate:** The patched x86_64 ntdll passes startup and write-copy tests without changing any other Wine component.
+
+**Evidence:** [`ubisoft-connect-phase-0-1-evidence.md`](ubisoft-connect-phase-0-1-evidence.md)
 
 ### Phase 2: Prove Ubisoft Connect manually
 

--- a/tools/wine/build-ubisoft-ntdll.sh
+++ b/tools/wine/build-ubisoft-ntdll.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PATCH="$SCRIPT_DIR/patches/ubisoft-writecopy/0001-wine-11.5-ubisoft-writecopy.patch"
+VERIFY="$SCRIPT_DIR/verify-ubisoft-ntdll.sh"
+DEFAULT_RUNTIME="$HOME/.metalsharp/runtime/wine"
+DEFAULT_SDK="/Library/Developer/CommandLineTools/SDKs/MacOSX26.5.sdk"
+SOURCE=""
+OUTPUT=""
+RUNTIME="$DEFAULT_RUNTIME"
+SDK="${METALSHARP_WINE_SDK:-$DEFAULT_SDK}"
+JOBS="${METALSHARP_WINE_JOBS:-$(sysctl -n hw.ncpu)}"
+
+usage() {
+  cat <<'USAGE'
+Usage: tools/wine/build-ubisoft-ntdll.sh --source PATH --output PATH [options]
+
+Incrementally configures a clean Wine 11.5 source tree and builds only the
+x86_64 Unix ntdll target needed by MetalSharp's Ubisoft support.
+
+Options:
+  --source PATH   Clean, unconfigured Wine 11.5 source tree (required)
+  --output PATH   Destination for the signed ntdll.so (required)
+  --runtime PATH  Installed MetalSharp Wine used for tools/baseline
+  --sdk PATH      macOS SDK (default: MacOSX26.5.sdk)
+  --jobs N        Parallel make jobs
+  -h, --help      Show this help
+
+The source path must not contain whitespace because Wine's generated Makefile
+embeds configured paths in preprocessor definitions without shell-safe quoting.
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --source) SOURCE="$2"; shift 2 ;;
+    --output) OUTPUT="$2"; shift 2 ;;
+    --runtime) RUNTIME="$2"; shift 2 ;;
+    --sdk) SDK="$2"; shift 2 ;;
+    --jobs) JOBS="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$SOURCE" ] && [ -n "$OUTPUT" ] || { usage >&2; exit 2; }
+case "$SOURCE" in *[[:space:]]*) echo "Wine source path must not contain whitespace: $SOURCE" >&2; exit 2 ;; esac
+for path_arg in "$SOURCE" "$OUTPUT" "$RUNTIME" "$SDK"; do
+  case "$path_arg" in /*) ;; *) echo "build paths must be absolute: $path_arg" >&2; exit 2 ;; esac
+done
+[ "$(uname -s)" = "Darwin" ] || { echo "this incremental build is macOS-only" >&2; exit 1; }
+[ -x "$SOURCE/configure" ] || { echo "Wine configure script missing: $SOURCE/configure" >&2; exit 1; }
+[ -f "$PATCH" ] || { echo "patch missing: $PATCH" >&2; exit 1; }
+[ -d "$SDK" ] || { echo "macOS SDK missing: $SDK" >&2; exit 1; }
+[ -x "$RUNTIME/bin/winebuild" ] || { echo "MetalSharp winebuild missing: $RUNTIME/bin/winebuild" >&2; exit 1; }
+[ -f "$RUNTIME/lib/wine/x86_64-unix/ntdll.so" ] || { echo "baseline ntdll missing in $RUNTIME" >&2; exit 1; }
+
+for tool in git make clang codesign file lipo nm otool python3 strings; do
+  command -v "$tool" >/dev/null || { echo "required tool missing: $tool" >&2; exit 1; }
+done
+
+runtime_real="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$RUNTIME")"
+output_real="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$OUTPUT")"
+case "$output_real" in
+  "$runtime_real"|"$runtime_real"/*)
+    echo "refusing to build directly into the installed runtime; use swap-metalsharp-ntdll.sh" >&2
+    exit 1
+    ;;
+esac
+
+[ "$("$RUNTIME/bin/metalsharp-wine" --version 2>&1)" = "wine-11.5" ] || {
+  echo "installed MetalSharp runtime is not Wine 11.5" >&2
+  exit 1
+}
+"$RUNTIME/bin/winebuild" --version 2>&1 | grep -q 'winebuild version 11\.5' || {
+  echo "installed MetalSharp winebuild is not version 11.5" >&2
+  exit 1
+}
+[ ! -e "$SOURCE/config.status" ] || { echo "Wine source is already configured; use a clean worktree" >&2; exit 1; }
+
+if git -C "$SOURCE" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  [ -z "$(git -C "$SOURCE" status --porcelain --untracked-files=no)" ] || {
+    echo "Wine source has tracked changes; use a clean Wine 11.5 worktree" >&2
+    exit 1
+  }
+fi
+
+"$SOURCE/configure" --version 2>/dev/null | grep -q 'Wine configure 11.5' || {
+  echo "source does not identify as Wine 11.5" >&2
+  exit 1
+}
+
+git -C "$SOURCE" apply --check "$PATCH"
+git -C "$SOURCE" apply "$PATCH"
+
+BISON_BIN="${BISON:-}"
+if [ -z "$BISON_BIN" ] && [ -x /opt/homebrew/opt/bison/bin/bison ]; then
+  BISON_BIN=/opt/homebrew/opt/bison/bin/bison
+fi
+[ -n "$BISON_BIN" ] || BISON_BIN="$(command -v bison)"
+"$BISON_BIN" --version | head -1
+
+cd "$SOURCE"
+SDKROOT="$SDK" ac_cv_func_pipe2=no ./configure \
+  --host=x86_64-apple-darwin --enable-archs=i386,x86_64 --with-mingw \
+  --without-alsa --without-capi --without-cups --without-dbus \
+  --without-fontconfig --without-freetype --without-gettext --without-gphoto \
+  --without-gssapi --without-gstreamer --without-hwloc --without-inotify \
+  --without-krb5 --without-netapi --without-opencl --without-opengl \
+  --without-oss --without-pcap --without-pcsclite --without-pulse \
+  --without-sane --without-sdl --without-udev --without-usb \
+  --without-v4l2 --without-vulkan --without-wayland --without-x \
+  --prefix="$SOURCE/install" \
+  CC=/usr/bin/clang CXX=/usr/bin/clang++ BISON="$BISON_BIN" PKG_CONFIG=/usr/bin/false \
+  "CFLAGS=-O2 -g -arch x86_64 -isysroot $SDK -mmacosx-version-min=14.0" \
+  "CXXFLAGS=-O2 -g -arch x86_64 -isysroot $SDK -mmacosx-version-min=14.0" \
+  "LDFLAGS=-arch x86_64 -isysroot $SDK -mmacosx-version-min=26.0" \
+  'CPPFLAGS='
+
+# This target may build Wine's generated-header tools as prerequisites, but it
+# does not build or install the rest of Wine.
+make -j"$JOBS" WINEBUILD="$RUNTIME/bin/winebuild" dlls/ntdll/ntdll.so
+
+mkdir -p "$(dirname "$OUTPUT")"
+cp -p dlls/ntdll/ntdll.so "$OUTPUT"
+chmod 755 "$OUTPUT"
+codesign --force --sign - --timestamp=none "$OUTPUT"
+"$VERIFY" "$OUTPUT" "$RUNTIME/lib/wine/x86_64-unix/ntdll.so"
+
+echo "Built patched Unix ntdll: $OUTPUT"

--- a/tools/wine/patches/ubisoft-writecopy/0001-wine-11.5-ubisoft-writecopy.patch
+++ b/tools/wine/patches/ubisoft-writecopy/0001-wine-11.5-ubisoft-writecopy.patch
@@ -1,0 +1,123 @@
+diff --git a/dlls/ntdll/unix/loader.c b/dlls/ntdll/unix/loader.c
+index 9bc040e..5e84e5b 100644
+--- a/dlls/ntdll/unix/loader.c
++++ b/dlls/ntdll/unix/loader.c
+@@ -1856,6 +1856,30 @@ static ULONG_PTR get_image_address(void)
+ /***********************************************************************
+  *           start_main_thread
+  */
++#ifdef __APPLE__
++/* Preserve the MetalSharp runtime's compatibility database autoload surface. */
++static void load_metalsharp_mscompatdb(void)
++{
++    const char *root = getenv( "MS_ROOT" );
++    char path[PATH_MAX];
++    void *handle = NULL;
++
++    if (root && *root)
++    {
++        snprintf( path, sizeof(path), "%s/lib/wine/%s/mscompatdb.so", root, get_so_dir( current_machine ) );
++        handle = dlopen( path, RTLD_NOW );
++    }
++    if (!handle && dll_dir)
++    {
++        snprintf( path, sizeof(path), "%s/mscompatdb.so", ntdll_dir );
++        handle = dlopen( path, RTLD_NOW );
++    }
++
++    if (handle) fprintf( stderr, "mscompatdb: loaded from %s\n", path );
++    else if ((root && *root) || dll_dir) fprintf( stderr, "mscompatdb: not found\n" );
++}
++#endif
++
+ static void start_main_thread(void)
+ {
+     TEB *teb = virtual_alloc_first_teb();
+@@ -1863,6 +1887,9 @@ static void start_main_thread(void)
+     signal_init_threading();
+     dbg_init();
+     startup_info_size = server_init_process();
++#ifdef __APPLE__
++    load_metalsharp_mscompatdb();
++#endif
+     virtual_map_user_shared_data();
+     init_cpu_info();
+     init_files();
+@@ -2222,6 +2249,16 @@ static void check_command_line( int argc, char *argv[] )
+ }
+
+
++BOOL simulate_writecopy;
++
++static void init_writecopy_hacks(void)
++{
++    const char *env = getenv( "WINE_SIMULATE_WRITECOPY" );
++
++    if (env) simulate_writecopy = atoi( env );
++    else if (main_argc > 1 && strstr( main_argv[1], "UplayWebCore.exe" )) simulate_writecopy = TRUE;
++}
++
+ /***********************************************************************
+  *           __wine_main
+  *
+@@ -2235,6 +2272,7 @@ DECLSPEC_EXPORT void __wine_main( int argc, char *argv[] )
+     init_paths();
+     if (!getenv( "WINELOADERNOEXEC" ) || argc <= 1) check_command_line( argc, argv );
+     unsetenv( "WINELOADERNOEXEC" );
++    init_writecopy_hacks();
+
+ #ifdef RLIMIT_NOFILE
+     set_max_limit( RLIMIT_NOFILE );
+diff --git a/dlls/ntdll/unix/unix_private.h b/dlls/ntdll/unix/unix_private.h
+index a9e8f52..ad6b497 100644
+--- a/dlls/ntdll/unix/unix_private.h
++++ b/dlls/ntdll/unix/unix_private.h
+@@ -197,6 +197,7 @@ extern const WCHAR system_dir[];
+ extern unsigned int supported_machines_count;
+ extern USHORT supported_machines[8];
+ extern BOOL process_exiting;
++extern BOOL simulate_writecopy;
+ extern HANDLE keyed_event;
+ extern int inproc_device_fd;
+ extern timeout_t server_start_time;
+diff --git a/dlls/ntdll/unix/virtual.c b/dlls/ntdll/unix/virtual.c
+index 781598f..bab03ef 100644
+--- a/dlls/ntdll/unix/virtual.c
++++ b/dlls/ntdll/unix/virtual.c
+@@ -138,6 +138,7 @@ struct file_view
+ #define VPROT_GUARD      0x10
+ #define VPROT_COMMITTED  0x20
+ #define VPROT_WRITEWATCH 0x40
++#define VPROT_COPIED     0x80
+ /* per-mapping protection flags */
+ #define VPROT_ARM64EC          0x0100  /* view may contain ARM64EC code */
+ #define VPROT_SYSTEM           0x0200  /* system view (underlying mmap not under our control) */
+@@ -1874,7 +1875,11 @@ static NTSTATUS create_view( struct file_view **view_ret, void *base, size_t siz
+  */
+ static DWORD get_win32_prot( BYTE vprot, unsigned int map_prot )
+ {
+-    DWORD ret = VIRTUAL_Win32Flags[vprot & 0x0f];
++    DWORD ret;
++
++    if ((vprot & (VPROT_COPIED | VPROT_WRITECOPY)) == (VPROT_COPIED | VPROT_WRITECOPY))
++        vprot = (vprot & ~VPROT_WRITECOPY) | VPROT_WRITE;
++    ret = VIRTUAL_Win32Flags[vprot & 0x0f];
+     if (vprot & VPROT_GUARD) ret |= PAGE_GUARD;
+     if (map_prot & SEC_NOCACHE) ret |= PAGE_NOCACHE;
+     return ret;
+@@ -5539,6 +5544,15 @@ NTSTATUS WINAPI NtProtectVirtualMemory( HANDLE process, PVOID *addr_ptr, SIZE_T
+         {
+             old = get_win32_prot( vprot, view->protect );
+             status = set_protection( view, base, size, new_prot );
++
++            if (simulate_writecopy && status == STATUS_SUCCESS &&
++                (old == PAGE_WRITECOPY || old == PAGE_EXECUTE_WRITECOPY))
++            {
++                TRACE( "Setting VPROT_COPIED.\n" );
++                set_page_vprot_bits( base, size, VPROT_COPIED, 0 );
++                vprot |= VPROT_COPIED;
++                old = get_win32_prot( vprot, view->protect );
++            }
+         }
+         else status = STATUS_NOT_COMMITTED;
+     }

--- a/tools/wine/patches/ubisoft-writecopy/README.md
+++ b/tools/wine/patches/ubisoft-writecopy/README.md
@@ -1,0 +1,56 @@
+# Wine 11.5 Ubisoft write-copy patch
+
+`0001-wine-11.5-ubisoft-writecopy.patch` is the MetalSharp Wine 11.5 adaptation of:
+
+- Valve Wine commit [`334f7a78190a`](https://github.com/ValveSoftware/wine/commit/334f7a78190a0a0a4abede0d598b28a2743f468a), which adds `WINE_SIMULATE_WRITECOPY`.
+- Valve Wine commit [`10a46db3c808`](https://github.com/ValveSoftware/wine/commit/10a46db3c80835d7a6038dbbac5163531dab6158), which automatically enables the behavior for `UplayWebCore.exe`.
+
+Wine 11.5 no longer contains the Proton-side `VPROT_COPIED` support assumed by the historical patches, so the adaptation also restores that bit and its `get_win32_prot()` conversion.
+
+The patch preserves the `MS_ROOT`-scoped `mscompatdb.so` autoload behavior present in MetalSharp's installed ntdll and fixes its direct-Wine fallback to search beside the architecture-specific Unix ntdll. The current `mscompatdb.so` still reports that `KeServiceDescriptorTable` is unavailable; this patch intentionally preserves the installed behavior rather than expanding the Ubisoft runtime change into the separate, deprecated mscompatdb implementation.
+
+## Incremental build
+
+Use a clean, unconfigured Wine 11.5 worktree whose path contains no whitespace:
+
+```bash
+tools/wine/build-ubisoft-ntdll.sh \
+  --source /path/to/wine-11.5-clean \
+  --output /path/to/candidate/ntdll.so
+```
+
+The script invokes only:
+
+```bash
+make dlls/ntdll/ntdll.so
+```
+
+Wine may build generated-header tools such as `widl` as prerequisites, but it does not build or install the complete Wine runtime.
+
+The resulting module is:
+
+- thin x86_64 Mach-O;
+- ad-hoc signed;
+- verified against the installed ntdll's exports, dependency identities, install name, rpath, and deployment target; and
+- checked for the Ubisoft write-copy feature markers.
+
+Run the functional probe against a disposable runtime before installation:
+
+```bash
+tools/wine/test-ubisoft-ntdll.sh /path/to/disposable/runtime/wine
+```
+
+Install and preserve an atomic rollback path with a new backup directory whose parent already exists:
+
+```bash
+tools/wine/swap-metalsharp-ntdll.sh install \
+  --candidate /path/to/candidate/ntdll.so \
+  --backup-dir /path/outside/the/runtime/ntdll-backup
+```
+
+Restore with the command printed by the installer, or:
+
+```bash
+tools/wine/swap-metalsharp-ntdll.sh restore \
+  --backup-dir /path/outside/the/runtime/ntdll-backup
+```

--- a/tools/wine/swap-metalsharp-ntdll.sh
+++ b/tools/wine/swap-metalsharp-ntdll.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VERIFY="$SCRIPT_DIR/verify-ubisoft-ntdll.sh"
+DEFAULT_RUNTIME="$HOME/.metalsharp/runtime/wine"
+ACTION="${1:-}"
+shift || true
+RUNTIME="$DEFAULT_RUNTIME"
+CANDIDATE=""
+BACKUP_DIR=""
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/wine/swap-metalsharp-ntdll.sh install --candidate PATH --backup-dir PATH [--runtime PATH]
+  tools/wine/swap-metalsharp-ntdll.sh restore --backup-dir PATH [--runtime PATH]
+
+Install backs up the current x86_64 Unix ntdll and atomically swaps a verified
+candidate. Restore verifies the saved hash and atomically restores the backup.
+The backup directory must be outside the Wine runtime.
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --runtime) RUNTIME="$2"; shift 2 ;;
+    --candidate) CANDIDATE="$2"; shift 2 ;;
+    --backup-dir) BACKUP_DIR="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+case "$ACTION" in install|restore) ;; *) usage >&2; exit 2 ;; esac
+[ -n "$BACKUP_DIR" ] || { echo "--backup-dir is required" >&2; exit 2; }
+command -v python3 >/dev/null || { echo "required tool missing: python3" >&2; exit 1; }
+TARGET="$RUNTIME/lib/wine/x86_64-unix/ntdll.so"
+[ -s "$TARGET" ] || { echo "installed ntdll missing: $TARGET" >&2; exit 1; }
+
+runtime_real="$(cd "$RUNTIME" && pwd -P)"
+backup_real="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$BACKUP_DIR")"
+case "$backup_real" in
+  "$runtime_real"|"$runtime_real"/*) echo "backup directory must be outside the Wine runtime" >&2; exit 1 ;;
+esac
+if [ "$ACTION" = install ]; then
+  [ -d "$(dirname "$BACKUP_DIR")" ] || { echo "backup parent directory not found: $(dirname "$BACKUP_DIR")" >&2; exit 1; }
+  if [ -e "$BACKUP_DIR" ] || [ -L "$BACKUP_DIR" ]; then
+    echo "install requires a new, non-existing backup directory: $BACKUP_DIR" >&2
+    exit 1
+  fi
+else
+  [ -d "$BACKUP_DIR" ] || { echo "backup directory not found: $BACKUP_DIR" >&2; exit 1; }
+  [ "$(cd "$BACKUP_DIR" && pwd -P)" = "$backup_real" ] || { echo "backup directory does not resolve safely" >&2; exit 1; }
+fi
+
+wineserver_pattern="$(python3 -c 'import re,sys; print(re.escape(sys.argv[1]))' "$runtime_real/bin/wineserver")"
+if pgrep -f "$wineserver_pattern" >/dev/null 2>&1; then
+  echo "MetalSharp wineserver is running; stop its prefixes before swapping ntdll" >&2
+  exit 1
+else
+  pgrep_status=$?
+  [ "$pgrep_status" -eq 1 ] || { echo "could not inspect running wineserver processes" >&2; exit 1; }
+fi
+
+if [ "$ACTION" = install ]; then
+  [ -n "$CANDIDATE" ] || { echo "--candidate is required for install" >&2; exit 2; }
+  candidate_real="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$CANDIDATE")"
+  target_real="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$TARGET")"
+  [ "$candidate_real" != "$target_real" ] || { echo "candidate must not be the installed ntdll" >&2; exit 1; }
+  candidate_hash_before="$(shasum -a 256 "$CANDIDATE" | awk '{print $1}')"
+  "$VERIFY" "$CANDIDATE" "$TARGET"
+  verified_candidate_hash="$(shasum -a 256 "$CANDIDATE" | awk '{print $1}')"
+  [ "$verified_candidate_hash" = "$candidate_hash_before" ] || { echo "candidate changed during verification" >&2; exit 1; }
+  mkdir -m 700 "$BACKUP_DIR"
+  [ "$(cd "$BACKUP_DIR" && pwd -P)" = "$backup_real" ] || { echo "backup path changed while creating it" >&2; exit 1; }
+fi
+
+atomic_replace() {
+  local source="$1" target="$2" expected_hash="$3" temp actual_hash
+  temp="$target.swap.$$"
+  trap 'rm -f "$temp"' EXIT
+  cp -p "$source" "$temp"
+  chmod 755 "$temp"
+  actual_hash="$(shasum -a 256 "$temp" | awk '{print $1}')"
+  [ "$actual_hash" = "$expected_hash" ] || { echo "replacement changed after verification" >&2; exit 1; }
+  codesign --verify --strict "$temp"
+  mv -f "$temp" "$target"
+  trap - EXIT
+}
+
+if [ "$ACTION" = install ]; then
+  cp -p "$TARGET" "$BACKUP_DIR/original-ntdll.so"
+  shasum -a 256 "$BACKUP_DIR/original-ntdll.so" > "$BACKUP_DIR/original-ntdll.so.sha256"
+  printf '%s  %s\n' "$verified_candidate_hash" "$TARGET" > "$BACKUP_DIR/installed-ntdll.so.sha256.pending"
+  mv "$BACKUP_DIR/installed-ntdll.so.sha256.pending" "$BACKUP_DIR/installed-ntdll.so.sha256"
+  atomic_replace "$CANDIDATE" "$TARGET" "$verified_candidate_hash"
+  echo "Installed patched ntdll: $TARGET"
+  echo "Rollback: $0 restore --runtime '$RUNTIME' --backup-dir '$BACKUP_DIR'"
+else
+  BACKUP="$BACKUP_DIR/original-ntdll.so"
+  HASH_FILE="$BACKUP_DIR/original-ntdll.so.sha256"
+  INSTALLED_HASH_FILE="$BACKUP_DIR/installed-ntdll.so.sha256"
+  [ -s "$BACKUP" ] && [ -s "$HASH_FILE" ] && [ -s "$INSTALLED_HASH_FILE" ] || {
+    echo "valid backup and installed-module record not found in $BACKUP_DIR" >&2
+    exit 1
+  }
+  expected_current="$(awk '{print $1}' "$INSTALLED_HASH_FILE")"
+  actual_current="$(shasum -a 256 "$TARGET" | awk '{print $1}')"
+  [ "$actual_current" = "$expected_current" ] || {
+    echo "installed ntdll changed since this backup was created; refusing stale rollback" >&2
+    exit 1
+  }
+  expected="$(awk '{print $1}' "$HASH_FILE")"
+  actual="$(shasum -a 256 "$BACKUP" | awk '{print $1}')"
+  [ "$actual" = "$expected" ] || { echo "backup hash mismatch" >&2; exit 1; }
+  codesign --verify --strict "$BACKUP"
+  atomic_replace "$BACKUP" "$TARGET" "$expected"
+  restored="$(shasum -a 256 "$TARGET" | awk '{print $1}')"
+  [ "$restored" = "$expected" ] || { echo "restored ntdll hash mismatch" >&2; exit 1; }
+  echo "Restored original ntdll: $TARGET ($restored)"
+fi

--- a/tools/wine/test-ubisoft-ntdll.sh
+++ b/tools/wine/test-ubisoft-ntdll.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RUNTIME="${1:-$HOME/.metalsharp/runtime/wine}"
+WRAPPER="$RUNTIME/bin/metalsharp-wine"
+WINESERVER="$RUNTIME/bin/wineserver"
+PROBE_SOURCE="$SCRIPT_DIR/tests/writecopy_probe.c"
+
+[ -x "$WRAPPER" ] || { echo "MetalSharp Wine wrapper missing: $WRAPPER" >&2; exit 1; }
+[ -x "$WINESERVER" ] || { echo "MetalSharp wineserver missing: $WINESERVER" >&2; exit 1; }
+[ -f "$PROBE_SOURCE" ] || { echo "probe source missing: $PROBE_SOURCE" >&2; exit 1; }
+command -v x86_64-w64-mingw32-gcc >/dev/null || { echo "x86_64 MinGW compiler is required" >&2; exit 1; }
+
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/metalsharp-writecopy-test.XXXXXX")"
+prefix="$tmp/prefix"
+cleanup() {
+  WINEPREFIX="$prefix" "$WINESERVER" -k >/dev/null 2>&1 || true
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+x86_64-w64-mingw32-gcc -O2 -s -o "$tmp/writecopy_probe.exe" "$PROBE_SOURCE"
+cp "$tmp/writecopy_probe.exe" "$tmp/UplayWebCore.exe"
+
+run_probe() {
+  local log="$1" expected="$2"
+  shift 2
+  "$@" > "$log" 2>&1
+  grep -q 'initial=0x8' "$log" && grep -q "old=$expected expected=$expected" "$log" || {
+    cat "$log" >&2
+    return 1
+  }
+  tail -1 "$log"
+}
+
+WINEPREFIX="$prefix" WINEDEBUG=-all WINEDEBUGGER=none "$WRAPPER" wineboot -u >/dev/null 2>&1
+run_probe "$tmp/unset.log" 0x8 \
+  env -u WINE_SIMULATE_WRITECOPY WINEPREFIX="$prefix" WINEDEBUG=-all WINEDEBUGGER=none \
+  "$WRAPPER" "$tmp/writecopy_probe.exe" writecopy
+run_probe "$tmp/explicit.log" 0x4 \
+  env WINEPREFIX="$prefix" WINEDEBUG=-all WINEDEBUGGER=none WINE_SIMULATE_WRITECOPY=1 \
+  "$WRAPPER" "$tmp/writecopy_probe.exe" readwrite
+run_probe "$tmp/automatic.log" 0x4 \
+  env -u WINE_SIMULATE_WRITECOPY WINEPREFIX="$prefix" WINEDEBUG=-all WINEDEBUGGER=none \
+  "$WRAPPER" "$tmp/UplayWebCore.exe" readwrite
+
+WINEPREFIX="$prefix" "$WINESERVER" -w
+echo "Ubisoft write-copy functional tests passed"

--- a/tools/wine/tests/writecopy_probe.c
+++ b/tools/wine/tests/writecopy_probe.c
@@ -1,0 +1,49 @@
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <stdio.h>
+#include <string.h>
+
+static int fail(const char *step)
+{
+    fprintf(stderr, "%s failed: error=%lu\n", step, GetLastError());
+    return 1;
+}
+
+int main(int argc, char **argv)
+{
+    char temp_path[MAX_PATH], file_path[MAX_PATH];
+    HANDLE file = INVALID_HANDLE_VALUE, mapping = NULL;
+    void *view = NULL;
+    MEMORY_BASIC_INFORMATION info;
+    DWORD written, old_protect = 0;
+    BYTE data[4096] = {0};
+    DWORD expected = argc > 1 && !strcmp(argv[1], "readwrite") ? PAGE_READWRITE : PAGE_WRITECOPY;
+    int result = 1;
+
+    if (!GetTempPathA(sizeof(temp_path), temp_path)) return fail("GetTempPathA");
+    if (!GetTempFileNameA(temp_path, "wcp", 0, file_path)) return fail("GetTempFileNameA");
+
+    file = CreateFileA(file_path, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                       NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_TEMPORARY | FILE_FLAG_DELETE_ON_CLOSE, NULL);
+    if (file == INVALID_HANDLE_VALUE) goto done;
+    if (!WriteFile(file, data, sizeof(data), &written, NULL) || written != sizeof(data)) goto done;
+
+    mapping = CreateFileMappingA(file, NULL, PAGE_WRITECOPY, 0, sizeof(data), NULL);
+    if (!mapping) goto done;
+    view = MapViewOfFile(mapping, FILE_MAP_COPY, 0, 0, sizeof(data));
+    if (!view) goto done;
+    if (!VirtualQuery(view, &info, sizeof(info))) goto done;
+    if (!VirtualProtect(view, sizeof(data), PAGE_READONLY, &old_protect)) goto done;
+
+    printf("initial=0x%lx old=0x%lx expected=0x%lx\n",
+           (unsigned long)info.Protect, (unsigned long)old_protect, (unsigned long)expected);
+    result = old_protect == expected ? 0 : 2;
+
+done:
+    if (result == 1) fprintf(stderr, "writecopy probe failed: error=%lu\n", GetLastError());
+    if (view) UnmapViewOfFile(view);
+    if (mapping) CloseHandle(mapping);
+    if (file != INVALID_HANDLE_VALUE) CloseHandle(file);
+    DeleteFileA(file_path);
+    return result;
+}

--- a/tools/wine/verify-ubisoft-ntdll.sh
+++ b/tools/wine/verify-ubisoft-ntdll.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  echo "Usage: tools/wine/verify-ubisoft-ntdll.sh CANDIDATE [BASELINE]" >&2
+  exit 2
+fi
+
+CANDIDATE="$1"
+BASELINE="${2:-$HOME/.metalsharp/runtime/wine/lib/wine/x86_64-unix/ntdll.so}"
+
+[ -s "$CANDIDATE" ] || { echo "candidate missing or empty: $CANDIDATE" >&2; exit 1; }
+[ -s "$BASELINE" ] || { echo "baseline missing or empty: $BASELINE" >&2; exit 1; }
+
+for tool in codesign file lipo nm otool shasum strings; do
+  command -v "$tool" >/dev/null || { echo "required tool missing: $tool" >&2; exit 1; }
+done
+
+archs="$(lipo -archs "$CANDIDATE")"
+[ "$archs" = "x86_64" ] || { echo "candidate must be thin x86_64, got: $archs" >&2; exit 1; }
+codesign --verify --strict "$CANDIDATE"
+
+grep -aFq 'wine-11.5' "$BASELINE" || { echo "baseline is not Wine 11.5" >&2; exit 1; }
+for marker in 'wine-11.5' 'WINE_SIMULATE_WRITECOPY' 'UplayWebCore.exe' 'MS_ROOT' 'mscompatdb.so'; do
+  grep -aFq "$marker" "$CANDIDATE" || { echo "candidate marker missing: $marker" >&2; exit 1; }
+done
+
+if nm -u "$CANDIDATE" | grep -q ' _pipe2$'; then
+  echo "candidate unexpectedly imports macOS 27-only pipe2" >&2
+  exit 1
+fi
+
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/metalsharp-ntdll-verify.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT
+nm -gjU "$BASELINE" | sort > "$tmp/baseline.exports"
+nm -gjU "$CANDIDATE" | sort > "$tmp/candidate.exports"
+if ! cmp -s "$tmp/baseline.exports" "$tmp/candidate.exports"; then
+  echo "candidate exported-symbol set differs from installed baseline" >&2
+  diff -u "$tmp/baseline.exports" "$tmp/candidate.exports" >&2 || true
+  exit 1
+fi
+
+otool -L "$BASELINE" | tail -n +2 | awk '{print $1}' > "$tmp/baseline.dependencies"
+otool -L "$CANDIDATE" | tail -n +2 | awk '{print $1}' > "$tmp/candidate.dependencies"
+if ! cmp -s "$tmp/baseline.dependencies" "$tmp/candidate.dependencies"; then
+  echo "candidate dependency identities differ from installed baseline" >&2
+  diff -u "$tmp/baseline.dependencies" "$tmp/candidate.dependencies" >&2 || true
+  exit 1
+fi
+
+candidate_id="$(otool -D "$CANDIDATE" | tail -1)"
+baseline_id="$(otool -D "$BASELINE" | tail -1)"
+[ "$candidate_id" = "$baseline_id" ] || {
+  echo "candidate install name differs: $candidate_id != $baseline_id" >&2
+  exit 1
+}
+
+candidate_rpaths="$(otool -l "$CANDIDATE" | awk '/cmd LC_RPATH/{getline; getline; print $2}')"
+baseline_rpaths="$(otool -l "$BASELINE" | awk '/cmd LC_RPATH/{getline; getline; print $2}')"
+[ "$candidate_rpaths" = "$baseline_rpaths" ] || {
+  echo "candidate rpaths differ from baseline" >&2
+  exit 1
+}
+
+candidate_minos="$(otool -l "$CANDIDATE" | awk '/cmd LC_BUILD_VERSION/{found=1} found && $1=="minos"{print $2; exit}')"
+baseline_minos="$(otool -l "$BASELINE" | awk '/cmd LC_BUILD_VERSION/{found=1} found && $1=="minos"{print $2; exit}')"
+[ "$candidate_minos" = "$baseline_minos" ] || {
+  echo "candidate deployment target differs: $candidate_minos != $baseline_minos" >&2
+  exit 1
+}
+
+printf 'candidate\t%s\n' "$(shasum -a 256 "$CANDIDATE" | awk '{print $1}')"
+printf 'baseline\t%s\n' "$(shasum -a 256 "$BASELINE" | awk '{print $1}')"
+printf 'architecture\t%s\n' "$archs"
+printf 'exports\t%s\n' "$(wc -l < "$tmp/candidate.exports" | tr -d ' ')"
+printf 'minos\t%s\n' "$candidate_minos"
+printf 'install_name\t%s\n' "$candidate_id"
+echo "Ubisoft ntdll verification passed"


### PR DESCRIPTION
## Summary

This draft tracks a dedicated Ubisoft Connect integration for Sharp Library, modeled after the existing GOG experience.

The completed implementation will provide:

- an isolated Ubisoft prefix;
- official Ubisoft Connect installation and Start/Stop controls;
- local synchronization of downloaded Ubisoft games;
- `uplay://launch/<id>/0` game launching;
- prefix-scoped launcher and game lifecycle management;
- suppression of recurring `winedbg` crash windows; and
- launcher filtering so Ubisoft Connect never appears as a game card.

The design is based on open-source patterns from Heroic, Bottles, Lutris, gcenx/Wineskin, and Valve Wine. It does not depend on CrossOver fixes or unofficial Ubisoft credential handling.

The full implementation plan is documented in [`docs/plans/ubisoft-connect-sharp-library.md`](https://github.com/aaf2tbz/metalsharp/blob/feature/ubisoft-connect/docs/plans/ubisoft-connect-sharp-library.md).

## Runtime strategy

This work will **not rebuild the entire Wine runtime**.

MetalSharp uses Wine 11.5 from `~/.metalsharp/runtime/wine`, with its active Unix ntdll at:

```text
~/.metalsharp/runtime/wine/lib/wine/x86_64-unix/ntdll.so
```

Valve's `WINE_SIMULATE_WRITECOPY` and `UplayWebCore.exe` fixes will be adapted to Wine 11.5 in a separate x86_64 configuration. Only Unix ntdll will be compiled:

```bash
make dlls/ntdll/ntdll.so
```

Only this runtime file will be replaced and packaged:

```text
runtime/wine/lib/wine/x86_64-unix/ntdll.so
```

The PE ntdll modules, Wine loader, Wine server, graphics stack, and all unrelated runtime files will remain unchanged.

## Phased plan

- [x] **Phase 0 — Preserve the installed runtime**
  - Record ntdll hashes, architecture, symbols, load commands, deployment target, and version.
  - Create a disposable runtime and atomic rollback path.

- [x] **Phase 1 — Incrementally rebuild x86_64 Unix ntdll only**
  - Adapt Valve commits [`334f7a7`](https://github.com/ValveSoftware/wine/commit/334f7a78190a0a0a4abede0d598b28a2743f468a) and [`10a46db`](https://github.com/ValveSoftware/wine/commit/10a46db3c80835d7a6038dbbac5163531dab6158).
  - Built only `dlls/ntdll/ntdll.so`; verified ABI compatibility, startup, explicit write-copy simulation, and automatic `UplayWebCore.exe` handling.
  - Evidence: [`docs/plans/ubisoft-connect-phase-0-1-evidence.md`](https://github.com/aaf2tbz/metalsharp/blob/feature/ubisoft-connect/docs/plans/ubisoft-connect-phase-0-1-evidence.md).

- [ ] **Phase 2 — Prove Ubisoft Connect manually**
  - Initialize an isolated prefix, suppress WineDbg, install the official launcher, and verify WebCore/login behavior.
  - Confirm prefix-scoped shutdown and absence of recurring crash dialogs.

- [ ] **Phase 3 — Add the dedicated Ubisoft backend**
  - Add prefix status, initialization/removal, installer, Start, and Stop endpoints.
  - Enforce runtime capability checks and Ubisoft-specific launch environment.

- [ ] **Phase 4 — Synchronize locally installed games**
  - Parse Ubisoft's `cache/configuration/configurations`, registry install records, and `uplay_install.state`.
  - Persist a transactional local library while preserving the last valid cache on parse failure.

- [ ] **Phase 5 — Add game launch and lifecycle handling**
  - Launch through `UbisoftConnect.exe uplay://launch/<launch-id>/0`.
  - Track exact launch IDs and avoid treating the persistent launcher as the game process.

- [ ] **Phase 6 — Guarantee launcher hiding**
  - Exclude exact Ubisoft launcher executables from Sharp Library discovery.
  - Keep the dedicated Ubisoft prefix outside ordinary installer-bottle scanning.

- [ ] **Phase 7 — Add the Ubisoft Sharp Library tab**
  - Add explicit `installers`, `gog`, and `ubisoft` source modes.
  - Add Initialize, Install, Start, Stop, and Sync controls plus installed-game cards.

- [ ] **Phase 8 — Automated and manual validation**
  - Cover configuration parsing, registry parsing, cache preservation, environment generation, process matching, and launcher filtering.
  - Regress Steam, GOG, installer, rollback, login, synchronization, and launch flows.

- [ ] **Phase 9 — Package the one-file runtime update**
  - Store patch provenance and reproducible incremental build tooling.
  - Replace only x86_64 Unix ntdll in a candidate runtime bundle and verify all unrelated runtime hashes remain unchanged.

## Initial scope

Included:

- official launcher installation;
- local installed-game discovery;
- dedicated prefix lifecycle;
- Ubisoft game launch and status;
- launcher hiding; and
- Wine runtime compatibility required by WebCore.

Deferred:

- full owned-but-uninstalled Ubisoft library synchronization;
- unofficial Ubisoft APIs or credential handling;
- anti-cheat compatibility guarantees; and
- any global Wine process termination.

## Current draft state

Phases 0–1 are complete. The original runtime is preserved externally, the reproducible Wine 11.5 patch/build/verification/swap tooling is committed, and the installed runtime passed the write-copy probes with a manifest proving that only x86_64 Unix `ntdll.so` changed. Phase 2 (manual Ubisoft Connect proof) remains next.

