### PR TITLE
fix(updater): prevent privileged path command injection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,3 +229,6 @@ jobs:
 
       - name: Verify DMG workflow contract
         run: python3 tools/ci/verify-dmg-workflow.py
+
+      - name: Updater security regression tests
+        run: python3 -m unittest -v tools/ci/test_updater_security.py

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -165,6 +165,9 @@ jobs:
       - name: Verify DMG workflow contract
         run: python3 tools/ci/verify-dmg-workflow.py
 
+      - name: Updater security regression tests
+        run: python3 -m unittest -v tools/ci/test_updater_security.py
+
   tooling-tests:
     name: Tooling Tests
     runs-on: ubuntu-latest

--- a/app/updater/update.py
+++ b/app/updater/update.py
@@ -24,15 +24,29 @@ import tempfile
 import time
 import urllib.request
 
-try:
-    os.setsid()
-except OSError:
-    pass
-
 APP_PATH = "/Applications/MetalSharp.app"
 BACKEND_PORT = 9274
 BACKEND_TOKEN_FILE = ".backend-token"
 UPDATE_DMG_PATH = None
+
+PRIVILEGED_APPLESCRIPT = """
+on run argv
+    set commandPath to item 1 of argv
+    set commandArgs to rest of argv
+    set shellCommand to quoted form of commandPath
+    repeat with commandArg in commandArgs
+        set shellCommand to shellCommand & " " & quoted form of (commandArg as text)
+    end repeat
+    do shell script shellCommand with administrator privileges
+end run
+"""
+
+PRIVILEGED_COMMANDS = {
+    "cp": "/bin/cp",
+    "hdiutil": "/usr/bin/hdiutil",
+    "mv": "/bin/mv",
+    "rm": "/bin/rm",
+}
 
 
 def write_status(status_file, phase, percent, message, error=None, new_version=None):
@@ -62,6 +76,15 @@ def read_status(status_file):
 
 def run(cmd, **kwargs):
     return subprocess.run(cmd, capture_output=True, text=True, timeout=30, **kwargs)
+
+
+def run_privileged(command, *args):
+    command_path = PRIVILEGED_COMMANDS.get(command)
+    if command_path is None:
+        raise ValueError("unsupported privileged command: {}".format(command))
+    return run(
+        ["osascript", "-e", PRIVILEGED_APPLESCRIPT, "--", command_path, *args]
+    )
 
 
 def is_pid_alive(pid):
@@ -179,13 +202,9 @@ def mount_dmg(dmg_path):
     if r.returncode == 0 and os.path.isdir(mount_dir) and os.listdir(mount_dir):
         return mount_dir
 
-    apple = (
-        'do shell script "hdiutil attach -nobrowse -quiet -mountpoint '
-        '\\"' + mount_dir + '\\" '
-        '\\"' + dmg_path + '\\""'
-        " with administrator privileges"
+    r = run_privileged(
+        "hdiutil", "attach", "-nobrowse", "-quiet", "-mountpoint", mount_dir, dmg_path
     )
-    r = run(["osascript", "-e", apple])
     if r.returncode == 0:
         time.sleep(2)
         if os.path.isdir(mount_dir) and os.listdir(mount_dir):
@@ -240,6 +259,15 @@ def find_app_in_mount(mount_point):
 
 
 def verify_app_bundle(app_path):
+    app_name = os.path.basename(os.path.normpath(app_path))
+    # The mounted DMG is untrusted input.  The bundle source is later passed
+    # to a privileged file operation, so reject shell-significant and control
+    # characters before inspecting or staging it.  Staging names use the same
+    # conservative character set by design.
+    safe_name_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-"
+    if not app_name or any(char not in safe_name_chars for char in app_name):
+        return False
+
     required = [
         os.path.join(app_path, "Contents", "Info.plist"),
         os.path.join(app_path, "Contents", "MacOS", "MetalSharp"),
@@ -336,8 +364,7 @@ def admin_rm_rf(path):
     r = run(["rm", "-rf", path])
     if r.returncode == 0:
         return True
-    apple = 'do shell script "rm -rf \\"' + path + '\\"" with administrator privileges'
-    r = run(["osascript", "-e", apple])
+    r = run_privileged("rm", "-rf", path)
     return r.returncode == 0
 
 
@@ -345,8 +372,7 @@ def admin_mv(src, dst):
     r = run(["mv", src, dst])
     if r.returncode == 0:
         return True
-    apple = 'do shell script "mv \\\"' + src + '\\\" \\\"' + dst + '\\\"" with administrator privileges'
-    r = run(["osascript", "-e", apple])
+    r = run_privileged("mv", src, dst)
     return r.returncode == 0
 
 
@@ -354,14 +380,7 @@ def admin_cp_r(src, dst):
     r = run(["cp", "-R", src, dst])
     if r.returncode == 0:
         return True
-    apple = (
-        'do shell script "cp -R \\"'
-        + src
-        + '\\" \\"'
-        + dst
-        + '\\"" with administrator privileges'
-    )
-    r = run(["osascript", "-e", apple])
+    r = run_privileged("cp", "-R", src, dst)
     return r.returncode == 0
 
 
@@ -422,6 +441,11 @@ def report_update_result(status_file, version, target_version):
 
 
 def main():
+    try:
+        os.setsid()
+    except OSError:
+        pass
+
     parser = argparse.ArgumentParser(description="MetalSharp Updater")
     parser.add_argument("--dmg", required=True)
     parser.add_argument("--dmg-size", required=True, type=int)

--- a/app/updater/update.sh
+++ b/app/updater/update.sh
@@ -148,12 +148,58 @@ cleanup() {
 trap cleanup EXIT
 
 run_privileged() {
-    local command="$1"
-    osascript -e "do shell script \"${command//\"/\\\"}\" with administrator privileges" 2>/dev/null
+    local operation="${1:-}"
+    local command_path
+    [ "$#" -gt 0 ] || return 2
+    shift
+
+    # Keep the executable selection fixed and pass every path as an
+    # AppleScript argument.  `quoted form of` is evaluated by AppleScript for
+    # each argument, so a path from the mounted DMG can never become shell
+    # syntax in the privileged fallback.
+    case "$operation" in
+        ditto)
+            [ "$#" -eq 2 ] || return 2
+            command_path="/usr/bin/ditto"
+            ;;
+        mv)
+            [ "$#" -eq 2 ] || return 2
+            command_path="/bin/mv"
+            ;;
+        hdiutil-attach)
+            [ "$#" -eq 2 ] || return 2
+            command_path="/usr/bin/hdiutil"
+            set -- attach -nobrowse -quiet -mountpoint "$1" "$2"
+            ;;
+        *)
+            return 2
+            ;;
+    esac
+
+    osascript \
+        -e 'on run argv' \
+        -e 'set commandPath to item 1 of argv' \
+        -e 'set commandArgs to rest of argv' \
+        -e 'set shellCommand to quoted form of commandPath' \
+        -e 'repeat with commandArg in commandArgs' \
+        -e 'set shellCommand to shellCommand & " " & quoted form of (commandArg as text)' \
+        -e 'end repeat' \
+        -e 'do shell script shellCommand with administrator privileges' \
+        -e 'end run' \
+        -- "$command_path" "$@"
 }
 
 verify_app_bundle() {
     local app_path="$1"
+    local app_name="${app_path##*/}"
+    # Mounted DMGs are untrusted input.  The source bundle name is later
+    # handed to a privileged file operation, so reject shell-significant and
+    # control characters before any install work.  Staging names are also
+    # checked here and intentionally use the same conservative character set.
+    [ -n "$app_name" ] || return 1
+    case "$app_name" in
+        *[!A-Za-z0-9._-]*) return 1 ;;
+    esac
     for required in \
         "$app_path/Contents/Info.plist" \
         "$app_path/Contents/MacOS/MetalSharp" \
@@ -243,7 +289,7 @@ require_app_version() {
 restore_backup() {
     if [ -d "$BACKUP_APP_PATH" ] && [ ! -d "$APP_PATH" ]; then
         mv "$BACKUP_APP_PATH" "$APP_PATH" 2>/dev/null || \
-            run_privileged "mv '$BACKUP_APP_PATH' '$APP_PATH'" || true
+            run_privileged mv "$BACKUP_APP_PATH" "$APP_PATH" || true
     fi
 }
 
@@ -297,9 +343,7 @@ MOUNT_POINT="$(mktemp -d "${TMPDIR:-/tmp}/metalsharp-update-mount.XXXXXX")" || {
     exit 1
 }
 if ! hdiutil attach -nobrowse -mountpoint "$MOUNT_POINT" "$DMG_PATH" >/dev/null 2>&1; then
-    escaped_dmg="${DMG_PATH//\"/\\\"}"
-    escaped_mount="${MOUNT_POINT//\"/\\\"}"
-    osascript -e "do shell script \"hdiutil attach -nobrowse -mountpoint \\\"$escaped_mount\\\" \\\"$escaped_dmg\\\"\" with administrator privileges" >/dev/null 2>&1 || true
+    run_privileged hdiutil-attach "$MOUNT_POINT" "$DMG_PATH" >/dev/null 2>&1 || true
     sleep 2
 fi
 
@@ -311,7 +355,7 @@ fi
 
 write_status "mounted" 45 "Mounted at $MOUNT_POINT"
 
-APP_SOURCE=$(find "$MOUNT_POINT" -maxdepth 1 -name "*.app" -iname "*metalsharp*" 2>/dev/null | head -1)
+APP_SOURCE="$(find "$MOUNT_POINT" -maxdepth 1 -type d -name "*.app" -iname "*metalsharp*" -print -quit 2>/dev/null)"
 if [ -z "$APP_SOURCE" ]; then
     write_status "error" 50 "MetalSharp.app not found in update" "app_not_found"
     exit 1
@@ -333,7 +377,7 @@ fi
 write_status "installing" 50 "Staging new version..."
 rm -rf "$TMP_APP_PATH" "$BACKUP_APP_PATH" 2>/dev/null || true
 ditto "$APP_SOURCE" "$TMP_APP_PATH" 2>/dev/null || {
-    run_privileged "ditto '$APP_SOURCE' '$TMP_APP_PATH'" || true
+    run_privileged ditto "$APP_SOURCE" "$TMP_APP_PATH" || true
     sleep 1
 }
 
@@ -346,7 +390,7 @@ require_app_version "$TMP_APP_PATH" "Staged app"
 write_status "installing" 65 "Installing new version..."
 if [ -d "$APP_PATH" ]; then
     mv "$APP_PATH" "$BACKUP_APP_PATH" 2>/dev/null || {
-        run_privileged "mv '$APP_PATH' '$BACKUP_APP_PATH'" || true
+        run_privileged mv "$APP_PATH" "$BACKUP_APP_PATH" || true
         sleep 1
     }
     if [ -d "$APP_PATH" ]; then
@@ -356,7 +400,7 @@ if [ -d "$APP_PATH" ]; then
 fi
 
 mv "$TMP_APP_PATH" "$APP_PATH" 2>/dev/null || {
-    run_privileged "mv '$TMP_APP_PATH' '$APP_PATH'" || true
+    run_privileged mv "$TMP_APP_PATH" "$APP_PATH" || true
     sleep 1
 }
 

--- a/tools/ci/test_updater_security.py
+++ b/tools/ci/test_updater_security.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Regression tests for updater privileged-operation path handling."""
+
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SHELL_UPDATER = ROOT / "app" / "updater" / "update.sh"
+PYTHON_UPDATER = ROOT / "app" / "updater" / "update.py"
+
+
+def load_python_updater():
+    spec = importlib.util.spec_from_file_location("metalsharp_updater", PYTHON_UPDATER)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("unable to load updater module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+updater = load_python_updater()
+
+
+class UpdaterSecurityTests(unittest.TestCase):
+    def test_shell_updater_passes_paths_as_osascript_arguments(self):
+        source = SHELL_UPDATER.read_text()
+
+        self.assertIn("on run argv", source)
+        self.assertIn("quoted form of (commandArg as text)", source)
+        self.assertIn('run_privileged ditto "$APP_SOURCE" "$TMP_APP_PATH"', source)
+        self.assertIn('run_privileged hdiutil-attach "$MOUNT_POINT" "$DMG_PATH"', source)
+        self.assertNotIn("${command//\\\"/", source)
+        self.assertNotIn("run_privileged \"ditto '$APP_SOURCE'", source)
+        self.assertNotIn("escaped_dmg=", source)
+        self.assertNotIn("escaped_mount=", source)
+
+    def test_shell_privileged_fallback_keeps_untrusted_path_out_of_script(self):
+        function_source = subprocess.run(
+            [
+                "sed",
+                "-n",
+                "/^run_privileged() {/,/^}/p",
+                str(SHELL_UPDATER),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        malicious_path = "/tmp/MetalSharp'$(touch /tmp/pwned)'.app"
+
+        with tempfile.TemporaryDirectory(prefix="updater-shell-security-") as temp:
+            temp_path = Path(temp)
+            capture = temp_path / "osascript-argv.json"
+            fake_osascript = temp_path / "osascript"
+            fake_osascript.write_text(
+                "#!/usr/bin/env python3\n"
+                "import json\n"
+                "import os\n"
+                "import sys\n"
+                "with open(os.environ['CAPTURE'], 'w') as handle:\n"
+                "    json.dump(sys.argv[1:], handle)\n"
+            )
+            fake_osascript.chmod(0o755)
+            environment = {
+                **os.environ,
+                "CAPTURE": str(capture),
+                "PATH": f"{temp}:{os.environ['PATH']}",
+            }
+
+            subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    'eval "$1"; run_privileged ditto "$2" "$3"',
+                    "updater-test",
+                    function_source,
+                    malicious_path,
+                    "/Applications/.MetalSharp.app.update.123",
+                ],
+                check=True,
+                env=environment,
+            )
+
+            osascript_argv = json.loads(capture.read_text())
+            script_end = osascript_argv.index("--")
+            self.assertNotIn(malicious_path, osascript_argv[:script_end])
+            self.assertEqual(osascript_argv[script_end + 1], "/usr/bin/ditto")
+            self.assertEqual(osascript_argv[script_end + 2], malicious_path)
+
+    def test_shell_updater_rejects_unsafe_bundle_names(self):
+        source = SHELL_UPDATER.read_text()
+
+        self.assertIn("*[!A-Za-z0-9._-]*) return 1", source)
+
+    def test_python_privileged_fallback_keeps_untrusted_path_out_of_script(self):
+        malicious_path = "/tmp/MetalSharp'$(touch /tmp/pwned)'.app"
+        completed = [
+            subprocess.CompletedProcess(["cp"], 1, "", "permission denied"),
+            subprocess.CompletedProcess(["osascript"], 0, "", ""),
+        ]
+
+        with patch.object(updater, "run", side_effect=completed) as run:
+            self.assertTrue(updater.admin_cp_r(malicious_path, "/Applications/MetalSharp.app"))
+
+        privileged_argv = run.call_args_list[1].args[0]
+        script = privileged_argv[privileged_argv.index("-e") + 1]
+        self.assertIn(malicious_path, privileged_argv)
+        self.assertNotIn(malicious_path, script)
+        self.assertIn("quoted form of", script)
+        self.assertEqual(privileged_argv[privileged_argv.index("--") + 1], "/bin/cp")
+
+    @unittest.skipUnless(
+        sys.platform == "darwin" and shutil.which("osascript"),
+        "requires macOS osascript",
+    )
+    def test_apple_script_quoting_does_not_execute_path_payload(self):
+        with tempfile.TemporaryDirectory(prefix="updater-security-") as temp:
+            marker = Path(temp) / "executed"
+            malicious_path = f"{temp}/MetalSharp'$(touch {marker})'.app"
+            script = updater.PRIVILEGED_APPLESCRIPT.replace(
+                "do shell script shellCommand with administrator privileges",
+                "return shellCommand",
+            )
+
+            result = subprocess.run(
+                ["osascript", "-e", script, "--", "/bin/echo", malicious_path],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertFalse(marker.exists())
+            self.assertIn("quoted form", script)
+            self.assertIn("MetalSharp", result.stdout)
+
+    def test_python_updater_rejects_unsafe_bundle_name_before_file_checks(self):
+        malicious_path = "/tmp/MetalSharp'$(touch /tmp/pwned)'.app"
+
+        with patch.object(updater.subprocess, "run") as run:
+            self.assertFalse(updater.verify_app_bundle(malicious_path))
+
+        run.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Prevent attacker-controlled update bundle names and paths from becoming shell syntax in privileged macOS updater fallbacks.

Fixes #444

## Changes

- Replace shell-string `osascript` fallbacks in `update.sh` with a fixed command allowlist and AppleScript `argv` handling using `quoted form of` for every argument.
- Apply the same safe privileged-operation contract to the legacy `update.py` updater, including DMG mounting and file operations.
- Reject mounted app bundle names containing characters outside the conservative updater-safe set before bundle verification or staging.
- Add shell/Python regression coverage for the reported `MetalSharp'$(...)'.app` payload and run it in PR and main CI.

## PR Readiness (MANDATORY)

<!-- The checklist-exception label is used only for the intentionally inapplicable
     real-game and user-facing-documentation items; this is an updater-only
     security fix and does not change game launch behavior. -->

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
  - Not applicable: this changes only privileged updater path handling; no game launch behavior changed.
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
  - Not applicable: no rules or DLL maps changed.
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped
  - Not applicable: no version surfaces changed.
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
  - No bottle, runtime, migration, or game launch behavior changed.
- [ ] Docs / compatibility matrix updated for user-facing changes
  - Not applicable: this is an internal security hardening change with no user-facing contract change.
- [x] Regression test added for each bug fix

## Local checks

- [x] `tools/ci/shellcheck.sh` — ShellCheck passed for all 40 maintained scripts.
- [x] `python3 -m unittest -v tools/ci/test_updater_security.py` — 6 tests passed.
- [x] `python3 tools/ci/verify-dmg-workflow.py` — DMG workflow contract verified.
- [x] `bash -n app/updater/update.sh` passed.
- [x] `python3 -m py_compile app/updater/update.py tools/ci/test_updater_security.py` passed.
- [x] `git diff --check` passed.
- Rust, native C++, Electron/TypeScript, and real-game suites were intentionally skipped because no files in those surfaces changed.
- `python3 tools/ci/check-doc-freshness.py` passed with the existing warning for `docs/OPENGL-2-4-PLAN.md` lacking an `Updated:` header.

## Test notes

The regression tests exercise the shell helper with a fake `osascript`, verify untrusted paths remain separate process arguments rather than AppleScript source, verify the Python fallback contract, and reject the malicious app bundle name before filesystem checks. On macOS, the suite also validates AppleScript quoting without requesting administrator privileges.

No game launch was performed because this change only affects updater security and does not alter runtime or launch behavior.

## Risk

This changes only privileged fallback argument handling and preflight bundle-name validation. Normal updater commands and the non-privileged fast paths remain unchanged. The allowlisted command paths and AppleScript quoting prevent DMG-controlled names from becoming shell syntax. Revert commit `b0255ca3` to restore the previous implementation if needed.
