### PR TITLE
fix(app): guard MetalSharp uninstall target

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -15,6 +15,7 @@
     "dev:vite": "vite",
     "preview": "npm run build && METALSHARP_PREVIEW=1 METALSHARP_HOME=\"$HOME/.metalsharp\" electron .",
     "preview:dev": "npm run build && METALSHARP_PREVIEW=1 METALSHARP_DEV_LIBRARY=1 METALSHARP_HOME=\"$HOME/.metalsharp\" electron .",
+    "test:uninstall-safety": "tsc && node --test tests/uninstall-safety.test.js",
     "rust:build": "cd src-rust && cargo build --release",
     "rust:dev": "cd src-rust && cargo build",
     "build:all": "npm run rust:build && npm run build",

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -6,6 +6,7 @@ import * as os from "os";
 import * as path from "path";
 import type { ProcessManagerAction, ProcessManagerActionResult, ProcessManagerSample } from "./process-manager-types";
 import { RustBridge } from "./rust-bridge";
+import { validateUninstallTarget } from "./uninstall-safety";
 import { UpdaterBridge } from "./updater-bridge";
 
 let shellPath: string | undefined;
@@ -808,6 +809,20 @@ async function requestMigrationBackend(
   return requestBackend(method, url, body, timeoutMs);
 }
 
+async function showUninstallBlocked(window: BrowserWindow, targetPath: string, reason: string): Promise<void> {
+  if (window.isDestroyed()) return;
+  await dialog.showMessageBox(window, {
+    type: "error",
+    title: "Uninstall blocked",
+    message: "MetalSharp data was not removed.",
+    detail:
+      `For safety, MetalSharp will not recursively delete this resolved data path:\n${targetPath}\n\n` + `${reason}`,
+    buttons: ["OK"],
+    defaultId: 0,
+    noLink: true,
+  });
+}
+
 function registerIpc() {
   ipcMain.handle(
     "backend:request",
@@ -1194,15 +1209,25 @@ function registerIpc() {
     app.quit();
   });
 
-  ipcMain.on("app:uninstall", async () => {
-    if (!mainWindow) return;
-    const choice = await dialog.showMessageBox(mainWindow, {
+  ipcMain.on("app:uninstall", async (event) => {
+    const window = mainWindow;
+    if (!window || window.isDestroyed() || event.sender !== window.webContents) return;
+
+    const initialTarget = validateUninstallTarget(getMetalsharpDir());
+    if (!initialTarget.ok) {
+      await showUninstallBlocked(window, initialTarget.path, initialTarget.reason);
+      return;
+    }
+
+    const msDir = initialTarget.path;
+    const choice = await dialog.showMessageBox(window, {
       type: "warning",
       title: "Uninstall MetalSharp",
       message: "Are you sure you want to uninstall MetalSharp?",
       detail:
         "This will permanently delete all Wine prefixes, bottles, game data, " +
         "Steam installation, Wine runtime, shader caches, and all settings. " +
+        `\n\nResolved MetalSharp data path:\n${msDir}\n\n` +
         "MetalSharp will also be removed from Applications and moved to Trash. " +
         "This action cannot be undone.",
       buttons: ["Cancel", "Uninstall"],
@@ -1214,13 +1239,30 @@ function registerIpc() {
 
     await cleanup();
 
-    const msDir = getMetalsharpDir();
-    let dataRemoved = false;
+    const deletionTarget = validateUninstallTarget(msDir);
+    if (!deletionTarget.ok) {
+      await showUninstallBlocked(window, deletionTarget.path, deletionTarget.reason);
+      return;
+    }
+
     try {
-      fs.rmSync(msDir, { recursive: true, force: true });
-      dataRemoved = true;
+      fs.rmSync(deletionTarget.path, { recursive: true, force: true });
     } catch (e) {
       console.error("Failed to remove MetalSharp data:", e);
+      if (!window.isDestroyed()) {
+        await dialog.showMessageBox(window, {
+          type: "error",
+          title: "Uninstall incomplete",
+          message: "MetalSharp data could not be removed.",
+          detail:
+            `The application was not moved to the Trash.\n\nResolved MetalSharp data path:\n${msDir}\n\n` +
+            `Error: ${e instanceof Error ? e.message : String(e)}`,
+          buttons: ["OK"],
+          defaultId: 0,
+          noLink: true,
+        });
+      }
+      return;
     }
 
     // Spawn a detached shell that waits for this process to exit, then
@@ -1238,8 +1280,8 @@ function registerIpc() {
     }
 
     // Show success dialog — user must close the app to finish.
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      await dialog.showMessageBox(mainWindow, {
+    if (!window.isDestroyed()) {
+      await dialog.showMessageBox(window, {
         type: "info",
         title: "MetalSharp Uninstalled",
         message: "MetalSharp data has been removed successfully.",

--- a/app/src/main/uninstall-safety.ts
+++ b/app/src/main/uninstall-safety.ts
@@ -1,0 +1,95 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const METALSHARP_MARKER = "setup.json";
+
+export type UninstallTargetValidation = { ok: true; path: string } | { ok: false; path: string; reason: string };
+
+function rejected(targetPath: string, reason: string): UninstallTargetValidation {
+  return { ok: false, path: targetPath, reason };
+}
+
+function canonicalPath(candidate: string): string | null {
+  try {
+    return fs.realpathSync.native(candidate);
+  } catch {
+    return null;
+  }
+}
+
+function isStrictDescendant(parent: string, candidate: string): boolean {
+  const relative = path.relative(parent, candidate);
+  return (
+    relative.length > 0 && relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative)
+  );
+}
+
+/**
+ * Check that a path is an actual, marked MetalSharp data directory before it
+ * is passed to a recursive delete. The home directory is injected for tests;
+ * production callers use the current user's home by default.
+ */
+export function validateUninstallTarget(targetPath: string, homePath = os.homedir()): UninstallTargetValidation {
+  const resolvedTarget = path.resolve(targetPath);
+  const resolvedHome = path.resolve(homePath);
+
+  let targetStats: fs.Stats;
+  try {
+    targetStats = fs.lstatSync(resolvedTarget);
+  } catch {
+    return rejected(resolvedTarget, "The MetalSharp data directory could not be inspected.");
+  }
+
+  if (targetStats.isSymbolicLink()) {
+    return rejected(resolvedTarget, "The resolved MetalSharp data path is a symbolic link.");
+  }
+  if (!targetStats.isDirectory()) {
+    return rejected(resolvedTarget, "The resolved MetalSharp data path is not a directory.");
+  }
+
+  const canonicalHome = canonicalPath(resolvedHome);
+  if (!canonicalHome) {
+    return rejected(resolvedTarget, "The user's home directory could not be resolved.");
+  }
+
+  let homeStats: fs.Stats;
+  try {
+    homeStats = fs.statSync(resolvedHome);
+  } catch {
+    return rejected(resolvedTarget, "The user's home directory could not be inspected.");
+  }
+  if (targetStats.dev !== homeStats.dev) {
+    return rejected(resolvedTarget, "The MetalSharp data directory is on a different filesystem than the user's home.");
+  }
+
+  const canonicalTarget = canonicalPath(resolvedTarget);
+  if (!canonicalTarget) {
+    return rejected(resolvedTarget, "The resolved MetalSharp data path could not be resolved.");
+  }
+
+  if (canonicalHome === path.parse(canonicalHome).root) {
+    return rejected(resolvedTarget, "The user's home directory cannot be the filesystem root.");
+  }
+  if (canonicalTarget === path.parse(canonicalTarget).root) {
+    return rejected(resolvedTarget, "Refusing to delete the filesystem root.");
+  }
+  if (canonicalTarget === canonicalHome) {
+    return rejected(resolvedTarget, "Refusing to delete the user's home directory.");
+  }
+  if (!isStrictDescendant(canonicalHome, canonicalTarget)) {
+    return rejected(resolvedTarget, "The MetalSharp data directory must be inside the user's home directory.");
+  }
+
+  const markerPath = path.join(resolvedTarget, METALSHARP_MARKER);
+  try {
+    const markerStats = fs.lstatSync(markerPath);
+    if (!markerStats.isFile() || markerStats.isSymbolicLink()) {
+      return rejected(resolvedTarget, `The MetalSharp marker ${METALSHARP_MARKER} is not a regular file.`);
+    }
+  } catch {
+    return rejected(resolvedTarget, `The MetalSharp marker ${METALSHARP_MARKER} was not found.`);
+  }
+
+  return { ok: true, path: resolvedTarget };
+}

--- a/app/tests/uninstall-safety.test.js
+++ b/app/tests/uninstall-safety.test.js
@@ -1,0 +1,83 @@
+const { strict: assert } = require("node:assert");
+const { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { afterEach, test } = require("node:test");
+const { validateUninstallTarget } = require("../dist/main/uninstall-safety.js");
+
+const temporaryRoots = [];
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+function fixture(withMarker = true) {
+  const root = mkdtempSync(path.join(os.tmpdir(), "metalsharp-uninstall-safety-"));
+  temporaryRoots.push(root);
+
+  const home = path.join(root, "home");
+  const target = path.join(home, ".metalsharp");
+  mkdirSync(target, { recursive: true });
+  if (withMarker) writeFileSync(path.join(target, "setup.json"), "{}\n");
+
+  return { root, home, target };
+}
+
+test("allows a marked MetalSharp directory below the user's home", () => {
+  const { home, target } = fixture();
+
+  assert.deepEqual(validateUninstallTarget(target, home), { ok: true, path: target });
+});
+
+test("rejects the user's home directory even when it has a marker", () => {
+  const { home } = fixture();
+  writeFileSync(path.join(home, "setup.json"), "{}\n");
+
+  const result = validateUninstallTarget(home, home);
+
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.match(result.reason, /home directory/);
+});
+
+test("rejects the filesystem root", () => {
+  const { home } = fixture();
+
+  const result = validateUninstallTarget(path.parse(home).root, home);
+
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.match(result.reason, /filesystem root/);
+});
+
+test("rejects a marked directory outside the user's home", () => {
+  const { root, home } = fixture(false);
+  const outside = path.join(root, "shared-data");
+  mkdirSync(outside);
+  writeFileSync(path.join(outside, "setup.json"), "{}\n");
+
+  const result = validateUninstallTarget(outside, home);
+
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.match(result.reason, /inside the user's home/);
+});
+
+test("rejects an unmarked directory", () => {
+  const { home, target } = fixture(false);
+
+  const result = validateUninstallTarget(target, home);
+
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.match(result.reason, /marker.*not found/);
+});
+
+test("rejects a symbolic-link target", () => {
+  const { home, target } = fixture();
+  const link = path.join(home, "linked-metalsharp");
+  symlinkSync(target, link, "dir");
+
+  const result = validateUninstallTarget(link, home);
+
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.match(result.reason, /symbolic link/);
+});

--- a/docs/guides/how-to-use-metalsharp.md
+++ b/docs/guides/how-to-use-metalsharp.md
@@ -1,5 +1,5 @@
 # How to Use MetalSharp
-**Updated:** 2026-07-08
+**Updated:** 2026-08-11
 
 
 ## Install
@@ -86,7 +86,7 @@ Switching between X and D removes the previously deployed set before deploying t
 
 ### Uninstall
 
-Settings includes a **Danger Zone** section at the bottom with an **Uninstall MetalSharp** button. This removes all Wine prefixes, bottles, Steam, runtime, caches, and settings, then moves the app to Trash.
+Settings includes a **Danger Zone** section at the bottom with an **Uninstall MetalSharp** button. The confirmation dialog shows the resolved MetalSharp data path before removal. For safety, uninstall only removes a marked MetalSharp data directory below the user's home directory; if `METALSHARP_HOME` points at the home directory, the filesystem root, an external/shared location, or an unmarked directory, MetalSharp refuses the uninstall without deleting data. A permitted uninstall removes all Wine prefixes, bottles, Steam, runtime, caches, and settings, then moves the app to Trash.
 
 ## Useful Docs
 


### PR DESCRIPTION
## Summary

Closes #450. Make the Electron uninstall path fail closed so a misconfigured `METALSHARP_HOME` cannot recursively remove the user's home, filesystem root, or an external/shared filesystem.

## Changes

- Added a filesystem-aware uninstall target validator requiring a real `setup.json` marker, a non-root path strictly below the user's home, and the same filesystem as the home directory.
- Validated the target before confirmation and again immediately before deletion.
- Displayed the resolved data path in the confirmation/error dialogs and stopped the uninstall if data removal fails.
- Validated that `app:uninstall` came from the main window's webContents.
- Added regression coverage for valid, home, root, outside-home, unmarked, and symlink targets.
- Documented the guarded uninstall behavior.

## PR Readiness (MANDATORY)

- [ ] Compatibility verified with at least one real game (game + launch method noted below) — not applicable: this change does not alter game compatibility or launch behavior; `checklist-exception` is applied.
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed — not applicable; neither changed.
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped — no version bump.
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

## Local toolchain (run before push)

- [x] `cargo fmt --all -- --check` passes (Rust)
- [x] `cargo clippy --all-targets -- -D warnings` passes (Rust)
- [x] `cargo build --release` passes (Rust backend)
- [x] `cargo test` passes (Rust — 762 tests)
- [ ] C++ compiles if changed — not applicable; no native files changed.
- [ ] `clang-format --dry-run --Werror` passes on any changed C/C++/Obj-C file — not applicable; no native files changed.
- [ ] `ctest --test-dir build-native` passes if tests changed — not applicable; no native tests changed.
- [x] TypeScript compiles if changed: `cd app && npx tsc --noEmit`
- [x] Biome + Prettier pass if TS/JS changed: `cd app && npx @biomejs/biome ci src/ && npx prettier --check 'src/**/*.{ts,js,html,css,json}'`
- [ ] Shell scripts lint if changed — not applicable; no shell scripts changed.
- [ ] `tools/ci/validate-rules-toml.py` passes if `configs/mtsp-rules.toml` changed — not applicable; rules did not change.
- [ ] `python3 tools/ci/verify-dmg-workflow.py` passes if release/bundle tooling changed — not applicable; release tooling did not change.
- [ ] Tested with at least one game (which one? which launch method? which drive?) — not applicable; no launch behavior changed.
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files should be added to the repo root; place them under `app/`, `tools/`, `tests/`, etc.

## Test notes

- `cd app && npm ci`
- `cd app && npm run test:uninstall-safety` — 6 passed
- `cd app && npx tsc --noEmit`
- `cd app && npm run build`
- `cd app && npx @biomejs/biome ci src/main src/shared src/renderer tests`
- `cd app && npx prettier --check 'src/main/**/*.{ts,js,json}' 'src/shared/**/*.{ts,js,json}' 'src/renderer/**/*.{ts,js,html,css,json}' 'tests/uninstall-safety.test.js'`
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo build --release`, and `cargo test` — 762 passed
- `python3 tools/ci/check-doc-freshness.py` — pass; reports one pre-existing missing date header for `docs/OPENGL-2-4-PLAN.md` (warn-only)
- Workspace: `/Volumes/AverySSD/MetalSharp-450-clean` on the external drive. No real game launch was needed because the fix is isolated to uninstall safety.

## Risk

The intentional behavior change is that uninstall refuses `METALSHARP_HOME` locations outside the user's home, the home directory itself, the filesystem root, different filesystems mounted below home, unmarked directories, and symlinks. This is fail-closed protection against data loss; users can still remove supported data after restoring a safe `METALSHARP_HOME`. Rollback is a one-commit revert of `90239dfa`.

The repository pre-commit hook's existing Prettier invocation passes repo-root-prefixed paths after changing into `app`, so that hook step could not resolve its arguments. The equivalent direct Prettier checks above passed; no generated or unrelated files were committed.
