### PR TITLE
fix(anticheat): deallocate Mach send right on every guest errno/pthread/mutex operation

### DIFF
--- a/src/anticheat/linux_substrate.c
+++ b/src/anticheat/linux_substrate.c
@@ -2565,7 +2565,13 @@ static MsLinuxSpecificSlot g_linux_specific_slots[MS_LINUX_SPECIFIC_SLOTS];
 static volatile int g_linux_thread_slot_lock;
 
 static uint32_t metalsharp_eac_thread_token(void) {
-    return (uint32_t)mach_thread_self();
+    mach_port_t thread = mach_thread_self();
+    /* Each mach_thread_self() call creates a fresh send right.  This runs on
+     * every guest errno/pthread/mutex operation, so release the right
+     * immediately; the port name stays valid as a thread identifier while
+     * the thread lives (the kernel holds the thread's self port). */
+    mach_port_deallocate(mach_task_self(), thread);
+    return (uint32_t)thread;
 }
 
 static int* metalsharp_eac_linux_errno_location(void) {
@@ -2771,7 +2777,7 @@ static int metalsharp_eac_pthread_mutex_lock(void* guest) {
     if (entry == NULL) {
         return ENOMEM;
     }
-    uint32_t owner = (uint32_t)mach_thread_self();
+    uint32_t owner = metalsharp_eac_thread_token();
     if (entry->recursive && entry->owner == owner && entry->state != 0) {
         entry->recursion++;
         return 0;
@@ -2806,7 +2812,7 @@ static int metalsharp_eac_pthread_mutex_trylock(void* guest) {
     if (entry == NULL) {
         return ENOMEM;
     }
-    uint32_t owner = (uint32_t)mach_thread_self();
+    uint32_t owner = metalsharp_eac_thread_token();
     if (entry->recursive && entry->owner == owner && entry->state != 0) {
         entry->recursion++;
         return 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -220,3 +220,15 @@ add_executable(test_phase5_error_ext
 )
 target_link_libraries(test_phase5_error_ext PRIVATE metalsharp_opengl32 metalsharp_core)
 add_test(NAME phase5_error_ext COMMAND test_phase5_error_ext)
+
+# Mach-port lifecycle regression test for the Linux EAC substrate
+# (metalsharp/MetalSharp#442). The substrate is x86_64/Rosetta-only; the
+# project default (Wine) architecture matches, as in CI.
+add_executable(test_eac_substrate
+    test_eac_substrate.c
+)
+target_compile_options(test_eac_substrate PRIVATE -Wno-deprecated-declarations)
+# The substrate links the Wine-only ntdll_get_unix_file_name via weak
+# dynamic lookup; keep the same link contract as metalsharp_eac_substrate.
+target_link_options(test_eac_substrate PRIVATE "-Wl,-undefined,dynamic_lookup")
+add_test(NAME eac_substrate COMMAND test_eac_substrate)

--- a/tests/test_eac_substrate.c
+++ b/tests/test_eac_substrate.c
@@ -1,0 +1,74 @@
+/*
+ * Regression test for the MetalSharp Linux EAC substrate's Mach port
+ * lifecycle (metalsharp/MetalSharp#442).
+ *
+ * Every guest errno/pthread/mutex operation obtains the current thread's
+ * Mach port name through mach_thread_self(), which creates a fresh send
+ * right.  If that right is not deallocated, the send-right reference count
+ * on the thread's self port grows without bound and long-running protected
+ * launchers exhaust the process Mach port budget.
+ *
+ * The substrate is x86_64/Rosetta-only, so this test is built with the
+ * project default (Wine) architecture, exactly like the substrate target.
+ * It includes the substrate source directly so the static hot-path entry
+ * points can be exercised, then asserts that the send-right count on the
+ * current thread's self port is unchanged after hammering every path that
+ * used to leak.
+ */
+
+#include <mach/mach.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../src/anticheat/linux_substrate.c"
+
+#define MS442_ITERATIONS       100000u
+#define MS442_MUTEX_ITERATIONS 1000u
+
+static mach_msg_type_number_t send_right_count(void) {
+    mach_port_t self = mach_thread_self();
+    mach_msg_type_number_t refs = 0;
+    kern_return_t result = mach_port_get_refs(mach_task_self(), self, MACH_PORT_RIGHT_SEND, &refs);
+    mach_port_deallocate(mach_task_self(), self);
+    if (result != KERN_SUCCESS) {
+        fprintf(stderr, "eac_substrate: mach_port_get_refs failed: %d\n", result);
+        exit(2);
+    }
+    return refs;
+}
+
+int main(void) {
+    mach_msg_type_number_t baseline = send_right_count();
+
+    uint32_t key = 0;
+    (void)metalsharp_eac_pthread_key_create(&key, NULL);
+
+    /* errno, TSD, and pthread_self lookups are the per-operation hot paths
+     * and do not log. */
+    for (uint32_t iteration = 0; iteration < MS442_ITERATIONS; iteration++) {
+        (void)metalsharp_eac_linux_errno_location();
+        (void)metalsharp_eac_pthread_setspecific(key, (const void*)(uintptr_t)iteration);
+        (void)metalsharp_eac_pthread_getspecific(key);
+        (void)metalsharp_eac_pthread_self();
+        (void)metalsharp_eac_thread_token();
+    }
+
+    /* The mutex paths log through ms_log, which opens/writes/closes a file
+     * per call; keep their share of the loop small. */
+    for (uint32_t iteration = 0; iteration < MS442_MUTEX_ITERATIONS; iteration++) {
+        (void)metalsharp_eac_pthread_mutex_lock((void*)(uintptr_t)0x442u);
+        (void)metalsharp_eac_pthread_mutex_unlock((void*)(uintptr_t)0x442u);
+        (void)metalsharp_eac_pthread_mutex_trylock((void*)(uintptr_t)0x442u);
+        (void)metalsharp_eac_pthread_mutex_unlock((void*)(uintptr_t)0x442u);
+    }
+
+    mach_msg_type_number_t after = send_right_count();
+    if (after != baseline) {
+        fprintf(stderr, "eac_substrate: Mach send-right leak: baseline=%u after=%u (delta=%d)\n", (unsigned)baseline,
+                (unsigned)after, (int)(after - baseline));
+        return 1;
+    }
+    printf("eac_substrate: OK send-right count stable (%u -> %u)\n", (unsigned)baseline, (unsigned)after);
+    return 0;
+}


### PR DESCRIPTION
Fixes #442

## Summary

Fixes a Mach send-right leak in the Linux EAC substrate (`src/anticheat/linux_substrate.c`): every guest `__errno_location`, `pthread_setspecific`/`getspecific`/`self`, and `pthread_mutex_lock`/`trylock` operation created a fresh send right via `mach_thread_self()` that was never released, so long-running protected launchers could exhaust the process Mach port budget and start failing syscalls.

## Changes

- `metalsharp_eac_thread_token()` now calls `mach_port_deallocate(mach_task_self(), thread)` immediately after capturing the thread port name. The name remains valid as a thread identifier while the thread lives (the kernel holds the thread's self port), matching the existing deallocate-after-use patterns in this file (`wine_guest_teb_for_current_thread`, `wine_thread_bridge_state`).
- `metalsharp_eac_pthread_mutex_lock` and `metalsharp_eac_pthread_mutex_trylock` now obtain the owner token through the same `metalsharp_eac_thread_token()` helper instead of calling `mach_thread_self()` directly, so every token acquisition shares one balanced port lifecycle.
- Added `tests/test_eac_substrate.c` (wired as `ctest` target `eac_substrate`): hammers the guest errno/TSD/`pthread_self`/mutex hot paths in a loop and asserts the thread self-port send-right count (via `mach_port_get_refs`) stays at its baseline. Verified it fails on the old code (send-right count grew from 5 to 65535) and passes on the fixed code (stable at 5).

## PR Readiness (MANDATORY)

- [x] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

## Local toolchain

- [x] `cargo fmt --all -- --check` — no Rust files changed
- [x] `cargo clippy --all-targets -- -D warnings` — no Rust files changed
- [x] `cargo build --release` — no Rust files changed
- [x] `cargo test` — no Rust files changed
- [x] C++ compiles if changed: `cmake -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON && cmake --build build-native --parallel 10` — full clean build passed, including `metalsharp_eac_substrate` (x86_64) and the ELF symbol-image target
- [x] `clang-format --dry-run --Werror` passes on any changed C/C++/Obj-C file — `src/anticheat/linux_substrate.c` and `tests/test_eac_substrate.c` clean
- [x] `ctest --test-dir build-native` passes if tests changed — 32/32 passed, including the new `eac_substrate` regression test
- [x] TypeScript compiles if changed — no TS files changed
- [x] Biome + Prettier pass if TS/JS changed — no TS/JS files changed
- [x] Shell scripts lint if changed — no shell files changed
- [x] `tools/ci/validate-rules-toml.py` passes if `configs/mtsp-rules.toml` changed — not changed
- [x] `python3 tools/ci/verify-dmg-workflow.py` passes if release/bundle tooling changed — not changed
- [x] Tested with at least one game (which one? which launch method? which drive?) — Elden Ring, see Test notes
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files should be added to the repo root; place them under `app/`, `tools/`, `tests/`, etc.

## Test notes

Regression test (proves the leak and the fix):

- Old code: `eac_substrate: Mach send-right leak: baseline=5 after=65535 (delta=65530)` — exits 1.
- Fixed code: `eac_substrate: OK send-right count stable (5 -> 5)` — 100,000 errno/TSD/self iterations plus 1,000 mutex lock/unlock/trylock cycles — exits 0.
- Full suite: `ctest --test-dir build-native` — 32/32 passed.

Real-game compatibility proof (unchanged behavior with the fix): Elden Ring on the external Steam library, launched explicitly from its real `Game/Start_protected_game.exe` via `python3 tools/anticheat/run_eac_proof.py --game-dir '/Volumes/AverySSD/SteamLibrary/steamapps/common/ELDEN RING/Game' --timeout 30` under the exact installed MetalSharp Wine 11.5 runtime (SHA-256 `e621bf88dd07872b391198aee50bf1503fe18d43b7a9c0183fa23075efc61395`).

- `ok: true`, proof level `real_eac_linux_module_relocated_initialized_exported` with the rebuilt substrate (SHA-256 `511ac5b1690e5b3e67857f334bb625036848edfcedf8d62143d967c89e5856e0`).
- Real 9,168,824-byte ELF64 x86-64 EAC module loaded; RELA/PLT relocation complete; all six constructors ran; `EAC_PROOF export_a_success=1`.
- No forbidden log markers; `residualWineProcesses: []` after the enforced 30-second teardown.
- The launch proof intentionally reports `protectedGameTransitionObserved: false` / `onlineSessionObserved: false`: it proves the real EAC module load/relocation/constructor/export surface through MetalSharp Wine 11.5 -> macOS, but does not claim an online session or protected-game handoff without a live Steam user.

## Risk

Low. The change only releases a send right that was previously leaked; port names and all comparison semantics are unchanged, and the deallocate-after-use pattern is already used elsewhere in the same file. No launch behavior, configuration, or migration changes — no rollback plan needed.

