### PR TITLE
docs: pin README release badge to v0.57.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 **Run Windows games on macOS Silicon with Metal.**
 
 <a href="https://github.com/aaf2tbz/metalsharp/actions"><img src="https://img.shields.io/github/actions/workflow/status/aaf2tbz/metalsharp/ci.yml?branch=main&style=for-the-badge" alt="CI"></a>
-<a href="https://github.com/metalsharp/MetalSharp/releases/tag/v0.57.0"><img src="https://img.shields.io/github/v/release/aaf2tbz/metalsharp?style=for-the-badge" alt="Release"></a>
+<a href="https://github.com/metalsharp/MetalSharp/releases/tag/v0.57.0"><img src="https://img.shields.io/github/v/release/aaf2tbz/metalsharp?filter=v0.57.0&style=for-the-badge" alt="Release"></a>
 <a href="https://github.com/aaf2tbz/metalsharp/discussions"><img src="https://img.shields.io/github/discussions/aaf2tbz/metalsharp?style=for-the-badge" alt="Discussions"></a>
 <a href="LICENSE"><img src="https://img.shields.io/badge/License-PolyForm%20Noncommercial-yellow.svg?style=for-the-badge" alt="PolyForm Noncommercial 1.0.0"></a>
 <a href="https://discord.gg/qW5rUr4dH"><img src="https://img.shields.io/badge/Discord-%235865F2.svg?style=for-the-badge&logo=discord&logoColor=white" alt="DISCORD"></a>


### PR DESCRIPTION
## Summary
- Pin the README release badge to the v0.57.0 release.
- Keep the badge from displaying the newer 0.60.0 dependency-bundles preview release.

## Validation
- `git diff --check`
- Verified the Shields badge renders `RELEASE V0.57.0`.