### PR TITLE
fix: build native host artifacts for arm64 (#451)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,12 +159,14 @@ target_link_libraries(metalsharp_core PUBLIC
     ${APPKIT_FRAMEWORK}
 )
 target_compile_options(metalsharp_core PRIVATE -fobjc-arc)
+metalsharp_wine_target(metalsharp_core)
 
 add_library(metalsharp_host_runtime SHARED
     src/runtime/host/HostRuntimeABI.cpp
 )
 target_include_directories(metalsharp_host_runtime PUBLIC include)
 set_target_properties(metalsharp_host_runtime PROPERTIES OUTPUT_NAME "metalsharp_host_runtime")
+metalsharp_host_target(metalsharp_host_runtime)
 
 add_library(metalsharp_d3d11 SHARED
     src/d3d/d3d11/D3D11Device.cpp
@@ -188,6 +190,7 @@ add_library(metalsharp_d3d11 SHARED
 target_link_libraries(metalsharp_d3d11 PRIVATE metalsharp_core metalsharp_dxgi)
 target_compile_options(metalsharp_d3d11 PRIVATE -fobjc-arc)
 set_target_properties(metalsharp_d3d11 PROPERTIES OUTPUT_NAME "d3d11" PREFIX "")
+metalsharp_wine_target(metalsharp_d3d11)
 metalsharp_stage_to_app_native(metalsharp_d3d11)
 
 add_library(metalsharp_d3d12 SHARED
@@ -205,6 +208,7 @@ add_library(metalsharp_d3d12 SHARED
 target_link_libraries(metalsharp_d3d12 PRIVATE metalsharp_core)
 target_compile_options(metalsharp_d3d12 PRIVATE -fobjc-arc)
 set_target_properties(metalsharp_d3d12 PROPERTIES OUTPUT_NAME "d3d12" PREFIX "")
+metalsharp_wine_target(metalsharp_d3d12)
 metalsharp_stage_to_app_native(metalsharp_d3d12)
 
 add_library(metalsharp_dxgi SHARED
@@ -217,6 +221,7 @@ add_library(metalsharp_dxgi SHARED
 target_link_libraries(metalsharp_dxgi PRIVATE metalsharp_core)
 target_compile_options(metalsharp_dxgi PRIVATE -fobjc-arc)
 set_target_properties(metalsharp_dxgi PROPERTIES OUTPUT_NAME "dxgi" PREFIX "")
+metalsharp_wine_target(metalsharp_dxgi)
 metalsharp_stage_to_app_native(metalsharp_dxgi)
 
 add_library(metalsharp_audio SHARED
@@ -230,6 +235,7 @@ add_library(metalsharp_audio SHARED
 )
 target_link_libraries(metalsharp_audio PRIVATE metalsharp_core ${AUDIOUNIT_FRAMEWORK})
 set_target_properties(metalsharp_audio PROPERTIES OUTPUT_NAME "xaudio2_9" PREFIX "")
+metalsharp_wine_target(metalsharp_audio)
 metalsharp_stage_to_app_native(metalsharp_audio)
 
 add_library(metalsharp_input SHARED
@@ -240,6 +246,7 @@ add_library(metalsharp_input SHARED
 target_link_libraries(metalsharp_input PRIVATE metalsharp_core ${GAMECONTROLLER_FRAMEWORK})
 target_compile_options(metalsharp_input PRIVATE -fobjc-arc)
 set_target_properties(metalsharp_input PROPERTIES OUTPUT_NAME "xinput1_4" PREFIX "")
+metalsharp_wine_target(metalsharp_input)
 metalsharp_stage_to_app_native(metalsharp_input)
 
 add_executable(metalsharp_launcher
@@ -249,7 +256,11 @@ add_executable(metalsharp_launcher
     tools/launcher/Config.cpp
     tools/launcher/SteamIntegration.cpp
 )
-target_link_libraries(metalsharp_launcher PRIVATE metalsharp_core ${FOUNDATION_FRAMEWORK})
+# The launcher is a native macOS helper that starts Wine; it does not load the
+# PE-facing core. Keeping that dependency out lets the helper use the host
+# architecture without mixing an arm64 executable with the x86_64 Wine core.
+target_link_libraries(metalsharp_launcher PRIVATE ${FOUNDATION_FRAMEWORK})
+metalsharp_host_target(metalsharp_launcher)
 metalsharp_stage_to_app_native(metalsharp_launcher)
 
 add_library(metalsharp_loader STATIC
@@ -303,6 +314,7 @@ target_include_directories(metalsharp_loader PUBLIC include)
 target_link_libraries(metalsharp_loader PRIVATE metalsharp_core ${SECURITY_FRAMEWORK})
 target_compile_options(metalsharp_loader PRIVATE -fobjc-arc)
 target_compile_definitions(metalsharp_loader PRIVATE METALSHARP_NATIVE_LOADER)
+metalsharp_wine_target(metalsharp_loader)
 
 add_executable(metalsharp_native
     tools/launcher/NativeLauncher.cpp
@@ -394,6 +406,7 @@ add_executable(metalsharp_migrator
 )
 target_link_libraries(metalsharp_migrator PRIVATE ${APPKIT_FRAMEWORK} ${FOUNDATION_FRAMEWORK})
 set_target_properties(metalsharp_migrator PROPERTIES OUTPUT_NAME "MetalSharpMigrator")
+metalsharp_host_target(metalsharp_migrator)
 metalsharp_stage_to_app_native(metalsharp_migrator)
 
 if(BUILD_TESTS)

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ Use this page as the repo map before changing launch/runtime code.
 
 ## Architecture
 
+- [macOS Artifact Matrix](architecture/macos-artifact-matrix.md) - native host and Wine/Rosetta artifact boundaries.
 - [Launch Architecture](architecture/launch-architecture.md) - pipeline selection and launch ownership.
 - [Backend HTTP Request Contract](architecture/backend-http-contract.md) - bounded JSON request bodies and client error responses.
 - [Electron IPC Security Contract](architecture/electron-ipc-security.md) - renderer trust boundary, backend allowlist, dependency actions, and updater validation.

--- a/docs/architecture/macos-artifact-matrix.md
+++ b/docs/architecture/macos-artifact-matrix.md
@@ -1,0 +1,29 @@
+# macOS artifact architecture matrix
+**Updated:** 2026-08-11
+
+MetalSharp ships one arm64 macOS application while its Wine-facing native
+artifacts remain x86_64 for Rosetta-backed Windows execution. The architecture
+boundary is explicit in `CMakeLists.txt` and is validated after native builds
+and before packaging.
+
+| Artifact | Architecture | Process boundary |
+| --- | --- | --- |
+| Electron app and Rust backend | arm64 | Native macOS application |
+| `metalsharp_launcher` | arm64 | Native helper that starts MetalSharp Wine |
+| `metalsharp_host_runtime` and `MetalSharpMigrator` | arm64 | Native host/runtime helpers |
+| `test_host_runtime_abi` | arm64 | Host ABI regression test |
+| `metalsharp_core` and `metalsharp_loader` | x86_64 | Wine/Rosetta native PE loader |
+| D3D11, D3D12, DXGI, audio/input, and OpenGL shims | x86_64 | Wine/Rosetta DLL surface |
+| `metalsharp`, EAC substrate, and other Wine-side native artifacts | x86_64 | Wine/Rosetta launch surface |
+| Other native CTest targets | x86_64 | Tests for the Wine-side surface |
+
+`METALSHARP_WINE_ARCH` and `METALSHARP_HOST_ARCH` are the CMake knobs for
+these two lanes. The project default remains the Wine architecture so vendor
+libraries and Wine-side tests resolve consistently; host targets use
+`metalsharp_host_target()` explicitly. The host launcher intentionally does
+not link `metalsharp_core`, which is an x86_64 PE-facing library.
+
+The macOS architecture regression test uses `lipo -info`/`lipo -archs` to
+check the configured target outputs. The native-shim, host-runtime, bundle,
+and DMG validators repeat the relevant checks so a wrong-architecture binary
+cannot silently enter the packaged arm64 application.

--- a/docs/guides/install-from-source.md
+++ b/docs/guides/install-from-source.md
@@ -28,7 +28,8 @@ cd metalsharp
 ## Build
 
 ```bash
-# Native engine (C++ D3D/Metal layer) - x86_64 for Rosetta 2 PE translation
+# Wine-facing native engine (C++ D3D/Metal layer) - x86_64 for Rosetta 2 PE translation
+# Host helpers, host runtime, and the update migrator are built arm64 for the app.
 mkdir -p build
 cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON
 cmake --build build --parallel $(sysctl -n hw.ncpu)

--- a/docs/runtime/host-runtime-abi.md
+++ b/docs/runtime/host-runtime-abi.md
@@ -76,6 +76,9 @@ Future bottle manifests should map directly to ABI structs:
 ## Packaging
 
 The shared host runtime target is `metalsharp_host_runtime`. macOS builds produce `libmetalsharp_host_runtime.dylib`.
+On Apple Silicon it is an arm64 host artifact; it is not part of the
+x86_64 Wine/Rosetta shim lane. See the [macOS artifact architecture
+matrix](../architecture/macos-artifact-matrix.md) for the complete boundary.
 
 `tools/package/create-host-runtime.sh` stages the package into `app/native/host/`:
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,6 +78,7 @@ add_executable(test_host_runtime_abi
 )
 target_include_directories(test_host_runtime_abi PRIVATE ${CMAKE_SOURCE_DIR}/include)
 target_link_libraries(test_host_runtime_abi PRIVATE metalsharp_host_runtime)
+metalsharp_host_target(test_host_runtime_abi)
 
 add_executable(test_mscoree_path_safety
     test_mscoree_path_safety.cpp
@@ -368,3 +369,26 @@ add_test(NAME mscoree_unix COMMAND test_mscoree_unix)
 set_tests_properties(mscoree_unix PROPERTIES
     ENVIRONMENT "METALSHARP_MONO_LIB=$<TARGET_FILE:test_mscoree_mono>"
 )
+
+if(APPLE)
+    add_test(
+        NAME macos_architecture_matrix
+        COMMAND ${CMAKE_COMMAND}
+            -DMETALSHARP_HOST_ARCH=${METALSHARP_HOST_ARCH}
+            -DMETALSHARP_WINE_ARCH=${METALSHARP_WINE_ARCH}
+            -DHOST_RUNTIME=$<TARGET_FILE:metalsharp_host_runtime>
+            -DHOST_RUNTIME_TEST=$<TARGET_FILE:test_host_runtime_abi>
+            -DHOST_LAUNCHER=$<TARGET_FILE:metalsharp_launcher>
+            -DHOST_MIGRATOR=$<TARGET_FILE:metalsharp_migrator>
+            -DWINE_CORE=$<TARGET_FILE:metalsharp_core>
+            -DWINE_NATIVE=$<TARGET_FILE:metalsharp_native>
+            -DWINE_D3D11=$<TARGET_FILE:metalsharp_d3d11>
+            -DWINE_D3D12=$<TARGET_FILE:metalsharp_d3d12>
+            -DWINE_DXGI=$<TARGET_FILE:metalsharp_dxgi>
+            -DWINE_AUDIO=$<TARGET_FILE:metalsharp_audio>
+            -DWINE_INPUT=$<TARGET_FILE:metalsharp_input>
+            -DWINE_LOADER=$<TARGET_FILE:metalsharp_loader>
+            -DWINE_OPENGL=$<TARGET_FILE:metalsharp_opengl32>
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/verify-macos-architectures.cmake
+    )
+endif()

--- a/tests/verify-macos-architectures.cmake
+++ b/tests/verify-macos-architectures.cmake
@@ -1,0 +1,59 @@
+cmake_minimum_required(VERSION 3.24)
+
+if(NOT APPLE)
+    message(STATUS "macOS architecture matrix skipped on non-Apple host")
+    return()
+endif()
+
+find_program(LIPO_EXECUTABLE lipo REQUIRED)
+
+function(assert_architecture label path expected)
+    if(NOT EXISTS "${path}")
+        message(FATAL_ERROR "${label} is missing: ${path}")
+    endif()
+
+    execute_process(
+        COMMAND "${LIPO_EXECUTABLE}" -info "${path}"
+        RESULT_VARIABLE info_result
+        OUTPUT_VARIABLE info_output
+        ERROR_VARIABLE info_error
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_STRIP_TRAILING_WHITESPACE
+    )
+    if(NOT info_result EQUAL 0)
+        message(FATAL_ERROR "lipo -info failed for ${label}: ${info_error}")
+    endif()
+
+    execute_process(
+        COMMAND "${LIPO_EXECUTABLE}" -archs "${path}"
+        RESULT_VARIABLE arch_result
+        OUTPUT_VARIABLE arch_output
+        ERROR_VARIABLE arch_error
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_STRIP_TRAILING_WHITESPACE
+    )
+    if(NOT arch_result EQUAL 0)
+        message(FATAL_ERROR "lipo -archs failed for ${label}: ${arch_error}")
+    endif()
+
+    if(NOT "${arch_output}" STREQUAL "${expected}")
+        message(FATAL_ERROR
+            "${label} has architecture '${arch_output}', expected '${expected}'; ${info_output}")
+    endif()
+    message(STATUS "${label}: ${info_output}")
+endfunction()
+
+assert_architecture("metalsharp_host_runtime" "${HOST_RUNTIME}" "${METALSHARP_HOST_ARCH}")
+assert_architecture("test_host_runtime_abi" "${HOST_RUNTIME_TEST}" "${METALSHARP_HOST_ARCH}")
+assert_architecture("metalsharp_launcher" "${HOST_LAUNCHER}" "${METALSHARP_HOST_ARCH}")
+assert_architecture("metalsharp_migrator" "${HOST_MIGRATOR}" "${METALSHARP_HOST_ARCH}")
+
+assert_architecture("metalsharp_core" "${WINE_CORE}" "${METALSHARP_WINE_ARCH}")
+assert_architecture("metalsharp_native" "${WINE_NATIVE}" "${METALSHARP_WINE_ARCH}")
+assert_architecture("metalsharp_d3d11" "${WINE_D3D11}" "${METALSHARP_WINE_ARCH}")
+assert_architecture("metalsharp_d3d12" "${WINE_D3D12}" "${METALSHARP_WINE_ARCH}")
+assert_architecture("metalsharp_dxgi" "${WINE_DXGI}" "${METALSHARP_WINE_ARCH}")
+assert_architecture("metalsharp_audio" "${WINE_AUDIO}" "${METALSHARP_WINE_ARCH}")
+assert_architecture("metalsharp_input" "${WINE_INPUT}" "${METALSHARP_WINE_ARCH}")
+assert_architecture("metalsharp_loader" "${WINE_LOADER}" "${METALSHARP_WINE_ARCH}")
+assert_architecture("metalsharp_opengl32" "${WINE_OPENGL}" "${METALSHARP_WINE_ARCH}")

--- a/tools/bundles/create-split-bundles.py
+++ b/tools/bundles/create-split-bundles.py
@@ -70,9 +70,31 @@ def require_file_type(src: Path, description: str, *needles: str) -> None:
         raise RuntimeError(f"invalid {description}: {src} ({result.stdout.strip()})")
 
 
+def require_macos_architecture(src: Path, expected: str, description: str) -> None:
+    if sys.platform != "darwin":
+        return
+    try:
+        info = subprocess.run(["lipo", "-info", str(src)], capture_output=True, text=True, check=False)
+        archs = subprocess.run(["lipo", "-archs", str(src)], capture_output=True, text=True, check=False)
+    except FileNotFoundError as exc:
+        raise RuntimeError("lipo is required to validate macOS package architectures") from exc
+    if info.returncode != 0 or archs.returncode != 0:
+        detail = (info.stderr or info.stdout or archs.stderr or archs.stdout).strip()
+        raise RuntimeError(f"invalid {description}: {src} ({detail})")
+    actual = archs.stdout.strip().split()
+    if actual != [expected]:
+        raise RuntimeError(f"invalid {description}: {src} has architectures {actual}, expected only {expected}")
+    print(f"{description}: {info.stdout.strip()}")
+
+
 def require_host_runtime(host_dir: Path) -> None:
     require_file(host_dir / "manifest.json", "host runtime manifest")
     require_file(host_dir / "HostRuntimeABI.h", "host runtime ABI header")
+    if sys.platform == "darwin":
+        library = host_dir / "libmetalsharp_host_runtime.dylib"
+        require_file(library, "macOS host runtime library")
+        require_macos_architecture(library, "arm64", "macOS host runtime library")
+        return
     libraries = [
         host_dir / "libmetalsharp_host_runtime.dylib",
         host_dir / "libmetalsharp_host_runtime.so",
@@ -276,6 +298,14 @@ def build_staging(tmp: Path) -> dict[str, Path]:
         platform_shlibs = native_dylibs + native_so
     for name in platform_shlibs + native_binaries:
         require_file(APP_DIR / "native" / name, f"native shim {name}")
+    if sys.platform == "darwin":
+        for name in platform_shlibs:
+            require_macos_architecture(APP_DIR / "native" / name, "x86_64", f"native Wine artifact {name}")
+        require_macos_architecture(APP_DIR / "native" / "metalsharp", "x86_64", "native PE loader")
+        require_macos_architecture(APP_DIR / "native" / "metalsharp_launcher", "arm64", "native host launcher")
+        migrator = APP_DIR / "native" / "MetalSharpMigrator"
+        if migrator.is_file():
+            require_macos_architecture(migrator, "arm64", "native host migrator")
     if sys.platform == "darwin":
         require_file_type(
             APP_DIR / "native" / "metalsharp_eac_substrate.dylib",

--- a/tools/bundles/verify-bundles.sh
+++ b/tools/bundles/verify-bundles.sh
@@ -171,7 +171,25 @@ verify_runtime_core() {
     runtime/wine/lib/metalsharp/i386-windows/xinput1_2.dll \
     runtime/wine/lib/metalsharp/i386-windows/xinput1_3.dll \
     runtime/wine/lib/metalsharp/i386-windows/xinput1_4.dll \
-    runtime/wine/lib/metalsharp/i386-windows/xinput9_1_0.dll
+    runtime/wine/lib/metalsharp/i386-windows/xinput9_1_0.dll &&
+    verify_runtime_host_architecture "$1"
+}
+
+verify_runtime_host_architecture() {
+  local path="$1"
+  local tmp
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/metalsharp-runtime-arch.XXXXXX")"
+  if ! tar --use-compress-program=unzstd -xf "$path" -C "$tmp" runtime/host/libmetalsharp_host_runtime.dylib; then
+    echo "RUNTIME INVALID: $path cannot extract the host runtime library" >&2
+    rm -rf "$tmp"
+    return 1
+  fi
+  if ! "$PROJECT_ROOT/tools/package/verify-macos-architecture.sh" arm64 \
+    "$tmp/runtime/host/libmetalsharp_host_runtime.dylib"; then
+    rm -rf "$tmp"
+    return 1
+  fi
+  rm -rf "$tmp"
 }
 
 verify_graphics_core() {
@@ -432,6 +450,10 @@ verify_eac_native_assets() {
   if ! file "$tmp/scripts/tools/native/metalsharp_eac_substrate.dylib" | grep -q "Mach-O" \
     || ! file "$tmp/scripts/tools/native/metalsharp_eac_substrate.dylib" | grep -q "x86_64"; then
     echo "SCRIPTS TOOLS INVALID: EAC substrate is not an x86_64 Mach-O dylib" >&2
+    failed=1
+  fi
+  if ! "$PROJECT_ROOT/tools/package/verify-macos-architecture.sh" x86_64 \
+    "$tmp/scripts/tools/native/metalsharp_eac_substrate.dylib"; then
     failed=1
   fi
   if ! file "$tmp/scripts/tools/native/metalsharp_eac_libc.so.6" | grep -q "ELF 64-bit.*x86-64"; then

--- a/tools/bundles/verify-native-shims.sh
+++ b/tools/bundles/verify-native-shims.sh
@@ -19,6 +19,8 @@ if [ "${1:-}" = "--eac-only" ]; then
     shift
 fi
 NATIVE_DIR="${1:-${METALSHARP_NATIVE_DIR:-app/native}}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ARCH_CHECK="$SCRIPT_DIR/../package/verify-macos-architecture.sh"
 
 if [ "$EAC_ONLY" -eq 1 ]; then
     required_dylibs=(metalsharp_eac_substrate.dylib)
@@ -51,6 +53,9 @@ for f in "${required_files[@]}"; do
                 echo "ERROR: $path is not a Mach-O binary"
                 errors=$((errors + 1))
             fi
+            if ! "$ARCH_CHECK" x86_64 "$path"; then
+                errors=$((errors + 1))
+            fi
             if [[ "$f" == "metalsharp_eac_substrate.dylib" ]] && ! file "$path" | grep -q "x86_64"; then
                 echo "ERROR: $path does not contain the x86_64 Wine/Rosetta slice"
                 errors=$((errors + 1))
@@ -65,8 +70,19 @@ for f in "${required_files[@]}"; do
                 done
             fi
         fi
+        if [[ "$f" == "metalsharp" ]] && ! "$ARCH_CHECK" x86_64 "$path"; then
+            errors=$((errors + 1))
+        fi
+        if [[ "$f" == "metalsharp_launcher" ]] && ! "$ARCH_CHECK" arm64 "$path"; then
+            errors=$((errors + 1))
+        fi
     fi
 done
+
+if [ "$EAC_ONLY" -eq 0 ] && [ -f "$NATIVE_DIR/MetalSharpMigrator" ] \
+  && ! "$ARCH_CHECK" arm64 "$NATIVE_DIR/MetalSharpMigrator"; then
+    errors=$((errors + 1))
+fi
 
 for f in "${required_elf[@]}"; do
     path="$NATIVE_DIR/$f"

--- a/tools/dmg/verify-dmg-runtime-assets.sh
+++ b/tools/dmg/verify-dmg-runtime-assets.sh
@@ -32,6 +32,7 @@ BACKEND="$RESOURCES/runtime/metalsharp-backend"
 HOST="$RESOURCES/runtime/host"
 BUNDLES="$RESOURCES/bundles"
 NATIVE="$RESOURCES/scripts/tools/native"
+ARCH_CHECK="$PROJECT_ROOT/tools/package/verify-macos-architecture.sh"
 # The two explicit bundle paths below are the installed EAC substrate contract:
 # Contents/Resources/scripts/tools/native/metalsharp_eac_substrate.dylib
 # Contents/Resources/scripts/tools/native/metalsharp_eac_libc.so.6
@@ -78,6 +79,10 @@ if [ ! -s "$HOST/libmetalsharp_host_runtime.dylib" ] \
   echo "DMG host runtime has no non-empty shared library" >&2
   exit 1
 fi
+
+"$ARCH_CHECK" arm64 "$HOST/libmetalsharp_host_runtime.dylib"
+"$ARCH_CHECK" arm64 "$NATIVE/metalsharp_launcher"
+"$ARCH_CHECK" x86_64 "$NATIVE/metalsharp"
 
 cp "$BUNDLES"/*.tar.zst "$LIST_DIR"/
 "$PROJECT_ROOT/tools/bundles/verify-bundles.sh" --bundle-dir "$LIST_DIR" --require mac

--- a/tools/package/create-host-runtime.sh
+++ b/tools/package/create-host-runtime.sh
@@ -34,6 +34,10 @@ if [ "$copied" -ne 1 ]; then
   exit 1
 fi
 
+if [ "$(uname -s)" = "Darwin" ]; then
+  "$SCRIPT_DIR/verify-macos-architecture.sh" arm64 "$HOST_DIR/libmetalsharp_host_runtime.dylib"
+fi
+
 cp "$PROJECT_ROOT/include/metalsharp/HostRuntimeABI.h" "$HOST_DIR/HostRuntimeABI.h"
 
 cat > "$HOST_DIR/manifest.json" <<'JSON'

--- a/tools/package/verify-macos-architecture.sh
+++ b/tools/package/verify-macos-architecture.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXPECTED_ARCH="${1:?usage: verify-macos-architecture.sh ARCH BINARY}"
+BINARY="${2:?usage: verify-macos-architecture.sh ARCH BINARY}"
+
+case "$EXPECTED_ARCH" in
+  arm64|x86_64) ;;
+  *)
+    echo "Unsupported expected macOS architecture: $EXPECTED_ARCH" >&2
+    exit 2
+    ;;
+esac
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "SKIP: macOS architecture check for $BINARY on $(uname -s)"
+  exit 0
+fi
+
+if [ ! -s "$BINARY" ]; then
+  echo "Missing or empty macOS binary: $BINARY" >&2
+  exit 1
+fi
+
+if ! command -v lipo >/dev/null 2>&1; then
+  echo "lipo is required to validate macOS binary architectures" >&2
+  exit 127
+fi
+
+info="$(lipo -info "$BINARY")"
+archs="$(lipo -archs "$BINARY")"
+echo "ARCH: $BINARY ($info)"
+
+if [ "$archs" != "$EXPECTED_ARCH" ]; then
+  echo "ERROR: $BINARY has architecture(s) '$archs'; expected only '$EXPECTED_ARCH'" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Fixes #451 by making MetalSharp's macOS host/Wine architecture boundary explicit in CMake and package validation. Host helpers now ship arm64 while Wine-facing native artifacts remain x86_64 for Rosetta.

## Changes

- Mark `metalsharp_launcher`, `metalsharp_host_runtime`, `MetalSharpMigrator`, and the host ABI test arm64.
- Mark the PE loader, core, D3D, audio/input, OpenGL, and native Wine targets x86_64 explicitly.
- Remove the unnecessary PE-facing core dependency from the native host launcher so the arm64 launcher links cleanly.
- Add a CTest architecture matrix plus `lipo -info`/`lipo -archs` checks to native-shim, bundle, host-runtime, and DMG packaging validation.
- Document the macOS artifact architecture matrix and source-build expectations.

## PR Readiness (MANDATORY)

<!-- The compatibility item is intentionally not applicable: this is a build/package architecture fix and does not change a game launch route. The `checklist-exception` label documents that exception for CI. -->

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
  - Not applicable for this build/package-only change; no game launch path or runtime route was changed.
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
  - Not applicable; no rules or DLL maps changed.
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped
  - Not applicable; no version was bumped.
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
  - No bottle, migration, route, or launch behavior changed; only target architecture and package validation changed.
- [x] Docs / compatibility matrix updated for user-facing changes
  - Added `docs/architecture/macos-artifact-matrix.md` and updated source-build/host-runtime documentation.
- [x] Regression test added for each bug fix
  - Added the `macos_architecture_matrix` CTest and package-level architecture gates.

## Local toolchain (run before push)

- [ ] `cargo fmt --all -- --check` passes (Rust)
  - Not applicable; no Rust files changed.
- [ ] `cargo clippy --all-targets -- -D warnings` passes (Rust)
  - Not applicable; no Rust files changed.
- [ ] `cargo build --release` passes (Rust backend)
  - Not applicable; no Rust files changed.
- [ ] `cargo test` passes (Rust — 628+ tests)
  - Not applicable; no Rust files changed.
- [x] C++ compiles if changed: `cmake -S . -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON && cmake --build build-native --parallel $(sysctl -n hw.ncpu)`
- [x] `clang-format --dry-run --Werror` passes on any changed C/C++/Obj-C file
  - `tools/ci/check-clang-format.sh`
- [x] `ctest --test-dir build-native` passes if tests changed
  - 32/32 passed, including `macos_architecture_matrix`.
- [ ] TypeScript compiles if changed: `cd app && npx tsc --noEmit`
  - Not applicable; no TypeScript files changed.
- [ ] Biome + Prettier pass if TS/JS changed: `cd app && npx @biomejs/biome ci src/ && npx prettier --check 'src/**/*.{ts,js,html,css,json}'`
  - Not applicable; no TS/JS files changed.
- [x] Shell scripts lint if changed: `tools/ci/shellcheck.sh`
- [ ] `tools/ci/validate-rules-toml.py` passes if `configs/mtsp-rules.toml` changed
  - Not applicable; no rules changed.
- [x] `python3 tools/ci/verify-dmg-workflow.py` passes if release/bundle tooling changed
- [ ] Tested with at least one game (which one? which launch method? which drive?)
  - Not applicable; no game launch behavior changed. See the readiness exception above.
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files should be added to the repo root; place them under `app/`, `tools/`, `tests/`, etc.

## Test notes

- Native Release CMake configure/build completed on macOS Apple Silicon from the clean checkout on `/Volumes/AverySSD/MetalSharp-451-clean`.
- `ctest --test-dir build-native --output-on-failure`: **32/32 passed**.
- Verified target outputs with `lipo`: host runtime, launcher, migrator, and host ABI test are `arm64`; core, loader, native launcher, D3D/audio/input, and OpenGL artifacts are `x86_64`.
- `tools/bundles/verify-native-shims.sh` passed against a clean staged native artifact set.
- `tools/package/create-host-runtime.sh` passed with an arm64 host runtime.
- Synthetic runtime bundle validation accepted the arm64 host runtime and rejected an x86_64 host runtime.
- `tools/ci/check-clang-format.sh`, `tools/ci/shellcheck.sh`, `python3 -B tools/ci/verify-dmg-workflow.py`, and `git diff --check` passed.
- The documentation freshness check completed with its existing warning for `docs/OPENGL-2-4-PLAN.md` (unrelated to this PR).

## Risk

This preserves the existing x86_64 Wine/Rosetta graphics and PE surface while moving only native host helpers to arm64. The launcher no longer links the x86_64 core because its source-level host helper implementation does not use it. Rollback is a single commit revert; the previous global x86_64 defaults remain the fallback if this change is reverted.
