### PR TITLE
fix(updater): report backend version mismatch as an error

### DIFF
--- a/app/updater/update.py
+++ b/app/updater/update.py
@@ -356,6 +356,29 @@ def wait_for_backend(timeout=45):
     return None, None
 
 
+def report_update_result(status_file, version, target_version):
+    if version == target_version:
+        write_status(
+            status_file,
+            "complete",
+            100,
+            "Update installed. Opening migration wizard...",
+            new_version=target_version,
+        )
+        return
+
+    write_status(
+        status_file,
+        "error",
+        95,
+        "Update installed, but backend reported v{} instead of v{}".format(
+            version or "?", target_version
+        ),
+        error="backend_version_mismatch",
+        new_version=target_version,
+    )
+
+
 def main():
     parser = argparse.ArgumentParser(description="MetalSharp Updater")
     parser.add_argument("--dmg", required=True)
@@ -567,22 +590,7 @@ def main():
         version, new_pid = wait_for_backend(timeout=30)
 
     # ── 10. Report result ────────────────────────────────────────────
-    if version == tv:
-        write_status(
-            sf,
-            "complete",
-            100,
-            "Update installed. Opening migration wizard...",
-            new_version=tv,
-        )
-    else:
-        write_status(
-            sf,
-            "complete",
-            100,
-            "Update installed. Backend: v{} (expected v{})".format(version or "?", tv),
-            new_version=tv,
-        )
+    report_update_result(sf, version, tv)
 
 
 if __name__ == "__main__":

--- a/tools/dmg/test_update_status.py
+++ b/tools/dmg/test_update_status.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Regression coverage for updater backend-version status reporting."""
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+UPDATE_SCRIPT = Path(__file__).resolve().parents[2] / "app" / "updater" / "update.py"
+
+
+def load_update_module():
+    spec = importlib.util.spec_from_file_location("metalsharp_update", UPDATE_SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load updater module from {UPDATE_SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+update = load_update_module()
+
+
+class UpdateStatusTests(unittest.TestCase):
+    def read_status(self, status_file: Path) -> dict:
+        return json.loads(status_file.read_text())
+
+    def test_backend_version_mismatch_is_reported_as_error(self):
+        with tempfile.TemporaryDirectory(prefix="metalsharp-update-status-") as temp:
+            status_file = Path(temp) / "status.json"
+
+            update.report_update_result(str(status_file), "0.59.1", "0.60.0")
+
+            status = self.read_status(status_file)
+            self.assertEqual(status["phase"], "error")
+            self.assertEqual(status["percent"], 95)
+            self.assertEqual(status["error"], "backend_version_mismatch")
+            self.assertEqual(
+                status["message"],
+                "Update installed, but backend reported v0.59.1 instead of v0.60.0",
+            )
+            self.assertEqual(status["new_version"], "0.60.0")
+
+    def test_matching_backend_version_is_reported_as_complete(self):
+        with tempfile.TemporaryDirectory(prefix="metalsharp-update-status-") as temp:
+            status_file = Path(temp) / "status.json"
+
+            update.report_update_result(str(status_file), "0.60.0", "0.60.0")
+
+            status = self.read_status(status_file)
+            self.assertEqual(status["phase"], "complete")
+            self.assertEqual(status["percent"], 100)
+            self.assertIsNone(status["error"])
+            self.assertEqual(status["message"], "Update installed. Opening migration wizard...")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Make the Python updater report a failed post-relaunch backend version verification as an error instead of a successful installation.

Fixes #455

## Changes

- Extract the final updater result reporting into a small status-contract helper.
- Report phase: "error" and error: "backend_version_mismatch" when the relaunched backend does not match the target version, mirroring update.sh.
- Preserve the existing phase: "complete" success path.
- Add regression coverage for both mismatch/error and matching/complete status JSON.
- Keep the regression spec under tools/dmg so it is not included in the packaged updater resources.

## PR Readiness (MANDATORY)

<!-- The checklist-exception label is used only for the intentionally inapplicable
     real-game and user-facing-documentation items; the updater status contract
     does not change game launch behavior or user-facing documented behavior. -->

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
  - Not applicable: this is updater-only status handling; no game launch behavior changed.
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
  - Not applicable: no rules or DLL maps changed.
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped
  - Not applicable: no version surfaces changed.
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
  - No bottle, runtime, migration, or launch code changed.
- [ ] Docs / compatibility matrix updated for user-facing changes
  - Not applicable: this is an internal updater status contract.
- [x] Regression test added for each bug fix

## Local checks

- [x] `python3 tools/dmg/test_update_status.py` — 2 tests passed.
- [x] `python3 tools/dmg/test_update_graphics_bundle.py` — 1 test passed.
- [x] `python3 tools/ci/verify-dmg-workflow.py` — DMG workflow contract verified.
- [x] `python3 -m py_compile app/updater/update.py tools/dmg/test_update_status.py` passed.
- [x] `git diff --check` passed.
- Rust, native C++, Electron/TypeScript, and real-game suites were intentionally skipped because no files in those surfaces changed.

## Test notes

The focused regression spec writes real status JSON and verifies that a mismatched backend produces `phase=error`, `percent=95`, and `error=backend_version_mismatch`; a matching backend still produces `phase=complete` at 100%.

No game launch was performed because this change only affects the updater's post-install status contract.

## Risk

This changes only the failure status emitted after the updater's relaunch/version verification. A mismatched or unavailable backend is now surfaced as an installation error and cannot be treated as a successful restart by the Electron UI. The success path is unchanged. Revert commit `6fc1bdd0` to restore the previous behavior if needed.
