### PR TITLE
Clean migration state before relaunch

### DIFF
--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -220,6 +220,7 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
         (Method::Get, "/update/migrate/progress") => resp(200, migrate::read_migrate_progress()),
         // Phase 2: report what the last migration preserved, skipped, and why.
         (Method::Get, "/update/migrate/report") => resp(200, migrate::latest_migration_report()),
+        (Method::Post, "/update/migrate/cleanup-preserved") => resp(200, migrate::cleanup_preserved_temp_dirs()),
         (Method::Get, "/setup/state") => resp(200, setup::state()),
         (Method::Post, "/setup/save") => {
             let body = read_body(req);
@@ -2285,17 +2286,27 @@ fn force_kill_metalsharp_processes() -> Value {
         }
     }
 
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    let survivors: Vec<serde_json::Value> = process_lines()
+        .into_iter()
+        .filter_map(|line| parse_process_line_owned(&line))
+        .filter(|(pid, command)| *pid != this_pid && is_force_kill_target(command, &home))
+        .map(|(pid, command)| json!({"pid": pid, "command": command}))
+        .collect();
+
     app_log(&format!(
-        "Force killed MetalSharp processes: {} TERM, {} KILL, {} errors",
+        "Force killed MetalSharp processes: {} TERM, {} KILL, {} survivors, {} errors",
         terminated.len(),
         killed.len(),
+        survivors.len(),
         errors.len()
     ));
 
     json!({
-        "ok": errors.is_empty(),
+        "ok": survivors.is_empty(),
         "terminated": terminated,
         "killed": killed,
+        "survivors": survivors,
         "errors": errors,
         "backendPid": this_pid,
     })
@@ -2884,6 +2895,20 @@ fn persist_crash_log(source: &str, path: &std::path::Path, timestamp: &str, size
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn force_kill_targets_metalsharp_wine_helpers_but_not_app_processes() {
+        let home = std::path::Path::new("/Users/test/.metalsharp");
+
+        assert!(is_force_kill_target("/Users/test/.metalsharp/runtime/wine/bin/wineserver", home));
+        assert!(is_force_kill_target(
+            "/Users/test/.metalsharp/runtime/wine/bin/wine64 C:\\windows\\system32\\wineboot.exe",
+            home
+        ));
+        assert!(is_force_kill_target("/Users/test/.metalsharp/runtime/wine/bin/wine Steam.exe", home));
+        assert!(!is_force_kill_target("/Applications/MetalSharp.app/Contents/MacOS/MetalSharp", home));
+        assert!(!is_force_kill_target("/Applications/Steam.app/Contents/MacOS/steam_osx", home));
+    }
 
     #[test]
     fn crash_preview_allowlist_rejects_unenumerated_metalsharp_files() {

--- a/app/src-rust/src/migrate.rs
+++ b/app/src-rust/src/migrate.rs
@@ -56,8 +56,59 @@ const MIGRATION_STEAM_METADATA_EXTENSIONS: &[&str] =
 const MIGRATION_STEAM_METADATA_DENY_NAMES: &[&str] =
     &["cache", "common", "compatdata", "crashes", "depotcache", "downloading", "logs", "shadercache", "Temp", "tmp"];
 const MIGRATION_TOTAL_STEPS: usize = 8;
+const MIGRATION_PRESERVE_TEMP_PREFIX: &str = "metalsharp-migration-preserve-";
 
 static MIGRATING: AtomicBool = AtomicBool::new(false);
+
+pub fn cleanup_preserved_temp_dirs() -> serde_json::Value {
+    let temp_root = std::env::temp_dir();
+    let (removed, errors) = cleanup_preserved_temp_dirs_in(&temp_root);
+    log_to_file(&format!(
+        "Migration handoff: removed {} preserved temp director{} with {} error(s)",
+        removed,
+        if removed == 1 { "y" } else { "ies" },
+        errors.len()
+    ));
+    json!({
+        "ok": errors.is_empty(),
+        "removed": removed,
+        "errors": errors,
+    })
+}
+
+fn cleanup_preserved_temp_dirs_in(temp_root: &Path) -> (usize, Vec<String>) {
+    let entries = match fs::read_dir(temp_root) {
+        Ok(entries) => entries,
+        Err(error) => {
+            return (0, vec![format!("read {}: {}", temp_root.display(), error)]);
+        },
+    };
+
+    let mut removed = 0usize;
+    let mut errors = Vec::new();
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        if !name.starts_with(MIGRATION_PRESERVE_TEMP_PREFIX) {
+            continue;
+        }
+
+        let path = entry.path();
+        let is_real_directory = entry.file_type().map(|kind| kind.is_dir() && !kind.is_symlink()).unwrap_or(false);
+        if !is_real_directory {
+            continue;
+        }
+
+        match fs::remove_dir_all(&path) {
+            Ok(()) => removed += 1,
+            Err(error) => errors.push(format!("remove {}: {}", path.display(), error)),
+        }
+    }
+
+    (removed, errors)
+}
 
 /// Phase 2: an observational record of what a migration preserved, what it
 /// skipped, and why. This does not change what is preserved or restored — it
@@ -756,7 +807,8 @@ struct PreservedData {
 fn preserve_user_data(ms_dir: &PathBuf) -> (PreservedData, MigrationReport) {
     let mut report = MigrationReport::new();
     let tmp = std::env::temp_dir().join(format!(
-        "metalsharp-migration-preserve-{}-{}-{:x}",
+        "{}{}-{}-{:x}",
+        MIGRATION_PRESERVE_TEMP_PREFIX,
         std::process::id(),
         temp_suffix(),
         std::hash::Hasher::finish(&std::collections::hash_map::DefaultHasher::new())
@@ -2351,6 +2403,35 @@ fn unix_days_to_ymd(days_since_epoch: u64) -> (i64, u32, u32) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cleanup_preserved_temp_dirs_removes_only_real_matching_directories() {
+        let temp_root = test_dir("cleanup-preserved-temp");
+        let stale_one = temp_root.join("metalsharp-migration-preserve-100-first");
+        let stale_two = temp_root.join("metalsharp-migration-preserve-200-second");
+        let unrelated = temp_root.join("metalsharp-other-cache");
+        let symlink_target = temp_root.join("symlink-target");
+        let matching_symlink = temp_root.join("metalsharp-migration-preserve-symlink");
+
+        for dir in [&stale_one, &stale_two, &unrelated, &symlink_target] {
+            fs::create_dir_all(dir).expect("create cleanup fixture");
+        }
+        fs::write(stale_one.join("prefix.reg"), b"preserved").expect("write stale fixture");
+        std::os::unix::fs::symlink(&symlink_target, &matching_symlink).expect("create matching symlink");
+
+        let (removed, errors) = cleanup_preserved_temp_dirs_in(&temp_root);
+
+        assert_eq!(removed, 2);
+        assert!(errors.is_empty());
+        assert!(!stale_one.exists());
+        assert!(!stale_two.exists());
+        assert!(unrelated.exists());
+        assert!(matching_symlink.symlink_metadata().is_ok());
+        assert!(symlink_target.exists());
+
+        let _ = fs::remove_file(matching_symlink);
+        let _ = fs::remove_dir_all(temp_root);
+    }
 
     #[test]
     fn migration_report_records_preserved_and_skipped_categories() {

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -819,6 +819,44 @@ function registerIpc() {
       return { ok: false, error: "Installed MetalSharp.app was not found in /Applications." };
     }
 
+    // A prefix update can leave Wine helpers alive after migration. Force-stop
+    // every MetalSharp Wine/runtime process and verify none survived before
+    // deleting the preservation cache or opening the updated app.
+    const processCleanup = (await requestMigrationBackend("POST", "/processes/force-kill", undefined, 15000)) as {
+      ok?: boolean;
+      survivors?: unknown[];
+      errors?: unknown[];
+      error?: string;
+    };
+    if (!processCleanup?.ok || (processCleanup.survivors?.length ?? 0) > 0) {
+      const survivorCount = processCleanup?.survivors?.length ?? 0;
+      return {
+        ok: false,
+        error:
+          processCleanup?.error ??
+          `Could not stop all Wine processes (${survivorCount} still running). Try Launch MetalSharp again.`,
+      };
+    }
+
+    // The restore is complete, so all exact-name migration preservation roots
+    // in the system temp directory are now stale and safe to remove.
+    const preserveCleanup = (await requestMigrationBackend(
+      "POST",
+      "/update/migrate/cleanup-preserved",
+      undefined,
+      30000,
+    )) as {
+      ok?: boolean;
+      removed?: number;
+      errors?: unknown[];
+      error?: string;
+    };
+    if (!preserveCleanup?.ok) {
+      console.warn(
+        `Migration handoff: preserved temp cleanup was incomplete: ${preserveCleanup?.error ?? JSON.stringify(preserveCleanup?.errors ?? [])}`,
+      );
+    }
+
     // Remove cached updater DMGs before tearing down the backend; this keeps the
     // user's disk from retaining the old installer image after a successful update.
     try {
@@ -849,7 +887,12 @@ function registerIpc() {
     spawnFreshInstalledAppAfterExit(appPath);
 
     setTimeout(() => app.exit(0), 50);
-    return { ok: true, deletedDmg, launched: appPath };
+    return {
+      ok: true,
+      deletedDmg,
+      removedMigrationTempDirs: preserveCleanup?.removed ?? 0,
+      launched: appPath,
+    };
   });
 
   ipcMain.handle("app:eject-dmg", async () => {

--- a/app/src/renderer/api-types.ts
+++ b/app/src/renderer/api-types.ts
@@ -200,7 +200,13 @@ type MetalsharpAPI = {
   ) => Promise<BackendResponse>;
   isFirstLaunch: () => Promise<boolean>;
   isMigrationMode: () => Promise<boolean>;
-  restartAfterMigration: () => Promise<{ ok: boolean; error?: string; deletedDmg?: string | null; launched?: string }>;
+  restartAfterMigration: () => Promise<{
+    ok: boolean;
+    error?: string;
+    deletedDmg?: string | null;
+    removedMigrationTempDirs?: number;
+    launched?: string;
+  }>;
   ejectDmg: () => Promise<void>;
   installDeps: (command: string) => Promise<{ ok: boolean; error?: string }>;
   installHomebrew: () => Promise<{ ok: boolean; installed?: boolean; path?: string; message?: string; error?: string }>;


### PR DESCRIPTION
## Summary

Make the post-migration **Launch MetalSharp** action complete the handoff in one guarded workflow: terminate leftover Wine/runtime processes, remove restored migration preservation caches, then continue the existing updater, backend, duplicate-app, and relaunch cleanup.

This fixes two leftovers from migration: `wineboot -u` helpers that could survive into the updated app session, and `metalsharp-migration-preserve-*` temp directories that remained after their contents had already been restored.

## Changes

- Call the existing MetalSharp runtime force-kill endpoint before the updated app is launched.
- Re-scan after TERM/KILL and keep the migration screen open if any matching Wine/runtime process survives.
- Add a migration cleanup endpoint that removes stale `metalsharp-migration-preserve-*` directories from the system temp directory.
- Restrict temp cleanup to real immediate-child directories; unrelated entries and matching symlinks are preserved.
- Log incomplete temp cleanup without trapping the user after Wine has been stopped.
- Return survivor and removed-temp-directory details through the migration handoff API.
- Add regression coverage for process targeting and safe temp-directory cleanup.

## PR Readiness (MANDATORY)

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed — not applicable; no config or DLL-map changes
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped — not applicable; version unchanged
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes — not applicable; no compatibility claims or user-facing copy changed
- [x] Regression test added for each bug fix

## Local toolchain (run before push)

- [x] `cargo fmt --all -- --check` passes (Rust)
- [x] `cargo clippy --all-targets -- -D warnings` passes (Rust)
- [x] `cargo build --release` passes (Rust backend)
- [x] `cargo test` passes (Rust — 643 tests)
- [x] C++ compiles if changed: not applicable; no C/C++ changes
- [x] `clang-format --dry-run --Werror` passes on any changed C/C++/Obj-C file: not applicable; no C/C++/Obj-C changes
- [x] `ctest --test-dir build-native` passes if tests changed: not applicable; no native tests changed
- [x] TypeScript compiles if changed: `cd app && npx tsc --noEmit`
- [x] Biome + Prettier pass if TS/JS changed: `cd app && npx @biomejs/biome ci src/ && npx prettier --check 'src/**/*.{ts,js,html,css,json}'`
- [x] Shell scripts lint if changed: not applicable; no shell changes
- [x] `tools/ci/validate-rules-toml.py` passes if `configs/mtsp-rules.toml` changed: not applicable; rules unchanged
- [x] `python3 tools/ci/verify-dmg-workflow.py` passes if release/bundle tooling changed: not applicable; release tooling unchanged
- [ ] Tested with at least one game (which one? which launch method? which drive?)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files should be added to the repo root; place them under `app/`, `tools/`, `tests/`, etc.

## Test notes

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --release`
- `cargo test` — 643 passed
- `npm run build`
- `npx tsc --noEmit`
- `npx @biomejs/biome ci src/`
- `npx prettier --check 'src/**/*.{ts,js,html,css,json}'`
- `git diff --check`
- Focused temp cleanup regression verifies two matching directories are removed while an unrelated directory, matching symlink, and symlink target remain intact.
- Focused process-targeting regression covers `wineserver`, `wine64`/`wineboot`, Wine Steam, and exclusions for MetalSharp and native macOS Steam processes.
- Biome reports four existing `noDescendingSpecificity` warnings in `src/renderer/styles/base.css` and exits successfully; this PR does not modify that file.
- Real-game post-update migration validation was not performed locally; `checklist-exception` documents that intentional gap while the PR remains draft.

## Risk

Moderate and limited to the post-migration relaunch boundary. The process sweep intentionally stops active MetalSharp Wine/runtime processes before relaunch. Temp deletion is constrained to real immediate-child directories under the system temp directory whose names begin with `metalsharp-migration-preserve-`; symlinks and unrelated entries are excluded. Cleanup failures are logged and do not strand the user.

Rollback is a revert of commit `07b7b444`. No persistent schema, bottle manifest, compatibility rule, version, or game payload is changed.