### PR TITLE
fix: isolate Wine runtime from foreign launchers (CrossOver/SakuraGiri)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ vkd3d-proton-reference/
 *.dmg
 *.pkg
 *.app/
+
+# Hermes local plans (not part of the repo)
+.hermes/

--- a/app/src-rust/src/launch.rs
+++ b/app/src-rust/src/launch.rs
@@ -325,19 +325,26 @@ fn find_wine() -> Result<String, Box<dyn std::error::Error>> {
         return Ok(ms_wine.to_string_lossy().to_string());
     }
 
-    let candidates = vec![
-        PathBuf::from("/opt/homebrew/bin/wine64"),
-        PathBuf::from("/usr/bin/wine"),
-        PathBuf::from("/usr/local/bin/wine"),
-    ];
+    // Isolation contract: MetalSharp must NEVER fall back to a system or
+    // third-party Wine (Homebrew, GPTK, CrossOver, Whisky, SakuraGiri…).
+    // Those runtimes are not ABI-compatible with MetalSharp's prefix and
+    // graphics stack, and resolving one of them is exactly how a foreign
+    // launcher's Wine ends up running MetalSharp's Steam/prefix. Fail
+    // loudly so the user runs setup instead.
+    Err(format!(
+        "MetalSharp Wine runtime missing at {} — run setup. System/third-party Wine is intentionally not used (found: {:?})",
+        ms_wine.display(),
+        system_wine_candidates_present()
+    )
+    .into())
+}
 
-    for c in candidates {
-        if c.exists() {
-            return Ok(c.to_string_lossy().to_string());
-        }
-    }
-
-    Err("wine not found".into())
+fn system_wine_candidates_present() -> Vec<String> {
+    ["/opt/homebrew/bin/wine64", "/usr/bin/wine", "/usr/local/bin/wine"]
+        .iter()
+        .filter(|path| PathBuf::from(path).exists())
+        .map(|path| (*path).to_string())
+        .collect()
 }
 
 pub fn ensure_wine_prefix(prefix: &PathBuf) -> Result<(), Box<dyn std::error::Error>> {
@@ -395,6 +402,15 @@ fn launch_via_wine(exe_path: &str) -> Result<u32, Box<dyn std::error::Error>> {
     let wine = find_wine()?;
     let prefix = crate::platform::metalsharp_home_dir_for(&home).join("prefix-steam");
     let prefix_str = prefix.to_string_lossy().to_string();
+
+    if std::env::var_os("MS_LAUNCH_TRACE").is_some() {
+        eprintln!("[trace] launch_via_wine wine_bin={}", wine);
+        eprintln!("[trace] prefix={}", prefix_str);
+        eprintln!("[trace] parent WINEPREFIX={:?}", std::env::var("WINEPREFIX"));
+        eprintln!("[trace] parent WINEDLLPATH={:?}", std::env::var("WINEDLLPATH"));
+        eprintln!("[trace] parent DYLD_FALLBACK_LIBRARY_PATH={:?}", std::env::var("DYLD_FALLBACK_LIBRARY_PATH"));
+        eprintln!("[trace] parent WINESERVER={:?}", std::env::var("WINESERVER"));
+    }
 
     ensure_wine_prefix(&prefix)?;
 
@@ -457,5 +473,57 @@ mod tests {
         assert!(ensure_steam_env_handoff_supported(true, &env).is_err());
         assert!(ensure_steam_env_handoff_supported(true, &[]).is_ok());
         assert!(ensure_steam_env_handoff_supported(false, &env).is_ok());
+    }
+
+    fn with_ms_home(temp: &std::path::Path, f: impl FnOnce()) {
+        let prev = std::env::var_os("METALSHARP_HOME");
+        std::env::set_var("METALSHARP_HOME", temp);
+        f();
+        match prev {
+            Some(v) => std::env::set_var("METALSHARP_HOME", v),
+            None => std::env::remove_var("METALSHARP_HOME"),
+        }
+    }
+
+    #[test]
+    fn find_wine_never_falls_back_to_system_wine_when_ms_runtime_missing() {
+        // Isolation contract: with no MetalSharp runtime, find_wine must fail
+        // loudly instead of resolving a system/third-party wine (CrossOver,
+        // SakuraGiri, GPTK/Homebrew all install into the candidate paths).
+        let temp = std::env::temp_dir().join(format!("ms-findwine-missing-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&temp);
+        std::fs::create_dir_all(&temp).unwrap();
+
+        with_ms_home(&temp, || {
+            let result = find_wine();
+            let err = result.expect_err("find_wine must fail when MS runtime is missing");
+            let msg = err.to_string();
+            assert!(msg.contains("run setup"), "error must direct user to setup: {}", msg);
+            assert!(!msg.contains("wine not found"), "error must not be the old generic message");
+        });
+
+        let _ = std::fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn find_wine_returns_ms_runtime_when_present() {
+        let temp = std::env::temp_dir().join(format!("ms-findwine-present-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&temp);
+        let bin = temp.join("runtime").join("wine").join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        let wrapper = bin.join("metalsharp-wine");
+        std::fs::write(&wrapper, "#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&wrapper, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        with_ms_home(&temp, || {
+            let found = find_wine().expect("find_wine must return the MS runtime wrapper");
+            assert_eq!(found, wrapper.to_string_lossy().to_string());
+        });
+
+        let _ = std::fs::remove_dir_all(&temp);
     }
 }

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -2358,8 +2358,21 @@ fn is_force_kill_target(command: &str, home: &std::path::Path) -> bool {
         || lower.contains("c:\\windows\\")
         || lower.contains(".exe");
 
-    if wine_process && (under_metalsharp_home || lower.contains("wine") || lower.contains("steamwebhelper")) {
-        return true;
+    // Isolation contract: MetalSharp must only ever kill processes it owns.
+    // A bare `wine`/`wineserver`/`wineloader` match is NOT enough — that
+    // would kill a foreign Wine (CrossOver, SakuraGiri, Whisky, GPTK) that
+    // happens to be running. Ownership is proven by the process command
+    // referencing the MetalSharp home, an MS prefix/bottle path, or the
+    // metalsharp-wine wrapper itself.
+    if wine_process {
+        let owned = under_metalsharp_home
+            || command.contains("metalsharp-wine")
+            || lower.contains("prefix-steam")
+            || lower.contains("sharp-prefix")
+            || lower.contains("/bottles/")
+            || lower.contains("gogdl")
+            || lower.contains("heroic_gogdl");
+        return owned;
     }
 
     under_metalsharp_home
@@ -2908,6 +2921,33 @@ mod tests {
         assert!(is_force_kill_target("/Users/test/.metalsharp/runtime/wine/bin/wine Steam.exe", home));
         assert!(!is_force_kill_target("/Applications/MetalSharp.app/Contents/MacOS/MetalSharp", home));
         assert!(!is_force_kill_target("/Applications/Steam.app/Contents/MacOS/steam_osx", home));
+    }
+
+    #[test]
+    fn force_kill_never_targets_foreign_wine_processes() {
+        // Isolation contract: a foreign Wine launcher (CrossOver, SakuraGiri,
+        // Whisky, GPTK) must never be killed by MetalSharp cleanup, even when
+        // its command line contains wine/wineserver/wineloader tokens.
+        let home = std::path::Path::new("/Users/test/.metalsharp");
+
+        assert!(!is_force_kill_target(
+            "/Applications/CrossOver.app/Contents/SharedSupport/CrossOver/bin/wineserver -f",
+            home
+        ));
+        assert!(!is_force_kill_target(
+            "/Applications/CrossOver.app/Contents/SharedSupport/CrossOver/bin/wine64 C:\\windows\\system32\\wineboot.exe",
+            home
+        ));
+        assert!(!is_force_kill_target(
+            "/Users/test/Library/Application Support/SakuraGiri/engine/wine/bin/wineloader",
+            home
+        ));
+        assert!(!is_force_kill_target("/opt/homebrew/bin/wineserver", home));
+        assert!(!is_force_kill_target("/usr/local/bin/wine", home));
+
+        // MS-owned processes must still be targeted.
+        assert!(is_force_kill_target("/Users/test/.metalsharp/runtime/wine/bin/wineserver -f", home));
+        assert!(is_force_kill_target("/Users/test/.metalsharp/runtime/wine/bin/metalsharp-wine Steam.exe", home));
     }
 
     #[test]

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -534,7 +534,7 @@ pub fn prepare_steam_pipeline_env(
     let recipe = super::recipe::build_launch_recipe(appid, node)?;
     validate_recipe_runtime(&recipe)?;
     if node.backend == "dxmt" {
-        repair_metalsharp_wine_wrapper_env_order()?;
+        sanitize_metalsharp_wine_wrapper_env()?;
     }
     if let Some(game_dir) = recipe.game_dir.as_ref() {
         prepare_steam_api_for_game_dir(&home, game_dir, appid, pipeline_id);
@@ -1021,7 +1021,7 @@ fn wine_debug_value() -> String {
     std::env::var("METALSHARP_WINEDEBUG").unwrap_or_else(|_| "-all".to_string())
 }
 
-fn repair_metalsharp_wine_wrapper_env_order() -> Result<(), Box<dyn std::error::Error>> {
+fn sanitize_metalsharp_wine_wrapper_env() -> Result<(), Box<dyn std::error::Error>> {
     let home = dirs::home_dir().ok_or("no home dir")?;
     let wrapper = crate::platform::metalsharp_home_dir_for(&home)
         .join("runtime")
@@ -1034,11 +1034,14 @@ fn repair_metalsharp_wine_wrapper_env_order() -> Result<(), Box<dyn std::error::
 
     let script = std::fs::read_to_string(&wrapper)?;
     let mut repaired = repair_metalsharp_wine_wrapper(&script);
-    let winedll_block = r#"if [ -n "${WINEDLLPATH:-}" ]; then
-  export WINEDLLPATH="$WINEDLLPATH:$MS_LIB/wine/x86_64-windows:$MS_LIB/wine/i386-windows"
-else
-  export WINEDLLPATH="$MS_LIB/wine/x86_64-windows:$MS_LIB/wine/i386-windows"
-fi
+
+    // Isolation contract: MetalSharp's own DLL/dylib directories MUST be
+    // searched before anything the parent environment inherited. Third-party
+    // Wine launchers (CrossOver, SakuraGiri, Whisky, GPTK…) can export
+    // WINEDLLPATH / DYLD_FALLBACK_LIBRARY_PATH from a shell profile or a
+    // parent launcher; honoring those first lets a foreign Wine's DLLs be
+    // loaded into MetalSharp's prefix, which breaks Steam and game launches.
+    let winedll_block = r#"export WINEDLLPATH="$MS_LIB/wine/x86_64-windows:$MS_LIB/wine/i386-windows${WINEDLLPATH:+:$WINEDLLPATH}"
 "#;
     if let (Some(start), Some(end)) =
         (repaired.find("export WINELOADER=\"$MS_WINE\"\n"), repaired.find("export WINEDEBUG=\"${WINEDEBUG:--all}\""))
@@ -1047,11 +1050,7 @@ fi
         repaired.replace_range(replace_start..end, winedll_block);
     }
 
-    let dyld_block = r#"if [ -n "${DYLD_FALLBACK_LIBRARY_PATH:-}" ]; then
-  export DYLD_FALLBACK_LIBRARY_PATH="$DYLD_FALLBACK_LIBRARY_PATH:$MS_LIB:$MS_LIB/wine/x86_64-unix"
-else
-  export DYLD_FALLBACK_LIBRARY_PATH="$MS_LIB:$MS_LIB/wine/x86_64-unix"
-fi
+    let dyld_block = r#"export DYLD_FALLBACK_LIBRARY_PATH="$MS_LIB:$MS_LIB/wine/x86_64-unix${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 "#;
     if let (Some(start), Some(end)) =
         (repaired.find("export WINEDATADIR=\"$MS_ROOT/share\"\n"), repaired.find("export VK_ICD_FILENAMES="))
@@ -1059,6 +1058,18 @@ fi
         let replace_start = start + "export WINEDATADIR=\"$MS_ROOT/share\"\n".len();
         repaired.replace_range(replace_start..end, dyld_block);
     }
+
+    // Drop CrossOver's CX_ROOT emulation: a real CrossOver reading CX_ROOT
+    // could mistake a MetalSharp process for one of its own bottles.
+    repaired = repaired.replace("export CX_ROOT=\"$MS_ROOT\"\n", "");
+
+    // VK_ICD_FILENAMES must never hardcode a Homebrew path (CrossOver users
+    // often have no Homebrew). Prefer the runtime-bundled MoltenVK ICD;
+    // otherwise unset and let the loader search standard locations.
+    repaired = repaired.replace(
+        "export VK_ICD_FILENAMES=\"/opt/homebrew/etc/vulkan/icd.d/MoltenVK_icd.json\"",
+        "if [ -f \"$MS_ROOT/etc/vulkan/icd.d/MoltenVK_icd.json\" ]; then\n  export VK_ICD_FILENAMES=\"$MS_ROOT/etc/vulkan/icd.d/MoltenVK_icd.json\"\nelse\n  unset VK_ICD_FILENAMES\nfi",
+    );
 
     if repaired != script {
         std::fs::write(&wrapper, repaired)?;
@@ -1115,7 +1126,7 @@ pub fn launch_custom_with_options(
         return Err("MetalSharp Wine not found — run setup first".into());
     }
     if node.backend == "dxmt" {
-        repair_metalsharp_wine_wrapper_env_order()?;
+        sanitize_metalsharp_wine_wrapper_env()?;
     }
 
     let mut recipe = super::recipe::build_custom_launch_recipe(launch_id, node, game_dir, Some(exe_path))?;
@@ -1528,7 +1539,7 @@ fn launch_dxmt_metal_with_context(
     if !wine.exists() {
         return Err("MetalSharp Wine not found — run setup first".into());
     }
-    repair_metalsharp_wine_wrapper_env_order()?;
+    sanitize_metalsharp_wine_wrapper_env()?;
 
     prepare_start_protected_game_for_pipeline(appid, node.id);
     let recipe = super::recipe::build_launch_recipe(appid, node)?;
@@ -5030,6 +5041,78 @@ mod tests {
         assert!(!repaired.contains("MS_FWD_COMPAT_GL_CTX"));
         assert!(repaired.contains("export WINEDATADIR=\"$MS_ROOT/share\""));
         assert!(repaired.contains("export VK_ICD_FILENAMES=foo"));
+    }
+
+    #[test]
+    fn sanitize_puts_ms_paths_first_when_ambient_wine_env_present() {
+        // Isolation contract: a foreign wine launcher (CrossOver, SakuraGiri,
+        // Whisky, GPTK) may export WINEDLLPATH / DYLD_FALLBACK_LIBRARY_PATH
+        // into the parent environment. The sanitized wrapper must search
+        // MetalSharp's own DLL/dylib dirs BEFORE any inherited foreign paths.
+        let wrapper = r#"export MS_ROOT="$MS_ROOT"
+export CX_ROOT="$MS_ROOT"
+export WINEPREFIX="${WINEPREFIX:-$HOME/.metalsharp/prefix-steam}"
+export WINESERVER="$MS_SERVER"
+export WINELOADER="$MS_WINE"
+export WINEDLLPATH="$MS_LIB/wine/x86_64-windows:$MS_LIB/wine/i386-windows"
+export WINEDEBUG="${WINEDEBUG:--all}"
+export WINEDATADIR="$MS_ROOT/share"
+export DYLD_FALLBACK_LIBRARY_PATH="$MS_LIB:$MS_LIB/wine/x86_64-unix"
+export MS_FWD_COMPAT_GL_CTX=1
+export VK_ICD_FILENAMES="/opt/homebrew/etc/vulkan/icd.d/MoltenVK_icd.json"
+"#;
+
+        // Replicate the full sanitize flow on the script string.
+        let mut repaired = repair_metalsharp_wine_wrapper(wrapper);
+        let winedll_block = r#"export WINEDLLPATH="$MS_LIB/wine/x86_64-windows:$MS_LIB/wine/i386-windows${WINEDLLPATH:+:$WINEDLLPATH}"
+"#;
+        if let (Some(start), Some(end)) = (
+            repaired.find("export WINELOADER=\"$MS_WINE\"\n"),
+            repaired.find("export WINEDEBUG=\"${WINEDEBUG:--all}\""),
+        ) {
+            let replace_start = start + "export WINELOADER=\"$MS_WINE\"\n".len();
+            repaired.replace_range(replace_start..end, winedll_block);
+        }
+        let dyld_block = r#"export DYLD_FALLBACK_LIBRARY_PATH="$MS_LIB:$MS_LIB/wine/x86_64-unix${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
+"#;
+        if let (Some(start), Some(end)) =
+            (repaired.find("export WINEDATADIR=\"$MS_ROOT/share\"\n"), repaired.find("export VK_ICD_FILENAMES="))
+        {
+            let replace_start = start + "export WINEDATADIR=\"$MS_ROOT/share\"\n".len();
+            repaired.replace_range(replace_start..end, dyld_block);
+        }
+        repaired = repaired.replace("export CX_ROOT=\"$MS_ROOT\"\n", "");
+        repaired = repaired.replace(
+            "export VK_ICD_FILENAMES=\"/opt/homebrew/etc/vulkan/icd.d/MoltenVK_icd.json\"",
+            "if [ -f \"$MS_ROOT/etc/vulkan/icd.d/MoltenVK_icd.json\" ]; then\n  export VK_ICD_FILENAMES=\"$MS_ROOT/etc/vulkan/icd.d/MoltenVK_icd.json\"\nelse\n  unset VK_ICD_FILENAMES\nfi",
+        );
+
+        // MS paths must come first; ambient values may only be appended after.
+        let winedll_line =
+            repaired.lines().find(|l| l.starts_with("export WINEDLLPATH=")).expect("WINEDLLPATH export present");
+        let winedll_prefix = winedll_line.split("${WINEDLLPATH").next().unwrap();
+        assert!(
+            winedll_prefix.starts_with("export WINEDLLPATH=\"$MS_LIB/"),
+            "MS DLL dirs must lead WINEDLLPATH: {}",
+            winedll_line
+        );
+
+        let dyld_line = repaired
+            .lines()
+            .find(|l| l.starts_with("export DYLD_FALLBACK_LIBRARY_PATH="))
+            .expect("DYLD_FALLBACK_LIBRARY_PATH export present");
+        let dyld_prefix = dyld_line.split("${DYLD_FALLBACK").next().unwrap();
+        assert!(
+            dyld_prefix.starts_with("export DYLD_FALLBACK_LIBRARY_PATH=\"$MS_LIB:"),
+            "MS unix lib dirs must lead DYLD_FALLBACK_LIBRARY_PATH: {}",
+            dyld_line
+        );
+
+        // CX_ROOT emulation must be gone, and the ICD must resolve inside the
+        // runtime instead of a hardcoded Homebrew path.
+        assert!(!repaired.contains("CX_ROOT"), "CX_ROOT emulation must be dropped");
+        assert!(!repaired.contains("/opt/homebrew/etc/vulkan"), "Homebrew ICD path must not remain");
+        assert!(repaired.contains("$MS_ROOT/etc/vulkan/icd.d/MoltenVK_icd.json"));
     }
 
     #[test]

--- a/app/src-rust/src/steam.rs
+++ b/app/src-rust/src/steam.rs
@@ -146,7 +146,19 @@ fn is_wine_steam_cleanup_command(command: &str) -> bool {
     }
 
     let prefix = steam_prefix().to_string_lossy().to_string();
+    let ms_home = crate::platform::metalsharp_home_dir().to_string_lossy().to_string();
     let lower = command.to_lowercase();
+
+    // Isolation contract: generic wine helper tokens (wineserver, wineloader,
+    // winedevice.exe) must NOT be killed on their own — a foreign Wine
+    // launcher (CrossOver, SakuraGiri, Whisky, GPTK) also runs those names.
+    // Only treat them as MetalSharp Steam processes when the command line
+    // also references the MetalSharp home (runtime/prefix/bottles all live
+    // under it), the MS wine runtime, or a Steam path inside the MS prefix.
+    let ms_owned = command.contains(&prefix)
+        || command.contains(&ms_home)
+        || lower.contains("metalsharp-wine")
+        || lower.contains("c:\\program files (x86)\\steam");
 
     command.contains(&prefix)
         || lower.contains("c:\\program files (x86)\\steam")
@@ -154,9 +166,8 @@ fn is_wine_steam_cleanup_command(command: &str) -> bool {
         || lower.contains("steamwebhelper_real.exe")
         || lower.contains("c:\\windows\\system32\\explorer.exe /desktop")
         || (lower.contains("c:\\windows\\system32\\conhost.exe") && lower.contains("--headless"))
-        || lower.contains("winedevice.exe")
-        || lower.contains("wineserver")
-        || lower.contains("wineloader")
+        || (ms_owned
+            && (lower.contains("winedevice.exe") || lower.contains("wineserver") || lower.contains("wineloader")))
 }
 
 fn wine_steam_cleanup_pids() -> Vec<u32> {
@@ -408,6 +419,18 @@ fn spawn_wine_steam_with_env(args: &[&str], extra_env: &[(String, String)]) -> R
 
     for (key, val) in extra_env {
         cmd.env(key, val);
+    }
+
+    if std::env::var_os("MS_LAUNCH_TRACE").is_some() {
+        eprintln!("[trace] wine_bin={}", wine.display());
+        eprintln!("[trace] prefix={}", prefix_str);
+        eprintln!("[trace] cwd={}", steam_dir.display());
+        eprintln!("[trace] parent WINEPREFIX={:?}", std::env::var("WINEPREFIX"));
+        eprintln!("[trace] parent WINEDLLPATH={:?}", std::env::var("WINEDLLPATH"));
+        eprintln!("[trace] parent DYLD_FALLBACK_LIBRARY_PATH={:?}", std::env::var("DYLD_FALLBACK_LIBRARY_PATH"));
+        eprintln!("[trace] parent DYLD_LIBRARY_PATH={:?}", std::env::var("DYLD_LIBRARY_PATH"));
+        eprintln!("[trace] parent WINESERVER={:?}", std::env::var("WINESERVER"));
+        eprintln!("[trace] parent WINELOADER={:?}", std::env::var("WINELOADER"));
     }
 
     let child = cmd.spawn()?;
@@ -1747,6 +1770,33 @@ mod tests {
         assert!(!is_wine_steam_cleanup_command(
             "/bin/zsh -lc ps axo pid=,command= | rg -i \"explorer.exe|conhost.exe\"",
         ));
+    }
+
+    #[test]
+    fn wine_steam_cleanup_ignores_foreign_wine_helpers() {
+        // Isolation contract: generic wineserver/wineloader/winedevice tokens
+        // are not enough — a foreign Wine launcher (CrossOver, SakuraGiri,
+        // Whisky, GPTK) also runs those names. Only MS-owned commands that
+        // reference the MS home (runtime/prefix/bottles live under it) or the
+        // metalsharp-wine wrapper qualify.
+        assert!(!is_wine_steam_cleanup_command(
+            "/Applications/CrossOver.app/Contents/SharedSupport/CrossOver/bin/wineserver -f",
+        ));
+        assert!(!is_wine_steam_cleanup_command(
+            "/Applications/CrossOver.app/Contents/SharedSupport/CrossOver/bin/wineloader",
+        ));
+        assert!(!is_wine_steam_cleanup_command(
+            "/Users/test/Library/Application Support/SakuraGiri/engine/wine/bin/winedevice.exe",
+        ));
+        assert!(!is_wine_steam_cleanup_command("/opt/homebrew/bin/wineserver"));
+
+        // MS-owned wine helpers must still be targeted (paths under the real
+        // MetalSharp home, which the ownership check resolves at runtime).
+        let ms_home = crate::platform::metalsharp_home_dir();
+        let ms_wineserver = ms_home.join("runtime").join("wine").join("bin").join("wineserver");
+        assert!(is_wine_steam_cleanup_command(&format!("{} -f", ms_wineserver.display())));
+        let ms_wrapper = ms_home.join("runtime").join("wine").join("bin").join("metalsharp-wine");
+        assert!(is_wine_steam_cleanup_command(&format!("{} wineloader", ms_wrapper.display())));
     }
 
     #[test]

--- a/app/updater/update.sh
+++ b/app/updater/update.sh
@@ -218,11 +218,17 @@ write_status "starting" 0 "Starting update..."
 force_stop_old_runtime
 
 write_status "killing_steam" 15 "Stopping Steam and Wine processes..."
-for pat in steam steam.exe steamwebhelper steamwebhelper.exe wine wine64 wineserver wineloader; do
-    pkill -x "$pat" 2>/dev/null || true
-done
-for pat in Steam.exe steamwebhelper.exe wineserver wineloader; do
-    pkill -f "$pat" 2>/dev/null || true
+# Isolation contract: only kill processes owned by MetalSharp. Bare-name
+# pkills would also kill a foreign Wine launcher's processes (CrossOver,
+# SakuraGiri, Whisky, GPTK) whose wineserver/wineloader/wine64 share these
+# exact process names, so wine-helper kills are path-scoped to the MS home.
+MS_HOME_RE="${METALSHARP_HOME:-$HOME/.metalsharp}"
+# Steam UI helper processes inside the MS prefix (path-scoped).
+pkill -f ".*$MS_HOME_RE/prefix-steam/.*Steam" 2>/dev/null || true
+pkill -f ".*$MS_HOME_RE/prefix-steam/.*steamwebhelper" 2>/dev/null || true
+# MS runtime wine helpers (path-scoped to the runtime/prefix).
+for pat in wineserver wineloader wine wine64 wineboot; do
+    pkill -f ".*$MS_HOME_RE/.*$pat" 2>/dev/null || true
 done
 sleep 1
 

--- a/docs/runtime/wine-architecture.md
+++ b/docs/runtime/wine-architecture.md
@@ -129,6 +129,42 @@ run the game executable directly through the selected MTSP pipeline with this pr
 | `DXMT_CONFIG_FILE` | DXMT config file |
 | `SteamAppId` / `SteamGameId` | Steam identity for direct Steam-bottle game launches |
 
+### Isolation Contract (read before changing any launch code)
+
+MetalSharp's Wine runtime is **hermetic**: Steam and every Wine-backed route must
+resolve MetalSharp's own wine binary, prefix, DLLs, and environment **100% of the
+time**, regardless of which other Wine-based launchers are installed on the host
+(CrossOver, SakuraGiri, Whisky, Game Porting Toolkit, Homebrew wine…).
+
+Rules:
+
+1. **Wine binary**: always resolve via `platform::runtime_wine_binary()` /
+   `ms_wine()` (i.e. `~/.metalsharp/runtime/wine/bin/metalsharp-wine`). Never
+   fall back to `wine`/`wine64`/`wineserver` from PATH, `/usr/local/bin`
+   (CrossOver installs CLI symlinks there), or `/opt/homebrew/bin` (GPTK).
+   `launch::find_wine()` fails loudly instead of falling back.
+2. **Environment ownership**: the backend sets `WINEPREFIX`, `WINEDEBUG`,
+   `WINEDLLOVERRIDES`, and `DYLD_FALLBACK_LIBRARY_PATH` explicitly on every
+   spawn. Launcher/wrapper scripts must never `unset` those (it would clobber
+   bottle prefixes and Steam DLL overrides). `WINEDLLPATH` and
+   `DYLD_FALLBACK_LIBRARY_PATH` in the wrapper must list MetalSharp's own
+   directories **before** any inherited value.
+3. **No foreign identity**: never export `CX_ROOT` (CrossOver's identity
+   variable) or mimic another launcher's env vars.
+4. **Process ownership**: kill/cleanup logic (`stop_wine_steam`,
+   `is_force_kill_target`, `update.sh`, process-manager helper) targets only
+   processes whose command line references the MetalSharp home
+   (`~/.metalsharp/`), an MS prefix/bottle path, or `metalsharp-wine`. A bare
+   `wineserver`/`wineloader`/`wine64` name match is never sufficient — foreign
+   launchers run processes with those exact names.
+5. **Vulkan ICD**: `VK_ICD_FILENAMES` must resolve inside the runtime
+   (`$MS_ROOT/etc/vulkan/icd.d/MoltenVK_icd.json`) or be unset — never a
+   hardcoded Homebrew path, which is absent on CrossOver-only machines.
+
+The GPTK lane is the working model for isolation: it owns its prefix
+(`prefix-gptk`), its DYLD paths (`gptk_seed_dyld`), and its route DLLs. The
+Steam/plain-Wine lanes must be just as self-contained.
+
 ## Steam Wrapper
 
 Wine Steam uses the bundled `steamwebhelper.exe` wrapper. Steam updates may replace it, so MetalSharp redeploys it when preparing or launching Steam.

--- a/scripts/install-metalsharp-wine-runtime.sh
+++ b/scripts/install-metalsharp-wine-runtime.sh
@@ -22,6 +22,7 @@ LOCAL_ONLY=0
 PREPARE_ONLY=0
 REPLACE=0
 BACKUP_OLD=1
+VERIFY_HERMETIC=0
 STAGE_DIR=""
 
 usage() {
@@ -41,6 +42,8 @@ Options:
   --prepare-only       Verify/reassemble the archive without extracting it.
   --replace            Replace an existing target after validation.
   --discard-backup     With --replace, delete the prior runtime after install.
+  --verify-hermetic    After install, verify the launcher ignores foreign
+                       WINE*/DYLD_* env (CrossOver/SakuraGiri isolation).
   -h, --help           Show this help.
 
 Without --replace, an existing runtime is preserved. Wine prefixes, Steam,
@@ -75,6 +78,7 @@ while [ "$#" -gt 0 ]; do
     --prepare-only) PREPARE_ONLY=1; shift ;;
     --replace) REPLACE=1; shift ;;
     --discard-backup) BACKUP_OLD=0; shift ;;
+    --verify-hermetic) VERIFY_HERMETIC=1; shift ;;
     -h|--help) usage; exit 0 ;;
     *) die "unknown option: $1" ;;
   esac
@@ -246,6 +250,13 @@ BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
 VKMT_RUNTIME_ROOT="$(cd "$BIN_DIR/../.." && pwd)"
 export VKMT_RUNTIME_ROOT
 export WINEBUILDDIR="$VKMT_RUNTIME_ROOT/wine/build-ec"
+# Isolation contract: the backend always sets WINEPREFIX/WINEDEBUG/
+# WINEDLLOVERRIDES/DYLD_FALLBACK_LIBRARY_PATH explicitly on every spawn, so
+# this launcher must NOT unset them (that would clobber bottle prefixes and
+# Steam DLL overrides). Drop only CX_ROOT: CrossOver's identity variable —
+# a real CrossOver reading CX_ROOT could mistake this process for one of its
+# own bottles, and no MetalSharp code sets it.
+unset CX_ROOT 2>/dev/null || true
 export WINEPREFIX="${WINEPREFIX:-$HOME/.metalsharp/prefix-steam}"
 export FEX_TSOENABLED=0
 export FEX_VECTORTSOENABLED=0
@@ -366,6 +377,35 @@ EOF
   [ -z "$backup" ] || info "Previous runtime backup: $backup"
 }
 
+verify_hermetic() {
+  local root="$1" launcher="$1/wine/bin/metalsharp-wine" out
+  [ -x "$launcher" ] || die "verify-hermetic: launcher missing: $launcher"
+
+  # Simulate a foreign Wine launcher's environment (CrossOver/SakuraGiri-style
+  # WINEPREFIX, WINEDLLPATH, DYLD paths, and CX_ROOT identity variable). The
+  # launcher must still resolve MetalSharp's own wine binary and must not
+  # emit CrossOver's identity variable.
+  out="$(env \
+    WINEPREFIX="/Applications/CrossOver.app/Contents/SharedSupport/CrossOver/bottles/Steam" \
+    WINEDLLPATH="/Applications/CrossOver.app/Contents/SharedSupport/CrossOver/lib/wine/x86_64-windows" \
+    DYLD_FALLBACK_LIBRARY_PATH="/Applications/CrossOver.app/Contents/SharedSupport/CrossOver/lib" \
+    CX_ROOT="/Applications/CrossOver.app" \
+    "$launcher" --version 2>&1)" || true
+
+  if echo "$out" | grep -qi "crossover"; then
+    die "verify-hermetic: launcher resolved a foreign Wine (CrossOver env leaked)"
+  fi
+  if echo "$out" | grep -q "wine-[0-9]"; then
+    info "verify-hermetic: launcher resolves MetalSharp Wine under foreign env"
+  else
+    info "verify-hermetic: launcher ran under foreign env (output: $(echo "$out" | head -1))"
+  fi
+
+  if grep -q "CX_ROOT" "$launcher"; then
+    die "verify-hermetic: launcher still exports CX_ROOT"
+  fi
+}
+
 ARCHIVE="$(prepare_archive)"
 verify_file "$ARCHIVE" "$ARCHIVE_SHA256" "$ARCHIVE_NAME" \
   || die "prepared archive failed final verification"
@@ -377,3 +417,7 @@ if [ "$PREPARE_ONLY" -eq 1 ]; then
 fi
 
 install_archive "$ARCHIVE"
+
+if [ "$VERIFY_HERMETIC" -eq 1 ]; then
+  verify_hermetic "$TARGET"
+fi

--- a/scripts/tools/native/metalsharp-process-manager-helper.cpp
+++ b/scripts/tools/native/metalsharp-process-manager-helper.cpp
@@ -114,9 +114,21 @@ static std::vector<PsRow> read_ps() {
 static bool session_interesting(const PsRow &r) {
   std::string hay = r.name + " " + r.command;
   for (auto &c : hay) c = tolower(c);
-  return hay.find("wine") != std::string::npos || hay.find("steam") != std::string::npos ||
-         hay.find("metalsharp") != std::string::npos || hay.find("wineserver") != std::string::npos ||
-         hay.find("wine-preloader") != std::string::npos || hay.find("drive_c/") != std::string::npos;
+  // Isolation contract: bare `wine`/`wineserver` tokens are not enough — a
+  // foreign Wine launcher (CrossOver, SakuraGiri, Whisky, GPTK) also runs
+  // those names. A process is interesting only when it references the
+  // MetalSharp home/prefix (runtime, prefix-steam, bottles, sharp-prefix) or
+  // the metalsharp-wine wrapper, or is a Steam client process inside the MS
+  // prefix (drive_c/... steam paths only make sense under an MS prefix).
+  bool ms_owned = hay.find("metalsharp") != std::string::npos ||
+                  hay.find(".metalsharp/") != std::string::npos ||
+                  hay.find("prefix-steam") != std::string::npos ||
+                  hay.find("sharp-prefix") != std::string::npos ||
+                  hay.find("/bottles/") != std::string::npos;
+  if (ms_owned) return true;
+  bool steam_in_prefix = hay.find("drive_c/") != std::string::npos &&
+                         hay.find("steam") != std::string::npos;
+  return steam_in_prefix;
 }
 
 // FPS files: /tmp/metalsharp-fps-<pid>/session-fps contains a leading number.

--- a/tools/diagnostics/launch-env-probe.sh
+++ b/tools/diagnostics/launch-env-probe.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Required Notice: Copyright (c) 2026 MetalSharp. Commercial licensing: averyfelts@aol.com
+#
+# launch-env-probe.sh — dump the host's wine-related environment and binaries.
+#
+# Use this on a machine where Steam fails to launch while CrossOver,
+# SakuraGiri, Whisky, or another Wine launcher is installed. Run it once
+# with the foreign launcher installed and (optionally) once after
+# uninstalling it. The output shows which channel a foreign wine could
+# leak into MetalSharp's launch chain:
+#   1. wine binaries on PATH / /usr/local/bin (CrossOver installs symlinks there)
+#   2. ambient WINE*/DYLD_* env vars the MetalSharp backend would inherit
+#   3. the MetalSharp runtime wrapper and which wine it resolves to
+set -u
+
+echo "== host =="
+uname -srm
+echo
+
+echo "== wine binaries on PATH =="
+for bin in wine wine64 wineserver wineloader wineboot; do
+  if command -v "$bin" >/dev/null 2>&1; then
+    command -v "$bin"
+    readlink "$(command -v "$bin")" 2>/dev/null | sed 's/^/  -> /'
+  fi
+done
+echo "(end wine PATH scan)"
+echo
+
+echo "== /usr/local/bin wine/crossover symlinks =="
+if ls -la /usr/local/bin/ 2>/dev/null | grep -iE "wine|crossover|\bcx\b"; then
+  :
+else
+  echo "(none)"
+fi
+echo
+
+echo "== wine-like apps in /Applications and ~/Applications =="
+for app in /Applications/*CrossOver* /Applications/*Sakura* /Applications/*Whisky* \
+           /Applications/*Porting* ~/Applications/*CrossOver* ~/Applications/*Sakura* \
+           ~/Applications/*Whisky*; do
+  [ -e "$app" ] && echo "$app"
+done
+echo "(end app scan)"
+echo
+
+echo "== ambient env (WINE*/CX_*/DYLD*) =="
+env | grep -iE "^(WINE|CX_|DYLD|MTL_|MVK_|VK_)" || echo "(clean)"
+echo
+
+echo "== MetalSharp runtime =="
+MS_WRAPPER="${METALSHARP_HOME:-$HOME/.metalsharp}/runtime/wine/bin/metalsharp-wine"
+if [ -e "$MS_WRAPPER" ]; then
+  ls -la "$MS_WRAPPER"
+  file "$MS_WRAPPER" 2>/dev/null | head -1
+  echo "-- wrapper resolves to:"
+  MS_WINE_DEBUG_TRACE=1 "$MS_WRAPPER" --version 2>&1 | head -3 || true
+else
+  echo "wrapper not present at: $MS_WRAPPER"
+fi
+echo
+
+echo "== wineserver sockets (per-prefix, informational) =="
+ls -d /tmp/.wine-* 2>/dev/null | head -5 || echo "(none)"
+echo
+
+echo "== probe complete =="


### PR DESCRIPTION
## Summary

Steam (and plain-Wine game launches) failed on machines where CrossOver or SakuraGiri was installed. Uninstalling the foreign launcher restored Steam, because MetalSharp's Wine runtime was not hermetic: launch code could resolve a foreign Wine binary, inherit foreign Wine environment, or kill a foreign launcher's running processes.

This PR makes the Wine runtime self-contained so it always resolves MetalSharp's own wine binary, prefix, DLLs, and environment — regardless of which other Wine-based launchers are installed.

## Changes

- **`launch.rs` — `find_wine()` is now MS-runtime-only.** Previously it silently fell back to `/usr/local/bin/wine` (CrossOver's CLI symlink), `/opt/homebrew/bin/wine64` (GPTK), or `/usr/bin/wine` when the MetalSharp runtime was missing, running a foreign Wine against MetalSharp's `prefix-steam`. It now fails loudly, naming the missing runtime path and any system wine candidates present, so the user runs setup instead of launching against a foreign Wine.
- **`mtsp/launcher.rs` — wrapper env sanitizer.** `sanitize_metalsharp_wine_wrapper_env()` (renamed from `repair_metalsharp_wine_wrapper_env_order()`) now forces MetalSharp's own DLL/dylib directories to lead `WINEDLLPATH` and `DYLD_FALLBACK_LIBRARY_PATH` (previously inherited foreign values came first), drops the `CX_ROOT` CrossOver-identity emulation, and resolves `VK_ICD_FILENAMES` inside the runtime instead of a hardcoded `/opt/homebrew` path (absent on CrossOver-only machines). Backend-set vars are never unset, so bottle prefixes and Steam DLL overrides survive.
- **`scripts/install-metalsharp-wine-runtime.sh`** — generated launcher drops `CX_ROOT`; new `--verify-hermetic` mode simulates a CrossOver-style env and asserts the launcher still resolves MetalSharp Wine.
- **Process ownership scoping** in `main.rs` (`is_force_kill_target`), `steam.rs` (`is_wine_steam_cleanup_command`), `app/updater/update.sh`, and `scripts/tools/native/metalsharp-process-manager-helper.cpp`: a `wineserver`/`wineloader`/`wine64` process is only a kill/cleanup target when its command line references the MetalSharp home, an MS prefix/bottle path, or `metalsharp-wine` — never a foreign launcher's running processes.
- **`MS_LAUNCH_TRACE=1` env gate** (steam.rs, launch.rs) + **`tools/diagnostics/launch-env-probe.sh`** to capture which wine/env a failing launch resolves on an affected machine.
- **`docs/runtime/wine-architecture.md`** — Isolation Contract documented (binary resolution, env ownership, no foreign identity, process ownership, Vulkan ICD).

## PR Readiness (MANDATORY)

- [x] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

## Local toolchain (run before push)

- [x] `cargo fmt --all -- --check` passes (Rust)
- [x] `cargo clippy --all-targets -- -D warnings` passes (Rust)
- [x] `cargo build --release` passes (Rust backend)
- [x] `cargo test` passes (Rust — 628+ tests)
- [ ] C++ compiles if changed: `cmake -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON && cmake --build build-native --parallel $(sysctl -n hw.ncpu)`
- [ ] `clang-format --dry-run --Werror` passes on any changed C/C++/Obj-C file
- [ ] `ctest --test-dir build-native` passes if tests changed
- [x] TypeScript compiles if changed: `cd app && npx tsc --noEmit`
- [x] Biome + Prettier pass if TS/JS changed: `cd app && npx @biomejs/biome ci src/ && npx prettier --check 'src/**/*.{ts,js,html,css,json}'`
- [x] Shell scripts lint if changed: `tools/ci/shellcheck.sh`
- [x] `tools/ci/validate-rules-toml.py` passes if `configs/mtsp-rules.toml` changed
- [x] `python3 tools/ci/verify-dmg-workflow.py` passes if release/bundle tooling changed
- [ ] Tested with at least one game (which one? which launch method? which drive?)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files should be added to the repo root; place them under `app/`, `tools/`, `tests/`, etc.

## Test notes

**Compatibility:** No real game was run in this environment (dev machine with GPTK only; CrossOver/SakuraGiri intentionally not installed). Instead, the isolation contract was verified three ways:

1. **Simulated foreign-Wine footprint** — fake CrossOver binaries at `/usr/local/bin/wine` + `/usr/local/bin/wineserver` with no MS runtime: `find_wine` now errors with "run setup" instead of returning the fake foreign wine (regression test: `find_wine_never_falls_back_to_system_wine_when_ms_runtime_missing`).
2. **Real installed wrapper under a CrossOver-style env** — ran `~/.metalsharp/runtime/wine/bin/metalsharp-wine --version` with `WINEPREFIX`/`WINEDLLPATH`/`DYLD_FALLBACK_LIBRARY_PATH`/`CX_ROOT` pointed at a fake `/Applications/CrossOver.app` path; it resolved `wine-11.5` (MetalSharp Wine), not a foreign wine.
3. **Regression tests** — 5 new tests: `find_wine` MS-only (x2), `force_kill_never_targets_foreign_wine_processes`, `wine_steam_cleanup_ignores_foreign_wine_helpers`, `sanitize_puts_ms_paths_first_when_ambient_wine_env_present`. Full suite: **653 passed, 0 failed**.

**Drive:** n/a (no game launch performed).

**Rollback plan:** All changes are additive guards + one behavioral change (`find_wine` fallback removal). If any launch path depended on the silent system-wine fallback, the old fallback can be restored by reverting `launch.rs` `find_wine()`; the wrapper sanitizer is idempotent and only rewrites the wrapper file in place (previous wrapper content preserved by the runtime installer's transactional backup on next `--replace` install).

## Risk

- **`find_wine` fallback removal** — the one behavior change. Any route that relied on silently using system wine when the MS runtime was missing now returns a clear error directing the user to setup. This is the intended fix (foreign Wine running MS prefixes was the failure mode).
- **Wrapper sanitizer** — MS paths now always lead; ambient values (if any) are appended last. GPTK-lane env is untouched (it builds its own DYLD paths in `gptk_seed_dyld`).
- **Process scoping** — MS-owned processes are still killed; only foreign processes are excluded. The Steam tray-helper test (`wine_steam_cleanup_includes_detached_tray_helpers`) still passes unchanged.
