### PR TITLE
Update GAMES-SUPPORTED.md with new game entries

### DIFF
--- a/docs/compatibility/GAMES-SUPPORTED.md
+++ b/docs/compatibility/GAMES-SUPPORTED.md
@@ -26,7 +26,7 @@ Internal routes (`dxmt` auto-detect, Wine Steam, macOS Steam, `wine_bare`) remai
 
 ## D3DMetal
 
-Games running through Homebrew GPTK and Apple's D3DMetal pipeline. D3DMetal bottles use the explicit Save → Repair Redist → Seed Prefix → Play D3DMetal flow, with route DLLs copied from `/Applications/Game Porting Toolkit.app` into the shared GPTK prefix.
+Games running through Homebrew GPTK and Apple's D3DMetal pipeline. D3DMetal bottles use the explicit Save → Repair Redist → Seed Prefix → Play D3DMetal flow, with route DLLs copied from `/Applications/Game Porting Toolkit.app` into the shared GPTK prefix. Mainly for Dx12 Gaming. 
 
 | Game | AppID | Notes |
 |---|---:|---|
@@ -35,18 +35,15 @@ Games running through Homebrew GPTK and Apple's D3DMetal pipeline. D3DMetal bott
 | High On Life | 1583230 | Also works on M12. |
 | Cyberpunk 2077 | 1091500 | Offline play. |
 | Ghostrunner | 1139900 | D3DMetal route confirmed. |
+| Control - Ultimate Edition | 870780 | |
+| Star Wars Jedi: Falln Order | 1172380 | |
+| Shadow Of The Tomb Raider | 750920 | |
 
 ---
 
 ## M12 — D3D12 to Metal
 
-| Game | AppID | Notes |
-|---|---:|---|
-| PEAK | 3527290 | Medium settings. |
-| Hollow Knight: Silksong | 1030300 | |
-| Schedule I | 3164500 | |
-| Yu-Gi-Oh! Master Duel | 1449850 | |
-| Dark Deception | 332950 | Runtime bootstrap required on first launch. |
+- In Development: Not yet running games, only launching them. 
 
 ---
 
@@ -75,6 +72,22 @@ Games running through Homebrew GPTK and Apple's D3DMetal pipeline. D3DMetal bott
 | Graveyard Keeper | 599140 | |
 | Brawlhalla | 291550 | |
 | Black Myth: Wukong | 2358720 | Compatibility Mode. |
+| Beam.ng Drive | 1067430 | |
+| Ball X Pit | 2062430 | |
+| Schedule I |	3164500 | |
+| Nine Sols | 1809540 | |
+| Skekiro Shadows Die Twice | 814380 | |
+| Sons Of The Forest | 1326470 | |
+| Thronefall | 2239150 | |
+| 9 Kings | 2784470 | |
+| Amid Evil | 673130 | |
+| Borderlands 3 | 397540 | |
+| Crab Champions | 774801 | |
+| Plate Up! | 1599600 | |
+| Rv There Yet? | 3949040 | | 
+| UltraKill | 1229490 | |
+| Velheim | 892970 | |
+| Untitled Goose Game | 837470 | |
 
 ---
 
@@ -84,12 +97,15 @@ Games running through Homebrew GPTK and Apple's D3DMetal pipeline. D3DMetal bott
 |---|---:|---|
 | Inscryption | 1092790 | Binary: `Inscryption.exe`. |
 | Hades | 1145360 | Binary: `x86/Hades.exe`. |
+| Balatro| 2379780 | |
 
 ---
 
 ## M10 — D3D10 to Metal
 
-*No games currently confirmed working through M10. Available for D3D10-specific titles.*
+| Game | AppID | Notes |
+|---|---:|---|
+| Mind Scanners | 1389550 | |
 
 ---
 
@@ -102,8 +118,7 @@ Games running through Homebrew GPTK and Apple's D3DMetal pipeline. D3DMetal bott
 | Portal 2 | 620 | Steam Emu supported. |
 | Among Us | 945360 | Steam online play. |
 | Team Fortress 2 | 440 | Steam online play. VAC works. |
-| Nidhogg 2 | 535520 | |
-| Fallout: New Vegas | 22380 | Direct Steam Launch. |
+| Undertale | 391540 | |
 
 ---
 
@@ -111,9 +126,7 @@ Games running through Homebrew GPTK and Apple's D3DMetal pipeline. D3DMetal bott
 
 | Game | AppID | Notes |
 |---|---:|---|
-| Celeste | 504230 | FNA/XNA assets, FMOD shims, Steamworks shim. x86_64 Mono. Install wizard fallback paths for `steam_api` detection. |
-| Terraria | 105600 | TerrariaLauncher/patcher support, x86_64 Mono, XNA/FNA assemblies. |
-| DREDGE | 1562430 | Auto-detected as FNA flavor. Generic FNA config. |
+| Celeste | 504230 | FNA/XNA assets, FMOD shims, Steamworks shim. x86_64 Mono |
 
 ---
 


### PR DESCRIPTION
Added new games to the D3DMetal and other compatibility sections, including Control, Star Wars Jedi: Fallen Order, and more. Updated notes for existing games and clarified M10 and M9 sections.

## Summary

<!-- Brief description of what this PR does and why -->

## Changes

<!-- List the key changes -->

-

## PR Readiness (MANDATORY)

<!-- Process/review gates enforced by CI
     (.github/workflows/pr-readiness-check.yml). Checked items must use [x].
     To bypass intentionally, apply the `checklist-exception` label. -->

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
- [ ] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [ ] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [ ] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped
- [ ] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [ ] Docs / compatibility matrix updated for user-facing changes
- [ ] Regression test added for each bug fix

## Local toolchain (run before push)

> **Install the pre-commit hook once per clone** (it catches the same things
> as this checklist, and the same things as CI, locally in ~3s):
>
> ```bash
> ln -s ../../.github/hooks/pre-commit .git/hooks/pre-commit
> chmod +x .git/hooks/pre-commit
> ```
>
> The hook **fails the commit** if any required toolchain is missing — it will
> not silently skip `cargo fmt`, `clippy`, `tsc`, `prettier`, `biome`, etc.
> See [`.github/hooks/README.md`](../.github/hooks/README.md) for details.

> Run locally before pushing. All of these also run automatically in CI.

- [ ] `cargo fmt --all -- --check` passes (Rust)
- [ ] `cargo clippy --all-targets -- -D warnings` passes (Rust)
- [ ] `cargo build --release` passes (Rust backend)
- [ ] `cargo test` passes (Rust — 628+ tests)
- [ ] C++ compiles if changed: `cmake -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON && cmake --build build-native --parallel $(sysctl -n hw.ncpu)`
- [ ] `clang-format --dry-run --Werror` passes on any changed C/C++/Obj-C file
- [ ] `ctest --test-dir build-native` passes if tests changed
- [ ] TypeScript compiles if changed: `cd app && npx tsc --noEmit`
- [ ] Biome + Prettier pass if TS/JS changed: `cd app && npx @biomejs/biome ci src/ && npx prettier --check 'src/**/*.{ts,js,html,css,json}'`
- [ ] Shell scripts lint if changed: `tools/ci/shellcheck.sh`
- [ ] `tools/ci/validate-rules-toml.py` passes if `configs/mtsp-rules.toml` changed
- [ ] `python3 tools/ci/verify-dmg-workflow.py` passes if release/bundle tooling changed
- [ ] Tested with at least one game (which one? which launch method? which drive?)
- [ ] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [ ] No new files should be added to the repo root; place them under `app/`, `tools/`, `tests/`, etc.

## Test notes

<!-- What did you test? Which game, which launch method, which drive? -->

## Risk

<!-- If this PR ships broken defaults or changes launch behavior, what's the rollback plan? -->
