### PR TITLE
fix: derive DMG artifact version from package.json at runtime

### DIFF
--- a/tools/ci/verify-dmg-workflow.py
+++ b/tools/ci/verify-dmg-workflow.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -110,6 +111,25 @@ def check_updater_handoff() -> None:
                 fail(f"{path} no longer mounts the downloaded DMG on a private update mount point before install")
 
 
+def check_create_dmg_version() -> None:
+    """create-dmg.sh must derive its artifact version from app/package.json.
+
+    A hardcoded version regressed the DMG name/output to 0.1.1 while the
+    project was at 0.59.1 (issue #454); keep the derivation contract so the
+    artifact name can never drift from the packaged version again.
+    """
+    script = read("tools/dmg/create-dmg.sh")
+    if re.search(r'DMG_NAME="MetalSharp-[0-9]', script):
+        fail("create-dmg.sh hardcodes a version into DMG_NAME; derive it from app/package.json")
+    for needle in [
+        'grep \'"version"\' "$APP_DIR/package.json"',
+        'DMG_NAME="MetalSharp-$VER"',
+        'DMG_OUTPUT="$PROJECT_DIR/dist/MetalSharp-$VER.dmg"',
+    ]:
+        if needle not in script:
+            fail(f"create-dmg.sh no longer derives its artifact version from app/package.json: {needle}")
+
+
 def check_bundle_scripts() -> None:
     create_bundles = read("tools/dmg/create-bundles.sh")
     for needle in [
@@ -205,6 +225,7 @@ def main() -> int:
     check_dmg_verifier(assets)
     check_updater_handoff()
     check_bundle_scripts()
+    check_create_dmg_version()
     check_workflows()
     print(f"DMG workflow contract verified ({len(assets)} mac bundle assets).")
     return 0

--- a/tools/dmg/create-dmg.sh
+++ b/tools/dmg/create-dmg.sh
@@ -3,10 +3,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+APP_DIR="$PROJECT_DIR/app"
 BUILD_DIR="$PROJECT_DIR/build"
-DMG_NAME="MetalSharp-0.1.1"
-DMG_DIR="$PROJECT_DIR/dist/$DMG_NAME"
-DMG_OUTPUT="$PROJECT_DIR/dist/MetalSharp-0.1.1.dmg"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -17,6 +15,17 @@ NC='\033[0m'
 info() { echo -e "${CYAN}[dmg]${NC} $*"; }
 ok()   { echo -e "${GREEN}[ok]${NC} $*"; }
 fail() { echo -e "${RED}[fail]${NC} $*"; exit 1; }
+
+if [[ ! -f "$APP_DIR/package.json" ]]; then
+    fail "app/package.json not found; cannot determine version"
+fi
+VER="$(grep '"version"' "$APP_DIR/package.json" | head -1 | sed 's/.*: *"//;s/".*//')"
+if [[ -z "$VER" ]]; then
+    fail "could not determine version from app/package.json"
+fi
+DMG_NAME="MetalSharp-$VER"
+DMG_DIR="$PROJECT_DIR/dist/$DMG_NAME"
+DMG_OUTPUT="$PROJECT_DIR/dist/MetalSharp-$VER.dmg"
 
 if [[ "$(uname)" != "Darwin" ]]; then
     fail "DMG creation requires macOS"
@@ -72,8 +81,8 @@ WRAPPER
 chmod +x "$DMG_DIR/metalsharp.sh"
 
 info "Writing install notes..."
-cat > "$DMG_DIR/INSTALL.txt" << 'NOTES'
-MetalSharp 0.1.1 — D3D to Metal Translation Layer
+cat > "$DMG_DIR/INSTALL.txt" << NOTES
+MetalSharp ${VER} — D3D to Metal Translation Layer
 
 Quick Install:
   1. Open Terminal


### PR DESCRIPTION
Fixes #454

## Summary

`tools/dmg/create-dmg.sh` hardcoded `0.1.1` in its DMG name, output path, and install notes while the project is at `0.59.1`, producing a mislabeled artifact that conflicts with the versioned electron-builder DMG. The script now derives the version from `app/package.json` at runtime — the same pattern already used by the sibling `tools/dmg/build-dmg.sh` — so the artifact is always named for the current project version.

## Changes

- Remove the hardcoded `MetalSharp-0.1.1` name/output from `tools/dmg/create-dmg.sh`.
- Derive `VER` from the top-level `version` field of `app/package.json` at runtime, with a fail-hard guard when the version cannot be determined.
- Name the artifact `dist/MetalSharp-<version>.dmg` and label `INSTALL.txt` with the derived version.
- Add a regression guard to `tools/ci/verify-dmg-workflow.py` so the DMG workflow contract CI fails if `create-dmg.sh` ever reintroduces a hardcoded version.

## PR Readiness (MANDATORY)

- [x] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

## Local toolchain

- [x] `tools/ci/shellcheck.sh` — 40 scripts, severity=error, clean (Shell CI parity)
- [x] `python3 tools/ci/verify-dmg-workflow.py` — DMG workflow contract verified (8 mac bundle assets), incl. new create-dmg.sh version-derivation guard
- [x] `python3 -B -m py_compile tools/ci/verify-dmg-workflow.py`
- [x] CMake Release configure/build with `BUILD_TESTS=ON`; full `ctest --test-dir build --output-on-failure` (all tests, incl. metal_device/dxbc/format_translation/phase17)
- [x] End-to-end `tools/dmg/create-dmg.sh` run — produced `dist/MetalSharp-0.59.1.dmg`; `INSTALL.txt` labels the artifact `MetalSharp 0.59.1`
- [x] `git diff --check`
- [x] No new files added at the repository root

## Test notes

This PR touches only the legacy DMG packaging script and its CI contract guard — no game runtime, launch, migration, or rules code changed, and the canonical electron-builder DMG flow (`install.sh` → `tools/dmg/create-bundles.sh` + `npx electron-builder --mac dmg`) is untouched. The full native ctest suite (the repo's game-compatibility gate) passes, and the packaging script was verified end-to-end: the produced DMG is named `MetalSharp-0.59.1.dmg` with install notes labeled `MetalSharp 0.59.1`, matching `CMakeLists.txt` / `app/package.json`. No game launch was performed because the fix cannot affect launch behavior; the packaged binaries are byte-identical to what the script already shipped, only the artifact name/label changed.

## Risk

No launch-behavior change and no rollback concerns: the fix only corrects the artifact name/version label of the legacy `tools/dmg/create-dmg.sh` packaging path. Note that `install.sh`'s documented DMG flow points at `tools/dmg/create-bundles.sh` + electron-builder; `create-dmg.sh` is a legacy standalone path that nothing else in the repo invokes, and it now produces a correctly versioned artifact.

## Follow-up observation (out of scope for this issue)

The launcher binaries also carry stale version constants that are **display-only**: `tools/launcher/main.cpp:11` (`METALSHARP_VERSION "0.1.1"`, used in `--help`/`--version` output) and `tools/launcher/WinePrefix.cpp:56` (writes `metalsharp-0.1.1` to `~/.metalsharp/prefix/.update-timestamp`, which nothing in the repo reads). These are not part of issue #454 (which is scoped to `tools/dmg/create-dmg.sh`), and fixing them properly means threading the CMake project version into the launcher targets — a separate, small build-system change worth its own PR if desired.

