### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,16 @@ This installs the signed MetalSharp release into `/Applications`. For developer 
 
 ## Routes
 
-| Route | Engine |
-|---|---|
-| **M12** | D3D12 to Metal (experimental DXMT) |
-| **M11** | D3D11 to Metal (DXMT) |
-| **M11(32)** | D3D11 i386 to Metal (DXMT) |
-| **M10** | D3D10 to Metal (DXMT) |
-| **M10(32)** | D3D10 i386 to Metal (DXMT) |
-| **M9** | D3D9 i386 Wine, DXMT Overrides|
-| **Mono/FNA** | Windows XNA/FNA via native Mono |
-| **D3DMetal** | Apple Game Porting Toolkit via Homebrew. GPTK is not bundled; selecting a D3DMetal bottle installs/trusts Homebrew GPTK + Rosetta, then seeds the GPTK prefix with Homebrew-matched D3DMetal route DLLs. |
+| Route | Engine | How To Use |
+|---|---|---|
+| **M12** | D3D12 to Metal (experimental DXMT) | Not yet playable |  
+| **M11** | D3D11 to Metal (DXMT) | Save 'M11' Bottle, Hit Play |
+| **M11(32)** | D3D11 i386 to Metal (DXMT) | Save M11(32) Bottle, Hit Play |
+| **M10** | D3D10 to Metal (DXMT) | Save 'M10' Bottle, Hit Play |
+| **M10(32)** | D3D10 i386 to Metal (DXMT) | Save M10(32) Bottle, Hit Play |
+| **M9** | D3D9 i386 Wine, DXMT Overrides| Save 'M9' Bottle, Hit Play |
+| **Mono/FNA** | Windows XNA/FNA via native Mono | Save 'Mono/Fna' Bottle, Hit Play |
+| **D3DMetal** | Apple Game Porting Toolkit via Homebrew. GPTK is not bundled; selecting a D3DMetal bottle installs/trusts Homebrew GPTK + Rosetta, then seeds the GPTK prefix with Homebrew-matched D3DMetal route DLLs. | Save 'D3DMetal' Bottle, Fix, Hit Play |
 
 ## Features
 


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does and why -->

## Changes

<!-- List the key changes -->

-

## PR Readiness (MANDATORY)

<!-- Process/review gates enforced by CI
     (.github/workflows/pr-readiness-check.yml). Checked items must use [x].
     To bypass intentionally, apply the `checklist-exception` label. -->

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
- [ ] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [ ] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [ ] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped
- [ ] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [ ] Docs / compatibility matrix updated for user-facing changes
- [ ] Regression test added for each bug fix

## Local toolchain (run before push)

> **Install the pre-commit hook once per clone** (it catches the same things
> as this checklist, and the same things as CI, locally in ~3s):
>
> ```bash
> ln -s ../../.github/hooks/pre-commit .git/hooks/pre-commit
> chmod +x .git/hooks/pre-commit
> ```
>
> The hook **fails the commit** if any required toolchain is missing — it will
> not silently skip `cargo fmt`, `clippy`, `tsc`, `prettier`, `biome`, etc.
> See [`.github/hooks/README.md`](../.github/hooks/README.md) for details.

> Run locally before pushing. All of these also run automatically in CI.

- [ ] `cargo fmt --all -- --check` passes (Rust)
- [ ] `cargo clippy --all-targets -- -D warnings` passes (Rust)
- [ ] `cargo build --release` passes (Rust backend)
- [ ] `cargo test` passes (Rust — 628+ tests)
- [ ] C++ compiles if changed: `cmake -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON && cmake --build build-native --parallel $(sysctl -n hw.ncpu)`
- [ ] `clang-format --dry-run --Werror` passes on any changed C/C++/Obj-C file
- [ ] `ctest --test-dir build-native` passes if tests changed
- [ ] TypeScript compiles if changed: `cd app && npx tsc --noEmit`
- [ ] Biome + Prettier pass if TS/JS changed: `cd app && npx @biomejs/biome ci src/ && npx prettier --check 'src/**/*.{ts,js,html,css,json}'`
- [ ] Shell scripts lint if changed: `tools/ci/shellcheck.sh`
- [ ] `tools/ci/validate-rules-toml.py` passes if `configs/mtsp-rules.toml` changed
- [ ] `python3 tools/ci/verify-dmg-workflow.py` passes if release/bundle tooling changed
- [ ] Tested with at least one game (which one? which launch method? which drive?)
- [ ] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [ ] No new files should be added to the repo root; place them under `app/`, `tools/`, `tests/`, etc.

## Test notes

<!-- What did you test? Which game, which launch method, which drive? -->

## Risk

<!-- If this PR ships broken defaults or changes launch behavior, what's the rollback plan? -->
