### PR TITLE
fix(app): harden DMG ejection against shell injection

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -147,6 +147,9 @@ jobs:
       - name: TypeScript
         run: npx tsc --noEmit
 
+      - name: Main-process tests
+        run: npm test
+
       - name: Biome
         run: npx @biomejs/biome ci src/main src/shared
 

--- a/app/package.json
+++ b/app/package.json
@@ -10,6 +10,7 @@
   "main": "dist/main/index.js",
   "scripts": {
     "build": "tsc && vite build && cp src/renderer/icon.png src/renderer/pressstart2p.ttf dist/renderer/",
+    "test": "tsc && node --test test/dmg-eject.test.js",
     "start": "npm run build && electron .",
     "dev": "tsc -w & vite build --watch & electron .",
     "dev:vite": "vite",

--- a/app/src/main/dmg-eject.ts
+++ b/app/src/main/dmg-eject.ts
@@ -1,0 +1,29 @@
+import { execFile } from "child_process";
+
+type DmgEjectOptions = {
+  shell: false;
+  stdio: "ignore";
+};
+
+export type DmgEjectExecutor = (
+  file: string,
+  args: string[],
+  options: DmgEjectOptions,
+  callback: (error: Error | null) => void,
+) => void;
+
+const executeDmgEject: DmgEjectExecutor = (file, args, options, callback) => {
+  execFile(file, args, options, (error) => callback(error));
+};
+
+export function ejectDmgVolume(volumeName: string, execute: DmgEjectExecutor = executeDmgEject): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execute("hdiutil", ["detach", `/Volumes/${volumeName}`, "-quiet"], { shell: false, stdio: "ignore" }, (error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -4,6 +4,7 @@ import * as fs from "fs";
 import * as http from "http";
 import * as os from "os";
 import * as path from "path";
+import { ejectDmgVolume } from "./dmg-eject";
 import type { ProcessManagerAction, ProcessManagerActionResult, ProcessManagerSample } from "./process-manager-types";
 import { RustBridge } from "./rust-bridge";
 import { UpdaterBridge } from "./updater-bridge";
@@ -936,10 +937,8 @@ function registerIpc() {
     const dmgMatch = exePath.match(/\/Volumes\/([^/]+)/);
     if (dmgMatch) {
       const vol = dmgMatch[1];
-      shell.openExternal("");
-      const { execSync } = require("child_process");
       try {
-        execSync(`hdiutil detach "/Volumes/${vol}" -quiet`);
+        await ejectDmgVolume(vol);
         dialog.showMessageBox({
           type: "info",
           title: "MetalSharp",

--- a/app/test/dmg-eject.test.js
+++ b/app/test/dmg-eject.test.js
@@ -1,0 +1,48 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const { ejectDmgVolume } = require("../dist/main/dmg-eject.js");
+
+test("passes an untrusted volume name as an argument without invoking a shell", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "metalsharp-dmg-eject-"));
+  const capturePath = path.join(tempDir, "args");
+  const markerPath = path.join(tempDir, "shell-executed");
+  const fakeHdiutilPath = path.join(tempDir, "hdiutil");
+  const volumeName = `Installer $(touch ${markerPath}) \`echo pwned\`;"`;
+  const previousPath = process.env.PATH;
+  const previousCapturePath = process.env.METALSHARP_TEST_CAPTURE;
+
+  fs.writeFileSync(fakeHdiutilPath, '#!/bin/sh\nprintf \'%s\\n\' "$@" > "$METALSHARP_TEST_CAPTURE"\n');
+  fs.chmodSync(fakeHdiutilPath, 0o755);
+  process.env.PATH = `${tempDir}${path.delimiter}${previousPath ?? ""}`;
+  process.env.METALSHARP_TEST_CAPTURE = capturePath;
+
+  try {
+    await ejectDmgVolume(volumeName);
+
+    assert.equal(fs.existsSync(markerPath), false);
+    assert.deepEqual(fs.readFileSync(capturePath, "utf8").trimEnd().split("\n"), [
+      "detach",
+      `/Volumes/${volumeName}`,
+      "-quiet",
+    ]);
+  } finally {
+    if (previousPath === undefined) delete process.env.PATH;
+    else process.env.PATH = previousPath;
+    if (previousCapturePath === undefined) delete process.env.METALSHARP_TEST_CAPTURE;
+    else process.env.METALSHARP_TEST_CAPTURE = previousCapturePath;
+    fs.rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+test("propagates hdiutil failures", async () => {
+  const error = new Error("detach failed");
+
+  await assert.rejects(
+    ejectDmgVolume("Installer", (_file, _args, _options, callback) => callback(error)),
+    error,
+  );
+});


### PR DESCRIPTION
## Summary

Fixes #446 by removing the shell-injection path from the installer DMG eject action.

## Changes

- Extract the DMG eject command into a small, testable main-process helper.
- Invoke `hdiutil` with `execFile` and an argument array with shell execution explicitly disabled.
- Remove the dead `shell.openExternal("")` call.
- Add regression coverage for shell metacharacters, argument preservation, and failure propagation; run it through `npm test` in PR CI.

## PR Readiness (MANDATORY)

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

The compatibility item is intentionally not applicable: this change is isolated to the macOS installer DMG eject action and does not alter game launch, routing, bottles, or runtime behavior. The `checklist-exception` label is applied per the repository policy.

## Local toolchain (run before push)

- [ ] `cargo fmt --all -- --check` passes (Rust; unchanged surface)
- [ ] `cargo clippy --all-targets -- -D warnings` passes (Rust; unchanged surface)
- [ ] `cargo build --release` passes (Rust backend; unchanged surface)
- [ ] `cargo test` passes (Rust; unchanged surface)
- [ ] C++ compiles if changed (not changed)
- [ ] `clang-format --dry-run --Werror` passes on any changed C/C++/Obj-C file (not changed)
- [ ] `ctest --test-dir build-native` passes if tests changed (not changed)
- [x] TypeScript compiles if changed: `cd app && npx tsc --noEmit`
- [x] Biome + Prettier pass if TS/JS changed
- [ ] Shell scripts lint if changed (not changed)
- [ ] `tools/ci/validate-rules-toml.py` passes if `configs/mtsp-rules.toml` changed (not changed)
- [ ] `python3 tools/ci/verify-dmg-workflow.py` passes if release/bundle tooling changed (not changed)
- [ ] Tested with at least one game (which one? which launch method? which drive?) (not applicable; no game-launch behavior changed)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files should be added to the repo root; place them under `app/`, `tools/`, `tests/`, etc.

## Test notes

- `npm ci`
- `npx tsc --noEmit`
- `npm test` — 2 regression tests passed
- `npm run build` — Electron/renderer build passed
- `npx @biomejs/biome ci src/main src/shared` — passed
- `npx @biomejs/biome ci src/renderer` — passed with three pre-existing CSS specificity warnings
- `npx prettier --check ...` — passed
- `git diff --check` — passed

## Risk

The only runtime change is that the volume path is passed as data to `hdiutil` rather than interpolated into a shell command. Normal eject success/failure dialogs are preserved. If a regression appears, revert commit `9bb84a4b` to restore the prior handler while retaining the added test seam for diagnosis.
