### PR TITLE
fix(audio): clamp X3DAudio matrix destination stride

### DIFF
--- a/include/metalsharp/X3DAudioEngine.h
+++ b/include/metalsharp/X3DAudioEngine.h
@@ -5,7 +5,9 @@
 /// distance rolloff, and Doppler pitch shifts from listener/emitter positions and
 /// velocities. Outputs matrix coefficients for up to 18 source channels × 2 output
 /// channels, plus reverb/LFE levels and low-pass filter coefficients. Used by games
-/// that position audio sources in 3D space via X3DAudio.
+/// that position audio sources in 3D space via X3DAudio. The fixed output
+/// matrix supports up to two destination channels; larger requests are
+/// represented using that same two-channel layout.
 
 #pragma once
 

--- a/src/audio/X3DAudioEngine.cpp
+++ b/src/audio/X3DAudioEngine.cpp
@@ -3,6 +3,7 @@
 ///
 /// Implements X3DAudioCalculate for 3D positional audio: distance attenuation, Doppler pitch shift, panning, and LF/RF
 /// matrix calculations. Used by games to place sound sources in 3D space relative to the listener.
+#include <algorithm>
 #include <cmath>
 #include <cstring>
 #include <metalsharp/Logger.h>
@@ -98,9 +99,10 @@ void X3DAudioEngine::calculate(const Audio3DListener& listener, const Audio3DEmi
     output.dopplerFactor = computeDoppler(listener, emitter);
     output.lpFDirectCoefficient = attenuation;
 
-    for (uint32_t ch = 0; ch < dstChannelCount && ch < 2; ch++) {
+    const uint32_t matrixDestinationChannelCount = std::min(dstChannelCount, 2u);
+    for (uint32_t ch = 0; ch < matrixDestinationChannelCount; ch++) {
         float channelGain = attenuation;
-        if (dstChannelCount == 2) {
+        if (matrixDestinationChannelCount == 2) {
             if (ch == 0) {
                 channelGain *= std::cos(pan * 0.5f * 3.14159f);
             } else {
@@ -108,7 +110,7 @@ void X3DAudioEngine::calculate(const Audio3DListener& listener, const Audio3DEmi
             }
         }
         for (uint32_t src = 0; src < emitter.channelCount && src < 18; src++) {
-            output.matrixCoefficients[src * dstChannelCount + ch] = channelGain;
+            output.matrixCoefficients[src * matrixDestinationChannelCount + ch] = channelGain;
         }
     }
 }

--- a/tests/test_phase22.cpp
+++ b/tests/test_phase22.cpp
@@ -224,6 +224,42 @@ static bool test_x3daudio_calculate() {
     return output.emitterToListenerDistance > 0 && output.dopplerFactor > 0;
 }
 
+static bool test_x3daudio_surround_matrix_bounds() {
+    auto& engine = X3DAudioEngine::instance();
+    engine.init(0x3);
+
+    Audio3DListener listener = {{0, 0, 0}, {0, 0, -1}, {0, 1, 0}, {0, 0, 0}, 1, 1, 0};
+    Audio3DEmitter emitter = {{0, 0, -10}, {0, 0, -1}, {0, 1, 0}, {0, 0, 0}, 0, 0, 18, 1, 1, 1};
+
+    struct GuardedOutput {
+        Audio3DOutput output;
+        uint32_t guard[32];
+    } guarded = {};
+    for (auto& value : guarded.guard)
+        value = 0xA5A5A5A5;
+
+    engine.calculate(listener, emitter, 0, 8, guarded.output);
+
+    bool guardIntact = true;
+    for (auto value : guarded.guard) {
+        if (value != 0xA5A5A5A5) {
+            guardIntact = false;
+            break;
+        }
+    }
+
+    bool matrixInitialized = true;
+    for (float coefficient : guarded.output.matrixCoefficients) {
+        if (!std::isfinite(coefficient) || coefficient <= 0.0f) {
+            matrixInitialized = false;
+            break;
+        }
+    }
+
+    engine.shutdown();
+    return guardIntact && matrixInitialized;
+}
+
 // 22.3 DirectSound
 static bool test_directsound_init() {
     auto& ds = DirectSoundBackend::instance();
@@ -297,6 +333,7 @@ int main() {
     TEST(x3daudio_pan);
     TEST(x3daudio_doppler);
     TEST(x3daudio_calculate);
+    TEST(x3daudio_surround_matrix_bounds);
 
     printf("\n--- 22.3 DirectSound Fallback ---\n");
     TEST(directsound_init);


### PR DESCRIPTION
## Summary

Fixes #432 by preventing X3DAudio surround requests from indexing outside the fixed 18-source × 2-destination matrix.

## Changes

- Clamp the destination channel count used by the matrix loop and source stride to the two-channel output contract.
- Document the fixed two-channel behavior for larger destination requests.
- Add a regression test that exercises an 18-channel source with an 8-channel destination and verifies a surrounding canary remains intact.

## PR Readiness (MANDATORY)

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

The real-game compatibility item is intentionally not applicable: this is an isolated native X3DAudio calculation and bounds fix; it does not change game launch, routing, bottles, or runtime migration behavior. The `checklist-exception` label is applied per repository policy. The public X3DAudio header contract was updated.

## Local toolchain (run before push)

- [ ] `cargo fmt --all -- --check` passes (Rust; unchanged surface)
- [ ] `cargo clippy --all-targets -- -D warnings` passes (Rust; unchanged surface)
- [ ] `cargo build --release` passes (Rust backend; unchanged surface)
- [ ] `cargo test` passes (Rust; unchanged surface)
- [x] C++ compiles if changed: `cmake -S . -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON && cmake --build build-native --parallel "$(sysctl -n hw.ncpu)"`
- [x] `clang-format --dry-run --Werror` passes on any changed C/C++/Obj-C file
- [x] `ctest --test-dir build-native` passes if tests changed
- [ ] TypeScript compiles if changed (unchanged surface)
- [ ] Biome + Prettier pass if TS/JS changed (unchanged surface)
- [ ] Shell scripts lint if changed (unchanged surface)
- [ ] `tools/ci/validate-rules-toml.py` passes if `configs/mtsp-rules.toml` changed (unchanged surface)
- [ ] `python3 tools/ci/verify-dmg-workflow.py` passes if release/bundle tooling changed (unchanged surface)
- [ ] Tested with at least one game (which one? which launch method? which drive?) (not applicable; no game-launch behavior changed)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files should be added to the repo root; place them under `app/`, `tools/`, `tests/`, etc.

## Test notes

All native checks ran from the clean checkout on external drive `/Volumes/AverySSD/MetalSharp-432-clean`, after waiting for concurrent native/Rust build and test work to finish:

- `cmake -S . -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON`
- `cmake --build build-native --parallel "$(sysctl -n hw.ncpu)"`
- `ctest --test-dir build-native --output-on-failure` — 31/31 tests passed
- `./build-native/tests/test_phase22` — 19/19 tests passed, including `x3daudio_surround_matrix_bounds`
- `ctest --test-dir build-native --output-on-failure -R '^phase22$'` — 1/1 passed
- `tools/ci/check-clang-format.sh` — passed
- `git diff --check` — passed
- Installed pre-commit hook — staged C++/header format check passed

## Risk

The existing fixed two-channel output ABI is preserved. Requests for more than two destination channels now produce the documented two-channel matrix instead of corrupting adjacent output state. The focused rollback is commit `0fcafb7b`.
