### PR TITLE
fix: stabilize legacy OpenGL games under Wine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- **Legacy OpenGL games under Wine** — stop forcing `MS_FWD_COMPAT_GL_CTX=1` globally for Steam, GOG prefix initialization, and the Wine wrapper. Games now receive compatibility-profile semantics by default, while route-specific environments can still opt into forward-compatible contexts. This fixes black output caused by legacy GLSL shader compilation failures in games such as The Binding of Isaac: Repentance.
+- **Legacy OpenGL games under Wine** — stop forcing `MS_FWD_COMPAT_GL_CTX=1` globally for Steam, GOG prefix initialization, and the Wine wrapper. Games now receive compatibility-profile semantics by default, while route-specific environments can still opt into forward-compatible contexts. Steam also disables Wine tracing by default instead of logging every OpenGL call; `METALSHARP_WINEDEBUG` remains available for explicit diagnostics. This fixes black output and unstable frame pacing in games such as The Binding of Isaac: Repentance.
 
 ## v0.54.5 — 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **Legacy OpenGL games under Wine** — stop forcing `MS_FWD_COMPAT_GL_CTX=1` globally for Steam, GOG prefix initialization, and the Wine wrapper. Games now receive compatibility-profile semantics by default, while route-specific environments can still opt into forward-compatible contexts. This fixes black output caused by legacy GLSL shader compilation failures in games such as The Binding of Isaac: Repentance.
+
 ## v0.54.5 — 2026-07-09
 
 Testing-surface hardening, pre-commit strictness, and compatibility database refresh.

--- a/app/src-rust/src/gog.rs
+++ b/app/src-rust/src/gog.rs
@@ -572,7 +572,7 @@ fn initialize_prefix() -> Result<(), String> {
         .env("WINEPREFIX", prefix.to_string_lossy().to_string())
         .env("WINEMSYNC", "1")
         .env("WINEDEBUG", "-all")
-        .env("MS_FWD_COMPAT_GL_CTX", "1")
+        .env_remove("MS_FWD_COMPAT_GL_CTX")
         .stdout(Stdio::null())
         .stderr(Stdio::null());
     crate::platform::set_runtime_library_env(&mut command, &wine_root());

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -1033,7 +1033,7 @@ fn repair_metalsharp_wine_wrapper_env_order() -> Result<(), Box<dyn std::error::
     }
 
     let script = std::fs::read_to_string(&wrapper)?;
-    let mut repaired = script.clone();
+    let mut repaired = repair_metalsharp_wine_wrapper(&script);
     let winedll_block = r#"if [ -n "${WINEDLLPATH:-}" ]; then
   export WINEDLLPATH="$WINEDLLPATH:$MS_LIB/wine/x86_64-windows:$MS_LIB/wine/i386-windows"
 else
@@ -1054,7 +1054,7 @@ else
 fi
 "#;
     if let (Some(start), Some(end)) =
-        (repaired.find("export WINEDATADIR=\"$MS_ROOT/share\"\n"), repaired.find("export MS_FWD_COMPAT_GL_CTX=1"))
+        (repaired.find("export WINEDATADIR=\"$MS_ROOT/share\"\n"), repaired.find("export VK_ICD_FILENAMES="))
     {
         let replace_start = start + "export WINEDATADIR=\"$MS_ROOT/share\"\n".len();
         repaired.replace_range(replace_start..end, dyld_block);
@@ -1064,6 +1064,10 @@ fi
         std::fs::write(&wrapper, repaired)?;
     }
     Ok(())
+}
+
+fn repair_metalsharp_wine_wrapper(script: &str) -> String {
+    script.replace("export MS_FWD_COMPAT_GL_CTX=1\n", "")
 }
 
 pub fn launch_custom_with_pipeline(
@@ -5015,6 +5019,18 @@ fn spawn_metalshaderconverter_sidecar(appid: u32, home: &Path, cache_paths: Opti
 mod tests {
     use super::*;
     use crate::mtsp::recipe;
+
+    #[test]
+    fn wine_wrapper_does_not_force_forward_compatible_opengl() {
+        let wrapper =
+            "export WINEDATADIR=\"$MS_ROOT/share\"\nexport MS_FWD_COMPAT_GL_CTX=1\nexport VK_ICD_FILENAMES=foo\n";
+
+        let repaired = repair_metalsharp_wine_wrapper(wrapper);
+
+        assert!(!repaired.contains("MS_FWD_COMPAT_GL_CTX"));
+        assert!(repaired.contains("export WINEDATADIR=\"$MS_ROOT/share\""));
+        assert!(repaired.contains("export VK_ICD_FILENAMES=foo"));
+    }
 
     #[test]
     fn deploy_steam_appid_writes_visible_appid_file_for_each_known_subdir() {

--- a/app/src-rust/src/mtsp/rules.rs
+++ b/app/src-rust/src/mtsp/rules.rs
@@ -480,6 +480,7 @@ mod tests {
 
         for (appid, pipeline) in [
             (17410, PipelineId::M9),
+            (250900, PipelineId::M11_32),
             (312520, PipelineId::M11),
             (387290, PipelineId::M11),
             (475150, PipelineId::M11_32),

--- a/app/src-rust/src/steam.rs
+++ b/app/src-rust/src/steam.rs
@@ -328,6 +328,14 @@ fn spawn_wine_steam(args: &[&str]) -> Result<u32, Box<dyn std::error::Error>> {
     spawn_wine_steam_with_env(args, &[])
 }
 
+fn use_legacy_compatible_opengl_context(cmd: &mut Command) {
+    // Wine's macOS driver treats the presence of this variable as a request
+    // for a forward-compatible context. Applying it to Steam globally also
+    // forces every child game into core-profile GLSL semantics, which breaks
+    // legacy OpenGL titles. Route-specific env can opt back in below.
+    cmd.env_remove("MS_FWD_COMPAT_GL_CTX");
+}
+
 fn spawn_wine_steam_with_env(args: &[&str], extra_env: &[(String, String)]) -> Result<u32, Box<dyn std::error::Error>> {
     let wine = ms_wine();
     if !wine.exists() {
@@ -377,7 +385,6 @@ fn spawn_wine_steam_with_env(args: &[&str], extra_env: &[(String, String)]) -> R
         .env("WINEDEBUG", "+vulkan,+d3d,+d3d11,+dxgi,+wined3d,+opengl")
         .env("WINEDEBUGGER", "none")
         .env("STEAM_RUNTIME", "0")
-        .env("MS_FWD_COMPAT_GL_CTX", "1")
         .env(
             "WINEDLLOVERRIDES",
             "dxgi,d3d11,d3d10core=n,b;bcrypt=b;ncrypt=b;gameoverlayrenderer,gameoverlayrenderer64=d",
@@ -393,6 +400,7 @@ fn spawn_wine_steam_with_env(args: &[&str], extra_env: &[(String, String)]) -> R
     }
 
     crate::platform::set_runtime_library_env(&mut cmd, &ms_root);
+    use_legacy_compatible_opengl_context(&mut cmd);
 
     for (key, val) in extra_env {
         cmd.env(key, val);
@@ -1642,6 +1650,28 @@ pub fn watch_steamapps() -> Vec<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn steam_defaults_to_legacy_compatible_opengl_contexts() {
+        let mut command = Command::new("wine");
+        command.env("MS_FWD_COMPAT_GL_CTX", "1");
+
+        use_legacy_compatible_opengl_context(&mut command);
+
+        assert!(matches!(command.get_envs().find(|(key, _)| *key == "MS_FWD_COMPAT_GL_CTX"), Some((_, None))));
+    }
+
+    #[test]
+    fn route_environment_can_opt_into_forward_compatible_opengl() {
+        let mut command = Command::new("wine");
+        use_legacy_compatible_opengl_context(&mut command);
+        command.env("MS_FWD_COMPAT_GL_CTX", "1");
+
+        assert_eq!(
+            command.get_envs().find(|(key, _)| *key == "MS_FWD_COMPAT_GL_CTX").and_then(|(_, value)| value),
+            Some(std::ffi::OsStr::new("1"))
+        );
+    }
 
     #[test]
     fn stop_wine_steam_targets_report_has_required_shape() {

--- a/app/src-rust/src/steam.rs
+++ b/app/src-rust/src/steam.rs
@@ -336,6 +336,10 @@ fn use_legacy_compatible_opengl_context(cmd: &mut Command) {
     cmd.env_remove("MS_FWD_COMPAT_GL_CTX");
 }
 
+fn steam_wine_debug_value(configured: Option<String>) -> String {
+    configured.filter(|value| !value.trim().is_empty()).unwrap_or_else(|| "-all".to_string())
+}
+
 fn spawn_wine_steam_with_env(args: &[&str], extra_env: &[(String, String)]) -> Result<u32, Box<dyn std::error::Error>> {
     let wine = ms_wine();
     if !wine.exists() {
@@ -382,7 +386,7 @@ fn spawn_wine_steam_with_env(args: &[&str], extra_env: &[(String, String)]) -> R
     let mut cmd = Command::new(&wine);
     cmd.current_dir(&steam_dir)
         .env("WINEPREFIX", &prefix_str)
-        .env("WINEDEBUG", "+vulkan,+d3d,+d3d11,+dxgi,+wined3d,+opengl")
+        .env("WINEDEBUG", steam_wine_debug_value(std::env::var("METALSHARP_WINEDEBUG").ok()))
         .env("WINEDEBUGGER", "none")
         .env("STEAM_RUNTIME", "0")
         .env(
@@ -1671,6 +1675,17 @@ mod tests {
             command.get_envs().find(|(key, _)| *key == "MS_FWD_COMPAT_GL_CTX").and_then(|(_, value)| value),
             Some(std::ffi::OsStr::new("1"))
         );
+    }
+
+    #[test]
+    fn steam_disables_wine_tracing_by_default() {
+        assert_eq!(steam_wine_debug_value(None), "-all");
+        assert_eq!(steam_wine_debug_value(Some(String::new())), "-all");
+    }
+
+    #[test]
+    fn steam_accepts_explicit_wine_debug_override() {
+        assert_eq!(steam_wine_debug_value(Some("+opengl".to_string())), "+opengl");
     }
 
     #[test]

--- a/configs/mtsp-rules.toml
+++ b/configs/mtsp-rules.toml
@@ -2103,6 +2103,7 @@ check_dlls = ["d3d11.dll", "dxgi.dll", "winemetal.dll"]
 [overrides.250900]
 pipeline = "m11_32"
 name = "The Binding of Isaac: Rebirth"
+exe_names = ["isaac-ng.exe"]
 
 [overrides.250900.dependencies]
 components = ["vcrun2019_x86", "directx_jun2010"]
@@ -6769,4 +6770,3 @@ components = ["vcrun2019_x86", "directx_jun2010"]
 
 [overrides.4498220.diagnostics]
 check_dlls = ["d3d11.dll", "dxgi.dll", "winemetal.dll"]
-

--- a/docs/compatibility/GAMES-SUPPORTED.md
+++ b/docs/compatibility/GAMES-SUPPORTED.md
@@ -1,6 +1,6 @@
 # Games Supported
 
-Updated: 2026-07-08
+Updated: 2026-08-05
 
 Tested and working games organized by pipeline. Only games confirmed playable are listed.
 
@@ -97,7 +97,8 @@ Games running through Homebrew GPTK and Apple's D3DMetal pipeline. D3DMetal bott
 |---|---:|---|
 | Inscryption | 1092790 | Binary: `Inscryption.exe`. |
 | Hades | 1145360 | Binary: `x86/Hades.exe`. |
-| Balatro| 2379780 | |
+| Balatro | 2379780 | |
+| The Binding of Isaac: Rebirth | 250900 | Binary: `isaac-ng.exe`. Windows OpenGL path verified on an internal drive; requires compatibility-profile context handling. |
 
 ---
 


### PR DESCRIPTION
## Summary

Stop forcing Wine's forward-compatible OpenGL context and verbose graphics tracing globally. Legacy OpenGL games can now receive compatibility-profile semantics without logging every rendered call, while route-specific environments can still opt into forward-compatible contexts and diagnostics.

This fixes The Binding of Isaac: Repentance running with working audio/input but a black window because every legacy GLSL vertex shader failed compilation, followed by unstable frame pacing from runaway OpenGL trace output.

## Changes

- Remove the global `MS_FWD_COMPAT_GL_CTX=1` export from Wine Steam startup.
- Explicitly clear the inherited flag for Steam and GOG prefix initialization.
- Migrate existing `metalsharp-wine` wrappers by removing the global export.
- Preserve per-route opt-in through the existing extra environment application order.
- Disable Wine tracing by default for Steam; preserve `METALSHARP_WINEDEBUG` as an explicit diagnostic override.
- Add regression coverage for context defaults, opt-in behavior, wrapper migration, and diagnostic logging.
- Pin Isaac to M11(32) with the verified `isaac-ng.exe` executable and document it in the supported-games matrix.
- Document the user-facing fix in the changelog.

## PR Readiness (MANDATORY)

- [x] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped (not bumped)
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted below)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

## Local toolchain (run before push)

- [x] `cargo fmt --all -- --check` passes (Rust)
- [x] `cargo clippy --all-targets -- -D warnings` passes (Rust)
- [x] `cargo build --release` passes (Rust backend)
- [ ] `cargo test` passes (Rust — 645/646 pass; existing host-dependent failure documented below)
- [x] C++ compiles if changed (not changed)
- [x] `clang-format --dry-run --Werror` passes on any changed C/C++/Obj-C file (not changed)
- [x] `ctest --test-dir build-native` passes if tests changed (C++ tests not changed)
- [x] TypeScript compiles if changed (not changed)
- [x] Biome + Prettier pass if TS/JS changed (not changed)
- [x] Shell scripts lint if changed (not changed)
- [x] `tools/ci/validate-rules-toml.py` passes if `configs/mtsp-rules.toml` changed
- [x] `python3 tools/ci/verify-dmg-workflow.py` passes if release/bundle tooling changed (not changed)
- [x] Tested with at least one game (The Binding of Isaac: Repentance, Windows Steam, M11(32), internal drive)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files added to the repository root

## Test notes

Real-game validation on macOS 26.5.1:

- Before: Isaac received OpenGL 4.1 / GLSL 4.10 and logged `#version required and missing` plus legacy `attribute` syntax failures for every vertex shader. Audio and input worked, but the window remained black.
- After: Isaac received OpenGL 2.1 / GLSL 1.20, initialized all 19 named shaders with zero compilation failures, rendered the intro, and remained running.
- Before the logging change, the Steam/Wine trace grew to 2.5 GB in roughly ten minutes while logging each OpenGL call. After the change, it stopped at 44 KB before gameplay and remained unchanged while Isaac rendered.
- Route: Windows Steam through MetalSharp M11(32), game installed on the internal drive.

Automated checks:

- Five focused OpenGL environment/wrapper/logging tests pass; the broader `cargo test steam_` filter passes all 60 tests.
- All three shipped-rules tests pass; the standalone TOML validator reports 704 valid override entries with no errors.
- Formatting, Clippy with warnings denied, and release build pass.
- Full `cargo test`: 645 passed, 1 failed. The unrelated existing `kernel_translation::ipc_bridge::tests::test_nt_query_virtual_memory_basic_returns_success` test receives `STATUS_CONFLICTING_ADDRESSES` from the host instead of success. It also fails alone and does not touch the changed launch code.

## Risk

The default changes for all Wine Steam children and GOG prefix initialization, so a title that specifically requires a forward-compatible context may need a route-level `MS_FWD_COMPAT_GL_CTX=1` environment override. Extra route environment is applied after the default removal and is covered by a regression test. Verbose Wine logging remains available through `METALSHARP_WINEDEBUG` when diagnostics are needed.

Rollback is limited to restoring the global Steam/GOG flag and wrapper export; no bottle, prefix, save, or game-resource migration is performed.
