### PR TITLE
fix(wine): preserve managed executable path and exit code

### DIFF
--- a/docs/runtime/host-runtime-abi.md
+++ b/docs/runtime/host-runtime-abi.md
@@ -44,6 +44,17 @@ The initial implementation removes two brittle assumptions from the runtime:
 
 These are small changes, but they are the necessary shape: bottle manifests and installer runtime profiles can now configure shims through explicit runtime state instead of requiring patched binaries or one global machine assumption.
 
+### Managed PE/unixlib launch contract
+
+The Wine `mscoree` shim keeps the managed executable identity explicit across
+the PE/unix boundary. `_CorExeMain` fills `mscoree_cor_exe_main_params` with
+the Unix-form executable path and directory, passes that structure to
+`MSCOREE_FUNC_COR_EXE_MAIN`, and exits with the `exit_code` written by the Unix
+handler. The Unix handler must not infer the executable from `_` or
+`/proc/self/cmdline`; those are not portable on macOS. A failed bridge call
+leaves a non-zero exit code so a managed launch cannot report success without
+executing its assembly.
+
 ## Bottle Manifest Mapping
 
 Future bottle manifests should map directly to ABI structs:

--- a/src/wine/mscoree_pe.cpp
+++ b/src/wine/mscoree_pe.cpp
@@ -307,14 +307,15 @@ void WINAPI _CorExeMain(void) {
     strncpy(params.exe_path, unix_exe, sizeof(params.exe_path) - 1);
     strncpy(params.exe_dir, unix_dir, sizeof(params.exe_dir) - 1);
     params.argc = 0;
-    params.exit_code = 0;
+    // Keep launch failures non-zero if the bridge cannot update the result.
+    params.exit_code = 1;
 
     fprintf(stderr, "[mscoree] calling unix bridge INIT...\n");
     NTSTATUS init_status = unix_call(MSCOREE_FUNC_INIT, NULL);
     fprintf(stderr, "[mscoree] INIT returned %ld\n", (long)init_status);
 
-    fprintf(stderr, "[mscoree] calling unix bridge _CorExeMain (no args)...\n");
-    NTSTATUS cor_status = unix_call(MSCOREE_FUNC_COR_EXE_MAIN, NULL);
+    fprintf(stderr, "[mscoree] calling unix bridge _CorExeMain (exe=%s)...\n", params.exe_path);
+    NTSTATUS cor_status = unix_call(MSCOREE_FUNC_COR_EXE_MAIN, &params);
     fprintf(stderr, "[mscoree] _CorExeMain returned %ld\n", (long)cor_status);
 
     ExitProcess(params.exit_code);

--- a/src/wine/mscoree_unix.c
+++ b/src/wine/mscoree_unix.c
@@ -182,42 +182,31 @@ static int do_init(void* args) {
 }
 
 static int do_cor_exe_main(void* args) {
-    (void)args;
     fprintf(stderr, "[mscoree-unix] do_cor_exe_main ENTRY\n");
     fflush(stderr);
+
+    struct mscoree_cor_exe_main_params* params = (struct mscoree_cor_exe_main_params*)args;
+    if (!params) {
+        fprintf(stderr, "[mscoree-unix] _CorExeMain requires launch parameters\n");
+        return -1;
+    }
+
+    // The PE side owns this structure and consumes the result after the call.
+    // Start in the failure state so every early return is reported as an error
+    // instead of silently becoming a successful process exit.
+    params->exit_code = 1;
 
     if (load_mono() < 0) {
         fprintf(stderr, "[mscoree-unix] mono not loaded\n");
         return -1;
     }
 
-    extern char** environ;
-    char exe_path[1024] = {0};
-    int found = 0;
-
-    for (int i = 0; environ[i]; i++) {
-        if (strncmp(environ[i], "WINELOADERNOEXEC=", 17) == 0)
-            continue;
+    if (!params->exe_path[0]) {
+        fprintf(stderr, "[mscoree-unix] _CorExeMain received an empty exe path\n");
+        return -1;
     }
 
-    for (char** env = environ; *env; env++) {
-        if (strncmp(*env, "_=", 2) == 0) {
-            strncpy(exe_path, *env + 2, sizeof(exe_path) - 1);
-            found = 1;
-            break;
-        }
-    }
-
-    if (!found) {
-        char* path = getenv("PATH");
-        (void)path;
-        FILE* f = fopen("/proc/self/cmdline", "r");
-        if (f) {
-            fgets(exe_path, sizeof(exe_path), f);
-            fclose(f);
-            found = 1;
-        }
-    }
+    fprintf(stderr, "[mscoree-unix] using PE launch parameters: exe=%s dir=%s\n", params->exe_path, params->exe_dir);
 
     fprintf(stderr, "[mscoree-unix] about to call mono_jit_init_version...\n");
     fflush(stderr);
@@ -252,14 +241,8 @@ static int do_cor_exe_main(void* args) {
 
     MonoImageOpenStatus status;
 
-    const char* exe_to_load = found ? exe_path : getenv("_");
-    if (!exe_to_load || !exe_to_load[0]) {
-        fprintf(stderr, "[mscoree-unix] no exe path found\n");
-        return -1;
-    }
-
     char unix_path[1024];
-    const char* src = exe_to_load;
+    const char* src = params->exe_path;
     char* dst = unix_path;
     while (*src && dst < unix_path + sizeof(unix_path) - 1) {
         *dst++ = (*src == '\\') ? '/' : *src;
@@ -284,6 +267,7 @@ static int do_cor_exe_main(void* args) {
     g_mono_initialized = 1;
     char* argv[] = {unix_path, NULL};
     int exit_code = p_mono_jit_exec(domain, assembly, 1, argv);
+    params->exit_code = exit_code;
     fprintf(stderr, "[mscoree-unix] mono_jit_exec returned %d\n", exit_code);
 
     p_mono_thread_manage();

--- a/src/wine/mscoree_unix.h
+++ b/src/wine/mscoree_unix.h
@@ -20,6 +20,8 @@ enum mscoree_func_id {
 };
 
 struct mscoree_cor_exe_main_params {
+    // The PE caller populates exe_path/exe_dir before MSCOREE_FUNC_COR_EXE_MAIN.
+    // The Unix handler writes the managed entry point's result to exit_code.
     char exe_path[1024];
     char exe_dir[1024];
     int argc;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -347,3 +347,23 @@ add_executable(test_kernel32_wide
 )
 target_link_libraries(test_kernel32_wide PRIVATE metalsharp_loader metalsharp_core)
 add_test(NAME kernel32_wide COMMAND test_kernel32_wide)
+
+# The mscoree PE shim is built for Wine's x86_64 lane outside the host-native
+# targets above. Exercise its host-side unixlib contract here with a small
+# fake Mono dylib: the regression must use the PE-provided executable path and
+# copy Mono's result back into the shared launch-parameter structure.
+add_library(test_mscoree_mono SHARED
+    test_mscoree_mono.c
+)
+
+add_executable(test_mscoree_unix
+    test_mscoree_unix.c
+    ${CMAKE_SOURCE_DIR}/src/wine/mscoree_unix.c
+)
+target_include_directories(test_mscoree_unix PRIVATE ${CMAKE_SOURCE_DIR}/src/wine)
+target_link_libraries(test_mscoree_unix PRIVATE ${CMAKE_DL_LIBS})
+add_dependencies(test_mscoree_unix test_mscoree_mono)
+add_test(NAME mscoree_unix COMMAND test_mscoree_unix)
+set_tests_properties(mscoree_unix PROPERTIES
+    ENVIRONMENT "METALSHARP_MONO_LIB=$<TARGET_FILE:test_mscoree_mono>"
+)

--- a/tests/test_mscoree_mono.c
+++ b/tests/test_mscoree_mono.c
@@ -1,0 +1,85 @@
+#include <stddef.h>
+#include <string.h>
+
+typedef struct _MonoDomain MonoDomain;
+typedef struct _MonoAssembly MonoAssembly;
+typedef struct _MonoImage MonoImage;
+typedef int MonoImageOpenStatus;
+
+struct _MonoDomain {
+    int unused;
+};
+
+struct _MonoAssembly {
+    int unused;
+};
+
+struct _MonoImage {
+    int unused;
+};
+
+static MonoDomain domain;
+static MonoAssembly assembly;
+static MonoImage image;
+
+static const char* expected_exe_path = "test-fixtures/managed-exit-37.exe";
+
+MonoDomain* mono_jit_init(const char* domain_name) {
+    return domain_name && domain_name[0] ? &domain : NULL;
+}
+
+MonoDomain* mono_jit_init_version(const char* domain_name, const char* runtime_version) {
+    (void)runtime_version;
+    return mono_jit_init(domain_name);
+}
+
+int mono_jit_exec(MonoDomain* jit_domain, MonoAssembly* jit_assembly, int argc, char* argv[]) {
+    if (jit_domain != &domain || jit_assembly != &assembly || argc != 1 || !argv || !argv[0] ||
+        strcmp(argv[0], expected_exe_path) != 0)
+        return 91;
+    return 37;
+}
+
+MonoAssembly* mono_assembly_open(const char* filename, MonoImageOpenStatus* status) {
+    (void)filename;
+    if (status)
+        *status = 0;
+    return &assembly;
+}
+
+MonoImage* mono_assembly_get_image(MonoAssembly* loaded_assembly) {
+    return loaded_assembly == &assembly ? &image : NULL;
+}
+
+MonoAssembly* mono_assembly_load_from(MonoImage* loaded_image, const char* filename, MonoImageOpenStatus* status) {
+    if (status)
+        *status = loaded_image == &image && filename && strcmp(filename, expected_exe_path) == 0 ? 0 : 1;
+    return loaded_image == &image && filename && strcmp(filename, expected_exe_path) == 0 ? &assembly : NULL;
+}
+
+MonoImage* mono_image_open(const char* filename, MonoImageOpenStatus* status) {
+    if (status)
+        *status = filename && strcmp(filename, expected_exe_path) == 0 ? 0 : 1;
+    return filename && strcmp(filename, expected_exe_path) == 0 ? &image : NULL;
+}
+
+void mono_set_dirs(const char* assembly_dir, const char* config_dir) {
+    (void)assembly_dir;
+    (void)config_dir;
+}
+
+void mono_config_parse(const char* filename) {
+    (void)filename;
+}
+
+MonoDomain* mono_domain_get(void) {
+    return &domain;
+}
+
+void mono_thread_attach(MonoDomain* attached_domain) {
+    (void)attached_domain;
+}
+
+void mono_thread_manage(void) {}
+
+void mono_runtime_quit(void) {}

--- a/tests/test_mscoree_unix.c
+++ b/tests/test_mscoree_unix.c
@@ -1,0 +1,36 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "mscoree_unix.h"
+
+typedef long NTSTATUS;
+typedef NTSTATUS (*unixlib_call_t)(unsigned int, void*);
+
+extern unixlib_call_t __wine_unix_call_funcs[2];
+
+static int fail(const char* message) {
+    fprintf(stderr, "test_mscoree_unix: %s\n", message);
+    return 1;
+}
+
+int main(void) {
+    unsetenv("_");
+
+    struct mscoree_cor_exe_main_params params;
+    memset(&params, 0, sizeof(params));
+    strcpy(params.exe_path, "test-fixtures/managed-exit-37.exe");
+    strcpy(params.exe_dir, "test-fixtures");
+    params.exit_code = 99;
+
+    if (__wine_unix_call_funcs[0](MSCOREE_FUNC_INIT, NULL) != 0)
+        return fail("Mono initialization failed");
+
+    NTSTATUS status = __wine_unix_call_funcs[1](MSCOREE_FUNC_COR_EXE_MAIN, &params);
+    if (status != 37)
+        return fail("the Unix bridge did not return Mono's exit code");
+    if (params.exit_code != 37)
+        return fail("the Unix bridge did not write the exit code to the launch parameters");
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

Fixes #436 by preserving the managed executable identity across MetalSharp's Wine `mscoree` PE/unixlib boundary and returning Mono's managed exit code to the PE caller.

## Changes

- Pass the populated `mscoree_cor_exe_main_params` to `MSCOREE_FUNC_COR_EXE_MAIN`.
- Make the Unix handler consume the PE-provided executable path instead of guessing through `_` or `/proc/self/cmdline`.
- Copy the managed entry-point result into `params.exit_code` and default bridge failures to a non-zero result.
- Add a fake-Mono CTest regression harness covering the macOS unixlib contract and document the contract in the host-runtime ABI guide.

## PR Readiness (MANDATORY)

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

The real-game item is intentionally excepted: this is an isolated Wine unixlib contract fix, and no managed game/Wine bottle was available in this checkout. The regression harness uses a fake Mono dylib to exercise the exact executable-path and exit-code handoff. The `checklist-exception` label is applied for this non-applicable readiness item.

## Local toolchain (run before push)

- [x] `cmake -S . -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON && cmake --build build-native --parallel "$(sysctl -n hw.ncpu)"` passes
- [x] `ctest --test-dir build-native --output-on-failure` passes (32/32)
- [x] `tools/ci/check-clang-format.sh` passes
- [x] `python3 tools/ci/check-doc-freshness.py` passes (existing warning: `docs/OPENGL-2-4-PLAN.md` has no `Updated:` header)
- [x] `git diff --check` passes
- [x] `x86_64-w64-mingw32-g++ -std=c++20 -D_WIN32 -D_WIN64 -fsyntax-only -Isrc/wine src/wine/mscoree_pe.cpp` passes
- [ ] Rust, Electron/TypeScript, shell, rules, DMG, and D3D12 SDK gates not run; no files in those surfaces changed
- [ ] Tested with at least one game; see the intentional exception above
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files added to the repository root

## Test notes

- `mscoree_unix` targeted CTest passed with the fake Mono dylib and no `_` environment executable hint.
- The full native suite passed: 32 tests, 0 failures, including the new `mscoree_unix` test.
- The MinGW syntax-only check passed for the modified PE shim.
- No real game launch was attempted because the required managed game/Wine bottle was not present in the isolated checkout.

## Risk

The change is limited to the Wine `mscoree` managed-launch bridge. Malformed or unavailable bridge state now exits non-zero rather than reporting success without running the assembly. No bottle migration, route selection, graphics runtime, or release bundle behavior changes. Rollback is a single commit revert if a Wine Mono consumer exposes an incompatible unixlib call shape.
