### PR TITLE
docs: add security and community guidelines

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,125 @@
+# Contributor Covenant Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socioeconomic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- demonstrating empathy and kindness toward other people;
+- being respectful of differing opinions, viewpoints, and experiences;
+- giving and gracefully accepting constructive feedback;
+- accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience; and
+- focusing on what is best not just for us as individuals, but for the overall
+  community.
+
+Examples of unacceptable behavior include:
+
+- the use of sexualized language or imagery, and sexual attention or advances
+  of any kind;
+- trolling, insulting or derogatory comments, and personal or political attacks;
+- public or private harassment;
+- publishing others' private information, such as a physical or email address,
+  without their explicit permission; and
+- other conduct which could reasonably be considered inappropriate in a
+  professional setting.
+
+## Enforcement responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to behavior they deem inappropriate, threatening, offensive, or
+harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned with this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing the community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported privately to the project maintainer at alex@metalsharp.dev. Reports
+will be reviewed promptly and fairly. All community leaders must respect the
+privacy and security of the reporter of an incident.
+
+## Enforcement guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community impact:** Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence:** A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community impact:** A violation through a single incident or series of
+actions.
+
+**Consequence:** A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary ban
+
+**Community impact:** A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence:** A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent ban
+
+**Community impact:** Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence:** A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla-coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org
+[mozilla-coc]: https://github.com/mozilla/diversity

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,112 @@
+# Contributing to MetalSharp
+
+Thanks for helping improve MetalSharp. Contributions can include bug reports,
+compatibility findings, documentation, tests, and code.
+
+By participating, you agree to follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+Report suspected vulnerabilities privately as described in the
+[Security Policy](SECURITY.md).
+
+## Before you start
+
+- Search existing [issues](https://github.com/metalsharp/MetalSharp/issues) and
+  pull requests before opening a duplicate.
+- Use [Discussions](https://github.com/metalsharp/MetalSharp/discussions) for
+  questions, usage help, and early design conversations.
+- Open an issue before a large or architectural change so maintainers can align
+  on scope and approach.
+- Keep pull requests focused. Unrelated fixes should use separate branches and
+  pull requests.
+
+## Development setup
+
+MetalSharp development requires an Apple Silicon Mac running macOS 14 or later.
+Clone the repository with its submodules:
+
+```sh
+git clone --recurse-submodules https://github.com/metalsharp/MetalSharp.git
+cd MetalSharp
+```
+
+Install the prerequisites and follow the complete build instructions in
+[Build from Source](../docs/guides/install-from-source.md).
+
+Create a topic branch from the latest `main`:
+
+```sh
+git switch main
+git pull --ff-only
+git switch -c type/short-description
+```
+
+Use a descriptive prefix such as `fix/`, `feat/`, `docs/`, or `test/`. Write
+small, focused commits with imperative messages that explain the change.
+
+## Making changes
+
+- Match the style and structure of nearby code.
+- Do not commit secrets, credentials, generated build output, machine-specific
+  paths, or absolute `/Users/...` paths.
+- Add or update tests for behavior changes and bug fixes.
+- Update relevant documentation and the compatibility matrix for user-visible
+  changes.
+- Keep new files in the appropriate existing directory. Root-level additions
+  require maintainer agreement.
+- Preserve third-party license notices and add required attribution when
+  introducing a dependency or vendored component.
+
+## Validation
+
+Run the checks relevant to the files you changed. The pull request template
+contains the authoritative checklist. Common checks include:
+
+```sh
+# Native code
+cmake -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON
+cmake --build build-native --parallel "$(sysctl -n hw.ncpu)"
+ctest --test-dir build-native
+
+# Rust backend
+cd app/src-rust
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+cd ../..
+
+# TypeScript and renderer formatting
+cd app
+npx tsc --noEmit
+npx @biomejs/biome ci src/
+npx prettier --check 'src/**/*.{ts,js,html,css,json}'
+cd ..
+```
+
+Documentation-only changes should at minimum pass `git diff --check` and have
+their links reviewed. If a check is not applicable, leave it unchecked and
+explain why in the pull request rather than claiming it ran.
+
+## Pull requests
+
+Complete the repository's pull request template, including:
+
+- a concise summary and list of changes;
+- the mandatory PR readiness section;
+- the local checks actually run and any intentionally skipped checks;
+- test notes, including the game and launch route when runtime behavior changes;
+  and
+- risk and rollback details.
+
+The `checklist-exception` label is reserved for readiness items that are
+intentionally not applicable. Explain the exception in the pull request body;
+a maintainer will decide whether to apply or retain the label.
+
+Pull requests must pass CI and review before merging. Reviewers may request a
+smaller scope, additional tests, documentation, or changes needed to protect
+compatibility and release quality.
+
+## Reporting bugs and compatibility results
+
+Use the appropriate issue form and provide reproducible details. Include the
+MetalSharp version, macOS version, Mac model, game or application version,
+launch route, relevant configuration, and sanitized logs. Never post account
+credentials, license keys, tokens, or other private information.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,53 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are applied to the latest released version of MetalSharp. The
+`main` branch may contain unreleased changes and is supported on a best-effort
+basis. Older releases are not supported; users should upgrade before reporting
+an issue that may already be fixed.
+
+| Version        | Supported   |
+| -------------- | ----------- |
+| Latest release | Yes         |
+| `main`         | Best effort |
+| Older releases | No          |
+
+## Reporting a vulnerability
+
+Please do not open a public issue, discussion, or pull request for a suspected
+security vulnerability.
+
+Use GitHub's private vulnerability reporting form:
+
+https://github.com/metalsharp/MetalSharp/security/advisories/new
+
+Include as much of the following as possible:
+
+- the affected MetalSharp version or commit;
+- the affected macOS version and Apple Silicon model;
+- a clear description of the impact and attack scenario;
+- steps or a minimal proof of concept that reproduce the issue;
+- relevant logs, crash reports, or screenshots with secrets and personal data
+  removed; and
+- any known mitigations or suggested fixes.
+
+The maintainers aim to acknowledge complete reports within five business days.
+After reproducing and assessing the issue, they will coordinate remediation and
+disclosure with the reporter. Timelines depend on severity and the complexity
+of safely distributing a fix.
+
+Please allow a reasonable remediation period before publishing details. The
+project will credit reporters who request attribution, unless legal or privacy
+constraints prevent it.
+
+## Scope
+
+Reports are in scope when they concern MetalSharp-owned code, release artifacts,
+update or installation behavior, runtime isolation, credential or secret
+exposure, or a dependency vulnerability with a demonstrated impact on
+MetalSharp.
+
+Game-specific bugs, compatibility problems without a security impact, and
+vulnerabilities in third-party software that MetalSharp does not distribute or
+control should be reported to the appropriate issue tracker or upstream vendor.


### PR DESCRIPTION
## Summary

Add the community health documentation GitHub expects for security reporting, contributor conduct, and project contributions. The policies are tailored to MetalSharp's private vulnerability reporting flow, Apple Silicon development requirements, and existing PR readiness gates.

## Changes

- Add a security policy covering supported versions, private reporting, response expectations, and vulnerability scope.
- Add Contributor Covenant 2.1 with a private enforcement contact and community impact guidelines.
- Add contribution guidance for setup, change scope, validation, pull requests, and compatibility reports.
- Keep all three files under `.github/` so GitHub discovers them without adding root-level files.

## PR Readiness (MANDATORY)

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [ ] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [ ] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped
- [ ] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [ ] Regression test added for each bug fix

Bypassed intentionally via `checklist-exception`: this PR adds documentation only. It does not change game compatibility, configs, DLL maps, versions, bottle/runtime behavior, or executable code, and it does not fix a runtime bug.

## Local toolchain (run before push)

- [x] `git diff --check` passes
- [x] Prettier passes for all three Markdown files
- [x] GitHub private vulnerability reporting is enabled for the security advisory link
- [x] No hardcoded secrets or machine-specific absolute paths introduced
- [x] No new files added to the repository root; community files are under `.github/`
- [ ] Rust, C++, TypeScript, shell, config, and release-tooling gates not run because those areas are unchanged
- [ ] Game launch testing not run because runtime behavior is unchanged

## Test notes

Validated Markdown formatting with the repository-installed Prettier and checked the staged diff for whitespace errors. Reviewed all relative repository links and verified that GitHub private vulnerability reporting is enabled. No build or game test is applicable to this documentation-only change.

## Risk

Low. This PR changes documentation only. The main risk is inaccurate or unclear community guidance; rollback is reverting the commit.
