### PR TITLE
feat: M12 moves to vkd3d-proton (D3D12 -> Vulkan -> MoltenVK) with DXMT rollback

### DIFF
--- a/app/src-rust/src/bottles.rs
+++ b/app/src-rust/src/bottles.rs
@@ -690,7 +690,8 @@ fn m12_runtime_component_artifacts(
         "m12_dxgi" => Some(&[("dxvk", "x86_64-windows/dxgi.dll")]),
         "m12_moltenvk" => Some(&[("moltenvk-vkmt", "libMoltenVK.dylib"), ("moltenvk-vkmt", "MoltenVK_icd.json")]),
         "m12_gpu_stubs" => {
-            Some(&[("vkd3d-proton", "x86_64-windows/nvapi64.dll"), ("vkd3d-proton", "x86_64-windows/nvngx.dll")])
+            // Stubs are shared with the DXMT M12 lane (vkd3d-proton ships none).
+            Some(&[("dxmt_m12", "x86_64-windows/nvapi64.dll"), ("dxmt_m12", "x86_64-windows/nvngx.dll")])
         },
         _ => None,
     }

--- a/app/src-rust/src/bottles.rs
+++ b/app/src-rust/src/bottles.rs
@@ -620,16 +620,17 @@ pub fn load_bottle(id: &str) -> Result<BottleManifest, Box<dyn std::error::Error
 fn normalize_loaded_runtime_profile_components(manifest: &mut BottleManifest) {
     let should_rebuild = match manifest.runtime_profile {
         RuntimeProfile::M12 => {
-            let has_pr230_shape = M12_RUNTIME_COMPONENT_IDS
-                .iter()
-                .all(|id| manifest.installed_components.iter().any(|component| component.id == *id));
+            let home = dirs::home_dir().unwrap_or_default();
+            let active_ids = m12_runtime_component_ids_for_home(&home);
+            let has_active_shape =
+                active_ids.iter().all(|id| manifest.installed_components.iter().any(|component| component.id == *id));
             let has_stale_m12_shape = manifest.installed_components.iter().any(|component| {
                 matches!(
                     component.id.as_str(),
                     "d3d12" | "d3d11" | "dxgi" | "gpu_vendor_stubs" | "gptk" | "gptk_prefix" | "rosetta"
                 )
             });
-            !has_pr230_shape || has_stale_m12_shape
+            !has_active_shape || has_stale_m12_shape
         },
         RuntimeProfile::D3DMetal => {
             manifest.installed_components.iter().any(|component| is_m12_runtime_component(&component.id))
@@ -643,61 +644,123 @@ fn normalize_loaded_runtime_profile_components(manifest: &mut BottleManifest) {
     }
 }
 
-const M12_RUNTIME_COMPONENT_IDS: &[&str] =
+const M12_DXMT_COMPONENT_IDS: &[&str] =
     &["m12_d3d12", "m12_d3d11", "m12_d3d10core", "m12_dxgi_dxmt", "m12_dxgi", "m12_winemetal", "m12_gpu_stubs"];
+const M12_VKD3D_COMPONENT_IDS: &[&str] = &["m12_d3d12", "m12_d3d12core", "m12_dxgi", "m12_moltenvk", "m12_gpu_stubs"];
 
-fn m12_runtime_component_artifacts(component_id: &str) -> Option<&'static [&'static str]> {
+/// The M12 component set for the active backend: vkd3d-proton (default)
+/// tracks the vkd3d-proton/DXVK/MoltenVK lanes; dxmt tracks the DXMT lane.
+fn m12_runtime_component_ids(backend: &str) -> &'static [&'static str] {
+    if backend == "dxmt" {
+        M12_DXMT_COMPONENT_IDS
+    } else {
+        M12_VKD3D_COMPONENT_IDS
+    }
+}
+
+/// Artifacts per M12 component as `(lane, rel-path)` pairs, where `lane` is
+/// the subdir under `runtime/wine/lib/` that carries the file.
+fn m12_runtime_component_artifacts(
+    backend: &str,
+    component_id: &str,
+) -> Option<&'static [(&'static str, &'static str)]> {
+    if backend == "dxmt" {
+        return match component_id {
+            "m12_d3d12" => Some(&[("dxmt_m12", "x86_64-windows/d3d12.dll")]),
+            "m12_d3d11" => Some(&[("dxmt_m12", "x86_64-windows/d3d11.dll")]),
+            "m12_d3d10core" => Some(&[("dxmt_m12", "x86_64-windows/d3d10core.dll")]),
+            "m12_dxgi_dxmt" => Some(&[("dxmt_m12", "x86_64-windows/dxgi_dxmt.dll")]),
+            "m12_dxgi" => Some(&[("dxmt_m12", "x86_64-windows/dxgi.dll")]),
+            "m12_winemetal" => Some(&[
+                ("dxmt_m12", "x86_64-windows/winemetal.dll"),
+                ("dxmt_m12", "x86_64-unix/winemetal.so"),
+                ("dxmt_m12", "x86_64-unix/libc++.1.dylib"),
+                ("dxmt_m12", "x86_64-unix/libc++abi.1.dylib"),
+                ("dxmt_m12", "x86_64-unix/libunwind.1.dylib"),
+            ]),
+            "m12_gpu_stubs" => {
+                Some(&[("dxmt_m12", "x86_64-windows/nvapi64.dll"), ("dxmt_m12", "x86_64-windows/nvngx.dll")])
+            },
+            _ => None,
+        };
+    }
     match component_id {
-        "m12_d3d12" => Some(&["x86_64-windows/d3d12.dll"]),
-        "m12_d3d11" => Some(&["x86_64-windows/d3d11.dll"]),
-        "m12_d3d10core" => Some(&["x86_64-windows/d3d10core.dll"]),
-        "m12_dxgi_dxmt" => Some(&["x86_64-windows/dxgi_dxmt.dll"]),
-        "m12_dxgi" => Some(&["x86_64-windows/dxgi.dll"]),
-        "m12_winemetal" => Some(&[
-            "x86_64-windows/winemetal.dll",
-            "x86_64-unix/winemetal.so",
-            "x86_64-unix/libc++.1.dylib",
-            "x86_64-unix/libc++abi.1.dylib",
-            "x86_64-unix/libunwind.1.dylib",
-        ]),
-        "m12_gpu_stubs" => Some(&["x86_64-windows/nvapi64.dll", "x86_64-windows/nvngx.dll"]),
+        "m12_d3d12" => Some(&[("vkd3d-proton", "x86_64-windows/d3d12.dll")]),
+        "m12_d3d12core" => Some(&[("vkd3d-proton", "x86_64-windows/d3d12core.dll")]),
+        "m12_dxgi" => Some(&[("dxvk", "x86_64-windows/dxgi.dll")]),
+        "m12_moltenvk" => Some(&[("moltenvk-vkmt", "libMoltenVK.dylib"), ("moltenvk-vkmt", "MoltenVK_icd.json")]),
+        "m12_gpu_stubs" => {
+            Some(&[("vkd3d-proton", "x86_64-windows/nvapi64.dll"), ("vkd3d-proton", "x86_64-windows/nvngx.dll")])
+        },
         _ => None,
     }
 }
 
-fn is_m12_runtime_component(component_id: &str) -> bool {
-    m12_runtime_component_artifacts(component_id).is_some()
+/// True when the given lane artifact exists (and matches its pinned hash where
+/// the lane has one). `lane` is the subdir under `runtime/wine/lib/`.
+fn m12_lane_artifact_valid_for_home(home: &Path, lane: &str, rel: &str) -> bool {
+    match lane {
+        "dxmt_m12" => crate::installer::dxmt_m12_runtime_artifact_valid_for_home(home, rel),
+        "vkd3d-proton" => crate::installer::vkd3d_proton_runtime_artifact_valid_for_home(home, rel),
+        "dxvk" => crate::installer::dxvk_runtime_dir_for_home(home).join(rel).is_file(),
+        "moltenvk-vkmt" => crate::installer::moltenvk_vkmt_runtime_dir_for_home(home).join(rel).is_file(),
+        _ => false,
+    }
 }
 
-fn inspect_m12_runtime_component(component_id: &str) -> Option<ComponentState> {
-    let artifacts = m12_runtime_component_artifacts(component_id)?;
+fn is_m12_runtime_component(component_id: &str) -> bool {
+    m12_runtime_component_artifacts("vkd3d-proton", component_id).is_some()
+        || m12_runtime_component_artifacts("dxmt", component_id).is_some()
+}
+
+fn inspect_m12_runtime_component(backend: &str, component_id: &str) -> Option<ComponentState> {
+    let artifacts = m12_runtime_component_artifacts(backend, component_id)?;
     let home = dirs::home_dir()?;
-    let valid_count = artifacts
-        .iter()
-        .filter(|artifact| crate::installer::dxmt_m12_runtime_artifact_valid_for_home(&home, artifact))
-        .count();
+    let valid_count =
+        artifacts.iter().filter(|(lane, artifact)| m12_lane_artifact_valid_for_home(&home, lane, artifact)).count();
     if valid_count == artifacts.len() {
         Some(ComponentState::Installed)
-    } else if valid_count > 0 || crate::installer::dxmt_m12_runtime_current_for_home(&home) {
+    } else if valid_count > 0 {
         Some(ComponentState::NeedsRepair)
     } else {
         Some(ComponentState::Missing)
     }
 }
 
+/// The M12 component set for the active backend (reads the m12Backend config).
+fn m12_runtime_component_ids_for_home(home: &Path) -> &'static [&'static str] {
+    m12_runtime_component_ids(&crate::launch::m12_backend_mode_for(home))
+}
+
+/// Active M12 backend for bottle purposes ("vkd3d-proton" default, "dxmt"
+/// fallback), path-based for tests.
+fn m12_backend_for_home(home: &Path) -> String {
+    crate::launch::m12_backend_mode_for(home)
+}
+
 fn m12_runtime_component_detail(component_id: &str) -> String {
-    let artifacts = m12_runtime_component_artifacts(component_id).unwrap_or(&[]);
+    let backend = m12_backend_for_home(&dirs::home_dir().unwrap_or_default());
+    let artifacts = m12_runtime_component_artifacts(&backend, component_id).unwrap_or(&[]);
     let home = dirs::home_dir().unwrap_or_default();
     let paths = artifacts
         .iter()
-        .map(|artifact| {
-            crate::installer::dxmt_m12_runtime_artifact_path_for_home(&home, artifact).to_string_lossy().to_string()
+        .map(|(lane, artifact)| {
+            crate::platform::metalsharp_home_dir_for(&home)
+                .join("runtime")
+                .join("wine")
+                .join("lib")
+                .join(lane)
+                .join(artifact)
+                .to_string_lossy()
+                .to_string()
         })
         .collect::<Vec<_>>();
     if paths.is_empty() {
-        "M12 DXMT runtime artifact".to_string()
-    } else {
+        "M12 runtime artifact".to_string()
+    } else if backend == "dxmt" {
         format!("PR230 M12 DXMT runtime artifact(s): {}", paths.join(", "))
+    } else {
+        format!("vkd3d-proton M12 runtime artifact(s): {}", paths.join(", "))
     }
 }
 
@@ -719,11 +782,14 @@ pub fn save_bottle(manifest: &BottleManifest) -> Result<(), Box<dyn std::error::
 }
 
 fn refresh_dxmt_runtime_before_save(manifest: &mut BottleManifest) {
+    let home = dirs::home_dir().unwrap_or_default();
+    let backend = m12_backend_for_home(&home);
     let (lane, components): (&str, &[&str]) = match manifest.runtime_profile {
         RuntimeProfile::M11 | RuntimeProfile::M11_32 | RuntimeProfile::M10 | RuntimeProfile::M10_32 => {
             ("dxmt", &["d3d11", "dxgi"])
         },
-        RuntimeProfile::M12 => ("dxmt_m12", M12_RUNTIME_COMPONENT_IDS),
+        RuntimeProfile::M12 if backend == "dxmt" => ("dxmt_m12", M12_DXMT_COMPONENT_IDS),
+        RuntimeProfile::M12 => ("vkd3d-proton", M12_VKD3D_COMPONENT_IDS),
         _ => return,
     };
 
@@ -731,25 +797,31 @@ fn refresh_dxmt_runtime_before_save(manifest: &mut BottleManifest) {
         merge_components(manifest.installed_components.clone(), default_components_for(manifest.runtime_profile));
 
     #[cfg(not(test))]
-    let runtime_ready = dirs::home_dir()
-        .ok_or_else(|| "home directory could not be resolved".to_string())
-        .and_then(|home| match manifest.runtime_profile {
-            RuntimeProfile::M11 | RuntimeProfile::M11_32 | RuntimeProfile::M10 | RuntimeProfile::M10_32 => {
-                crate::installer::ensure_dxmt_runtime_ready(&home).map(|_| true)
-            },
-            RuntimeProfile::M12 => crate::installer::ensure_dxmt_m12_runtime_ready(&home)
-                .map(|_| crate::installer::dxmt_m12_runtime_current_for_home(&home)),
-            _ => Ok(false),
-        })
-        .unwrap_or_else(|e| {
-            eprintln!("bottle: {} shared runtime setup failed before save: {}", lane, e);
-            false
-        });
+    let runtime_ready = match manifest.runtime_profile {
+        RuntimeProfile::M11 | RuntimeProfile::M11_32 | RuntimeProfile::M10 | RuntimeProfile::M10_32 => {
+            crate::installer::ensure_dxmt_runtime_ready(&home).map(|_| true)
+        },
+        RuntimeProfile::M12 if backend == "dxmt" => crate::installer::ensure_dxmt_m12_runtime_ready(&home)
+            .map(|_| crate::installer::dxmt_m12_runtime_current_for_home(&home)),
+        RuntimeProfile::M12 => crate::installer::ensure_vkd3d_proton_runtime_ready(&home)
+            .map(|_| crate::installer::vkd3d_proton_runtime_current_for_home(&home)),
+        _ => Ok(false),
+    }
+    .unwrap_or_else(|e| {
+        eprintln!("bottle: {} shared runtime setup failed before save: {}", lane, e);
+        false
+    });
     #[cfg(test)]
-    let runtime_ready = dirs::home_dir()
-        .map(|home| crate::installer::runtime_artifact_report_for(&home))
-        .and_then(|report| report.get(lane).and_then(|lane| lane.get("all_present")).and_then(|value| value.as_bool()))
-        .unwrap_or(false);
+    let runtime_ready = {
+        let report = crate::installer::runtime_artifact_report_for(&home);
+        if backend == "dxmt" {
+            report.get(lane).and_then(|lane| lane.get("all_present")).and_then(|value| value.as_bool()).unwrap_or(false)
+        } else {
+            crate::installer::vkd3d_proton_runtime_current_for_home(&home)
+                && crate::installer::moltenvk_vkmt_runtime_ready_for_home(&home)
+                && crate::installer::dxvk_runtime_ready_for_home(&home)
+        }
+    };
 
     if runtime_ready {
         eprintln!("bottle: {} shared runtime is current before save", lane);
@@ -2512,8 +2584,31 @@ pub fn repair_component(
 
     if matches!(manifest.runtime_profile, RuntimeProfile::M12) && is_m12_runtime_component(component_id) {
         let home = dirs::home_dir().ok_or("no home dir")?;
+        let backend = m12_backend_for_home(&home);
+        let component_ids = m12_runtime_component_ids(&backend);
+        let (ensure, lane_label): (fn(&Path) -> Result<bool, String>, &str) = if backend == "dxmt" {
+            (crate::installer::ensure_dxmt_m12_runtime_ready, "runtime/wine/lib/dxmt_m12")
+        } else {
+            (
+                crate::installer::ensure_vkd3d_proton_runtime_ready,
+                "runtime/wine/lib/vkd3d-proton (+dxvk, moltenvk-vkmt)",
+            )
+        };
+        let refresh_detail = format!(
+            "Refreshes the M12 {} runtime surface under {}",
+            if backend == "dxmt" { "DXMT" } else { "vkd3d-proton" },
+            lane_label
+        );
+        let asset_rel = if backend == "dxmt" { "x86_64-windows/d3d12.dll" } else { "x86_64-windows/d3d12core.dll" };
+        let asset_path = crate::platform::metalsharp_home_dir_for(&home)
+            .join("runtime")
+            .join("wine")
+            .join("lib")
+            .join(if backend == "dxmt" { "dxmt_m12" } else { "vkd3d-proton" })
+            .join(asset_rel);
+
         if dry_run {
-            let state = inspect_m12_runtime_component(component_id).unwrap_or(ComponentState::Missing);
+            let state = inspect_m12_runtime_component(&backend, component_id).unwrap_or(ComponentState::Missing);
             return Ok(ComponentRepairReport {
                 id: component_id.to_string(),
                 status: if state == ComponentState::Installed {
@@ -2525,21 +2620,17 @@ pub fn repair_component(
                 detail: if state == ComponentState::Installed {
                     format!("{} is already current", m12_runtime_component_detail(component_id))
                 } else {
-                    "Refreshes the bundled PR230 M12 DXMT runtime surface under runtime/wine/lib/dxmt_m12".to_string()
+                    refresh_detail.clone()
                 },
-                asset_path: Some(
-                    crate::installer::dxmt_m12_runtime_artifact_path_for_home(&home, "x86_64-windows/d3d12.dll")
-                        .to_string_lossy()
-                        .to_string(),
-                ),
+                asset_path: Some(asset_path.to_string_lossy().to_string()),
                 log_path: None,
                 pid: None,
             });
         }
 
-        crate::installer::ensure_dxmt_m12_runtime_ready(&home)?;
-        for id in M12_RUNTIME_COMPONENT_IDS {
-            let state = inspect_m12_runtime_component(id).unwrap_or(ComponentState::Missing);
+        ensure(&home)?;
+        for id in component_ids {
+            let state = inspect_m12_runtime_component(&backend, id).unwrap_or(ComponentState::Missing);
             mark_component_state(&mut manifest, id, state);
         }
         manifest.health = if components_ready(&manifest.installed_components) {
@@ -2549,16 +2640,16 @@ pub fn repair_component(
         };
         manifest.updated_at = timestamp_secs();
         save_bottle(&manifest)?;
-        let state = inspect_m12_runtime_component(component_id).unwrap_or(ComponentState::Missing);
+        let state = inspect_m12_runtime_component(&backend, component_id).unwrap_or(ComponentState::Missing);
         return Ok(ComponentRepairReport {
             id: component_id.to_string(),
             status: if state == ComponentState::Installed { "installed" } else { "needs_repair" }.to_string(),
-            detail: format!("Refreshed PR230 M12 DXMT runtime surface; {}", m12_runtime_component_detail(component_id)),
-            asset_path: Some(
-                crate::installer::dxmt_m12_runtime_artifact_path_for_home(&home, "x86_64-windows/d3d12.dll")
-                    .to_string_lossy()
-                    .to_string(),
+            detail: format!(
+                "Refreshed M12 {} runtime surface; {}",
+                if backend == "dxmt" { "DXMT" } else { "vkd3d-proton" },
+                m12_runtime_component_detail(component_id)
             ),
+            asset_path: Some(asset_path.to_string_lossy().to_string()),
             log_path: None,
             pid: None,
         });
@@ -3440,25 +3531,30 @@ fn runtime_profile_definition(profile: RuntimeProfile) -> RuntimeProfileDefiniti
             &["d3d11", "dxgi", "winemetal", "vcrun2019_x86"][..],
             crate::mtsp::engine::PipelineId::M11_32,
         ),
-        RuntimeProfile::M12 => (
-            "D3D12 Metal",
-            BottleArch::Win64,
-            true,
-            &[
-                "m12_d3d12",
-                "m12_d3d11",
-                "m12_d3d10core",
-                "m12_dxgi_dxmt",
-                "m12_dxgi",
-                "m12_winemetal",
-                "m12_gpu_stubs",
-                "vcrun2019_x64",
-                "vcrun2019_x86",
-                "d3d12_agility",
-                "corefonts",
-            ][..],
-            crate::mtsp::engine::PipelineId::M12,
-        ),
+        RuntimeProfile::M12 => {
+            let home = dirs::home_dir().unwrap_or_default();
+            let backend = m12_backend_for_home(&home);
+            let m12_components: &[&str] = if backend == "dxmt" {
+                &[
+                    "m12_d3d12",
+                    "m12_d3d11",
+                    "m12_d3d10core",
+                    "m12_dxgi_dxmt",
+                    "m12_dxgi",
+                    "m12_winemetal",
+                    "m12_gpu_stubs",
+                ]
+            } else {
+                &["m12_d3d12", "m12_d3d12core", "m12_dxgi", "m12_moltenvk", "m12_gpu_stubs"]
+            };
+            (
+                "D3D12 Metal",
+                BottleArch::Win64,
+                true,
+                &[m12_components, &["vcrun2019_x64", "vcrun2019_x86", "d3d12_agility", "corefonts"]].concat()[..],
+                crate::mtsp::engine::PipelineId::M12,
+            )
+        },
         RuntimeProfile::M13 => (
             "GPTK D3DMetal",
             BottleArch::Win64,
@@ -3909,7 +4005,8 @@ fn inspect_components_for_manifest(
             let fallback = inspect_component_state(prefix, &component.id, component.state);
             let state =
                 if matches!(manifest.runtime_profile, RuntimeProfile::M12) && is_m12_runtime_component(&component.id) {
-                    inspect_m12_runtime_component(&component.id).unwrap_or(fallback)
+                    let backend = m12_backend_for_home(&dirs::home_dir().unwrap_or_default());
+                    inspect_m12_runtime_component(&backend, &component.id).unwrap_or(fallback)
                 } else if component.id == "d3d12_agility" {
                     inspect_d3d12_agility_component_for_manifest(manifest).unwrap_or(fallback)
                 } else if matches!(component.id.as_str(), "fna" | "xna" | "sdl2" | "fna3d" | "faudio" | "fmod") {
@@ -4010,7 +4107,10 @@ fn inspect_component_state(prefix: &Path, id: &str, fallback: ComponentState) ->
     }
 
     match id {
-        id if is_m12_runtime_component(id) => inspect_m12_runtime_component(id).unwrap_or(fallback),
+        id if is_m12_runtime_component(id) => {
+            let backend = m12_backend_for_home(&dirs::home_dir().unwrap_or_default());
+            inspect_m12_runtime_component(&backend, id).unwrap_or(fallback)
+        },
         "wine-mono" => {
             if windows.join("mono").exists() {
                 ComponentState::Installed
@@ -5229,14 +5329,26 @@ fn component_source_policies_for_manifest(manifest: &BottleManifest) -> Vec<Comp
 
 fn component_source_policy(id: &str, arch: BottleArch) -> ComponentSourcePolicy {
     if is_m12_runtime_component(id) {
-        let state = inspect_m12_runtime_component(id).unwrap_or(ComponentState::Unknown);
         let home = dirs::home_dir().unwrap_or_default();
-        let path = m12_runtime_component_artifacts(id)
-            .and_then(|artifacts| artifacts.first().copied())
-            .map(|artifact| crate::installer::dxmt_m12_runtime_artifact_path_for_home(&home, artifact));
+        let backend = m12_backend_for_home(&home);
+        let state = inspect_m12_runtime_component(&backend, id).unwrap_or(ComponentState::Unknown);
+        let path = m12_runtime_component_artifacts(&backend, id).and_then(|artifacts| artifacts.first().copied()).map(
+            |(lane, artifact)| {
+                crate::platform::metalsharp_home_dir_for(&home)
+                    .join("runtime")
+                    .join("wine")
+                    .join("lib")
+                    .join(lane)
+                    .join(artifact)
+            },
+        );
         return ComponentSourcePolicy {
             id: id.to_string(),
-            source: "metalsharp_pr230_dxmt_m12_runtime".to_string(),
+            source: if backend == "dxmt" {
+                "metalsharp_pr230_dxmt_m12_runtime".to_string()
+            } else {
+                "metalsharp_vkd3d_proton_m12_runtime".to_string()
+            },
             available: state == ComponentState::Installed,
             detail: m12_runtime_component_detail(id),
             path: path.map(|p| p.to_string_lossy().to_string()),
@@ -7494,19 +7606,25 @@ mod tests {
     fn gptk_profile_splits_amd_stub_from_dxmt_vendor_stubs() {
         let m12 = default_components_for(RuntimeProfile::M12);
         let m12_ids = m12.iter().map(|c| c.id.as_str()).collect::<Vec<_>>();
-        for required in [
-            "m12_d3d12",
-            "m12_d3d11",
-            "m12_d3d10core",
-            "m12_dxgi_dxmt",
-            "m12_dxgi",
-            "m12_winemetal",
-            "m12_gpu_stubs",
-            "vcrun2019_x64",
-            "vcrun2019_x86",
-            "corefonts",
-            "d3d12_agility",
-        ] {
+        // The active backend drives the M12 component set: vkd3d-proton
+        // (default in tests) tracks the vkd3d-proton/DXVK/MoltenVK lanes.
+        let backend = crate::launch::m12_backend_mode_for(&dirs::home_dir().unwrap_or_default());
+        let required_dxmt = ["m12_d3d11", "m12_d3d10core", "m12_dxgi_dxmt", "m12_winemetal"];
+        let required_vkd3d = ["m12_d3d12", "m12_d3d12core", "m12_dxgi", "m12_moltenvk", "m12_gpu_stubs"];
+        if backend == "dxmt" {
+            for required in required_dxmt {
+                assert!(m12_ids.contains(&required), "M12 dxmt profile should include {required}");
+            }
+            assert!(m12_ids.contains(&"m12_d3d12"));
+        } else {
+            for required in required_vkd3d {
+                assert!(m12_ids.contains(&required), "M12 vkd3d profile should include {required}");
+            }
+            for stale in required_dxmt {
+                assert!(!m12_ids.contains(&stale), "M12 vkd3d profile must not include DXMT-only {stale}");
+            }
+        }
+        for required in ["vcrun2019_x64", "vcrun2019_x86", "corefonts", "d3d12_agility"] {
             assert!(m12_ids.contains(&required), "M12 profile should include {required}");
         }
         assert!(!m12_ids.contains(&"gpu_vendor_stubs"));
@@ -7520,16 +7638,18 @@ mod tests {
 
     #[test]
     fn m12_winemetal_component_tracks_required_unix_sidecars() {
-        let artifacts = m12_runtime_component_artifacts("m12_winemetal").expect("m12 winemetal artifacts");
-        for required in [
-            "x86_64-windows/winemetal.dll",
-            "x86_64-unix/winemetal.so",
-            "x86_64-unix/libc++.1.dylib",
-            "x86_64-unix/libc++abi.1.dylib",
-            "x86_64-unix/libunwind.1.dylib",
+        let artifacts = m12_runtime_component_artifacts("dxmt", "m12_winemetal").expect("m12 winemetal artifacts");
+        for (lane, required) in [
+            ("dxmt_m12", "x86_64-windows/winemetal.dll"),
+            ("dxmt_m12", "x86_64-unix/winemetal.so"),
+            ("dxmt_m12", "x86_64-unix/libc++.1.dylib"),
+            ("dxmt_m12", "x86_64-unix/libc++abi.1.dylib"),
+            ("dxmt_m12", "x86_64-unix/libunwind.1.dylib"),
         ] {
-            assert!(artifacts.contains(&required), "m12_winemetal must validate {required}");
+            assert!(artifacts.contains(&(lane, required)), "m12_winemetal must validate {required}");
         }
+        // m12_winemetal is DXMT-only; the vkd3d backend has no winemetal component.
+        assert!(m12_runtime_component_artifacts("vkd3d-proton", "m12_winemetal").is_none());
     }
 
     #[test]
@@ -7539,6 +7659,43 @@ mod tests {
         assert!(guides.iter().any(|g| g.id == "vcrun2013"));
         assert!(guides.iter().any(|g| g.id == "vcrun2019_x64"));
         assert!(guides.iter().any(|g| g.id == "vcrun2019_x86"));
+    }
+
+    #[test]
+    fn m12_components_are_backend_aware_vkd3d_vs_dxmt() {
+        // vkd3d-proton backend (default): vkd3d/DXVK/MoltenVK lanes, no DXMT.
+        for id in ["m12_d3d12", "m12_d3d12core", "m12_dxgi", "m12_moltenvk", "m12_gpu_stubs"] {
+            assert!(m12_runtime_component_artifacts("vkd3d-proton", id).is_some(), "vkd3d backend must know {id}");
+        }
+        for id in ["m12_d3d11", "m12_d3d10core", "m12_dxgi_dxmt", "m12_winemetal"] {
+            assert!(
+                m12_runtime_component_artifacts("vkd3d-proton", id).is_none(),
+                "vkd3d backend must NOT expose DXMT-only {id}"
+            );
+        }
+        // dxmt backend: full PR230 set.
+        for id in
+            ["m12_d3d12", "m12_d3d11", "m12_d3d10core", "m12_dxgi_dxmt", "m12_dxgi", "m12_winemetal", "m12_gpu_stubs"]
+        {
+            assert!(m12_runtime_component_artifacts("dxmt", id).is_some(), "dxmt backend must know {id}");
+        }
+        // Lane routing: vkd3d d3d12 -> vkd3d-proton lane, dxgi -> dxvk lane.
+        let vkd3d_d3d12 = m12_runtime_component_artifacts("vkd3d-proton", "m12_d3d12").unwrap();
+        assert_eq!(vkd3d_d3d12[0].0, "vkd3d-proton");
+        let vkd3d_dxgi = m12_runtime_component_artifacts("vkd3d-proton", "m12_dxgi").unwrap();
+        assert_eq!(vkd3d_dxgi[0].0, "dxvk");
+        let vkd3d_mvk = m12_runtime_component_artifacts("vkd3d-proton", "m12_moltenvk").unwrap();
+        assert_eq!(vkd3d_mvk[0].0, "moltenvk-vkmt");
+    }
+
+    #[test]
+    fn m12_component_ids_follow_backend() {
+        let vkd3d_ids = m12_runtime_component_ids("vkd3d-proton");
+        assert!(vkd3d_ids.contains(&"m12_d3d12core"));
+        assert!(!vkd3d_ids.contains(&"m12_winemetal"));
+        let dxmt_ids = m12_runtime_component_ids("dxmt");
+        assert!(dxmt_ids.contains(&"m12_winemetal"));
+        assert!(!dxmt_ids.contains(&"m12_d3d12core"));
     }
 
     #[test]

--- a/app/src-rust/src/installer.rs
+++ b/app/src-rust/src/installer.rs
@@ -91,6 +91,32 @@ pub(crate) fn write_dxmt_m12_expected_test_files(dxmt_m12_dir: &Path) {
     }
 }
 
+/// Pinned hashes for the vkd3d-proton M12 lane (production). Sources are the
+/// VKMT win64-filtered x86-64 builds (see docs/roadmaps/m12-vkd3d-proton-migration.md).
+#[cfg(not(test))]
+const VKD3D_PROTON_EXPECTED_HASHES: &[(&str, &str)] = &[
+    ("x86_64-windows/d3d12.dll", "15a7ad7af07120c79075dc1bc08284731c4ca53f82bb81002a14a7b5701cb535"),
+    ("x86_64-windows/d3d12core.dll", "43b92ad53843c819443b1c5d21930c36fe3e6cc7a893df6b2b18528477259631"),
+    ("i386-windows/d3d12.dll", "52cfe58b301771dc163fd45a5c0689bf22d1bc2396133456e7f2bd94cc3b87f1"),
+    ("i386-windows/d3d12core.dll", "56abc44d741df607ccf4ae7d3cdbd801d592fba4124bccab1705661fefbeaad3"),
+];
+#[cfg(test)]
+const VKD3D_PROTON_EXPECTED_HASHES: &[(&str, &str)] = &[
+    ("x86_64-windows/d3d12.dll", "941484b218dec5b9467d004be71d90b6077149d94e4640e2fbf236afc62a7b72"),
+    ("x86_64-windows/d3d12core.dll", "a27e3a5b3043019702ef34749742ff75cb1e8c08d63f67155ed7ad6bc46dc8fc"),
+    ("i386-windows/d3d12.dll", "c3d61a53c10aaabd4cc30dc0894f4e6bd6989443d1f3ad530f1fd873818c2074"),
+    ("i386-windows/d3d12core.dll", "3615937283c780116908fca55aad9015a3f6ee0dbd51f90a9a1a4e88f01417c9"),
+];
+#[cfg(test)]
+pub(crate) fn write_vkd3d_proton_expected_test_files(vkd3d_dir: &Path) {
+    for (rel, _) in VKD3D_PROTON_EXPECTED_HASHES {
+        let path = vkd3d_dir.join(rel);
+        fs::create_dir_all(path.parent().expect("vkd3d test fixture parent"))
+            .expect("create vkd3d test fixture parent");
+        fs::write(path, format!("test-vkd3d:{rel}")).expect("write vkd3d test fixture payload");
+    }
+}
+
 const RUNTIME_REQUIRED_ARCHIVE_FILES: &[&str] = &[
     "runtime/wine/bin/metalsharp-wine",
     "runtime/metalsharp-backend",
@@ -142,6 +168,23 @@ const GRAPHICS_REQUIRED_ARCHIVE_FILES: &[&str] = &[
     "Graphics/dll/dxmt-m12/x86_64-windows/nvapi64.dll",
     "Graphics/dll/dxmt-m12/x86_64-windows/nvngx.dll",
     "Graphics/dll/dxmt-m12/x86_64-windows/winemetal.dll",
+    // vkd3d-proton lane (M12 default backend): D3D12 -> Vulkan -> MoltenVK.
+    "Graphics/dll/vkd3d-proton/x86_64-windows/d3d12.dll",
+    "Graphics/dll/vkd3d-proton/x86_64-windows/d3d12core.dll",
+    "Graphics/dll/vkd3d-proton/i386-windows/d3d12.dll",
+    "Graphics/dll/vkd3d-proton/i386-windows/d3d12core.dll",
+    // DXVK lane: dxgi/d3d11/d3d10/d3d9 surfaces (M12 uses dxgi; M9-M11 use d3d11+).
+    "Graphics/dll/dxvk/x86_64-windows/dxgi.dll",
+    "Graphics/dll/dxvk/x86_64-windows/d3d11.dll",
+    "Graphics/dll/dxvk/x86_64-windows/d3d10core.dll",
+    "Graphics/dll/dxvk/x86_64-windows/d3d9.dll",
+    "Graphics/dll/dxvk/i386-windows/dxgi.dll",
+    "Graphics/dll/dxvk/i386-windows/d3d11.dll",
+    "Graphics/dll/dxvk/i386-windows/d3d10core.dll",
+    "Graphics/dll/dxvk/i386-windows/d3d9.dll",
+    // VKMT MoltenVK lane: patched Vulkan-on-Metal for the vkd3d-proton stack.
+    "Graphics/dll/moltenvk-vkmt/libMoltenVK.dylib",
+    "Graphics/dll/moltenvk-vkmt/MoltenVK_icd.json",
 ];
 const ASSETS_REQUIRED_ARCHIVE_FILES: &[&str] = &[
     "assets/fna-kickstart/kick.bin.osx",
@@ -701,8 +744,24 @@ pub fn moltenvk_ready(wine_dir: &Path) -> bool {
     wine_dir.join("lib").join("wine").join("x86_64-unix").join("libMoltenVK.dylib").is_file()
 }
 
+/// True when the VKMT-patched MoltenVK lane is installed (preferred for the
+/// vkd3d-proton M12 stack). Falls back to the stock runtime dylib.
+pub fn moltenvk_vkmt_ready(wine_dir: &Path) -> bool {
+    wine_dir.join("lib").join("moltenvk-vkmt").join("libMoltenVK.dylib").is_file()
+}
+
+/// Resolve the MoltenVK dylib to prefer: VKMT lane first, then the stock
+/// runtime location.
+fn moltenvk_library_path(wine_dir: &Path) -> PathBuf {
+    let vkmt = wine_dir.join("lib").join("moltenvk-vkmt").join("libMoltenVK.dylib");
+    if vkmt.is_file() {
+        return vkmt;
+    }
+    wine_dir.join("lib").join("wine").join("x86_64-unix").join("libMoltenVK.dylib")
+}
+
 fn fix_moltenvk_icd_paths(wine_dir: &Path) {
-    let actual_lib = wine_dir.join("lib").join("wine").join("x86_64-unix").join("libMoltenVK.dylib");
+    let actual_lib = moltenvk_library_path(wine_dir);
     if !actual_lib.exists() {
         eprintln!("moltenvk: libMoltenVK.dylib not found in runtime — skipping ICD fix");
         return;
@@ -712,6 +771,16 @@ fn fix_moltenvk_icd_paths(wine_dir: &Path) {
     if !icd_dir.is_dir() {
         eprintln!("moltenvk: ICD directory not found — skipping");
         return;
+    }
+
+    // The VKMT package ships its own ICD json; stage it into the runtime
+    // icd.d so the Vulkan loader resolves the patched dylib.
+    let vkmt_icd = wine_dir.join("lib").join("moltenvk-vkmt").join("MoltenVK_icd.json");
+    if vkmt_icd.is_file() {
+        let target = icd_dir.join("MoltenVK_icd.json");
+        if let Ok(data) = fs::read_to_string(&vkmt_icd) {
+            let _ = fs::write(&target, data);
+        }
     }
 
     let correct_path = format!("{}", actual_lib.to_string_lossy());
@@ -1178,6 +1247,13 @@ pub fn ensure_graphics_runtimes_ready(home: &Path) -> Result<bool, String> {
     changed |= install_dxmt_runtime(&home_buf)?;
     changed |= install_dxmt_m12_runtime(&home_buf)?;
 
+    // Stage the vkd3d-proton M12 stack (vkd3d-proton + dxvk + VKMT MoltenVK)
+    // from the graphics bundle. Best-effort: if the bundle does not yet carry
+    // the new lanes, DXMT remains the M12 fallback and setup still succeeds.
+    if let Err(err) = ensure_vkd3d_proton_runtime_ready(home) {
+        eprintln!("setup: vkd3d-proton lanes not staged (DXMT fallback remains active): {}", err);
+    }
+
     if dxmt_runtime_current_for_dir(&dxmt_dir) && dxmt_m12_runtime_current_for_dir(&dxmt_m12_dir) {
         Ok(changed)
     } else {
@@ -1330,8 +1406,91 @@ pub fn dxmt_m12_runtime_artifact_valid_for_home(home: &Path, rel: &str) -> bool 
     crate::diagnostics::file_sha256(&dxmt_m12_runtime_dir_for_home(home).join(rel)).as_deref() == Some(*expected)
 }
 
+/// Stage the vkd3d-proton M12 stack from the graphics bundle:
+/// `Graphics/dll/{vkd3d-proton,dxvk,moltenvk-vkmt}` -> the runtime wine lib
+/// lanes. Installs when the bundle carries the lanes; returns Ok(true) when
+/// the lanes are present and hash-valid afterwards.
+pub fn ensure_vkd3d_proton_runtime_ready(home: &Path) -> Result<bool, String> {
+    let wine_dir = crate::platform::metalsharp_home_dir_for(&home).join("runtime").join("wine");
+    let vkd3d_dir = wine_dir.join("lib").join("vkd3d-proton");
+    let dxvk_dir = wine_dir.join("lib").join("dxvk");
+    let moltenvk_dir = wine_dir.join("lib").join("moltenvk-vkmt");
+
+    if let Some(archive) = find_bundled_archive(GRAPHICS_DLL_BUNDLE) {
+        let tmp = std::env::temp_dir().join("metalsharp-vkd3d-extract");
+        let _ = fs::remove_dir_all(&tmp);
+        let _ = fs::create_dir_all(&tmp);
+        extract_zst(&archive, &tmp, GRAPHICS_DLL_BUNDLE)?;
+
+        let dll_root = tmp.join("Graphics").join("dll");
+        for (bundle_surface, dst) in
+            [("vkd3d-proton", &vkd3d_dir), ("dxvk", &dxvk_dir), ("moltenvk-vkmt", &moltenvk_dir)]
+        {
+            let src = dll_root.join(bundle_surface);
+            if src.exists() {
+                let _ = fs::remove_dir_all(dst);
+                copy_dir_recursive(&src, dst)?;
+            }
+        }
+        let _ = fs::remove_dir_all(&tmp);
+        mark_split_bundle_installed(home, GRAPHICS_DLL_BUNDLE, &archive);
+    }
+
+    if vkd3d_proton_runtime_current_for_home(home)
+        && moltenvk_vkmt_runtime_ready_for_home(home)
+        && dxvk_runtime_ready_for_home(home)
+    {
+        Ok(true)
+    } else {
+        Err("vkd3d-proton M12 runtime lanes not installed — refresh the metalsharp-graphics-dll bundle".into())
+    }
+}
+
 pub fn dxmt_m12_runtime_artifact_path_for_home(home: &Path, rel: &str) -> PathBuf {
     dxmt_m12_runtime_dir_for_home(home).join(rel)
+}
+
+pub fn vkd3d_proton_runtime_dir_for_home(home: &Path) -> PathBuf {
+    crate::platform::metalsharp_home_dir_for(&home).join("runtime").join("wine").join("lib").join("vkd3d-proton")
+}
+
+pub fn moltenvk_vkmt_runtime_dir_for_home(home: &Path) -> PathBuf {
+    crate::platform::metalsharp_home_dir_for(&home).join("runtime").join("wine").join("lib").join("moltenvk-vkmt")
+}
+
+pub fn dxvk_runtime_dir_for_home(home: &Path) -> PathBuf {
+    crate::platform::metalsharp_home_dir_for(&home).join("runtime").join("wine").join("lib").join("dxvk")
+}
+
+/// vkd3d-proton lane is current when every pinned artifact matches its hash.
+pub fn vkd3d_proton_runtime_current_for_home(home: &Path) -> bool {
+    let dir = vkd3d_proton_runtime_dir_for_home(home);
+    VKD3D_PROTON_EXPECTED_HASHES
+        .iter()
+        .all(|(rel, expected)| crate::diagnostics::file_sha256(&dir.join(rel)).as_deref() == Some(*expected))
+}
+
+pub fn vkd3d_proton_runtime_artifact_valid_for_home(home: &Path, rel: &str) -> bool {
+    let Some((_, expected)) = VKD3D_PROTON_EXPECTED_HASHES.iter().find(|(candidate, _)| *candidate == rel) else {
+        return false;
+    };
+    crate::diagnostics::file_sha256(&vkd3d_proton_runtime_dir_for_home(home).join(rel)).as_deref() == Some(*expected)
+}
+
+pub fn vkd3d_proton_runtime_artifact_path_for_home(home: &Path, rel: &str) -> PathBuf {
+    vkd3d_proton_runtime_dir_for_home(home).join(rel)
+}
+
+/// The VKMT MoltenVK lane is present when the patched dylib + ICD exist.
+pub fn moltenvk_vkmt_runtime_ready_for_home(home: &Path) -> bool {
+    let dir = moltenvk_vkmt_runtime_dir_for_home(home);
+    dir.join("libMoltenVK.dylib").is_file() && dir.join("MoltenVK_icd.json").is_file()
+}
+
+/// The DXVK lane (dxgi/d3d11/d3d10/d3d9) is present for the x86_64 surface.
+pub fn dxvk_runtime_ready_for_home(home: &Path) -> bool {
+    let dir = dxvk_runtime_dir_for_home(home).join("x86_64-windows");
+    ["dxgi.dll", "d3d11.dll", "d3d10core.dll", "d3d9.dll"].iter().all(|dll| dir.join(dll).is_file())
 }
 
 pub fn dxmt_runtime_current_for_ms_dir(ms_dir: &Path) -> bool {
@@ -2886,5 +3045,73 @@ mod tests {
 
         let _ = fs::remove_file(&archive);
         let _ = fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn vkd3d_proton_runtime_current_requires_all_pinned_hashes() {
+        let home = test_home("vkd3d-current");
+        let dir = vkd3d_proton_runtime_dir_for_home(&home);
+        write_vkd3d_proton_expected_test_files(&dir);
+
+        // All fixtures present + matching test hashes -> current.
+        assert!(vkd3d_proton_runtime_current_for_home(&home));
+
+        // Corrupt one artifact -> not current.
+        let artifact = dir.join("x86_64-windows/d3d12core.dll");
+        fs::write(&artifact, b"corrupted").expect("corrupt artifact");
+        assert!(!vkd3d_proton_runtime_current_for_home(&home));
+        assert!(!vkd3d_proton_runtime_artifact_valid_for_home(&home, "x86_64-windows/d3d12core.dll"));
+        assert!(vkd3d_proton_runtime_artifact_valid_for_home(&home, "x86_64-windows/d3d12.dll"));
+
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn vkd3d_proton_unknown_artifact_is_never_valid() {
+        let home = test_home("vkd3d-unknown");
+        assert!(!vkd3d_proton_runtime_artifact_valid_for_home(&home, "x86_64-windows/nope.dll"));
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn moltenvk_vkmt_and_dxvk_lanes_ready_only_when_files_present() {
+        let home = test_home("vkmt-lanes");
+        assert!(!moltenvk_vkmt_runtime_ready_for_home(&home));
+        assert!(!dxvk_runtime_ready_for_home(&home));
+
+        let mvk = moltenvk_vkmt_runtime_dir_for_home(&home);
+        fs::create_dir_all(&mvk).expect("create moltenvk lane");
+        fs::write(mvk.join("libMoltenVK.dylib"), b"dylib").expect("write dylib");
+        assert!(!moltenvk_vkmt_runtime_ready_for_home(&home), "ICD still missing");
+        fs::write(mvk.join("MoltenVK_icd.json"), b"{}").expect("write icd");
+        assert!(moltenvk_vkmt_runtime_ready_for_home(&home));
+
+        let dxvk = dxvk_runtime_dir_for_home(&home).join("x86_64-windows");
+        fs::create_dir_all(&dxvk).expect("create dxvk lane");
+        fs::write(dxvk.join("dxgi.dll"), b"dxgi").expect("write dxgi");
+        assert!(!dxvk_runtime_ready_for_home(&home), "d3d11 still missing");
+        for dll in ["d3d11.dll", "d3d10core.dll", "d3d9.dll"] {
+            fs::write(dxvk.join(dll), dll.as_bytes()).expect("write dll");
+        }
+        assert!(dxvk_runtime_ready_for_home(&home));
+
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn moltenvk_library_path_prefers_vkmt_lane_over_stock() {
+        let wine_dir = test_home("moltenvk-preference").join("runtime").join("wine");
+        let stock = wine_dir.join("lib").join("wine").join("x86_64-unix").join("libMoltenVK.dylib");
+        let vkmt = wine_dir.join("lib").join("moltenvk-vkmt").join("libMoltenVK.dylib");
+        fs::create_dir_all(stock.parent().unwrap()).expect("stock parent");
+        fs::create_dir_all(vkmt.parent().unwrap()).expect("vkmt parent");
+        fs::write(&stock, b"stock").expect("stock dylib");
+        assert_eq!(moltenvk_library_path(&wine_dir), stock);
+
+        fs::write(&vkmt, b"vkmt").expect("vkmt dylib");
+        assert_eq!(moltenvk_library_path(&wine_dir), vkmt);
+        assert!(moltenvk_vkmt_ready(&wine_dir));
+
+        let _ = fs::remove_dir_all(wine_dir.parent().unwrap());
     }
 }

--- a/app/src-rust/src/launch.rs
+++ b/app/src-rust/src/launch.rs
@@ -206,7 +206,23 @@ pub fn get_config_for_home(home: &Path) -> Value {
         "graphicsRuntimeLogs": graphics_runtime_logs,
         "graphics_runtime_logs": graphics_runtime_logs,
         "controllerInput": controller_input,
+        "m12Backend": m12_backend_mode_for(home),
     })
+}
+
+/// The active M12 graphics backend: `"vkd3d-proton"` (default, D3D12 ->
+/// vkd3d-proton -> Vulkan -> MoltenVK -> Metal) or `"dxmt"` (legacy D3D12 ->
+/// DXMT -> Metal, kept as rollback). Anything else resolves to the default.
+pub fn m12_backend_mode() -> String {
+    m12_backend_mode_for(&dirs::home_dir().unwrap_or_default())
+}
+
+/// Path-based variant (testable without touching the global METALSHARP_HOME).
+pub fn m12_backend_mode_for(home: &Path) -> String {
+    read_config_string_for_home(home, "m12Backend")
+        .map(|v| v.trim().to_ascii_lowercase())
+        .filter(|v| matches!(v.as_str(), "vkd3d-proton" | "dxmt"))
+        .unwrap_or_else(|| "vkd3d-proton".to_string())
 }
 
 /// Read the persisted controller input shim mode. Valid values are
@@ -456,6 +472,13 @@ pub fn set_config_for_home(home: &Path, body: &Map<String, Value>) -> Result<Val
         }
     }
 
+    if let Some(value) = body.get("m12Backend").and_then(|v| v.as_str()) {
+        let normalized = value.trim().to_ascii_lowercase();
+        if matches!(normalized.as_str(), "vkd3d-proton" | "dxmt") {
+            cfg.insert("m12Backend".into(), json!(normalized));
+        }
+    }
+
     std::fs::write(&path, serde_json::to_string_pretty(&cfg)?)?;
     Ok(get_config_for_home(home))
 }
@@ -637,6 +660,67 @@ mod tests {
 
         let found = find_wine_for(&temp).expect("find_wine must return the MS runtime wrapper");
         assert_eq!(found, wrapper.to_string_lossy().to_string());
+
+        let _ = std::fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn m12_backend_defaults_to_vkd3d_proton() {
+        let temp = std::env::temp_dir().join(format!("ms-m12backend-default-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&temp);
+        std::fs::create_dir_all(&temp).unwrap();
+
+        // No config -> vkd3d-proton (the new default).
+        assert_eq!(m12_backend_mode_for(&temp), "vkd3d-proton");
+
+        // Unknown value -> vkd3d-proton.
+        let configs = temp.join(".metalsharp").join("configs");
+        std::fs::create_dir_all(&configs).unwrap();
+        std::fs::write(configs.join("config.json"), r#"{"m12Backend": "bogus"}"#).unwrap();
+        assert_eq!(m12_backend_mode_for(&temp), "vkd3d-proton");
+
+        let _ = std::fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn m12_backend_accepts_vkd3d_proton_and_dxmt() {
+        let temp = std::env::temp_dir().join(format!("ms-m12backend-modes-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&temp);
+        let configs = temp.join(".metalsharp").join("configs");
+        std::fs::create_dir_all(&configs).unwrap();
+
+        for (raw, expected) in
+            [("vkd3d-proton", "vkd3d-proton"), ("VKD3D-PROTON", "vkd3d-proton"), ("dxmt", "dxmt"), (" DXMT ", "dxmt")]
+        {
+            std::fs::write(configs.join("config.json"), serde_json::json!({ "m12Backend": raw }).to_string()).unwrap();
+            assert_eq!(m12_backend_mode_for(&temp), expected, "raw={raw}");
+        }
+
+        let _ = std::fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn set_config_persists_m12_backend_with_whitelist() {
+        let temp = std::env::temp_dir().join(format!("ms-m12backend-set-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&temp);
+        std::fs::create_dir_all(&temp).unwrap();
+
+        let mut dxmt = serde_json::Map::new();
+        dxmt.insert("m12Backend".into(), json!("dxmt"));
+        let result = set_config_for_home(&temp, &dxmt).expect("set_config");
+        assert_eq!(result.get("m12Backend").and_then(|v| v.as_str()), Some("dxmt"));
+
+        // Invalid value is rejected, keeps dxmt.
+        let mut bad = serde_json::Map::new();
+        bad.insert("m12Backend".into(), json!("hax"));
+        let result = set_config_for_home(&temp, &bad).expect("set_config");
+        assert_eq!(result.get("m12Backend").and_then(|v| v.as_str()), Some("dxmt"));
+
+        // Back to default.
+        let mut vk = serde_json::Map::new();
+        vk.insert("m12Backend".into(), json!("vkd3d-proton"));
+        let result = set_config_for_home(&temp, &vk).expect("set_config");
+        assert_eq!(result.get("m12Backend").and_then(|v| v.as_str()), Some("vkd3d-proton"));
 
         let _ = std::fs::remove_dir_all(&temp);
     }

--- a/app/src-rust/src/migrate.rs
+++ b/app/src-rust/src/migrate.rs
@@ -555,6 +555,12 @@ fn run_migration() {
     restore_user_data(&ms_dir, &preserved, &mut report);
     write_migration_report(&report);
 
+    // M12 backend reconciliation: the vkd3d-proton stack is the default, but
+    // an older graphics bundle may lack the lanes. When they did not stage,
+    // fall back to DXMT so existing users keep working — never leave the
+    // default pointing at a missing runtime.
+    reconcile_m12_backend(&home);
+
     if !install_ok {
         write_migrate_progress(
             "error",
@@ -658,6 +664,32 @@ fn verify_migration_ready(ms_dir: &Path, marker: Option<&PostUpdateMigrationMark
     }
 
     Ok(())
+}
+
+/// Decide the M12 backend after a migration: keep the vkd3d-proton default
+/// when its runtime lanes staged, otherwise fall back to DXMT in config so
+/// the default never points at a missing runtime. Returns the decision.
+fn reconcile_m12_backend(home: &Path) -> String {
+    if crate::installer::vkd3d_proton_runtime_current_for_home(home)
+        && crate::installer::moltenvk_vkmt_runtime_ready_for_home(home)
+        && crate::installer::dxvk_runtime_ready_for_home(home)
+    {
+        log_to_file("Migration: vkd3d-proton M12 lanes present; keeping vkd3d-proton default");
+        "vkd3d-proton".to_string()
+    } else {
+        let mut body = serde_json::Map::new();
+        body.insert("m12Backend".into(), json!("dxmt"));
+        match crate::launch::set_config_for_home(home, &body) {
+            Ok(_) => {
+                log_to_file("Migration: vkd3d-proton lanes missing — M12 fell back to DXMT backend");
+                "dxmt".to_string()
+            },
+            Err(e) => {
+                log_to_file(&format!("Migration: failed to fall back to DXMT backend: {}", e));
+                "unknown".to_string()
+            },
+        }
+    }
 }
 
 fn repair_runtime_for_migration_verify(ms_dir: &Path) -> Result<bool, String> {
@@ -3709,5 +3741,44 @@ mod tests {
             }
         }
         false
+    }
+
+    #[test]
+    fn reconcile_m12_backend_keeps_vkd3d_default_when_lanes_present() {
+        let home = test_dir("reconcile-vkd3d");
+        crate::installer::write_vkd3d_proton_expected_test_files(&crate::installer::vkd3d_proton_runtime_dir_for_home(
+            &home,
+        ));
+        let mvk = crate::installer::moltenvk_vkmt_runtime_dir_for_home(&home);
+        fs::create_dir_all(&mvk).expect("mvk dir");
+        fs::write(mvk.join("libMoltenVK.dylib"), b"dylib").expect("write dylib");
+        fs::write(mvk.join("MoltenVK_icd.json"), b"{}").expect("write icd");
+        let dxvk = crate::installer::dxvk_runtime_dir_for_home(&home).join("x86_64-windows");
+        fs::create_dir_all(&dxvk).expect("dxvk dir");
+        for dll in ["dxgi.dll", "d3d11.dll", "d3d10core.dll", "d3d9.dll"] {
+            fs::write(dxvk.join(dll), dll.as_bytes()).expect("write dll");
+        }
+
+        let decision = reconcile_m12_backend(&home);
+        assert_eq!(decision, "vkd3d-proton");
+
+        // No config written, default stays vkd3d-proton.
+        let configs = home.join(".metalsharp").join("configs");
+        assert!(!configs.join("config.json").exists());
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn reconcile_m12_backend_falls_back_to_dxmt_when_lanes_missing() {
+        let home = test_dir("reconcile-dxmt-fallback");
+
+        let decision = reconcile_m12_backend(&home);
+        assert_eq!(decision, "dxmt");
+
+        // Config now pins dxmt so the default never points at a missing runtime.
+        let configs = home.join(".metalsharp").join("configs");
+        let contents = fs::read_to_string(configs.join("config.json")).expect("config written");
+        assert!(contents.contains("\"m12Backend\": \"dxmt\""), "config must pin dxmt: {}", contents);
+        let _ = fs::remove_dir_all(home);
     }
 }

--- a/app/src-rust/src/mtsp/engine.rs
+++ b/app/src-rust/src/mtsp/engine.rs
@@ -94,16 +94,16 @@ fn m12_vkd3d_proton_node() -> PipelineNode {
                 dest_filename: None,
             },
             DllDeploy { source_subpath: "lib/dxvk/x86_64-windows", filename: "dxgi.dll", dest_filename: None },
-            DllDeploy {
-                source_subpath: "lib/vkd3d-proton/x86_64-windows",
-                filename: "nvapi64.dll",
-                dest_filename: None,
-            },
-            DllDeploy { source_subpath: "lib/vkd3d-proton/x86_64-windows", filename: "nvngx.dll", dest_filename: None },
+            // GPU vendor stubs: vkd3d-proton ships none (its lane is
+            // d3d12/d3d12core only), so these come from the shared dxmt_m12
+            // lane, which is always staged (hash-pinned, DXMT fallback).
+            DllDeploy { source_subpath: "lib/dxmt_m12/x86_64-windows", filename: "nvapi64.dll", dest_filename: None },
+            DllDeploy { source_subpath: "lib/dxmt_m12/x86_64-windows", filename: "nvngx.dll", dest_filename: None },
         ],
         env_vars: vec![
             EnvVar { key: "VKD3D_LOG_LEVEL", value: "warn" },
-            EnvVar { key: "VKD3D_SHADER_CACHE_PATH", value: "m12" },
+            // VKD3D_SHADER_CACHE_PATH is set to the absolute isolated cache dir
+            // by cache_env_pairs; do not override it with a relative value here.
         ],
         launch_args: vec!["-windowed", "-ResX=1280", "-ResY=720", "-ForceRes"],
         alternatives: vec![PipelineId::M11, PipelineId::M10, PipelineId::M9, PipelineId::Steam, PipelineId::MacSteam],
@@ -789,7 +789,13 @@ mod tests {
         }
         assert!(m12_dlls.contains(&("lib/dxvk/x86_64-windows", "dxgi.dll")));
         assert!(!m12.deploy_dlls.iter().any(|dll| dll.source_subpath == "lib/dxmt/x86_64-windows"));
-        assert!(!m12.deploy_dlls.iter().any(|dll| dll.source_subpath == "lib/dxmt_m12/x86_64-windows"));
+        // The only dxmt_m12 lane usage is the GPU vendor stubs (nvapi64/nvngx),
+        // which vkd3d-proton does not ship; everything else must stay isolated.
+        assert!(m12.deploy_dlls.iter().all(|dll| {
+            dll.source_subpath != "lib/dxmt_m12/x86_64-windows"
+                || dll.filename == "nvapi64.dll"
+                || dll.filename == "nvngx.dll"
+        }));
         assert!(!m12.deploy_dlls.iter().any(|dll| dll.filename == "winemetal.dll"));
         assert!(!m12.deploy_dlls.iter().any(|dll| dll.filename == "dxgi_dxmt.dll"));
         assert!(!m12.deploy_dlls.iter().any(|dll| dll.filename == "metalsharp_ntdll_hook.dll"));

--- a/app/src-rust/src/mtsp/engine.rs
+++ b/app/src-rust/src/mtsp/engine.rs
@@ -62,6 +62,55 @@ static PIPELINES: OnceLock<Vec<PipelineNode>> = OnceLock::new();
 const DXMT_70_PERCENT_UPSCALE_CONFIG: &str = "d3d11.metalSpatialUpscaleFactor=1.43;d3d11.preferredMaxFrameRate=60";
 const DXMT_M12_SAFE_CONFIG: &str = "d3d11.metalSpatialUpscaleFactor=1.43;d3d11.preferredMaxFrameRate=60";
 
+/// Cache of the effective M12 node (vkd3d-proton by default, DXMT when
+/// `m12Backend=dxmt`). Built once at first access from the config so the
+/// backend is stable for the process lifetime.
+static M12_EFFECTIVE_NODE: OnceLock<PipelineNode> = OnceLock::new();
+
+/// The M12 pipeline node for the vkd3d-proton graphics stack:
+/// D3D12 -> vkd3d-proton -> Vulkan -> MoltenVK -> Metal.
+///
+/// Deploys vkd3d-proton's `d3d12.dll` + `d3d12core.dll` plus DXVK's
+/// `dxgi.dll` (vkd3d-proton ships no dxgi of its own) into the game dir,
+/// routes D3D12/DXGI through the vkd3d-proton lane, and points the Vulkan
+/// loader at the VKMT MoltenVK ICD.
+fn m12_vkd3d_proton_node() -> PipelineNode {
+    PipelineNode {
+        id: PipelineId::M12,
+        name: "M12",
+        description: "D3D12 -> Metal via vkd3d-proton (Vulkan) + MoltenVK",
+        backend: "vkd3d-proton",
+        graphics_backend: "vkd3d-proton",
+        experimental: false,
+        requires_wine: true,
+        wine_overrides: Some("d3d12,d3d12core,dxgi=n,b;gameoverlayrenderer,gameoverlayrenderer64=d"),
+        dyld_paths: vec!["lib/vkd3d-proton/x86_64-unix", "lib/wine/x86_64-unix", "lib/moltenvk-vkmt"],
+        winedllpath_dirs: vec!["lib/vkd3d-proton/x86_64-windows"],
+        deploy_dlls: vec![
+            DllDeploy { source_subpath: "lib/vkd3d-proton/x86_64-windows", filename: "d3d12.dll", dest_filename: None },
+            DllDeploy {
+                source_subpath: "lib/vkd3d-proton/x86_64-windows",
+                filename: "d3d12core.dll",
+                dest_filename: None,
+            },
+            DllDeploy { source_subpath: "lib/dxvk/x86_64-windows", filename: "dxgi.dll", dest_filename: None },
+            DllDeploy {
+                source_subpath: "lib/vkd3d-proton/x86_64-windows",
+                filename: "nvapi64.dll",
+                dest_filename: None,
+            },
+            DllDeploy { source_subpath: "lib/vkd3d-proton/x86_64-windows", filename: "nvngx.dll", dest_filename: None },
+        ],
+        env_vars: vec![
+            EnvVar { key: "VKD3D_LOG_LEVEL", value: "warn" },
+            EnvVar { key: "VKD3D_SHADER_CACHE_PATH", value: "m12" },
+        ],
+        launch_args: vec!["-windowed", "-ResX=1280", "-ResY=720", "-ForceRes"],
+        alternatives: vec![PipelineId::M11, PipelineId::M10, PipelineId::M9, PipelineId::Steam, PipelineId::MacSteam],
+        shader_cache_subdir: Some("m12"),
+    }
+}
+
 pub fn pipelines() -> &'static Vec<PipelineNode> {
     PIPELINES.get_or_init(|| {
         vec![
@@ -549,7 +598,22 @@ pub fn pipelines() -> &'static Vec<PipelineNode> {
 }
 
 pub fn get_pipeline(id: PipelineId) -> &'static PipelineNode {
+    if id == PipelineId::M12 {
+        return m12_effective_node();
+    }
     pipelines().iter().find(|p| p.id == id).expect("pipeline not found")
+}
+
+/// The M12 node selected by the `m12Backend` config: vkd3d-proton by
+/// default, legacy DXMT when the user opted back. Cached once per process.
+pub fn m12_effective_node() -> &'static PipelineNode {
+    M12_EFFECTIVE_NODE.get_or_init(|| {
+        if crate::launch::m12_backend_mode() == "dxmt" {
+            pipelines().iter().find(|p| p.id == PipelineId::M12).expect("M12 pipeline not found").clone()
+        } else {
+            m12_vkd3d_proton_node()
+        }
+    })
 }
 
 impl PipelineId {
@@ -687,59 +751,65 @@ mod tests {
     }
 
     #[test]
-    fn m12_is_primary_d3d12_dxmt_profile() {
+    fn m12_is_primary_d3d12_vkd3d_proton_profile() {
         let m12 = get_pipeline(PipelineId::M12);
         assert!(!m12.experimental);
-        assert_eq!(m12.backend, "dxmt");
+        assert_eq!(m12.backend, "vkd3d-proton");
+        assert_eq!(m12.graphics_backend, "vkd3d-proton");
         assert!(m12.launch_args.contains(&"-windowed"));
         assert!(m12.deploy_dlls.iter().any(|dll| dll.filename == "d3d12.dll"));
+        assert!(m12.deploy_dlls.iter().any(|dll| dll.filename == "d3d12core.dll"));
+        assert!(m12.deploy_dlls.iter().any(|dll| dll.filename == "dxgi.dll"));
         assert_eq!(m12.shader_cache_subdir, Some("m12"));
     }
 
     #[test]
-    fn m12_is_stronger_than_other_dxmt_d3d_paths() {
+    fn m12_vkd3d_proton_uses_isolated_lanes() {
         let m12 = get_pipeline(PipelineId::M12);
 
-        for required in ["lib/wine/x86_64-unix", "lib/dxmt_m12/x86_64-unix"] {
+        // vkd3d-proton lane + runtime wine + VKMT MoltenVK lane.
+        for required in ["lib/wine/x86_64-unix", "lib/vkd3d-proton/x86_64-unix", "lib/moltenvk-vkmt"] {
             assert!(m12.dyld_paths.contains(&required));
         }
         assert!(!m12.dyld_paths.contains(&"lib/dxmt/x86_64-unix"));
-        assert!(m12.winedllpath_dirs.contains(&"lib/dxmt_m12/x86_64-windows"));
+        assert!(!m12.dyld_paths.contains(&"lib/dxmt_m12/x86_64-unix"));
+        assert!(m12.winedllpath_dirs.contains(&"lib/vkd3d-proton/x86_64-windows"));
         assert!(!m12.winedllpath_dirs.contains(&"lib/dxmt/x86_64-windows"));
-        assert!(!m12.winedllpath_dirs.contains(&"lib/metalsharp/x86_64-windows"));
+        assert!(!m12.winedllpath_dirs.contains(&"lib/dxmt_m12/x86_64-windows"));
 
+        // Deploys vkd3d-proton d3d12/d3d12core + DXVK dxgi; never DXMT.
         let m12_dlls: std::collections::HashSet<_> =
             m12.deploy_dlls.iter().map(|dll| (dll.source_subpath, dll.filename)).collect();
-        for required in ["d3d12.dll", "d3d11.dll", "dxgi.dll", "dxgi_dxmt.dll", "d3d10core.dll", "winemetal.dll"] {
+        for required in ["d3d12.dll", "d3d12core.dll"] {
             assert!(
-                m12_dlls.contains(&("lib/dxmt_m12/x86_64-windows", required)),
-                "M12 missing isolated DXMT DLL {}",
+                m12_dlls.contains(&("lib/vkd3d-proton/x86_64-windows", required)),
+                "M12 missing vkd3d-proton DLL {}",
                 required
             );
         }
+        assert!(m12_dlls.contains(&("lib/dxvk/x86_64-windows", "dxgi.dll")));
         assert!(!m12.deploy_dlls.iter().any(|dll| dll.source_subpath == "lib/dxmt/x86_64-windows"));
+        assert!(!m12.deploy_dlls.iter().any(|dll| dll.source_subpath == "lib/dxmt_m12/x86_64-windows"));
+        assert!(!m12.deploy_dlls.iter().any(|dll| dll.filename == "winemetal.dll"));
+        assert!(!m12.deploy_dlls.iter().any(|dll| dll.filename == "dxgi_dxmt.dll"));
         assert!(!m12.deploy_dlls.iter().any(|dll| dll.filename == "metalsharp_ntdll_hook.dll"));
 
-        let m12_env: std::collections::HashSet<_> = m12.env_vars.iter().map(|env| env.key).collect();
-        assert!(m12_env.contains("DXMT_ASYNC_PIPELINE_COMPILE"));
-        assert!(m12_env.contains("DXMT_D3D12_PSO_WORKERS"));
-        assert!(m12_env.contains("DXMT_METALFX_SPATIAL_SWAPCHAIN"));
-        assert!(m12_env.contains("DXMT_METALFX_SPATIAL"));
-        assert!(m12_env.contains("DXMT_METALFX_TEMPORAL"));
-        let m12_env_values: std::collections::HashMap<_, _> =
-            m12.env_vars.iter().map(|env| (env.key, env.value)).collect();
-        assert_eq!(m12_env_values.get("DXMT_ASYNC_PIPELINE_COMPILE"), Some(&"1"));
-        assert_eq!(m12_env_values.get("DXMT_D3D12_PSO_WORKERS"), Some(&"6"));
-        assert_eq!(m12_env_values.get("DXMT_METALFX_SPATIAL_SWAPCHAIN"), Some(&"1"));
-        assert_eq!(m12_env_values.get("DXMT_METALFX_SPATIAL"), Some(&"1"));
-        assert_eq!(m12_env_values.get("DXMT_METALFX_TEMPORAL"), Some(&"1"));
-        assert_eq!(m12_env_values.get("DXMT_CONFIG"), Some(&DXMT_M12_SAFE_CONFIG));
-
-        assert_eq!(
-            m12.wine_overrides,
-            Some("winemetal,d3d12,dxgi,dxgi_dxmt,d3d11,d3d10core=n,b;gameoverlayrenderer,gameoverlayrenderer64=d")
-        );
+        // Overrides route d3d12/d3d12core/dxgi to the deployed natives.
+        assert_eq!(m12.wine_overrides, Some("d3d12,d3d12core,dxgi=n,b;gameoverlayrenderer,gameoverlayrenderer64=d"));
         assert!(m12.alternatives.contains(&PipelineId::M11));
+    }
+
+    #[test]
+    fn m12_dxmt_fallback_node_keeps_legacy_profile() {
+        let dxmt = m12_vkd3d_proton_node();
+        assert_eq!(dxmt.backend, "vkd3d-proton");
+
+        // The static pipelines() list still carries the legacy DXMT M12 node
+        // for the m12Backend=dxmt fallback path.
+        let legacy = pipelines().iter().find(|p| p.id == PipelineId::M12).expect("legacy M12 in list");
+        assert_eq!(legacy.backend, "dxmt");
+        assert!(legacy.winedllpath_dirs.contains(&"lib/dxmt_m12/x86_64-windows"));
+        assert!(legacy.deploy_dlls.iter().any(|dll| dll.filename == "winemetal.dll"));
     }
 
     #[test]

--- a/app/src-rust/src/mtsp/engine.rs
+++ b/app/src-rust/src/mtsp/engine.rs
@@ -85,7 +85,7 @@ fn m12_vkd3d_proton_node() -> PipelineNode {
         requires_wine: true,
         wine_overrides: Some("d3d12,d3d12core,dxgi=n,b;gameoverlayrenderer,gameoverlayrenderer64=d"),
         dyld_paths: vec!["lib/vkd3d-proton/x86_64-unix", "lib/wine/x86_64-unix", "lib/moltenvk-vkmt"],
-        winedllpath_dirs: vec!["lib/vkd3d-proton/x86_64-windows"],
+        winedllpath_dirs: vec!["lib/vkd3d-proton/x86_64-windows", "lib/dxvk/x86_64-windows"],
         deploy_dlls: vec![
             DllDeploy { source_subpath: "lib/vkd3d-proton/x86_64-windows", filename: "d3d12.dll", dest_filename: None },
             DllDeploy {

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -2564,6 +2564,17 @@ fn cache_env_pairs_with_logs(
                 env.push(("VK_ICD_FILENAMES".to_string(), moltenvk_icd.to_string_lossy().to_string()));
             }
         },
+        "vkd3d-proton" => {
+            // D3D12 -> vkd3d-proton -> Vulkan -> MoltenVK -> Metal.
+            // vkd3d-proton uses the Vulkan loader, so the VKMT MoltenVK ICD
+            // must be pinned; state/cache routing mirrors the dxvk lane.
+            env.push(("DXVK_STATE_CACHE_PATH".to_string(), shader_dir.clone()));
+            env.push(("VKD3D_SHADER_CACHE_PATH".to_string(), shader_dir));
+            let moltenvk_icd = ms_root.join("etc").join("vulkan").join("icd.d").join("MoltenVK_icd.json");
+            if moltenvk_icd.exists() {
+                env.push(("VK_ICD_FILENAMES".to_string(), moltenvk_icd.to_string_lossy().to_string()));
+            }
+        },
         "wine32" | "wine" | "wine-steam" => {
             env.push(("DXMT_SHADER_CACHE_PATH".to_string(), shader_dir.clone()));
             env.push(("DXVK_STATE_CACHE_PATH".to_string(), shader_dir));
@@ -5157,32 +5168,32 @@ export VK_ICD_FILENAMES="/opt/homebrew/etc/vulkan/icd.d/MoltenVK_icd.json"
     }
 
     #[test]
-    fn m12_pipeline_deploy_list_includes_d3d12_and_uses_isolated_dxmt_m12_surface() {
-        // Phase 3 contract: M12 must deploy d3d12.dll (plus dxgi/d3d11/
-        // d3d10core/winemetal) from the isolated lib/dxmt_m12 surface.
+    fn m12_pipeline_deploy_list_includes_d3d12_and_uses_isolated_vkd3d_proton_surface() {
+        // Phase 3 contract: M12 must deploy d3d12.dll + d3d12core.dll from the
+        // isolated lib/vkd3d-proton surface plus DXVK's dxgi.dll — never DXMT.
         let node = get_pipeline(PipelineId::M12);
         let filenames: Vec<&str> = node.deploy_dlls.iter().map(|d| d.filename).collect();
-        let required = [
-            "d3d12.dll",
-            "d3d11.dll",
-            "dxgi.dll",
-            "dxgi_dxmt.dll",
-            "d3d10core.dll",
-            "winemetal.dll",
-            "nvapi64.dll",
-            "nvngx.dll",
-        ];
-        assert_eq!(filenames.len(), required.len(), "M12 deploy list must be the Elden-proven 8 DLL set");
+        let required = ["d3d12.dll", "d3d12core.dll", "dxgi.dll", "nvapi64.dll", "nvngx.dll"];
+        assert_eq!(filenames.len(), required.len(), "M12 deploy list must be the vkd3d-proton 5 DLL set");
         for required in required {
             assert!(filenames.contains(&required), "M12 deploy list must include {} (got {:?})", required, filenames);
         }
         for deploy in &node.deploy_dlls {
-            assert_eq!(
-                deploy.source_subpath, "lib/dxmt_m12/x86_64-windows",
-                "M12 DLL {} must come from the isolated PR230 dxmt_m12 runtime surface",
-                deploy.filename
-            );
+            if deploy.filename == "dxgi.dll" {
+                assert_eq!(
+                    deploy.source_subpath, "lib/dxvk/x86_64-windows",
+                    "M12 dxgi.dll must come from the DXVK lane (vkd3d-proton ships no dxgi)"
+                );
+            } else {
+                assert_eq!(
+                    deploy.source_subpath, "lib/vkd3d-proton/x86_64-windows",
+                    "M12 DLL {} must come from the isolated vkd3d-proton runtime surface",
+                    deploy.filename
+                );
+            }
         }
+        assert!(!filenames.contains(&"winemetal.dll"), "M12 must never deploy winemetal.dll (got {:?})", filenames);
+        assert!(!filenames.contains(&"dxgi_dxmt.dll"), "M12 must never deploy dxgi_dxmt.dll (got {:?})", filenames);
     }
 
     #[test]
@@ -5414,15 +5425,17 @@ export VK_ICD_FILENAMES="/opt/homebrew/etc/vulkan/icd.d/MoltenVK_icd.json"
     }
 
     #[test]
-    fn m12_pipeline_env_vars_set_winemetal_overrides_and_shader_cache() {
-        // Phase 3 contract: the M12 env builder must set the winemetal
-        // WINEDLLOVERRIDES, route the wine DLL path to dxmt_m12, and point the
-        // shader cache at the isolated m12 lane.
+    fn m12_pipeline_env_vars_set_vkd3d_overrides_and_shader_cache() {
+        // Phase 3 contract: the M12 env builder must set the vkd3d-proton
+        // WINEDLLOVERRIDES, route the wine DLL path to the vkd3d-proton lane,
+        // and point the shader cache at the isolated m12 lane.
         let node = get_pipeline(PipelineId::M12);
-        assert!(node.wine_overrides.unwrap_or("").contains("winemetal"));
+        assert!(node.wine_overrides.unwrap_or("").contains("d3d12core"));
+        assert!(node.wine_overrides.unwrap_or("").contains("d3d12"));
+        assert!(!node.wine_overrides.unwrap_or("").contains("winemetal"));
         assert!(
-            node.winedllpath_dirs.iter().any(|d| d.starts_with("lib/dxmt_m12")),
-            "M12 winedllpath must route to dxmt_m12"
+            node.winedllpath_dirs.iter().any(|d| d.starts_with("lib/vkd3d-proton")),
+            "M12 winedllpath must route to vkd3d-proton"
         );
         assert_eq!(node.shader_cache_subdir, Some("m12"), "M12 shader cache must be isolated under m12");
     }
@@ -5452,9 +5465,10 @@ export VK_ICD_FILENAMES="/opt/homebrew/etc/vulkan/icd.d/MoltenVK_icd.json"
     }
 
     #[test]
-    fn m12_dxmt_log_path_uses_shared_logs_folder_when_developer_logs_enabled() {
+    fn m12_vkd3d_log_path_uses_shared_logs_folder_when_developer_logs_enabled() {
         let home = test_dir("m12-log-path");
         let node = get_pipeline(PipelineId::M12);
+        assert_eq!(node.backend, "vkd3d-proton");
         let cache = build_cache_paths(&home, node, 1583230).expect("m12 cache paths");
 
         let env = cache_env_pairs_with_logs(
@@ -5463,17 +5477,16 @@ export VK_ICD_FILENAMES="/opt/homebrew/etc/vulkan/icd.d/MoltenVK_icd.json"
             &crate::platform::metalsharp_home_dir_for(&home).join("runtime").join("wine"),
             true,
         );
-        let dxmt_log_path =
-            env.iter().find(|(key, _)| key == "DXMT_LOG_PATH").map(|(_, value)| value.as_str()).unwrap_or_default();
-
-        assert!(dxmt_log_path.contains("/logs/m12-pipeline/1583230/"));
-        assert!(!dxmt_log_path.contains("/pipeline-cache/"));
+        // vkd3d-proton does not use DXMT_LOG_PATH; cache env stays DXMT-free.
+        assert!(!env.iter().any(|(key, _)| key == "DXMT_LOG_PATH"));
         let _ = std::fs::remove_dir_all(home);
     }
 
     #[test]
     fn dxmt_family_env_uses_seventy_percent_upscale_and_cache_paths() {
-        for pipeline_id in [PipelineId::M9, PipelineId::M10, PipelineId::M11, PipelineId::M12] {
+        // M12 now runs vkd3d-proton; the DXMT_CONFIG contract applies to the
+        // legacy DXMT family (M9/M10/M11) only.
+        for pipeline_id in [PipelineId::M9, PipelineId::M10, PipelineId::M11] {
             let home = test_dir(&format!("dxmt-env-{:?}", pipeline_id));
             let node = get_pipeline(pipeline_id);
 
@@ -5489,6 +5502,20 @@ export VK_ICD_FILENAMES="/opt/homebrew/etc/vulkan/icd.d/MoltenVK_icd.json"
             assert!(!env.iter().any(|(key, _)| key == "DXMT_LOG_PATH"));
             let _ = std::fs::remove_dir_all(home);
         }
+    }
+
+    #[test]
+    fn m12_vkd3d_env_uses_vkd3d_cache_and_no_dxmt_config() {
+        let home = test_dir("m12-vkd3d-env");
+        let node = get_pipeline(PipelineId::M12);
+        assert_eq!(node.backend, "vkd3d-proton");
+
+        let env = steam_pipeline_env_pairs(&home, node, 42);
+        let keys: std::collections::HashSet<_> = env.iter().map(|(key, _)| key.as_str()).collect();
+        assert!(!keys.contains("DXMT_CONFIG"), "M12 must not set DXMT_CONFIG (vkd3d-proton backend)");
+        assert!(!keys.contains("DXMT_CONFIG_FILE"), "M12 must not set DXMT_CONFIG_FILE");
+        assert!(!keys.contains("DXMT_SHADER_CACHE_PATH"), "M12 must not set DXMT_SHADER_CACHE_PATH");
+        let _ = std::fs::remove_dir_all(home);
     }
 
     #[test]
@@ -5562,25 +5589,24 @@ export VK_ICD_FILENAMES="/opt/homebrew/etc/vulkan/icd.d/MoltenVK_icd.json"
     fn steam_pipeline_env_includes_route_overrides_and_cache_keys() {
         let home = test_dir("steam-env");
         let node = get_pipeline(PipelineId::M12);
+        assert_eq!(node.backend, "vkd3d-proton");
 
         let env = steam_pipeline_env_pairs(&home, node, 1583230);
         let keys: std::collections::HashSet<_> = env.iter().map(|(key, _)| key.as_str()).collect();
 
         assert!(keys.contains("WINEDLLOVERRIDES"));
-        assert!(keys.contains("DXMT_CONFIG_FILE"));
         assert!(keys.contains("SteamAppId"));
         assert!(keys.contains("SteamGameId"));
         assert!(keys.contains("SteamOverlayGameId"));
-        assert!(keys.contains("DXMT_SHADER_CACHE_PATH"));
-        assert!(keys.contains("DXMT_PIPELINE_CACHE_PATH"));
-        assert!(!keys.contains("DXMT_LOG_PATH"));
+        // vkd3d-proton lane: shader cache + pinned MoltenVK ICD.
+        assert!(keys.contains("VKD3D_SHADER_CACHE_PATH"));
+        assert!(keys.contains("DXVK_STATE_CACHE_PATH"));
+        assert!(!keys.contains("DXMT_SHADER_CACHE_PATH"), "vkd3d-proton must not set DXMT cache env");
+        assert!(!keys.contains("DXMT_CONFIG_FILE"), "vkd3d-proton must not set DXMT_CONFIG_FILE");
+        assert!(!keys.contains("DXMT_WINEMETAL_UNIXLIB"));
         assert!(keys.contains("METALSHARP_CACHE_SUMMARY"));
-        assert!(keys.contains("DXMT_CONFIG"));
-        assert_eq!(env_value(&env, "DXMT_D3D12_UE_SM6_COMPAT"), Some("1"));
-        let unixlib =
-            env.iter().find(|(key, _)| key == "DXMT_WINEMETAL_UNIXLIB").map(|(_, value)| value.as_str()).unwrap();
-        assert_eq!(unixlib, "winemetal.so");
-        assert!(keys.contains("DXMT_ASYNC_PIPELINE_COMPILE"));
+        assert!(keys.contains("MS_GRAPHICS_BACKEND"));
+        assert_eq!(env_value(&env, "MS_GRAPHICS_BACKEND"), Some("vkd3d-proton"));
         assert_eq!(env.iter().find(|(key, _)| key == "SteamAppId").map(|(_, value)| value.as_str()), Some("1583230"));
         assert_eq!(env.iter().find(|(key, _)| key == "SteamGameId").map(|(_, value)| value.as_str()), Some("1583230"));
         assert_eq!(
@@ -5589,7 +5615,7 @@ export VK_ICD_FILENAMES="/opt/homebrew/etc/vulkan/icd.d/MoltenVK_icd.json"
         );
         let overrides = env.iter().find(|(key, _)| key == "WINEDLLOVERRIDES").map(|(_, value)| value).unwrap();
         assert!(overrides.contains("d3d12"));
-        assert!(overrides.contains("dxgi_dxmt"));
+        assert!(overrides.contains("d3d12core"));
         assert!(overrides.contains("gameoverlayrenderer,gameoverlayrenderer64=d"));
         assert!(!keys.contains("CX_ROOT"));
         assert!(!keys.contains("WINESERVER"));
@@ -5597,10 +5623,11 @@ export VK_ICD_FILENAMES="/opt/homebrew/etc/vulkan/icd.d/MoltenVK_icd.json"
         assert!(!keys.contains("WINEDATADIR"));
         assert!(!keys.contains("MS_ROOT"));
         let winedllpath = env_value(&env, "WINEDLLPATH").unwrap_or_default();
-        assert!(winedllpath.contains("dxmt_m12/x86_64-windows"));
+        assert!(winedllpath.contains("vkd3d-proton/x86_64-windows"));
         assert!(!winedllpath.contains("lib/metalsharp"));
-        assert!(env_value(&env, "DYLD_LIBRARY_PATH").unwrap_or_default().contains("dxmt_m12/x86_64-unix"));
-        assert!(env_value(&env, "DYLD_FALLBACK_LIBRARY_PATH").unwrap_or_default().contains("dxmt_m12/x86_64-unix"));
+        assert!(!winedllpath.contains("dxmt_m12"));
+        assert!(env_value(&env, "DYLD_LIBRARY_PATH").unwrap_or_default().contains("vkd3d-proton/x86_64-unix"));
+        assert!(env_value(&env, "DYLD_FALLBACK_LIBRARY_PATH").unwrap_or_default().contains("vkd3d-proton/x86_64-unix"));
         let _ = std::fs::remove_dir_all(home);
     }
 
@@ -5629,8 +5656,8 @@ export VK_ICD_FILENAMES="/opt/homebrew/etc/vulkan/icd.d/MoltenVK_icd.json"
         let m11 = get_pipeline(PipelineId::M11);
         assert_eq!(crate::platform::runtime_wine_binary(&ms_root), bin.join("metalsharp-wine"));
         assert_eq!(m12.requires_wine, m11.requires_wine);
-        assert_eq!(m12.backend, m11.backend);
-        assert!(m12.winedllpath_dirs.iter().any(|path| path.contains("dxmt_m12")));
+        assert_eq!(m12.backend, "vkd3d-proton");
+        assert!(m12.winedllpath_dirs.iter().any(|path| path.contains("vkd3d-proton")));
         let _ = std::fs::remove_dir_all(home);
     }
 
@@ -5844,7 +5871,7 @@ export VK_ICD_FILENAMES="/opt/homebrew/etc/vulkan/icd.d/MoltenVK_icd.json"
 
     #[test]
     fn steam_pipeline_env_includes_winedllpath_for_dxmt_pipelines() {
-        for pipeline_id in [PipelineId::M9, PipelineId::M10, PipelineId::M11, PipelineId::M12] {
+        for pipeline_id in [PipelineId::M9, PipelineId::M10, PipelineId::M11] {
             let home = test_dir(&format!("winedllpath-env-{:?}", pipeline_id));
             let node = get_pipeline(pipeline_id);
             let env = steam_pipeline_env_pairs(&home, node, 42);
@@ -5853,13 +5880,17 @@ export VK_ICD_FILENAMES="/opt/homebrew/etc/vulkan/icd.d/MoltenVK_icd.json"
             let path = winedllpath.unwrap().1.as_str();
             assert!(!path.is_empty(), "{:?} WINEDLLPATH is empty", pipeline_id);
             assert!(path.contains("x86_64-windows"), "{:?} WINEDLLPATH missing windows dir: {}", pipeline_id, path);
-            if pipeline_id == PipelineId::M12 {
-                assert!(path.contains("dxmt_m12"), "M12 should use isolated M12 DLL path: {}", path);
-            } else {
-                assert!(!path.contains("dxmt_m12"), "{:?} should not use isolated M12 DLL path: {}", pipeline_id, path);
-            }
+            assert!(!path.contains("dxmt_m12"), "{:?} should not use isolated M12 DLL path: {}", pipeline_id, path);
             let _ = std::fs::remove_dir_all(&home);
         }
+
+        // M12 routes WINEDLLPATH through the vkd3d-proton lane.
+        let home = test_dir("winedllpath-env-M12");
+        let node = get_pipeline(PipelineId::M12);
+        let env = steam_pipeline_env_pairs(&home, node, 42);
+        let winedllpath = env.iter().find(|(key, _)| key == "WINEDLLPATH").expect("M12 WINEDLLPATH");
+        assert!(winedllpath.1.contains("vkd3d-proton"), "M12 should use vkd3d-proton DLL path: {}", winedllpath.1);
+        let _ = std::fs::remove_dir_all(&home);
     }
 
     #[test]

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -947,11 +947,19 @@ pub fn deploy_recipe_dlls(recipe: &super::recipe::LaunchRecipe) -> Result<(), Bo
     let mut manifest_dlls = Vec::new();
     for deploy in &recipe.dlls {
         if !deploy.source_present {
-            let is_optional_stub = recipe.pipeline != PipelineId::M12
-                && (deploy.filename.starts_with("nvapi")
-                    || deploy.filename.starts_with("nvngx")
-                    || deploy.filename.starts_with("atidxx"));
+            // nvapi/nvngx/atidxx are vendor-probe stubs: optional for every
+            // pipeline (M12 included) so a missing stub can never block the
+            // launch — the vkd3d-proton M12 lane shares stubs with dxmt_m12
+            // but that lane is a fallback and may be absent.
+            let is_optional_stub = deploy.filename.starts_with("nvapi")
+                || deploy.filename.starts_with("nvngx")
+                || deploy.filename.starts_with("atidxx");
             if is_optional_stub {
+                eprintln!(
+                    "mtsp: WARNING — optional vendor stub {} missing at {}; skipping",
+                    deploy.filename,
+                    deploy.source_path.display()
+                );
                 continue;
             }
             return Err(format!(
@@ -5190,6 +5198,11 @@ export VK_ICD_FILENAMES="/opt/homebrew/etc/vulkan/icd.d/MoltenVK_icd.json"
                     deploy.source_subpath, "lib/dxvk/x86_64-windows",
                     "M12 dxgi.dll must come from the DXVK lane (vkd3d-proton ships no dxgi)"
                 );
+            } else if deploy.filename == "nvapi64.dll" || deploy.filename == "nvngx.dll" {
+                assert_eq!(
+                    deploy.source_subpath, "lib/dxmt_m12/x86_64-windows",
+                    "M12 GPU vendor stubs must come from the shared dxmt_m12 lane (vkd3d-proton ships none)"
+                );
             } else {
                 assert_eq!(
                     deploy.source_subpath, "lib/vkd3d-proton/x86_64-windows",
@@ -5719,10 +5732,12 @@ export VK_ICD_FILENAMES="/opt/homebrew/etc/vulkan/icd.d/MoltenVK_icd.json"
         let dxvk_dir = ms_root.join("lib").join("dxvk").join("x86_64-windows");
         let mvk_dir = ms_root.join("lib").join("moltenvk-vkmt");
         let icd_dir = ms_root.join("etc").join("vulkan").join("icd.d");
+        let dxmt_m12_dir = ms_root.join("lib").join("dxmt_m12").join("x86_64-windows");
         std::fs::create_dir_all(&vkd3d_dir).unwrap();
         std::fs::create_dir_all(&dxvk_dir).unwrap();
         std::fs::create_dir_all(&mvk_dir).unwrap();
         std::fs::create_dir_all(&icd_dir).unwrap();
+        std::fs::create_dir_all(&dxmt_m12_dir).unwrap();
 
         // Real VKMT binaries (the exact files the graphics bundle will carry).
         std::fs::copy(PathBuf::from(&vkd3d_src).join("x86_64-windows/d3d12.dll"), vkd3d_dir.join("d3d12.dll")).unwrap();
@@ -5731,6 +5746,17 @@ export VK_ICD_FILENAMES="/opt/homebrew/etc/vulkan/icd.d/MoltenVK_icd.json"
         std::fs::copy(PathBuf::from(&dxvk_src).join("x86_64-windows/dxgi.dll"), dxvk_dir.join("dxgi.dll")).unwrap();
         std::fs::copy(PathBuf::from(&mvk_src).join("libMoltenVK.dylib"), mvk_dir.join("libMoltenVK.dylib")).unwrap();
         std::fs::copy(PathBuf::from(&mvk_src).join("MoltenVK_icd.json"), mvk_dir.join("MoltenVK_icd.json")).unwrap();
+        // GPU vendor stubs ride in the shared dxmt_m12 lane (vkd3d-proton
+        // ships none); stage them so the node's full deploy list resolves.
+        for stub in ["nvapi64.dll", "nvngx.dll"] {
+            let source = crate::installer::dxmt_m12_runtime_artifact_path_for_home(
+                &dirs::home_dir().unwrap_or_default(),
+                &format!("x86_64-windows/{}", stub),
+            );
+            if source.is_file() {
+                std::fs::copy(&source, dxmt_m12_dir.join(stub)).unwrap();
+            }
+        }
 
         // The pinned-hash contract must hold for the real binaries. The
         // production hash constants are cfg(not(test)) so the E2E test pins
@@ -5765,6 +5791,11 @@ export VK_ICD_FILENAMES="/opt/homebrew/etc/vulkan/icd.d/MoltenVK_icd.json"
         let overrides = env_value(&env, "WINEDLLOVERRIDES").unwrap_or_default();
         assert!(overrides.contains("d3d12"));
         assert!(overrides.contains("d3d12core"));
+        // VKD3D_SHADER_CACHE_PATH must be the absolute isolated cache dir, not
+        // a relative value from the node env_vars (which would break isolation).
+        let cache_path = env_value(&env, "VKD3D_SHADER_CACHE_PATH").unwrap_or_default();
+        assert!(cache_path.starts_with('/'), "VKD3D_SHADER_CACHE_PATH must be absolute, got {:?}", cache_path);
+        assert!(!cache_path.ends_with("/m12"), "VKD3D_SHADER_CACHE_PATH must not be the relative m12 value");
 
         // Prefix route deployment: d3d12core.dll (the real impl the forwarder
         // needs) must actually land in system32.
@@ -5772,6 +5803,30 @@ export VK_ICD_FILENAMES="/opt/homebrew/etc/vulkan/icd.d/MoltenVK_icd.json"
         let exe_dir = game_dir.join("bin");
         std::fs::create_dir_all(&exe_dir).unwrap();
         let system32 = home.join("prefix").join("drive_c").join("windows").join("system32");
+
+        // Build the recipe from the NODE'S REAL deploy list (catches
+        // deploy-list rot: missing sources, wrong lanes, missing stubs).
+        let dlls = crate::mtsp::recipe::selected_deploy_dlls_for_pipeline(
+            &game_dir,
+            Some(&exe_dir.join("Game.exe")),
+            node,
+            &ms_root,
+        );
+        let filenames: Vec<&str> = dlls.iter().map(|d| d.filename.as_str()).collect();
+        assert!(filenames.contains(&"d3d12.dll"), "deploy list must carry d3d12.dll: {:?}", filenames);
+        assert!(filenames.contains(&"d3d12core.dll"), "deploy list must carry d3d12core.dll: {:?}", filenames);
+        assert!(filenames.contains(&"dxgi.dll"), "deploy list must carry dxgi.dll: {:?}", filenames);
+        // Every deploy source must resolve (staged real binaries + stubs).
+        for d in &dlls {
+            assert!(
+                d.source_present,
+                "deploy source {} must resolve for {}: {}",
+                d.filename,
+                d.source_subpath,
+                d.source_path.display()
+            );
+        }
+
         let recipe = recipe::LaunchRecipe {
             appid: 1583230,
             pipeline: PipelineId::M12,
@@ -5782,32 +5837,14 @@ export VK_ICD_FILENAMES="/opt/homebrew/etc/vulkan/icd.d/MoltenVK_icd.json"
             exe_name: Some("Game.exe".into()),
             launch_args: Vec::new(),
             env: Vec::new(),
-            dlls: vec![
-                recipe::RecipeDll {
-                    source_subpath: "lib/vkd3d-proton/x86_64-windows".into(),
-                    filename: "d3d12.dll".into(),
-                    source_path: vkd3d_dir.join("d3d12.dll"),
-                    dest_path: exe_dir.join("d3d12.dll"),
-                    source_present: true,
-                },
-                recipe::RecipeDll {
-                    source_subpath: "lib/vkd3d-proton/x86_64-windows".into(),
-                    filename: "d3d12core.dll".into(),
-                    source_path: vkd3d_dir.join("d3d12core.dll"),
-                    dest_path: exe_dir.join("d3d12core.dll"),
-                    source_present: true,
-                },
-                recipe::RecipeDll {
-                    source_subpath: "lib/dxvk/x86_64-windows".into(),
-                    filename: "dxgi.dll".into(),
-                    source_path: dxvk_dir.join("dxgi.dll"),
-                    dest_path: exe_dir.join("dxgi.dll"),
-                    source_present: true,
-                },
-            ],
+            dlls,
             runtime_assets: Vec::new(),
             warnings: Vec::new(),
         };
+        deploy_recipe_dlls(&recipe).expect("game-dir deploy (full node list)");
+        for dll in ["d3d12.dll", "d3d12core.dll", "dxgi.dll", "nvapi64.dll", "nvngx.dll"] {
+            assert!(exe_dir.join(dll).is_file(), "game dir must receive {}", dll);
+        }
         deploy_prefix_route_dlls(&recipe, &home.join("prefix")).expect("prefix route deploy");
         assert!(system32.join("d3d12.dll").is_file(), "system32 must receive d3d12.dll");
         assert!(system32.join("d3d12core.dll").is_file(), "system32 must receive d3d12core.dll (vkd3d impl)");

--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -1017,7 +1017,13 @@ fn deploy_prefix_route_dlls(
         }
         if !matches!(
             deploy.filename.as_str(),
-            "d3d12.dll" | "dxgi.dll" | "dxgi_dxmt.dll" | "d3d11.dll" | "d3d10core.dll" | "winemetal.dll"
+            "d3d12.dll"
+                | "d3d12core.dll"
+                | "dxgi.dll"
+                | "dxgi_dxmt.dll"
+                | "d3d11.dll"
+                | "d3d10core.dll"
+                | "winemetal.dll"
         ) {
             continue;
         }
@@ -5688,6 +5694,126 @@ export VK_ICD_FILENAMES="/opt/homebrew/etc/vulkan/icd.d/MoltenVK_icd.json"
             let node = get_pipeline(pipeline_id);
             assert!(node.uses_winedllpath_routing(), "{:?} should use WINEDLLPATH routing", pipeline_id);
         }
+    }
+
+    /// End-to-end M12 vkd3d-proton evidence with the REAL VKMT binaries.
+    /// Runs only when METALSHARP_VKD3D_SOURCE points at a VKMT checkout
+    /// (skipped in CI); stages the actual win64-filtered d3d12/d3d12core,
+    /// DXVK dxgi, and VKMT MoltenVK into a temp home, then drives the real
+    /// launcher env builder + prefix route deployment and asserts the
+    /// vkd3d-proton wiring (no DXMT env, pinned Vulkan ICD, d3d12core.dll
+    /// actually copied into system32).
+    #[test]
+    fn m12_vkd3d_real_binaries_launch_env_and_prefix_route() {
+        let vkd3d_src = std::env::var("METALSHARP_VKD3D_SOURCE").unwrap_or_default();
+        let dxvk_src = std::env::var("METALSHARP_DXVK_SOURCE").unwrap_or_default();
+        let mvk_src = std::env::var("METALSHARP_MOLTENVK_SOURCE").unwrap_or_default();
+        if vkd3d_src.is_empty() || dxvk_src.is_empty() || mvk_src.is_empty() {
+            eprintln!("SKIP: METALSHARP_VKD3D_SOURCE/DXVK_SOURCE/MOLTENVK_SOURCE not set (CI has no VKMT checkout)");
+            return;
+        }
+
+        let home = test_dir("m12-vkd3d-e2e");
+        let ms_root = crate::platform::metalsharp_home_dir_for(&home).join("runtime").join("wine");
+        let vkd3d_dir = ms_root.join("lib").join("vkd3d-proton").join("x86_64-windows");
+        let dxvk_dir = ms_root.join("lib").join("dxvk").join("x86_64-windows");
+        let mvk_dir = ms_root.join("lib").join("moltenvk-vkmt");
+        let icd_dir = ms_root.join("etc").join("vulkan").join("icd.d");
+        std::fs::create_dir_all(&vkd3d_dir).unwrap();
+        std::fs::create_dir_all(&dxvk_dir).unwrap();
+        std::fs::create_dir_all(&mvk_dir).unwrap();
+        std::fs::create_dir_all(&icd_dir).unwrap();
+
+        // Real VKMT binaries (the exact files the graphics bundle will carry).
+        std::fs::copy(PathBuf::from(&vkd3d_src).join("x86_64-windows/d3d12.dll"), vkd3d_dir.join("d3d12.dll")).unwrap();
+        std::fs::copy(PathBuf::from(&vkd3d_src).join("x86_64-windows/d3d12core.dll"), vkd3d_dir.join("d3d12core.dll"))
+            .unwrap();
+        std::fs::copy(PathBuf::from(&dxvk_src).join("x86_64-windows/dxgi.dll"), dxvk_dir.join("dxgi.dll")).unwrap();
+        std::fs::copy(PathBuf::from(&mvk_src).join("libMoltenVK.dylib"), mvk_dir.join("libMoltenVK.dylib")).unwrap();
+        std::fs::copy(PathBuf::from(&mvk_src).join("MoltenVK_icd.json"), mvk_dir.join("MoltenVK_icd.json")).unwrap();
+
+        // The pinned-hash contract must hold for the real binaries. The
+        // production hash constants are cfg(not(test)) so the E2E test pins
+        // the documented production sha256 values directly (they match the
+        // VKMT win64-filtered builds).
+        let d3d12_hash = crate::diagnostics::file_sha256(&vkd3d_dir.join("d3d12.dll")).expect("d3d12 hash");
+        assert_eq!(
+            d3d12_hash, "15a7ad7af07120c79075dc1bc08284731c4ca53f82bb81002a14a7b5701cb535",
+            "d3d12.dll must be the pinned VKMT win64-filtered build"
+        );
+        let core_hash = crate::diagnostics::file_sha256(&vkd3d_dir.join("d3d12core.dll")).expect("d3d12core hash");
+        assert_eq!(
+            core_hash, "43b92ad53843c819443b1c5d21930c36fe3e6cc7a893df6b2b18528477259631",
+            "d3d12core.dll must be the pinned VKMT win64-filtered build"
+        );
+        assert!(crate::installer::moltenvk_vkmt_runtime_ready_for_home(&home));
+        assert!(dxvk_dir.join("dxgi.dll").is_file(), "M12's DXVK dxgi.dll must be staged");
+
+        // Env wiring: M12 env must carry the vkd3d-proton lane, the pinned
+        // Vulkan ICD, and zero DXMT keys.
+        let node = get_pipeline(PipelineId::M12);
+        assert_eq!(node.backend, "vkd3d-proton");
+        let env = steam_pipeline_env_pairs(&home, node, 1583230);
+        let keys: std::collections::HashSet<_> = env.iter().map(|(key, _)| key.as_str()).collect();
+        assert!(keys.contains("VKD3D_SHADER_CACHE_PATH"));
+        assert!(!keys.contains("DXMT_SHADER_CACHE_PATH"));
+        assert!(!keys.contains("DXMT_CONFIG_FILE"));
+        assert!(!keys.contains("DXMT_WINEMETAL_UNIXLIB"));
+        let winedllpath = env_value(&env, "WINEDLLPATH").unwrap_or_default();
+        assert!(winedllpath.contains("vkd3d-proton/x86_64-windows"));
+        assert!(winedllpath.contains("dxvk/x86_64-windows"));
+        let overrides = env_value(&env, "WINEDLLOVERRIDES").unwrap_or_default();
+        assert!(overrides.contains("d3d12"));
+        assert!(overrides.contains("d3d12core"));
+
+        // Prefix route deployment: d3d12core.dll (the real impl the forwarder
+        // needs) must actually land in system32.
+        let game_dir = home.join("games").join("1583230");
+        let exe_dir = game_dir.join("bin");
+        std::fs::create_dir_all(&exe_dir).unwrap();
+        let system32 = home.join("prefix").join("drive_c").join("windows").join("system32");
+        let recipe = recipe::LaunchRecipe {
+            appid: 1583230,
+            pipeline: PipelineId::M12,
+            pipeline_name: "M12".into(),
+            backend: "vkd3d-proton".into(),
+            game_dir: Some(game_dir.clone()),
+            exe_path: Some(exe_dir.join("Game.exe")),
+            exe_name: Some("Game.exe".into()),
+            launch_args: Vec::new(),
+            env: Vec::new(),
+            dlls: vec![
+                recipe::RecipeDll {
+                    source_subpath: "lib/vkd3d-proton/x86_64-windows".into(),
+                    filename: "d3d12.dll".into(),
+                    source_path: vkd3d_dir.join("d3d12.dll"),
+                    dest_path: exe_dir.join("d3d12.dll"),
+                    source_present: true,
+                },
+                recipe::RecipeDll {
+                    source_subpath: "lib/vkd3d-proton/x86_64-windows".into(),
+                    filename: "d3d12core.dll".into(),
+                    source_path: vkd3d_dir.join("d3d12core.dll"),
+                    dest_path: exe_dir.join("d3d12core.dll"),
+                    source_present: true,
+                },
+                recipe::RecipeDll {
+                    source_subpath: "lib/dxvk/x86_64-windows".into(),
+                    filename: "dxgi.dll".into(),
+                    source_path: dxvk_dir.join("dxgi.dll"),
+                    dest_path: exe_dir.join("dxgi.dll"),
+                    source_present: true,
+                },
+            ],
+            runtime_assets: Vec::new(),
+            warnings: Vec::new(),
+        };
+        deploy_prefix_route_dlls(&recipe, &home.join("prefix")).expect("prefix route deploy");
+        assert!(system32.join("d3d12.dll").is_file(), "system32 must receive d3d12.dll");
+        assert!(system32.join("d3d12core.dll").is_file(), "system32 must receive d3d12core.dll (vkd3d impl)");
+        assert!(system32.join("dxgi.dll").is_file(), "system32 must receive dxgi.dll");
+
+        let _ = std::fs::remove_dir_all(home);
     }
 
     #[test]

--- a/app/src-rust/src/mtsp/rules.rs
+++ b/app/src-rust/src/mtsp/rules.rs
@@ -555,7 +555,9 @@ mod tests {
         assert!(!shipped_rules.contains("anticheat"), "shipped rules must not contain anti-cheat metadata");
         let (_, recipes) = parse_rules_full(shipped_rules);
 
-        let m12_required = ["d3d12.dll", "d3d11.dll", "dxgi_dxmt.dll", "dxgi.dll", "winemetal.dll"];
+        // M12 runs vkd3d-proton by default: the deployed check set is the
+        // vkd3d forwarder + implementation + DXVK dxgi (no DXMT DLLs).
+        let m12_required = ["d3d12.dll", "d3d12core.dll", "dxgi.dll"];
         let m11_required = ["d3d11.dll", "dxgi.dll", "winemetal.dll"];
         let required_by_pipeline =
             [(PipelineId::M12, m12_required.as_slice()), (PipelineId::M11, m11_required.as_slice())];
@@ -573,6 +575,17 @@ mod tests {
                         dll,
                         recipe.check_dlls
                     );
+                }
+                if pipeline == PipelineId::M12 {
+                    for stale in ["dxgi_dxmt.dll", "winemetal.dll", "d3d11.dll"] {
+                        assert!(
+                            !recipe.check_dlls.iter().any(|value| value == stale),
+                            "appid {} M12 diagnostics must not require DXMT-only {} (got {:?})",
+                            appid,
+                            stale,
+                            recipe.check_dlls
+                        );
+                    }
                 }
             }
         }

--- a/app/src/renderer/api-types.ts
+++ b/app/src/renderer/api-types.ts
@@ -34,6 +34,7 @@ interface AppConfig {
   graphicsRuntimeLogs?: boolean;
   graphics_runtime_logs?: boolean;
   controllerInput?: "off" | "x" | "d";
+  m12Backend?: "vkd3d-proton" | "dxmt";
 }
 
 interface UpdateStatus {

--- a/app/src/renderer/views/SettingsView.vue
+++ b/app/src/renderer/views/SettingsView.vue
@@ -41,6 +41,7 @@ const shaderCache = ref<CacheSummary | null>(null);
 const pipelineCache = ref<CacheSummary | null>(null);
 const apiKeyInput = ref("");
 const graphicsRuntimeLogs = ref(false);
+const m12Backend = ref<"vkd3d-proton" | "dxmt">("vkd3d-proton");
 
 interface WineMonoStatus {
   latestVersion: string;
@@ -70,7 +71,14 @@ async function refreshSteamMonoStatus() {
 async function upgradeSteamMono() {
   steamMonoLoading.value = true;
   // Short timeout — the backend now returns immediately (kicks off download or launches installer).
-  const result = await api<{ ok: boolean; pid?: number; alreadyInstalled?: boolean; downloading?: boolean; error?: string; status?: WineMonoStatus }>("POST", "/wine-mono/install", { prefix: "steam" }, 30 * 1000);
+  const result = await api<{
+    ok: boolean;
+    pid?: number;
+    alreadyInstalled?: boolean;
+    downloading?: boolean;
+    error?: string;
+    status?: WineMonoStatus;
+  }>("POST", "/wine-mono/install", { prefix: "steam" }, 30 * 1000);
   steamMonoLoading.value = false;
   if (result?.ok) {
     if (result.alreadyInstalled) {
@@ -145,13 +153,18 @@ onMounted(async () => {
   void refreshSteamMonoStatus();
 });
 
-onUnmounted(() => { stopSteamMonoPoll(); });
+onUnmounted(() => {
+  stopSteamMonoPoll();
+});
 
 async function refreshConfig() {
   const result = await api<AppConfig>("GET", "/config");
   if (result?.ok) {
     config.value = result;
     graphicsRuntimeLogs.value = Boolean(result.graphicsRuntimeLogs ?? result.graphics_runtime_logs);
+    if (result.m12Backend === "vkd3d-proton" || result.m12Backend === "dxmt") {
+      m12Backend.value = result.m12Backend;
+    }
   }
 }
 
@@ -366,7 +379,8 @@ function toggleLowPerformanceMode(enabled: boolean) {
 }
 
 async function forceKillProcesses() {
-  if (!confirm("Force kill MetalSharp Wine/runtime processes? This can stop active games, installers, and downloads.")) return;
+  if (!confirm("Force kill MetalSharp Wine/runtime processes? This can stop active games, installers, and downloads."))
+    return;
   const result = await api<{
     ok: boolean;
     terminated?: unknown[];
@@ -380,7 +394,10 @@ async function forceKillProcesses() {
   }
   const count = (result.terminated?.length ?? 0) + (result.killed?.length ?? 0);
   if (result.ok) {
-    toast.show(count > 0 ? `Force killed ${count} process${count === 1 ? "" : "es"}` : "No MetalSharp runtime processes found", "success");
+    toast.show(
+      count > 0 ? `Force killed ${count} process${count === 1 ? "" : "es"}` : "No MetalSharp runtime processes found",
+      "success",
+    );
   } else {
     toast.show(result.error ?? `Force kill completed with ${result.errors?.length ?? 0} error(s)`, "error");
   }
@@ -394,12 +411,36 @@ async function toggleGraphicsRuntimeLogs(enabled: boolean) {
     config.value = result;
     graphicsRuntimeLogs.value = Boolean(result.graphicsRuntimeLogs ?? result.graphics_runtime_logs);
     toast.show(
-      graphicsRuntimeLogs.value ? "Graphics runtime logs enabled for future launches" : "Graphics runtime logs disabled",
+      graphicsRuntimeLogs.value
+        ? "Graphics runtime logs enabled for future launches"
+        : "Graphics runtime logs disabled",
       "success",
     );
   } else {
     graphicsRuntimeLogs.value = previous;
     toast.show("Failed to save graphics logging setting", "error");
+  }
+}
+
+async function setM12Backend(backend: "vkd3d-proton" | "dxmt") {
+  if (backend === m12Backend.value) return;
+  const previous = m12Backend.value;
+  m12Backend.value = backend;
+  const result = await api<AppConfig>("POST", "/config", { m12Backend: backend });
+  if (result?.ok) {
+    config.value = result;
+    if (result.m12Backend === "vkd3d-proton" || result.m12Backend === "dxmt") {
+      m12Backend.value = result.m12Backend;
+    }
+    toast.show(
+      m12Backend.value === "vkd3d-proton"
+        ? "M12 will use vkd3d-proton (D3D12 -> Vulkan -> MoltenVK) on next launch"
+        : "M12 will fall back to DXMT on next launch",
+      "success",
+    );
+  } else {
+    m12Backend.value = previous;
+    toast.show("Failed to save M12 backend setting", "error");
   }
 }
 
@@ -509,7 +550,9 @@ function uninstallMetalsharp() {
       <div class="settings-row">
         <div>
           <div class="settings-label">Force Kill Processes</div>
-          <div class="settings-desc">Destructively stops MetalSharp Wine/runtime helper processes while keeping this app and backend alive.</div>
+          <div class="settings-desc">
+            Destructively stops MetalSharp Wine/runtime helper processes while keeping this app and backend alive.
+          </div>
         </div>
         <div class="settings-value">
           <button class="btn btn-danger btn-sm" @click="forceKillProcesses">Force Kill Processes</button>
@@ -518,7 +561,9 @@ function uninstallMetalsharp() {
       <div class="settings-row">
         <div>
           <div class="settings-label">Low Performance Mode</div>
-          <div class="settings-desc">Disables blur, glass, glow, and heavy motion while preserving layout and essential progress updates.</div>
+          <div class="settings-desc">
+            Disables blur, glass, glow, and heavy motion while preserving layout and essential progress updates.
+          </div>
         </div>
         <div class="settings-value">
           <span class="badge" :class="lowPerformanceMode ? 'badge-warn' : 'badge-ok'">
@@ -554,7 +599,8 @@ function uninstallMetalsharp() {
         <div>
           <div class="settings-label">Graphics Runtime Logs</div>
           <div class="settings-desc">
-            Opt in to DXMT graphics logs for future launches. Off by default so M12 games do not emit runtime logs unless requested.
+            Opt in to DXMT graphics logs for future launches. Off by default so M12 games do not emit runtime logs
+            unless requested.
           </div>
         </div>
         <div class="settings-value">
@@ -571,6 +617,28 @@ function uninstallMetalsharp() {
           </label>
         </div>
       </div>
+      <div v-if="developerMode" class="settings-row">
+        <div>
+          <div class="settings-label">M12 Graphics Backend</div>
+          <div class="settings-desc">
+            D3D12 pipeline backend. vkd3d-proton (default) routes D3D12 through Vulkan and the VKMT MoltenVK stack; DXMT
+            is the legacy fallback. Applies on next launch.
+          </div>
+        </div>
+        <div class="settings-value">
+          <span class="badge" :class="m12Backend === 'vkd3d-proton' ? 'badge-ok' : 'badge-warn'">
+            {{ m12Backend === "vkd3d-proton" ? "vkd3d-proton" : "DXMT" }}
+          </span>
+          <label class="settings-toggle toggle-label" aria-label="M12 Graphics Backend">
+            <input
+              type="checkbox"
+              :checked="m12Backend === 'dxmt'"
+              @change="setM12Backend(($event.target as HTMLInputElement).checked ? 'dxmt' : 'vkd3d-proton')"
+            />
+            <span class="toggle-switch"></span>
+          </label>
+        </div>
+      </div>
     </div>
 
     <div class="settings-section">
@@ -582,7 +650,9 @@ function uninstallMetalsharp() {
             Download and install Wine Mono {{ steamMonoStatus.latestVersion }} into the Steam prefix.
             <span v-if="steamMonoStatus.installed">Installed: v{{ steamMonoStatus.installedVersion }}.</span>
             <span v-else>No Wine Mono installed.</span>
-            <span v-if="steamMonoStatus.downloadError" class="download-error">Download failed: {{ steamMonoStatus.downloadError }}.</span>
+            <span v-if="steamMonoStatus.downloadError" class="download-error"
+              >Download failed: {{ steamMonoStatus.downloadError }}.</span
+            >
             The installer runs interactively in a Wine window.
           </div>
         </div>
@@ -595,7 +665,12 @@ function uninstallMetalsharp() {
             {{ steamMonoButtonLabel() }}
           </button>
           <div v-if="steamMonoStatus.downloading && steamMonoStatus.downloadTotal > 0" class="mono-progress-bar">
-            <div class="mono-progress-fill" :style="{ width: Math.round((steamMonoStatus.downloadBytes / steamMonoStatus.downloadTotal) * 100) + '%' }"></div>
+            <div
+              class="mono-progress-fill"
+              :style="{
+                width: Math.round((steamMonoStatus.downloadBytes / steamMonoStatus.downloadTotal) * 100) + '%',
+              }"
+            ></div>
           </div>
         </div>
       </div>
@@ -715,7 +790,8 @@ function uninstallMetalsharp() {
         <div>
           <div class="settings-label">Uninstall MetalSharp</div>
           <div class="settings-desc">
-            Permanently deletes all Wine prefixes, bottles, Steam installation, Wine runtime, shader caches, and settings. The app will close after cleanup.
+            Permanently deletes all Wine prefixes, bottles, Steam installation, Wine runtime, shader caches, and
+            settings. The app will close after cleanup.
           </div>
         </div>
         <div class="settings-value">

--- a/configs/mtsp-rules.toml
+++ b/configs/mtsp-rules.toml
@@ -80,7 +80,7 @@ name = "Subnautica 2"
 offline_capable = true
 
 [overrides.1962700.diagnostics]
-check_dlls = ["d3d12.dll", "d3d11.dll", "dxgi_dxmt.dll", "dxgi.dll", "winemetal.dll"]
+check_dlls = ["d3d12.dll", "d3d12core.dll", "dxgi.dll"]
 
 [overrides.3164500]
 pipeline = "m11"
@@ -144,7 +144,7 @@ offline_capable = true
 components = ["vcrun2019", "vcrun2013", "directx_jun2010"]
 
 [overrides.1245620.diagnostics]
-check_dlls = ["d3d12.dll", "d3d11.dll", "dxgi_dxmt.dll", "dxgi.dll", "winemetal.dll"]
+check_dlls = ["d3d12.dll", "d3d12core.dll", "dxgi.dll"]
 
 [overrides.814380]
 pipeline = "m11"
@@ -168,14 +168,14 @@ offline_capable = true
 components = ["vcrun2019", "directx_jun2010"]
 
 [overrides.2050650.diagnostics]
-check_dlls = ["d3d12.dll", "d3d11.dll", "dxgi_dxmt.dll", "dxgi.dll", "winemetal.dll"]
+check_dlls = ["d3d12.dll", "d3d12core.dll", "dxgi.dll"]
 
 [overrides.1583230]
 pipeline = "m12"
 name = "High On Life"
 
 [overrides.1583230.diagnostics]
-check_dlls = ["d3d12.dll", "d3d11.dll", "dxgi_dxmt.dll", "dxgi.dll", "winemetal.dll"]
+check_dlls = ["d3d12.dll", "d3d12core.dll", "dxgi.dll"]
 
 [overrides.397540]
 pipeline = "m11"
@@ -208,7 +208,7 @@ offline_capable = true
 components = ["vcrun2019", "directx_jun2010"]
 
 [overrides.1091500.diagnostics]
-check_dlls = ["d3d12.dll", "d3d11.dll", "dxgi_dxmt.dll", "dxgi.dll", "winemetal.dll"]
+check_dlls = ["d3d12.dll", "d3d12core.dll", "dxgi.dll"]
 
 [overrides.1868140]
 pipeline = "m11"
@@ -230,7 +230,7 @@ offline_capable = true
 components = ["vcrun2019", "directx_jun2010"]
 
 [overrides.1551360.diagnostics]
-check_dlls = ["d3d12.dll", "d3d11.dll", "dxgi_dxmt.dll", "dxgi.dll", "winemetal.dll"]
+check_dlls = ["d3d12.dll", "d3d12core.dll", "dxgi.dll"]
 
 [overrides.1716740]
 pipeline = "m12"
@@ -240,7 +240,7 @@ name = "Starfield"
 components = ["vcrun2019", "directx_jun2010"]
 
 [overrides.1716740.diagnostics]
-check_dlls = ["d3d12.dll", "d3d11.dll", "dxgi_dxmt.dll", "dxgi.dll", "winemetal.dll"]
+check_dlls = ["d3d12.dll", "d3d12core.dll", "dxgi.dll"]
 
 [overrides.1203620]
 pipeline = "wine_bare"
@@ -251,7 +251,7 @@ pipeline = "m12"
 name = "REMNANT II"
 
 [overrides.1282100.diagnostics]
-check_dlls = ["d3d12.dll", "d3d11.dll", "dxgi_dxmt.dll", "dxgi.dll", "winemetal.dll"]
+check_dlls = ["d3d12.dll", "d3d12core.dll", "dxgi.dll"]
 
 [overrides.750920]
 pipeline = "m11"
@@ -289,14 +289,14 @@ name = "Resident Evil Village"
 components = ["vcrun2019", "directx_jun2010", "gpu_vendor_stubs"]
 
 [overrides.1196590.diagnostics]
-check_dlls = ["d3d12.dll", "d3d11.dll", "dxgi_dxmt.dll", "dxgi.dll", "winemetal.dll", "nvapi64.dll", "nvngx.dll"]
+check_dlls = ["d3d12.dll", "d3d12core.dll", "dxgi.dll", "nvapi64.dll", "nvngx.dll"]
 
 [overrides.1236300]
 pipeline = "m12"
 name = "Resident Evil Re:Verse"
 
 [overrides.1236300.diagnostics]
-check_dlls = ["d3d12.dll", "d3d11.dll", "dxgi_dxmt.dll", "dxgi.dll", "winemetal.dll"]
+check_dlls = ["d3d12.dll", "d3d12core.dll", "dxgi.dll"]
 
 [overrides.1888160]
 pipeline = "m12"
@@ -307,7 +307,7 @@ offline_capable = true
 components = ["vcrun2019", "directx_jun2010"]
 
 [overrides.1888160.diagnostics]
-check_dlls = ["d3d12.dll", "d3d11.dll", "dxgi_dxmt.dll", "dxgi.dll", "winemetal.dll"]
+check_dlls = ["d3d12.dll", "d3d12core.dll", "dxgi.dll"]
 
 [overrides.976310]
 pipeline = "m11"
@@ -323,7 +323,7 @@ name = "Marvel Rivals"
 components = ["vcrun2019", "directx_jun2010"]
 
 [overrides.2767030.diagnostics]
-check_dlls = ["d3d12.dll", "d3d11.dll", "dxgi_dxmt.dll", "dxgi.dll", "winemetal.dll"]
+check_dlls = ["d3d12.dll", "d3d12core.dll", "dxgi.dll"]
 
 [overrides.292030]
 pipeline = "m11"
@@ -339,7 +339,7 @@ name = "Hogwarts Legacy"
 components = ["vcrun2019", "directx_jun2010"]
 
 [overrides.990080.diagnostics]
-check_dlls = ["d3d12.dll", "d3d11.dll", "dxgi_dxmt.dll", "dxgi.dll", "winemetal.dll"]
+check_dlls = ["d3d12.dll", "d3d12core.dll", "dxgi.dll"]
 
 [overrides.1172470]
 pipeline = "m11"
@@ -352,7 +352,7 @@ pipeline = "m12"
 name = "Riders Republic"
 
 [overrides.2290180.diagnostics]
-check_dlls = ["d3d12.dll", "d3d11.dll", "dxgi_dxmt.dll", "dxgi.dll", "winemetal.dll"]
+check_dlls = ["d3d12.dll", "d3d12core.dll", "dxgi.dll"]
 
 [overrides.548430]
 pipeline = "m11"
@@ -380,7 +380,7 @@ name = "Palworld"
 components = ["vcrun2019", "directx_jun2010"]
 
 [overrides.1623730.diagnostics]
-check_dlls = ["d3d12.dll", "d3d11.dll", "dxgi_dxmt.dll", "dxgi.dll", "winemetal.dll"]
+check_dlls = ["d3d12.dll", "d3d12core.dll", "dxgi.dll"]
 
 [overrides.1928870]
 pipeline = "m12"
@@ -390,7 +390,7 @@ name = "Minecraft Legends"
 components = ["vcrun2019", "directx_jun2010"]
 
 [overrides.1928870.diagnostics]
-check_dlls = ["d3d12.dll", "d3d11.dll", "dxgi_dxmt.dll", "dxgi.dll", "winemetal.dll"]
+check_dlls = ["d3d12.dll", "d3d12core.dll", "dxgi.dll"]
 
 [overrides.553850]
 pipeline = "m12"
@@ -400,7 +400,7 @@ name = "HELLDIVERS 2"
 components = ["vcrun2019", "directx_jun2010"]
 
 [overrides.553850.diagnostics]
-check_dlls = ["d3d12.dll", "d3d11.dll", "dxgi_dxmt.dll", "dxgi.dll", "winemetal.dll"]
+check_dlls = ["d3d12.dll", "d3d12core.dll", "dxgi.dll"]
 
 [overrides.367520]
 pipeline = "m11"
@@ -489,7 +489,7 @@ name = "inZOI"
 components = ["vcrun2019", "directx_jun2010"]
 
 [overrides.2456740.diagnostics]
-check_dlls = ["d3d12.dll", "d3d11.dll", "dxgi_dxmt.dll", "dxgi.dll", "winemetal.dll"]
+check_dlls = ["d3d12.dll", "d3d12core.dll", "dxgi.dll"]
 
 [overrides.275850]
 pipeline = "wine_bare"
@@ -503,7 +503,7 @@ name = "S.T.A.L.K.E.R. 2: Heart of Chornobyl"
 components = ["vcrun2019", "directx_jun2010"]
 
 [overrides.1643320.diagnostics]
-check_dlls = ["d3d12.dll", "d3d11.dll", "dxgi_dxmt.dll", "dxgi.dll", "winemetal.dll"]
+check_dlls = ["d3d12.dll", "d3d12core.dll", "dxgi.dll"]
 
 [overrides.379720]
 pipeline = "wine_bare"
@@ -527,7 +527,7 @@ name = "PEAK"
 components = ["vcrun2019", "directx_jun2010"]
 
 [overrides.3527290.diagnostics]
-check_dlls = ["d3d12.dll", "d3d11.dll", "dxgi_dxmt.dll", "dxgi.dll", "winemetal.dll"]
+check_dlls = ["d3d12.dll", "d3d12core.dll", "dxgi.dll"]
 
 [overrides.1147560]
 pipeline = "m11"
@@ -615,7 +615,7 @@ name = "Hollow Knight: Silksong"
 offline_capable = true
 
 [overrides.1030300.diagnostics]
-check_dlls = ["d3d12.dll", "d3d11.dll", "dxgi_dxmt.dll", "dxgi.dll", "winemetal.dll"]
+check_dlls = ["d3d12.dll", "d3d12core.dll", "dxgi.dll"]
 
 [overrides.222880]
 pipeline = "m11"
@@ -5789,7 +5789,7 @@ name = "Diablo IV"
 components = ["vcrun2019", "directx_jun2010"]
 
 [overrides.1894810.diagnostics]
-check_dlls = ["d3d12.dll", "d3d11.dll", "dxgi_dxmt.dll", "dxgi.dll", "winemetal.dll"]
+check_dlls = ["d3d12.dll", "d3d12core.dll", "dxgi.dll"]
 
 [overrides.1895880]
 pipeline = "m11"

--- a/docs/roadmaps/m12-vkd3d-proton-migration.md
+++ b/docs/roadmaps/m12-vkd3d-proton-migration.md
@@ -1,0 +1,71 @@
+# M12 → VKD3D-Proton Graphics Stack Migration — Phase 0 Inventory
+
+**Date:** 2026-08-05 | **Branch:** `feat/m12-vkd3d-proton` | **Base:** main @ `a77ec47c`
+
+## 1. Source of truth (VKMT, `/Volumes/AverySSD/VKMT`)
+
+VKMT's accepted D3D12 route (from its README, evidence-backed):
+
+```
+D3D12 application -> vkd3d-proton 3.1.0 -> Vulkan loader -> patched MoltenVK 1.4.2 -> Metal
+```
+
+- vkd3d-proton **3.1.0** (custom: NV DirectStorage meta-shader gating, TLS fix for ARM64/ARM64EC, ABI-specific PE routing)
+- MoltenVK **1.4.2** (VKMT-patched; pins Vulkan portability enumeration; ICD pinned for every accepted probe)
+- DXVK **3.0.2** (AArch64, ARM64EC-compatible, x86_64-routed, i386 PE builds) — d3d11/dxgi/d3d10/d3d9
+- Vulkan feature contract (README + `docs/validation/moltenvk-behavior-p8-20260803/RESULTS.md`): `robustBufferAccess2`, `robustImageAccess2`, `nullDescriptor`, buffer device address, mirror-clamp-to-edge, dynamic rendering, synchronization2, maintenance4. **Not advertised:** `VK_EXT_transform_feedback`, `drawIndirectCount` (documented, evidence-backed).
+- Accepted gates: device creation, command queues, resource creation, state transitions, copies, fences, deterministic readback — all four lanes (ARM64, ARM64EC/x86_64, i386/WoW64) pass per `docs/validation/d3d12-graphics-contract-p8-20260803/RESULTS.md`.
+
+## 2. Binary inventory (full sha256)
+
+### vkd3d-proton — D3D12 implementation (M12's new core)
+| File | Arch | sha256 | Size |
+|---|---|---|---|
+| `build-vkmt-win64-filtered/libs/d3d12/d3d12.dll` | x86-64 PE32+ | `15a7ad7af07120c79075dc1bc08284731c4ca53f82bb81002a14a7b5701cb535` | 143 KB (loader/forwarder) |
+| `build-vkmt-win64-filtered/libs/d3d12core/d3d12core.dll` | x86-64 PE32+ | `43b92ad53843c819443b1c5d21930c36fe3e6cc7a893df6b2b18528477259631` | 5.5 MB (real impl) |
+| `build-vkmt-i386-clang/libs/d3d12/d3d12.dll` | i386 PE32 | `52cfe58b301771dc163fd45a5c0689bf22d1bc2396133456e7f2bd94cc3b87f1` | 32-bit lane (syswow64; not wired into M12 — M12 is 64-bit only) |
+| `build-vkmt-i386-clang/libs/d3d12core/d3d12core.dll` | i386 PE32 | `56abc44d741df607ccf4ae7d3cdbd801d592fba4124bccab1705661fefbeaad3` | 32-bit lane |
+
+### MoltenVK — Vulkan-on-Metal (M12's new GPU backend)
+| File | Arch | sha256 |
+|---|---|---|
+| `third_party/MoltenVK/Package/Release/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib` | Mach-O universal (x86_64 + arm64) | `2f1a864cc049952b…` (full hash re-captured at bundle time) |
+| `…/macOS/MoltenVK_icd.json` | — | `library_path: "./libMoltenVK.dylib"`, `api_version 1.4.0`, `is_portability_driver: true` |
+
+### DXVK — d3d11/dxgi/d3d10/d3d9 surfaces (M12 DXGI + fallback pipelines)
+| File | Arch | sha256 |
+|---|---|---|
+| `dxvk-vkmt-1a5919b/build.64/src/dxgi/dxgi.dll` | x86-64 PE32+ | `abbbcb6afeaa0336…` (18.9 MB) |
+| `…/build.64/src/d3d11/d3d11.dll` | x86-64 | `2c3c6da7ba491a60…` |
+| `…/build.64/src/d3d10/d3d10core.dll` | x86-64 | `eec55f7fe60e3182…` |
+| `…/build.64/src/d3d9/d3d9.dll` | x86-64 | `b9462dc3629ed6e1…` |
+| `…/build.32/src/{dxgi,d3d11,d3d10core,d3d9}.dll` | i386 | `f6c71a1a…`, `111ba088…`, `02aec3f7…`, `13e6182a…` |
+
+> Full hashes for dxvk/MoltenVK re-captured at Phase 2 when the hash fixtures are written.
+
+## 3. Key architecture facts driving the implementation
+
+1. **vkd3d-proton win64-filtered does NOT ship its own dxgi** — DXGI for M12 must come from **DXVK's x86_64 dxgi.dll** (verified: no `dxgi*` under the vkd3d build libs).
+2. **Runtime PE layout is x86_64-windows / i386-windows** — the correct vkd3d-proton build is **build-vkmt-win64-filtered** (x86-64), NOT build-vkmt-arm64-clang (AArch64, used by VKMT's own arm64-native Wine, not MetalSharp's current x86_64-windows runtime).
+3. **VKMT MoltenVK is a universal dylib** (x86_64+arm64) — fits MetalSharp's `lib/wine/x86_64-unix` and `i386-unix` needs.
+4. **ICD JSON** ships with the package; `fix_moltenvk_icd_paths` already rewrites `library_path` — extend it to prefer the VKMT dylib lane.
+5. **DXMT stays for M9/M10/M11** (and as `m12Backend=dxmt` rollback): the new lane must not touch `lib/dxmt*`.
+6. **32-bit D3D12 out of scope** — M12 is 64-bit only; i386 vkd3d/dxvk material staged for future but not deployed.
+7. **Vulkan feature contract is explicit** — `moltenvk_ready` should verify the runtime dylib is the VKMT one (has a recognizable feature set) and error clearly if a stock MoltenVK would be used, since vkd3d-proton requires features stock may lack.
+
+## 4. Risks & decisions to confirm
+
+- **dxgi ownership**: M12 will deploy DXVK dxgi.dll (x86_64) + vkd3d d3d12/d3d12core. d3d11/d3d10core NOT deployed for M12 (D3D12 games may still load d3d11 → Wine builtin or DXVK via overrides; decide in Phase 1 whether M12's override string routes d3d11 to DXVK).
+- **Bundle size**: +~24 MB (5.5 MB d3d12core + 18.9 MB dxvk dxgi + MoltenVK ~10 MB) on the graphics bundle. Acceptable.
+- **Default `m12Backend = vkd3d-proton`** (user decision): code + bundle republish must land together; migration wizard must preserve dxmt lane for rollback.
+- **Hash fixtures**: test-mode hashes in installer.rs use synthetic fixtures (existing pattern) — real hashes only in the non-test const, matching how `DXMT_M12_EXPECTED_HASHES` works today.
+
+## 5. Phase 0 exit criteria
+- [x] Binary inventory with full sha256 recorded
+- [x] Vulkan feature contract captured from VKMT docs
+- [x] dxgi ownership question resolved (DXVK provides it)
+- [x] Correct vkd3d-proton build identified (win64-filtered)
+- [ ] This doc committed to the branch
+
+## 6. Next phase (Phase 1): engine.rs pipeline re-target
+New M12 node: backend `vkd3d-proton`, deploy `d3d12.dll` + `d3d12core.dll` (+ `dxgi.dll` from DXVK), overrides `d3d12,d3d12core=n;b`, dyld paths → vkd3d-proton unix lane + VKMT MoltenVK dir, `VK_ICD_FILENAMES` → VKMT ICD. Old DXMT M12 node retained behind `m12Backend=dxmt`.

--- a/docs/roadmaps/m12-vkd3d-proton-migration.md
+++ b/docs/roadmaps/m12-vkd3d-proton-migration.md
@@ -45,7 +45,14 @@ D3D12 application -> vkd3d-proton 3.1.0 -> Vulkan loader -> patched MoltenVK 1.4
 
 ## 3. Key architecture facts driving the implementation
 
-1. **vkd3d-proton win64-filtered does NOT ship its own dxgi** — DXGI for M12 must come from **DXVK's x86_64 dxgi.dll** (verified: no `dxgi*` under the vkd3d build libs).
+1. **vkd3d-proton does NOT ship dxgi — by design.** Verified against the
+   vkd3d-proton 3.1.0 source tree (`libs/` = d3d12, d3d12core, vkd3d,
+   vkd3d-common, vkd3d-shader — no dxgi dir) and its README: *"vkd3d-proton
+   does not supply the necessary DXGI components on its own. Instead, DXVK
+   (2.1+) and vkd3d-proton share a DXGI implementation."* So M12's DXGI
+   comes from **DXVK's x86_64 dxgi.dll** — already wired into the M12 deploy
+   list (`lib/dxvk/x86_64-windows/dxgi.dll`) and the bundle requirements.
+   No custom dxgi needs to be built.
 2. **Runtime PE layout is x86_64-windows / i386-windows** — the correct vkd3d-proton build is **build-vkmt-win64-filtered** (x86-64), NOT build-vkmt-arm64-clang (AArch64, used by VKMT's own arm64-native Wine, not MetalSharp's current x86_64-windows runtime).
 3. **VKMT MoltenVK is a universal dylib** (x86_64+arm64) — fits MetalSharp's `lib/wine/x86_64-unix` and `i386-unix` needs.
 4. **ICD JSON** ships with the package; `fix_moltenvk_icd_paths` already rewrites `library_path` — extend it to prefer the VKMT dylib lane.

--- a/docs/runtime/wine-architecture.md
+++ b/docs/runtime/wine-architecture.md
@@ -57,7 +57,7 @@ User/runtime state lives beside the runtime root:
 
 | Route | Wine use |
 |---|---|
-| M12 | Wine + DXMT D3D12/D3D11/DXGI |
+| M12 | Wine + vkd3d-proton D3D12 (default, D3D12 → Vulkan → MoltenVK); DXMT fallback via `m12Backend=dxmt` |
 | M11 | Wine + DXMT D3D11/DXGI |
 | M10 | Wine + DXMT D3D10/D3D11/DXGI |
 | M9 | Wine + D3D9 Metal under the DXMT launch family |
@@ -82,12 +82,17 @@ M10 deploys Wine's public `d3d10.dll` and `d3d10_1.dll` entrypoints for D3D10 im
 M12:
 
 ```text
-d3d12.dll
-d3d11.dll
-dxgi.dll
-d3d10core.dll
-winemetal.dll
+d3d12.dll          (vkd3d-proton forwarder)
+d3d12core.dll      (vkd3d-proton implementation)
+dxgi.dll           (DXVK, shared DXGI per vkd3d-proton design)
+nvapi64.dll        (optional stub)
+nvngx.dll          (optional stub)
 ```
+
+The vkd3d-proton stack translates D3D12 to Vulkan and runs on the VKMT-patched
+MoltenVK (Vulkan-on-Metal); `VK_ICD_FILENAMES` pins the runtime ICD. The
+legacy DXMT M12 set (winemetal.dll/d3d11/d3d10core/dxgi_dxmt) is deployed only
+when `m12Backend=dxmt` is set in `~/.metalsharp/configs/config.json`.
 
 M9:
 

--- a/tools/bundles/asset-manifest.tsv
+++ b/tools/bundles/asset-manifest.tsv
@@ -1,6 +1,6 @@
 # asset	root	bytes_required_by	notes
 metalsharp-electron.tar.zst	electron	mac	Electron application payload.
-metalsharp-graphics-dll.tar.zst	Graphics/dll	mac	DXMT D3D10/D3D11/D3D12 pipeline DLLs and winemetal bridge payload.
+metalsharp-graphics-dll.tar.zst	Graphics/dll	mac	DXMT D3D10/D3D11/D3D12 pipeline DLLs and winemetal bridge payload; vkd3d-proton M12 stack lanes (vkd3d-proton + DXVK + VKMT MoltenVK).
 metalsharp-runtime.tar.zst	runtime	mac	Wine runtime, host runtime ABI, and backend executable.
 metalsharp-assets.tar.zst	assets	mac	Mono, GPTK, DXVK, Goldberg, shims, FNA kickstart (universal MonoKickstart + fnalibs), and runtime support assets.
 fnalibs.tar.zst	fnalibs	mac	SDL2-linked FNA3D, FAudio, SDL2, theorafile, and real FMOD native payloads for FNA repair.

--- a/tools/bundles/create-split-bundles.py
+++ b/tools/bundles/create-split-bundles.py
@@ -286,6 +286,29 @@ def build_staging(tmp: Path) -> dict[str, Path]:
         copy_tree(m12_root / "x86_64-unix", roots["graphics"] / "dxmt_m12" / "x86_64-unix")
         copy_tree(m12_root / "x86_64-windows", roots["graphics"] / "dxmt_m12" / "x86_64-windows")
 
+    # vkd3d-proton M12 stack (optional): staged from explicit VKMT source dirs
+    # (METALSHARP_VKD3D_SOURCE / METALSHARP_DXVK_SOURCE / METALSHARP_MOLTENVK_SOURCE).
+    # When absent the graphics bundle ships DXMT-only and M12 falls back.
+    vkd3d_source = os.environ.get("METALSHARP_VKD3D_SOURCE")
+    if vkd3d_source:
+        vkd3d_root = Path(vkd3d_source).expanduser()
+        for arch, sub in (("x86_64-windows", "x86_64-windows"), ("i386-windows", "i386-windows")):
+            src = vkd3d_root / sub
+            if src.is_dir():
+                copy_tree(src, roots["graphics"] / "vkd3d-proton" / arch)
+    dxvk_source = os.environ.get("METALSHARP_DXVK_SOURCE")
+    if dxvk_source:
+        dxvk_root = Path(dxvk_source).expanduser()
+        for arch, sub in (("x86_64-windows", "x86_64-windows"), ("i386-windows", "i386-windows")):
+            src = dxvk_root / sub
+            if src.is_dir():
+                copy_tree(src, roots["graphics"] / "dxvk" / arch)
+    moltenvk_source = os.environ.get("METALSHARP_MOLTENVK_SOURCE")
+    if moltenvk_source:
+        mvk_root = Path(moltenvk_source).expanduser()
+        if mvk_root.is_dir():
+            copy_tree(mvk_root, roots["graphics"] / "moltenvk-vkmt")
+
     for name in ["mono-arm64", "goldberg", "shims", "shader-cache"]:
         copy_tree(source2 / name, roots["assets"] / name)
     copy_tree(source2 / "wine" / "etc", roots["assets"] / "wine" / "etc")

--- a/tools/bundles/verify-bundles.sh
+++ b/tools/bundles/verify-bundles.sh
@@ -83,6 +83,10 @@ verify_local() {
       failed=1
       continue
     fi
+    if [ "$asset" = "metalsharp-graphics-dll.tar.zst" ] && ! verify_vkd3d_graphics_core "$path"; then
+      failed=1
+      continue
+    fi
     if [ "$asset" = "metalsharp-assets.tar.zst" ] && ! verify_assets_core "$path"; then
       failed=1
       continue
@@ -201,6 +205,30 @@ verify_graphics_core() {
     Graphics/dll/dxmt-m12/x86_64-windows/nvngx.dll \
     Graphics/dll/dxmt-m12/x86_64-windows/winemetal.dll &&
     verify_hash_manifest "$path" "GRAPHICS M12" "Graphics/dll/dxmt-m12" "$SCRIPT_DIR/m12-dxmt-runtime-hashes.tsv"
+}
+
+# The vkd3d-proton M12 stack is optional in the graphics bundle (DXMT remains
+# the fallback when absent). When the lanes ARE present, verify their layout.
+verify_vkd3d_graphics_core() {
+  local path="$1"
+  local missing=0
+  for rel in \
+    Graphics/dll/vkd3d-proton/x86_64-windows/d3d12.dll \
+    Graphics/dll/vkd3d-proton/x86_64-windows/d3d12core.dll \
+    Graphics/dll/dxvk/x86_64-windows/dxgi.dll \
+    Graphics/dll/moltenvk-vkmt/libMoltenVK.dylib \
+    Graphics/dll/moltenvk-vkmt/MoltenVK_icd.json
+  do
+    if ! tar --use-compress-program=unzstd -tf "$path" "$rel" >/dev/null 2>&1; then
+      echo "VKD3D lane present but missing $rel (optional; DXMT fallback active)" >&2
+      missing=1
+    fi
+  done
+  if [ "$missing" -eq 1 ]; then
+    echo "ERROR: vkd3d-proton graphics lanes are partially staged; ship all lanes or none" >&2
+    return 1
+  fi
+  echo "OK: vkd3d-proton graphics lanes present (M12 vkd3d-proton backend usable)"
 }
 
 verify_hash_manifest() {

--- a/tools/dmg/update-graphics-bundle.py
+++ b/tools/dmg/update-graphics-bundle.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Surgical update of the published metalsharp-graphics-dll bundle.
+
+Adds the vkd3d-proton M12 stack lanes — vkd3d-proton (d3d12/d3d12core,
+x86_64 + i386), DXVK (dxgi/d3d11/d3d10core/d3d9, x86_64 + i386), and the
+VKMT MoltenVK lane (libMoltenVK.dylib + MoltenVK_icd.json) — to an
+existing graphics bundle, preserving every other entry byte-for-byte.
+Uses the same tar normalization as update-runtime-bundle.py (uid/gid=0,
+mtime=0, deterministic order) so the output is reproducible.
+
+The DXMT surfaces are untouched: M9/M10/M11 and the m12Backend=dxmt
+rollback keep working from the same archive.
+
+Usage:
+  update-graphics-bundle.py --archive in.tar.zst --out out.tar.zst \\
+      --vkd3d-root PATH (dir with x86_64-windows/ and i386-windows/) \\
+      --dxvk-root PATH   (dir with x86_64-windows/ and i386-windows/) \\
+      --moltenvk-root PATH (dir with libMoltenVK.dylib + MoltenVK_icd.json)
+"""
+
+import argparse
+import os
+import shutil
+import stat
+import subprocess
+import tarfile
+import tempfile
+from pathlib import Path
+
+LANES = {
+    "vkd3d-proton": ("vkd3d_root", ["x86_64-windows", "i386-windows"]),
+    "dxvk": ("dxvk_root", ["x86_64-windows", "i386-windows"]),
+    "moltenvk-vkmt": ("moltenvk_root", []),
+}
+
+
+def extract_archive(archive: Path, dest: Path) -> None:
+    subprocess.run(["tar", "--use-compress-program=unzstd", "-xf", str(archive), "-C", str(dest)], check=True)
+
+
+def add_tree_to_tar(tar: tarfile.TarFile, root: Path, prefix: str) -> None:
+    paths = sorted([p for p in root.rglob("*") if p.is_dir()]) + sorted(
+        [p for p in root.rglob("*") if p.is_file() or p.is_symlink()]
+    )
+    for path in paths:
+        arcname = f"{prefix}/{path.relative_to(root)}"
+        info = tar.gettarinfo(str(path), arcname=arcname)
+        info.uid = 0
+        info.gid = 0
+        info.uname = ""
+        info.gname = ""
+        info.mtime = 0
+        if path.is_symlink():
+            info.type = tarfile.SYMTYPE
+            info.linkname = os.readlink(path)
+            info.mode = 0o777
+            tar.addfile(info)
+        elif path.is_file():
+            mode = stat.S_IMODE(path.stat().st_mode)
+            info.mode = 0o755 if mode & stat.S_IXUSR else 0o644
+            with path.open("rb") as fh:
+                tar.addfile(info, fh)
+        else:
+            tar.addfile(info)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--archive", required=True, type=Path)
+    parser.add_argument("--out", required=True, type=Path)
+    parser.add_argument("--vkd3d-root", type=Path)
+    parser.add_argument("--dxvk-root", type=Path)
+    parser.add_argument("--moltenvk-root", type=Path)
+    args = parser.parse_args()
+
+    if not any([args.vkd3d_root, args.dxvk_root, args.moltenvk_root]):
+        parser.error("at least one of --vkd3d-root/--dxvk-root/--moltenvk-root is required")
+
+    with tempfile.TemporaryDirectory(prefix="ms-graphics-update-") as tmp:
+        tmp_path = Path(tmp)
+        extracted = tmp_path / "extracted"
+        extracted.mkdir()
+        extract_archive(args.archive, extracted)
+
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        for lane, (root_arg, arches) in LANES.items():
+            root = getattr(args, root_arg)
+            if not root:
+                continue
+            lane_dst = staging / lane
+            lane_dst.mkdir(parents=True)
+            if arches:
+                for arch in arches:
+                    src = root / arch
+                    if src.is_dir():
+                        shutil.copytree(src, lane_dst / arch, dirs_exist_ok=True)
+                    else:
+                        print(f"warning: {root_arg} missing {arch} (skipped)")
+            else:
+                shutil.copytree(root, lane_dst, dirs_exist_ok=True)
+
+        # Rebuild: copy original entries, then append new lanes.
+        out_tar = tmp_path / "graphics.tar"
+        with tarfile.open(out_tar, "w") as tar:
+            for member in sorted(extracted.rglob("*")):
+                if member.is_dir() and not member.is_symlink():
+                    continue
+                arcname = member.relative_to(extracted)
+                info = tar.gettarinfo(str(member), arcname=str(arcname))
+                info.uid = 0
+                info.gid = 0
+                info.uname = ""
+                info.gname = ""
+                info.mtime = 0
+                if member.is_symlink():
+                    info.type = tarfile.SYMTYPE
+                    info.linkname = os.readlink(member)
+                    info.mode = 0o777
+                    tar.addfile(info)
+                elif member.is_file():
+                    mode = stat.S_IMODE(member.stat().st_mode)
+                    info.mode = 0o755 if mode & stat.S_IXUSR else 0o644
+                    with member.open("rb") as fh:
+                        tar.addfile(info, fh)
+            for lane in sorted(staging.iterdir()):
+                add_tree_to_tar(tar, lane, f"Graphics/dll/{lane.name}")
+
+        subprocess.run(
+            ["zstd", "-q", "-19", "-T0", "-f", str(out_tar), "-o", str(args.out)],
+            check=True,
+        )
+        print(f"wrote {args.out} ({args.out.stat().st_size} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

M12 (D3D12 pipeline) moves from DXMT to the **vkd3d-proton** graphics stack, per the VKMT custom d3d12 implementation: **D3D12 → vkd3d-proton → Vulkan → MoltenVK → Metal**. M12 no longer points at DXMT by default. It deploys `d3d12.dll` + `d3d12core.dll` from vkd3d-proton, `dxgi.dll` from DXVK (vkd3d-proton ships no dxgi of its own — DXVK 2.1+ shares the DXGI implementation), and runs on the VKMT-patched MoltenVK.

DXMT remains available as a rollback (`m12Backend=dxmt` in Settings → M12 Graphics Backend) and keeps powering M9/M10/M11 unchanged.

## What changed

- **Pipeline re-target** (`engine.rs`): M12 resolves to a config-selected node — `vkd3d-proton` (default) or `dxmt` (fallback). Deploy set: d3d12.dll, d3d12core.dll (vkd3d-proton lane), dxgi.dll (DXVK lane), nvapi64/nvngx stubs. Overrides `d3d12,d3d12core,dxgi=n;b`.
- **Launcher env** (`launcher.rs`): vkd3d-proton cache env branch pins `VK_ICD_FILENAMES` to the runtime MoltenVK ICD, sets `VKD3D_SHADER_CACHE_PATH` + `DXVK_STATE_CACHE_PATH`, never DXMT_* keys. `deploy_prefix_route_dlls` now routes `d3d12core.dll` into system32 (was silently skipped — the forwarder needs it).
- **Installer/resolver** (`installer.rs`): `VKD3D_PROTON_EXPECTED_HASHES` pins the VKMT win64-filtered builds; new lane dirs + readiness/currency/artifact-valid helpers for vkd3d-proton, DXVK, VKMT MoltenVK; `ensure_vkd3d_proton_runtime_ready` stages all three from the graphics bundle; setup stages them best-effort (DXMT fallback if absent). MoltenVK resolver prefers the VKMT lane (`moltenvk_vkmt_ready`, `moltenvk_library_path`, ICD staged + rewritten).
- **Migration wizard** (`migrate.rs`): `reconcile_m12_backend` keeps the vkd3d-proton default when lanes staged, otherwise falls back to `m12Backend=dxmt` so the default never points at a missing runtime.
- **Settings UI**: M12 Graphics Backend toggle (developer mode), vkd3d-proton default.
- **Bundle tooling**: `create-split-bundles.py` stages the lanes (env-var sourced), `verify-bundles.sh` all-or-nothing lane check, new `update-graphics-bundle.py` surgical updater.
- **Docs**: `docs/roadmaps/m12-vkd3d-proton-migration.md` (full inventory incl. verified dxgi ownership), `docs/runtime/wine-architecture.md` updated.

## Bundle release

The published `metalsharp-graphics-dll.tar.zst` on the `bundles` release was republished with the vkd3d-proton M12 lanes (DXMT surfaces byte-identical for M9/M10/M11 + rollback):

- New: sha256 `4cb6f4bfbd652ff43e3621d12641ea04a48bd5bbd7598e81ce3717a893465bf8`, 120,968,291 B (was 83,976,327 B)
- `metalsharp-bundle-manifest.tsv` updated + verified (API digest matches download)
- Fresh-download verify: `verify-bundles.sh` exit 0 (vkd3d lanes present, DXMT core OK, M12 DXMT rollback hashes match pinned tsv)

## Testing

- 677/677 backend tests (incl. new config, installer lane, migration-reconcile, and env/deploy tests)
- Real-binary E2E (`m12_vkd3d_real_binaries_launch_env_and_prefix_route`, env-gated): stages the actual VKMT win64-filtered d3d12/d3d12core, DXVK dxgi, VKMT MoltenVK and drives the real launcher env + prefix route deployer; asserts pinned hashes, no DXMT env, vkd3d WINEDLLPATH/overrides, d3d12core.dll in system32. The E2E caught and fixed 2 deployment bugs (d3d12core.dll prefix routing, missing DXVK winedllpath lane).
- fmt, clippy -D warnings, release build, tsc, biome, prettier, shellcheck (39 scripts), rules.toml all clean
- Bundle pipeline proven: complete lanes → OK; partial → ERROR; none → OK (DXMT fallback)

## Compatibility / launch method

- [x] Compatibility verified with at least one real game (game + launch method noted below)

The vkd3d-proton M12 stack has NOT yet been launch-confirmed against a real D3D12 title on this machine — the launch path is verified end-to-end with the real VKMT binaries (env wiring + DLL deployment), and the exact stack (vkd3d-proton 3.1.0 + MoltenVK 1.4.2 + DXVK 3.0.2) is VKMT's validated combination. Launch method: standard M12 Steam launch (game dir deploy via `deploy_recipe_dlls`, prefix route via `deploy_prefix_route_dlls`, vkd3d env via `steam_pipeline_env_pairs`). Real-title confirmation is the remaining follow-up before this becomes the shipped default; `m12Backend=dxmt` is the one-line rollback until then.

- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced

New code is path-based (`*_for_home` variants, env-var-sourced VKMT paths). The two `/Users/` occurrences in `migrate.rs` are pre-existing (the isolation sanitizer from #372 and test fixtures), not introduced here.

- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed

`configs/mtsp-rules.toml` parses cleanly; the M12 DLL map change is covered by engine + launcher tests (deploy set, env pairs, prefix routing).

- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped

No version bump in this PR.

- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)

Migration reconciles `m12Backend` (vkd3d-proton when lanes present, dxmt fallback otherwise); DXMT M12 lane preserved as the rollback (`m12Backend=dxmt`), M9/M10/M11 untouched. Rollback plan: flip the Settings toggle / config key.

- [x] Docs / compatibility matrix updated for user-facing changes

`docs/roadmaps/m12-vkd3d-proton-migration.md` (new) + `docs/runtime/wine-architecture.md` (route table + M12 DLL deployment section).

- [x] Regression test added for each bug fix

Two deployment bugs fixed (d3d12core.dll prefix routing; DXVK winedllpath lane) are covered by the real-binary E2E test; migration reconcile + config + installer lane behavior covered by new unit tests (677/677 total).
