### PR TITLE
fix(dxmt): select Metal shader version by macOS

### DIFF
--- a/app/src-rust/src/mtsp/launcher.rs
+++ b/app/src-rust/src/mtsp/launcher.rs
@@ -1437,6 +1437,7 @@ pub fn launch_custom_with_options(
     // MetalFX strength is the user's choice (metalfx.overlay.json): reconcile
     // the DXMT env after node env so the toggle is authoritative.
     apply_metal_fx_config_cmd(&mut cmd, node, &home);
+    apply_dxmt_shader_metal_version_config_cmd(&mut cmd, node);
 
     cmd.arg(&exe_name);
     cmd.args(&recipe.launch_args);
@@ -1882,6 +1883,9 @@ fn launch_dxmt_metal_with_context(
     for (key, value) in extra_env {
         cmd.env(key, value);
     }
+    // Reconcile after game recipe and caller-provided environment so the host
+    // Metal shader dialect remains authoritative on direct launch paths.
+    apply_dxmt_shader_metal_version_config_cmd(&mut cmd, node);
 
     cmd.arg(&exe_name);
     cmd.args(&recipe.launch_args);
@@ -2842,6 +2846,9 @@ fn steam_pipeline_env_pairs(home: &PathBuf, node: &PipelineNode, appid: u32) -> 
     // MetalFX strength is the user's choice: applied last so it overrides the
     // node default and any game-recipe DXMT_CONFIG/DXMT_METALFX_* entries.
     apply_metal_fx_config(&mut env, node, home);
+    // DXMT's Metal shader dialect must match the host macOS capability. Apply
+    // this after route and recipe config so a stale per-game value cannot win.
+    apply_dxmt_shader_metal_version_config(&mut env, node);
     // msync toggle likewise wins over recipe env.
     apply_msync_config(&mut env, home);
     env
@@ -2925,8 +2932,8 @@ fn apply_metal_fx_config(env: &mut Vec<(String, String)>, node: &PipelineNode, h
 }
 
 /// Command-wrapper variant for the direct launch paths (they apply
-/// `node.env_vars` straight onto the Command, so we reconcile via the same
-/// pair-rewrite logic then push the overrides back).
+/// `node.env_vars` straight onto the Command, so we reconcile the DXMT
+/// configuration before pushing the overrides back).
 fn apply_metal_fx_config_cmd(cmd: &mut std::process::Command, node: &PipelineNode, home: &Path) {
     let mut env: Vec<(String, String)> = Vec::new();
     for ev in &node.env_vars {
@@ -2936,6 +2943,114 @@ fn apply_metal_fx_config_cmd(cmd: &mut std::process::Command, node: &PipelineNod
     for (key, value) in env {
         cmd.env(key, value);
     }
+}
+
+/// DXMT routes that compile D3D10/11 shaders and require an explicit Metal
+/// shader language version on macOS 14 and 15 through 25.
+fn is_dxmt_shader_metal_version_route(pipeline_id: PipelineId) -> bool {
+    matches!(pipeline_id, PipelineId::M10 | PipelineId::M10_32 | PipelineId::M11 | PipelineId::M11_32)
+}
+
+/// Map a macOS ProductVersion to the DXMT Metal shader language override.
+/// macOS 14 uses Metal 3.1; macOS 15 through 25 use Metal 3.2. macOS 26 and
+/// newer use Metal 4, for which DXMT's automatic selection requires no flag.
+fn dxmt_shader_metal_version_for_macos_product_version(product_version: &str) -> Option<u16> {
+    let components: Vec<&str> = product_version.trim().split('.').collect();
+    if !(1..=3).contains(&components.len())
+        || components.iter().any(|component| component.is_empty() || component.parse::<u32>().is_err())
+    {
+        return None;
+    }
+    let major = components[0].parse::<u32>().ok()?;
+    if major < 14 {
+        return None;
+    }
+    match major {
+        14 => Some(310),
+        15..=25 => Some(320),
+        _ => None,
+    }
+}
+
+/// Read the host product version via the system-owned macOS utility. Failure is
+/// deliberately fail-open: DXMT then retains its own supported-host detection.
+fn macos_product_version() -> Option<String> {
+    let output = std::process::Command::new("/usr/bin/sw_vers").arg("-productVersion").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let version = String::from_utf8(output.stdout).ok()?;
+    (!version.trim().is_empty()).then_some(version)
+}
+
+fn apply_dxmt_shader_metal_version_config(env: &mut Vec<(String, String)>, node: &PipelineNode) {
+    let product_version = macos_product_version();
+    apply_dxmt_shader_metal_version_config_for_macos_version(env, node, product_version.as_deref());
+}
+
+/// Final command-path reconciliation. `Command::get_envs` exposes the explicit
+/// environment accumulated by route, recipe, and caller configuration, so this
+/// preserves every other DXMT option while making only the shader version host
+/// authoritative.
+fn apply_dxmt_shader_metal_version_config_cmd(cmd: &mut std::process::Command, node: &PipelineNode) {
+    let product_version = macos_product_version();
+    apply_dxmt_shader_metal_version_config_cmd_for_macos_version(cmd, node, product_version.as_deref());
+}
+
+fn apply_dxmt_shader_metal_version_config_cmd_for_macos_version(
+    cmd: &mut std::process::Command,
+    node: &PipelineNode,
+    product_version: Option<&str>,
+) {
+    if !is_dxmt_shader_metal_version_route(node.id) {
+        return;
+    }
+    let mut env = cmd
+        .get_envs()
+        .filter_map(|(key, value)| {
+            (key == "DXMT_CONFIG")
+                .then(|| {
+                    value.and_then(|value| value.to_str()).map(|value| ("DXMT_CONFIG".to_string(), value.to_string()))
+                })
+                .flatten()
+        })
+        .collect();
+    apply_dxmt_shader_metal_version_config_for_macos_version(&mut env, node, product_version);
+    if let Some((_, config)) = env.last() {
+        cmd.env("DXMT_CONFIG", config);
+    }
+}
+
+/// Apply the DXMT shader-language policy using an explicit product-version
+/// input. Kept separate from `sw_vers` for deterministic boundary testing.
+fn apply_dxmt_shader_metal_version_config_for_macos_version(
+    env: &mut Vec<(String, String)>,
+    node: &PipelineNode,
+    product_version: Option<&str>,
+) {
+    if !is_dxmt_shader_metal_version_route(node.id) {
+        return;
+    }
+    let shader_version = product_version.and_then(dxmt_shader_metal_version_for_macos_product_version);
+    if let Some((_, config)) = env.iter_mut().rev().find(|(key, _)| key == "DXMT_CONFIG") {
+        *config = dxmt_config_with_shader_metal_version(config, shader_version);
+    } else if let Some(shader_version) = shader_version {
+        env.push(("DXMT_CONFIG".to_string(), format!("dxmt.shaderMetalVersion={shader_version}")));
+    }
+}
+
+/// Replace the shader Metal version pair while retaining all unrelated DXMT
+/// configuration. `None` removes the launch override for Metal 4 hosts.
+fn dxmt_config_with_shader_metal_version(config: &str, shader_version: Option<u16>) -> String {
+    let mut pairs: Vec<String> = config
+        .split(';')
+        .filter(|pair| pair.split_once('=').is_some_and(|(key, _)| key != "dxmt.shaderMetalVersion"))
+        .map(ToString::to_string)
+        .collect();
+    if let Some(shader_version) = shader_version {
+        pairs.push(format!("dxmt.shaderMetalVersion={shader_version}"));
+    }
+    pairs.join(";")
 }
 
 /// Rebuild a `DXMT_CONFIG` value with the MetalFX upscale pair set to
@@ -7940,6 +8055,101 @@ export WINEDEBUG="${WINEDEBUG:--all}"
         let config = last_env_value(&env, "DXMT_CONFIG").expect("DXMT_CONFIG");
         assert!(config.contains("d3d11.metalSpatialUpscaleFactor=1.60"), "1.6 factor must pass through: {}", config);
         let _ = std::fs::remove_dir_all(&home);
+    }
+
+    // ---- DXMT shader Metal version: macOS capability policy ----
+
+    #[test]
+    fn dxmt_shader_metal_version_maps_macos_boundaries() {
+        assert_eq!(dxmt_shader_metal_version_for_macos_product_version("14.7.6"), Some(310));
+        assert_eq!(dxmt_shader_metal_version_for_macos_product_version("15.0"), Some(320));
+        assert_eq!(dxmt_shader_metal_version_for_macos_product_version("25.4.1"), Some(320));
+        assert_eq!(dxmt_shader_metal_version_for_macos_product_version("26.0"), None);
+        assert_eq!(dxmt_shader_metal_version_for_macos_product_version("not-a-version"), None);
+        assert_eq!(dxmt_shader_metal_version_for_macos_product_version("14..x"), None);
+        assert_eq!(dxmt_shader_metal_version_for_macos_product_version("14.0.0.0"), None);
+        assert_eq!(dxmt_shader_metal_version_for_macos_product_version("0"), None);
+    }
+
+    #[test]
+    fn dxmt_shader_metal_version_reconciles_all_four_dxmt_routes() {
+        for pipeline_id in [PipelineId::M10, PipelineId::M10_32, PipelineId::M11, PipelineId::M11_32] {
+            let node = get_pipeline(pipeline_id);
+            for (product_version, expected_shader_version) in
+                [("14.7.6", Some("310")), ("15.0", Some("320")), ("25.4.1", Some("320")), ("26.0", None)]
+            {
+                let mut env = dxmt_env_with_node(pipeline_id);
+                env.push((
+                    "DXMT_CONFIG".to_string(),
+                    "d3d11.preferredMaxFrameRate=60;dxmt.shaderMetalVersion=310".to_string(),
+                ));
+                apply_dxmt_shader_metal_version_config_for_macos_version(&mut env, node, Some(product_version));
+
+                let config = last_env_value(&env, "DXMT_CONFIG").expect("DXMT_CONFIG");
+                assert!(config.contains("d3d11.preferredMaxFrameRate=60"), "{pipeline_id:?}: {config}");
+                assert_eq!(
+                    config.matches("dxmt.shaderMetalVersion").count(),
+                    usize::from(expected_shader_version.is_some())
+                );
+                if let Some(version) = expected_shader_version {
+                    assert!(
+                        config.contains(&format!("dxmt.shaderMetalVersion={version}")),
+                        "{pipeline_id:?}: {config}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn dxmt_shader_metal_version_leaves_non_target_routes_unchanged() {
+        for pipeline_id in [PipelineId::M9, PipelineId::M12, PipelineId::M13, PipelineId::Steam, PipelineId::WineBare] {
+            let node = get_pipeline(pipeline_id);
+            let mut env = dxmt_env_with_node(pipeline_id);
+            let before = env.clone();
+            apply_dxmt_shader_metal_version_config_for_macos_version(&mut env, node, Some("14.7.6"));
+            assert_eq!(env, before, "{pipeline_id:?} must not receive a shader Metal version override");
+        }
+    }
+
+    #[test]
+    fn dxmt_shader_metal_version_command_reconciliation_beats_late_env() {
+        let node = get_pipeline(PipelineId::M11);
+        for (product_version, expected_shader_version) in
+            [("14.7.6", Some("310")), ("15.0", Some("320")), ("25.4.1", Some("320")), ("26.0", None)]
+        {
+            let mut cmd = std::process::Command::new("/usr/bin/true");
+            // Model recipe/extra_env setting a stale value after node defaults.
+            cmd.env("DXMT_CONFIG", "d3d11.preferredMaxFrameRate=45;dxmt.shaderMetalVersion=310;custom.option=keep");
+            apply_dxmt_shader_metal_version_config_cmd_for_macos_version(&mut cmd, node, Some(product_version));
+
+            let config = cmd
+                .get_envs()
+                .find_map(|(key, value)| (key == "DXMT_CONFIG").then(|| value.and_then(|value| value.to_str())))
+                .flatten()
+                .expect("DXMT_CONFIG after command reconciliation");
+            assert!(config.contains("d3d11.preferredMaxFrameRate=45"), "{product_version}: {config}");
+            assert!(config.contains("custom.option=keep"), "{product_version}: {config}");
+            assert_eq!(
+                config.matches("dxmt.shaderMetalVersion").count(),
+                usize::from(expected_shader_version.is_some())
+            );
+            if let Some(version) = expected_shader_version {
+                assert!(config.contains(&format!("dxmt.shaderMetalVersion={version}")), "{product_version}: {config}");
+            }
+        }
+    }
+
+    #[test]
+    fn dxmt_shader_metal_version_missing_detector_output_fails_open() {
+        let node = get_pipeline(PipelineId::M11);
+        let mut env = dxmt_env_with_node(PipelineId::M11);
+        env.push(("DXMT_CONFIG".to_string(), "d3d11.preferredMaxFrameRate=60;dxmt.shaderMetalVersion=310".to_string()));
+        apply_dxmt_shader_metal_version_config_for_macos_version(&mut env, node, None);
+
+        let config = last_env_value(&env, "DXMT_CONFIG").expect("DXMT_CONFIG");
+        assert!(config.contains("d3d11.preferredMaxFrameRate=60"), "{config}");
+        assert!(!config.contains("dxmt.shaderMetalVersion"), "{config}");
     }
 
     // ---- Wine msync toggle: WINEMSYNC env from config ----

--- a/app/src/renderer/components/Sidebar.vue
+++ b/app/src/renderer/components/Sidebar.vue
@@ -196,7 +196,7 @@ const navItems = computed<NavItem[]>(() => [
       </button>
     </div>
 
-    <div class="sidebar-bottom">
+    <div class="sidebar-center-controls">
       <div class="sidebar-input-selector" :title="collapsed ? 'msync' : undefined">
         <div v-if="!collapsed" class="sidebar-input-label">
           <IconActivity class="sidebar-input-icon" width="14" height="14" />
@@ -301,6 +301,8 @@ const navItems = computed<NavItem[]>(() => [
           </button>
         </div>
       </div>
+    </div>
+    <div class="sidebar-bottom">
       <button
         class="sidebar-nav-item sidebar-theme-toggle"
         @click="themePickerOpen = !themePickerOpen"
@@ -509,13 +511,20 @@ const navItems = computed<NavItem[]>(() => [
 }
 
 .sidebar-nav {
-  flex: 1;
-  min-height: 0;
+  flex: 0 0 auto;
   padding: 10px 8px;
   display: flex;
   flex-direction: column;
   gap: 2px;
-  overflow-y: auto;
+}
+
+.sidebar-center-controls {
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 .sidebar-nav-item {

--- a/docs/architecture/launch-architecture.md
+++ b/docs/architecture/launch-architecture.md
@@ -85,6 +85,18 @@ M11/M10/M9 read from the legacy runtime surface:
 ~/.metalsharp/runtime/wine/lib/dxmt
 ```
 
+### DXMT shader Metal version
+
+For DXMT shader-compiling routes M10, M10(32), M11, and M11(32), the backend reads the host product version through `sw_vers -productVersion` at launch and writes a final `DXMT_CONFIG` overlay. This overlay has precedence over `DXMT_CONFIG_FILE` while preserving unrelated DXMT options:
+
+| macOS major version | DXMT overlay | Rationale |
+|---|---|---|
+| 14 | `dxmt.shaderMetalVersion=310` | Metal 3.1 |
+| 15 through 25 | `dxmt.shaderMetalVersion=320` | Metal 3.2 |
+| 26 or newer | no shader-version overlay | DXMT automatically selects Metal 4 |
+
+Malformed or unavailable version output fails open: no shader-version overlay is set, so DXMT keeps its own supported-host detection. The policy is applied after game recipe and caller configuration on direct/bottle paths, preventing stale per-game shader-version values from overriding the host capability.
+
 M12 reads from its default vkd3d-proton/DXVK/MoltenVK surface:
 
 ```text


### PR DESCRIPTION
## Summary

Make DXMT shader Metal-language selection host-version-aware for legacy DXMT launch routes, and center the sidebar’s launch controls between Logs and Theme.

## Changes

### DXMT host policy

- Detect the host ProductVersion with `/usr/bin/sw_vers -productVersion`.
- For M10, M10(32), M11, and M11(32), set `dxmt.shaderMetalVersion=310` on macOS 14 and `=320` on macOS 15 through 25.
- On macOS 26+, unavailable detection, failed commands, or malformed output, remove only this overlay key so DXMT retains automatic selection.
- Apply the direct/bottle final reconciliation after recipe and caller environment assembly; preserve unrelated `DXMT_CONFIG` pairs.
- Document the launch-policy boundary and add regression coverage for supported versions, malformed input, missing detector output, target scope, and late config precedence.

### Sidebar layout

- Move the existing msync, MetalFX, and controller-input boxes into a dedicated flex region centered between the Logs navigation item and Theme/Settings footer controls.
- Preserve all existing toggle handlers, disabled states, labels, and ARIA semantics.

## PR Readiness (MANDATORY)

- [x] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

## Local toolchain (run before push)

- [x] `cargo fmt --all -- --check` passes (Rust)
- [x] `cargo clippy --all-targets -- -D warnings` passes (Rust)
- [x] `cargo build --release` passes (Rust backend)
- [x] `cargo test` passes (Rust — 734 tests)
- [x] `cd app && npx tsc --noEmit` passes
- [x] `cd app && npx @biomejs/biome ci src/` passes (three existing base.css warnings)
- [x] `cd app && npx prettier --check src/renderer/components/Sidebar.vue` passes
- [x] `cd app && npm run build` passes
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths

## Test notes

- `cargo test`: 734 passed.
- Targeted policy tests cover macOS 14, 15, 25, 26; malformed numeric and nonnumeric ProductVersions; missing detector output; all four target routes; non-target routes; unrelated DXMT config preservation; and direct-command late-environment precedence.
- Independent UI review confirmed the new order is Logs → centered controls → Theme/Settings in expanded and collapsed sidebar modes, with no handler or accessibility regression.
- The build host is macOS 27, so it exercises the intentional no-override Metal 4 path. A real M10/M11 game launch is still required before this draft is marked ready.

## Risk

Only the per-launch `DXMT_CONFIG` shader-language overlay changes. M12 and non-target routes are excluded. On detection uncertainty the implementation fails open and removes only `dxmt.shaderMetalVersion`. If a regression occurs, quit MetalSharp and restore the prior `metalsharp-backend` backup before relaunching. The sidebar change only changes layout container placement.
