### PR TITLE
docs: add Homebrew installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,13 @@ Download the latest DMG from [Releases](https://github.com/aaf2tbz/metalsharp/re
 
 If Gatekeeper cannot verify the app, open **System Settings → Privacy & Security** and choose **Open Anyway** for MetalSharp. VirusTotal scans are included with release notes when available.
 
-For building from source, see [Install from Source](docs/guides/install-from-source.md).
+### Install With Homebrew:
+
+```sh
+brew install --cask aaf2tbz/tap/metalsharp
+```
+
+This installs the signed MetalSharp release into `/Applications`. For developer builds, see [Build from Source](docs/guides/install-from-source.md).
 
 ## Routes
 
@@ -68,7 +74,7 @@ Current maintainer validation is happening on this hardware/software setup. This
 
 ## Documentation
 
-- [Install from Source](docs/guides/install-from-source.md)
+- [Build from Source](docs/guides/install-from-source.md)
 - [How to Use MetalSharp](docs/guides/how-to-use-metalsharp.md)
 - [GPTK (D3DMetal) Guide](docs/guides/gptk-guide.md)
 - [Game Compatibility](docs/compatibility/GAMES-SUPPORTED.md)


### PR DESCRIPTION
## Summary

Add a first-party Homebrew cask installation path to MetalSharp's README. The cask is maintained in the new [aaf2tbz/homebrew-tap](https://github.com/aaf2tbz/homebrew-tap) and installs the signed arm64 DMG release into `/Applications`.

## Changes

- Add the `brew install --cask aaf2tbz/tap/metalsharp` installation command.
- Keep source builds available as a clearly labelled developer path.
- Replace the user-facing “Install from Source” documentation label with “Build from Source.”

## PR Readiness (MANDATORY)

- [ ] Compatibility verified with at least one real game (game + launch method noted below) — documentation-only change; no runtime paths changed.
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [ ] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed — not applicable; neither changed.
- [ ] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped — not applicable; no version bump.
- [ ] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed) — not applicable; no runtime behavior changed.
- [x] Docs / compatibility matrix updated for user-facing changes
- [ ] Regression test added for each bug fix — not applicable; this is not a bug fix.

## Local toolchain (run before push)

- [x] `git diff --check` passes
- [x] Homebrew cask style passes: `brew style --cask aaf2tbz/tap/metalsharp`
- [x] Homebrew cask audit passes: `brew audit --cask --strict aaf2tbz/tap/metalsharp`
- [x] Homebrew install resolution passes: `brew install --cask --dry-run aaf2tbz/tap/metalsharp`
- [ ] Rust/C++/TypeScript/Shell project gates — not run; this PR changes only `README.md`.

## Test notes

Validated the companion cask against the published `v0.56.8` DMG digest. Homebrew resolves the cask as arm64/macOS and identifies `MetalSharp.app` as its artifact. No game launch was performed because this PR contains documentation only.

## Risk

Low. This changes only installation documentation. Roll back by reverting the README commit; the existing DMG release path remains unchanged.
