### PR TITLE
fix: harden renderer IPC and updater install

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -20,6 +20,7 @@
     "rust:build": "cd src-rust && cargo build --release",
     "rust:dev": "cd src-rust && cargo build",
     "build:all": "npm run rust:build && npm run build",
+    "test:security": "rm -rf .test-dist && trap 'rm -rf .test-dist' EXIT && tsc -p tsconfig.test.json && node --test .test-dist/main/security.test.js",
     "build:native": "bash ../scripts/tools/native/build-helper.sh",
     "pack": "npm run build:all && npm run prepare:native && electron-builder --dir",
     "prepare:native": "../tools/package/prepare-native.sh",
@@ -138,6 +139,10 @@
       {
         "from": "updater",
         "to": "scripts/tools/updater"
+      },
+      {
+        "from": "../scripts/install-metalsharp-wine-runtime.sh",
+        "to": "scripts/install-metalsharp-wine-runtime.sh"
       },
       {
         "from": "../configs",

--- a/app/src/main/dependency-actions.ts
+++ b/app/src/main/dependency-actions.ts
@@ -1,0 +1,46 @@
+export type BrewDependency = "game-porting-toolkit" | "molten-vk" | "mono";
+export type DependencyScript = "install-metalsharp-wine-runtime";
+
+export type InstallDepsAction = { kind: "brew"; package: BrewDependency } | { kind: "script"; name: DependencyScript };
+
+const BREW_DEPENDENCIES: readonly BrewDependency[] = ["game-porting-toolkit", "molten-vk", "mono"];
+const DEPENDENCY_SCRIPTS: Readonly<Record<DependencyScript, string>> = {
+  "install-metalsharp-wine-runtime": "install-metalsharp-wine-runtime.sh",
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const actual = Object.keys(value).sort();
+  return actual.length === keys.length && actual.every((key, index) => key === [...keys].sort()[index]);
+}
+
+export function parseInstallDepsAction(value: unknown): InstallDepsAction | null {
+  if (!isRecord(value) || typeof value.kind !== "string") return null;
+
+  if (
+    value.kind === "brew" &&
+    typeof value.package === "string" &&
+    BREW_DEPENDENCIES.includes(value.package as BrewDependency)
+  ) {
+    if (!hasExactKeys(value, ["kind", "package"])) return null;
+    return { kind: "brew", package: value.package as BrewDependency };
+  }
+
+  if (
+    value.kind === "script" &&
+    typeof value.name === "string" &&
+    Object.prototype.hasOwnProperty.call(DEPENDENCY_SCRIPTS, value.name)
+  ) {
+    if (!hasExactKeys(value, ["kind", "name"])) return null;
+    return { kind: "script", name: value.name as DependencyScript };
+  }
+
+  return null;
+}
+
+export function dependencyScriptFileName(name: DependencyScript): string {
+  return DEPENDENCY_SCRIPTS[name];
+}

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -11,6 +11,13 @@ import {
   type ProcessRow,
   stopMetalSharpWineProcesses,
 } from "./process-manager";
+import { dependencyScriptFileName, parseInstallDepsAction } from "./dependency-actions";
+import {
+  type BackendMethod,
+  type BackendRequestSource,
+  isBackendRequestBody,
+  validateBackendRequest,
+} from "./ipc-security";
 import type { ProcessManagerAction, ProcessManagerActionResult, ProcessManagerSample } from "./process-manager-types";
 import { RustBridge } from "./rust-bridge";
 import { validateUninstallTarget } from "./uninstall-safety";
@@ -282,9 +289,17 @@ function deleteInstalledUpdateDmg(): string | null {
 
   const msDir = path.resolve(getMetalsharpDir());
   const updatesDir = path.join(msDir, "cache", "updates");
-  const allowed =
-    dmgPath.startsWith(updatesDir + path.sep) || path.basename(dmgPath).toLowerCase().startsWith("metalsharp-");
-  if (!allowed) return null;
+  if (!dmgPath.startsWith(path.resolve(updatesDir) + path.sep)) return null;
+  try {
+    if (
+      fs.lstatSync(dmgPath).isSymbolicLink() ||
+      !fs.realpathSync(dmgPath).startsWith(path.resolve(updatesDir) + path.sep)
+    ) {
+      return null;
+    }
+  } catch {
+    return null;
+  }
 
   fs.rmSync(dmgPath, { force: true });
   return dmgPath;
@@ -553,7 +568,7 @@ function registerProcessManagerShortcut(): void {
 }
 
 async function stopActiveGameFromShortcut(): Promise<void> {
-  const result = (await requestBackend("POST", "/games/stop-active", undefined, 15000)) as {
+  const result = (await requestBackend("POST", "/games/stop-active", undefined, 15000, "main")) as {
     ok?: boolean;
     active?: boolean;
     stopped?: Array<{ appid?: number }>;
@@ -583,7 +598,7 @@ function registerGameStopShortcut(): void {
 async function checkNeedsMigration(): Promise<boolean> {
   const marker = hasPostUpdateMigrationMarker();
   try {
-    const data = (await requestBackend("GET", "/update/migrate/check", undefined, 3000)) as {
+    const data = (await requestBackend("GET", "/update/migrate/check", undefined, 3000, "main")) as {
       ok?: boolean;
       needed?: boolean;
     };
@@ -754,13 +769,24 @@ function backendErrorMessage(error: unknown): string {
 }
 
 async function requestBackend(
-  method: string,
-  url: string,
-  body?: Record<string, unknown>,
-  timeoutMs?: number,
+  method: unknown,
+  url: unknown,
+  body?: unknown,
+  timeoutMs?: unknown,
+  source: BackendRequestSource = "renderer",
 ): Promise<unknown> {
+  const validation = validateBackendRequest(method, url, source);
+  if (!validation.ok) return { ok: false, error: validation.error };
+  if (!isBackendRequestBody(body)) return { ok: false, error: "Backend request body is not allowed" };
+  if (
+    timeoutMs !== undefined &&
+    (typeof timeoutMs !== "number" || !Number.isInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 10 * 60 * 1000)
+  ) {
+    return { ok: false, error: "Backend request timeout is not allowed" };
+  }
+
   if (isUiOnlyRuntime()) {
-    return uiOnlyBackendResponse(method, url);
+    return uiOnlyBackendResponse(validation.method, validation.url);
   }
 
   const ready = await bridge.ensureRunning();
@@ -769,7 +795,7 @@ async function requestBackend(
   }
 
   try {
-    return await bridge.request(method, url, body, timeoutMs);
+    return await bridge.request(validation.method, validation.url, body, timeoutMs as number | undefined);
   } catch (e) {
     return { ok: false, error: backendErrorMessage(e) };
   }
@@ -793,7 +819,7 @@ async function requestBackendAsset(url: string, timeoutMs?: number): Promise<unk
 }
 
 async function requestMigrationBackend(
-  method: string,
+  method: BackendMethod,
   url: string,
   body?: Record<string, unknown>,
   timeoutMs?: number,
@@ -806,7 +832,7 @@ async function requestMigrationBackend(
     };
   }
 
-  return requestBackend(method, url, body, timeoutMs);
+  return requestBackend(method, url, body, timeoutMs, "main");
 }
 
 async function showUninstallBlocked(window: BrowserWindow, targetPath: string, reason: string): Promise<void> {
@@ -824,12 +850,9 @@ async function showUninstallBlocked(window: BrowserWindow, targetPath: string, r
 }
 
 function registerIpc() {
-  ipcMain.handle(
-    "backend:request",
-    async (_e, method: string, url: string, body?: Record<string, unknown>, timeoutMs?: number) => {
-      return requestBackend(method, url, body, timeoutMs);
-    },
-  );
+  ipcMain.handle("backend:request", async (_e, method: unknown, url: unknown, body?: unknown, timeoutMs?: unknown) => {
+    return requestBackend(method, url, body, timeoutMs);
+  });
   ipcMain.handle("backend:cover", async (_e, id: string) => {
     if (
       isUiOnlyRuntime() ||
@@ -996,21 +1019,15 @@ function registerIpc() {
     }
   });
 
-  ipcMain.handle("app:install-deps", async (_e, command: string) => {
-    return new Promise((resolve) => {
-      const { spawn } = require("child_process");
-      const env = { ...process.env, PATH: ensureShellPath() };
-      const brewPath = ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"].find((p) => {
-        try {
-          fs.accessSync(p);
-          return true;
-        } catch {
-          return false;
-        }
-      });
+  ipcMain.handle("app:install-deps", async (_e, input: unknown) => {
+    const action = parseInstallDepsAction(input);
+    if (!action) return { ok: false, error: "Unsupported dependency install action" };
 
-      let proc;
-      if (command.startsWith("brew ")) {
+    return new Promise((resolve) => {
+      const env = { ...process.env, PATH: ensureShellPath() };
+      let proc: ReturnType<typeof spawn>;
+      if (action.kind === "brew") {
+        const brewPath = findHomebrew();
         if (!brewPath) {
           resolve({
             ok: false,
@@ -1018,24 +1035,22 @@ function registerIpc() {
           });
           return;
         }
-        const args = command.split(/\s+/).slice(1);
-        proc = spawn(brewPath, args, { env });
-      } else if (command.startsWith("script:")) {
-        const scriptName = command.slice(7);
-        const candidates = [
-          path.join(path.dirname(app.getPath("exe")), "..", "scripts", scriptName),
-          path.join(getMetalsharpDir(), "scripts", scriptName),
-          path.join(__dirname, "..", "..", "..", "scripts", scriptName),
-        ];
-        const resolved = candidates.find((p) => fs.existsSync(p)) ?? null;
-        if (!resolved) {
-          resolve({ ok: false, error: `Script not found: ${scriptName}` });
+        proc = spawn(brewPath, ["install", action.package], { env });
+      } else {
+        const scriptsDir = app.isPackaged
+          ? path.join(process.resourcesPath, "scripts")
+          : path.resolve(__dirname, "..", "..", "..", "scripts");
+        const scriptPath = path.join(scriptsDir, dependencyScriptFileName(action.name));
+        try {
+          if (!fs.statSync(scriptPath).isFile()) {
+            resolve({ ok: false, error: `Dependency script is not available: ${action.name}` });
+            return;
+          }
+        } catch {
+          resolve({ ok: false, error: `Dependency script is not available: ${action.name}` });
           return;
         }
-        proc = spawn("/bin/bash", [resolved], { env });
-      } else {
-        const parts = command.split(/\s+/);
-        proc = spawn(parts[0], parts.slice(1), { env });
+        proc = spawn("/bin/bash", [scriptPath], { env });
       }
 
       let stdout = "";
@@ -1056,8 +1071,8 @@ function registerIpc() {
         10 * 60 * 1000,
       );
 
-      proc.stdout.on("data", (d: Buffer) => (stdout += d.toString()));
-      proc.stderr.on("data", (d: Buffer) => (stderr += d.toString()));
+      proc.stdout?.on("data", (d: Buffer) => (stdout += d.toString()));
+      proc.stderr?.on("data", (d: Buffer) => (stderr += d.toString()));
       proc.on("error", (err: Error) => {
         if (!settled) {
           settled = true;
@@ -1065,10 +1080,10 @@ function registerIpc() {
         }
         resolve({
           ok: false,
-          error: `Failed to run "${command}": ${err.message}`,
+          error: `Dependency installation failed: ${err.message}`,
         });
       });
-      proc.on("close", (code: number) => {
+      proc.on("close", (code: number | null) => {
         if (settled) return;
         settled = true;
         clearTimeout(timer);
@@ -1187,13 +1202,10 @@ function registerIpc() {
     return updaterBridge.ensureReady();
   });
 
-  ipcMain.handle(
-    "updater:spawn-install",
-    async (_e, dmgPath: string, backendPid: number, targetVersion: string, dmgSize: number, dmgSha256: string) => {
-      if (isUiOnlyRuntime()) return { ok: false, error: "Updater is disabled in UI-only preview mode." };
-      return updaterBridge.spawnInstallUpdater(dmgPath, backendPid, targetVersion, dmgSize, dmgSha256);
-    },
-  );
+  ipcMain.handle("updater:spawn-install", async () => {
+    if (isUiOnlyRuntime()) return { ok: false, error: "Updater is disabled in UI-only preview mode." };
+    return updaterBridge.spawnInstallUpdater();
+  });
 
   ipcMain.handle("updater:install-status", async () => {
     if (isUiOnlyRuntime()) return null;
@@ -1203,11 +1215,6 @@ function registerIpc() {
   ipcMain.handle("updater:clear-status", async () => {
     if (isUiOnlyRuntime()) return;
     updaterBridge.clearInstallStatus();
-  });
-
-  ipcMain.handle("backend:get-pid", async () => {
-    if (isUiOnlyRuntime()) return null;
-    return bridge.getBackendPid();
   });
 
   ipcMain.handle("migrate:check", async () => {

--- a/app/src/main/ipc-security.ts
+++ b/app/src/main/ipc-security.ts
@@ -1,0 +1,207 @@
+export type BackendMethod = "GET" | "POST";
+export type BackendRequestSource = "renderer" | "main";
+
+type QueryValidator = (params: URLSearchParams) => boolean;
+
+interface EndpointRule {
+  sources: readonly BackendRequestSource[];
+  validateQuery?: QueryValidator;
+}
+
+const RENDERER_ENDPOINTS = [
+  "GET /bottles",
+  "GET /bottles/profiles",
+  "GET /cache/size",
+  "GET /config",
+  "GET /diagnostics/m12/dry-run",
+  "GET /eac/status",
+  "GET /goldberg/status",
+  "GET /logs",
+  "GET /logs/crash-reports",
+  "GET /logs/stream",
+  "GET /metalfx/state",
+  "GET /mtsp/default-rules",
+  "GET /mtsp/pipelines",
+  "GET /scan",
+  "GET /setup/dependencies",
+  "GET /setup/device-name",
+  "GET /setup/install-progress",
+  "GET /setup/state",
+  "GET /sharp-library",
+  "GET /sharp-library/gog/games",
+  "GET /sharp-library/gog/status",
+  "GET /status",
+  "GET /steam/api-key",
+  "GET /steam/library",
+  "GET /steam/status",
+  "GET /steam/watch-steamapps",
+  "GET /update/check",
+  "GET /update/progress",
+  "GET /wine-mono/status",
+  "POST /bottles/doctor",
+  "POST /bottles/edit",
+  "POST /bottles/prepare",
+  "POST /bottles/refresh",
+  "POST /bottles/relaunch-installer",
+  "POST /bottles/repair-component",
+  "POST /bottles/set-runtime-profile",
+  "POST /bottles/set-windows-version",
+  "POST /cache/clear",
+  "POST /config",
+  "POST /d3dmetal/bottles/install-homebrew-gptk",
+  "POST /d3dmetal/bottles/install-rosetta",
+  "POST /d3dmetal/bottles/install-x64-redist",
+  "POST /d3dmetal/bottles/play",
+  "POST /d3dmetal/bottles/repair-gptk-payload",
+  "POST /d3dmetal/bottles/save",
+  "POST /d3dmetal/bottles/seed-prefix",
+  "POST /d3dmetal/bottles/status",
+  "POST /diagnostics/open",
+  "POST /eac/toggle",
+  "POST /game/launch-auto",
+  "POST /goldberg/toggle",
+  "POST /kill",
+  "POST /logs/crash-report",
+  "POST /metalfx/toggle",
+  "POST /mtsp/doctor",
+  "POST /processes/force-kill",
+  "POST /setup/install-all",
+  "POST /setup/install-vcpp-x64",
+  "POST /setup/install-vcpp-x86",
+  "POST /setup/save",
+  "POST /sharp-library/add-asset",
+  "POST /sharp-library/doctor",
+  "POST /sharp-library/gog/auth-code",
+  "POST /sharp-library/gog/initialize-prefix",
+  "POST /sharp-library/gog/install",
+  "POST /sharp-library/gog/logout",
+  "POST /sharp-library/gog/play",
+  "POST /sharp-library/gog/progress",
+  "POST /sharp-library/gog/remove-prefix",
+  "POST /sharp-library/gog/stop",
+  "POST /sharp-library/gog/sync",
+  "POST /sharp-library/gog/uninstall",
+  "POST /sharp-library/import-bottle-app",
+  "POST /sharp-library/install",
+  "POST /sharp-library/launch",
+  "POST /sharp-library/set-cover",
+  "POST /sharp-library/set-cover-position",
+  "POST /sharp-library/set-engine",
+  "POST /sharp-library/stop",
+  "POST /sharp-library/uninstall",
+  "POST /steam/install",
+  "POST /steam/launch",
+  "POST /steam/launch-game",
+  "POST /steam/mac-install",
+  "POST /steam/mac-launch",
+  "POST /steam/mac-stop",
+  "POST /steam/runtime-doctor",
+  "POST /steam/save-api-key",
+  "POST /steam/stop",
+  "POST /steam/uninstall-game",
+  "POST /update/start",
+  "POST /wine-mono/install",
+  "POST /wine-mono/reset",
+] as const;
+
+const MAIN_ONLY_ENDPOINTS = [
+  "GET /update/dmg-path",
+  "GET /update/migrate/check",
+  "GET /update/migrate/progress",
+  "POST /games/stop-active",
+  "POST /update/cleanup",
+  "POST /update/migrate/cleanup-preserved",
+  "POST /update/migrate/start",
+] as const;
+
+const appIdQuery: QueryValidator = (params) => {
+  if (params.size !== 1 || params.getAll("appid").length !== 1) return false;
+  const value = params.get("appid") ?? "";
+  if (!/^\d+$/.test(value)) return false;
+  const appid = Number(value);
+  return Number.isSafeInteger(appid) && appid >= 0 && appid <= 0xffffffff;
+};
+
+const prefixQuery: QueryValidator = (params) =>
+  params.size === 1 && params.getAll("prefix").length === 1 && ["gog", "steam"].includes(params.get("prefix") ?? "");
+
+const logStreamQuery: QueryValidator = (params) => {
+  if (params.size !== 1 || params.getAll("after").length !== 1) return false;
+  return /^(0|[1-9]\d*)$/.test(params.get("after") ?? "");
+};
+
+const QUERY_VALIDATORS = new Map<string, QueryValidator>([
+  ["GET /diagnostics/m12/dry-run", appIdQuery],
+  ["GET /eac/status", appIdQuery],
+  ["GET /goldberg/status", appIdQuery],
+  ["GET /logs/stream", logStreamQuery],
+  ["GET /mtsp/pipelines", appIdQuery],
+  ["GET /wine-mono/status", prefixQuery],
+]);
+
+const ENDPOINTS = new Map<string, EndpointRule>();
+for (const key of RENDERER_ENDPOINTS) {
+  ENDPOINTS.set(key, {
+    sources: ["renderer", "main"],
+    validateQuery: QUERY_VALIDATORS.get(key),
+  });
+}
+for (const key of MAIN_ONLY_ENDPOINTS) {
+  ENDPOINTS.set(key, { sources: ["main"] });
+}
+
+export type BackendRequestValidation = { ok: true; method: BackendMethod; url: string } | { ok: false; error: string };
+
+export function validateBackendRequest(
+  method: unknown,
+  url: unknown,
+  source: BackendRequestSource = "renderer",
+): BackendRequestValidation {
+  if (method !== "GET" && method !== "POST") {
+    return { ok: false, error: "Backend method is not allowed" };
+  }
+  if (typeof url !== "string" || url.length === 0 || !url.startsWith("/") || url.startsWith("//")) {
+    return { ok: false, error: "Backend URL must be a relative path" };
+  }
+  if (
+    [...url].some((character) => character.charCodeAt(0) < 0x20 || character.charCodeAt(0) === 0x7f) ||
+    /[\\%#]/.test(url)
+  ) {
+    return { ok: false, error: "Backend URL contains unsupported characters" };
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url, "http://127.0.0.1");
+  } catch {
+    return { ok: false, error: "Backend URL is invalid" };
+  }
+
+  const pathPart = url.split("?", 1)[0];
+  if (parsed.origin !== "http://127.0.0.1" || parsed.pathname !== pathPart || parsed.hash) {
+    return { ok: false, error: "Backend URL is invalid" };
+  }
+
+  const key = `${method} ${parsed.pathname}`;
+  const rule = ENDPOINTS.get(key);
+  if (!rule?.sources.includes(source)) {
+    return { ok: false, error: "Backend endpoint is not allowed" };
+  }
+  if (rule.validateQuery ? !rule.validateQuery(parsed.searchParams) : parsed.search !== "") {
+    return { ok: false, error: "Backend query is not allowed" };
+  }
+
+  return { ok: true, method, url };
+}
+
+export function isBackendRequestBody(value: unknown): value is Record<string, unknown> | undefined {
+  if (value === undefined) return true;
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  if (Object.getPrototypeOf(value) !== Object.prototype && Object.getPrototypeOf(value) !== null) return false;
+  try {
+    JSON.stringify(value);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/app/src/main/preload.ts
+++ b/app/src/main/preload.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer } from "electron";
+import type { InstallDepsAction } from "./dependency-actions";
 import type { ProcessManagerAction } from "./process-manager-types";
 
 contextBridge.exposeInMainWorld("metalsharp", {
@@ -10,7 +11,7 @@ contextBridge.exposeInMainWorld("metalsharp", {
   isMigrationMode: () => ipcRenderer.invoke("app:is-migration-mode"),
   restartAfterMigration: () => ipcRenderer.invoke("app:restart-after-migration"),
   ejectDmg: () => ipcRenderer.invoke("app:eject-dmg"),
-  installDeps: (command: string) => ipcRenderer.invoke("app:install-deps", command),
+  installDeps: (action: InstallDepsAction) => ipcRenderer.invoke("app:install-deps", action),
   installHomebrew: () => ipcRenderer.invoke("app:install-homebrew"),
   homebrewStatus: () => ipcRenderer.invoke("app:homebrew-status"),
   onSteamappsChanged: (callback: () => void) => ipcRenderer.on("steamapps:changed", callback),
@@ -27,16 +28,9 @@ contextBridge.exposeInMainWorld("metalsharp", {
   restartBackend: () => ipcRenderer.invoke("backend:restart"),
   isBackendAlive: () => ipcRenderer.invoke("backend:is-alive"),
   updaterEnsureReady: () => ipcRenderer.invoke("updater:ensure-ready"),
-  updaterSpawnInstall: (
-    dmgPath: string,
-    backendPid: number,
-    targetVersion: string,
-    dmgSize: number,
-    dmgSha256: string,
-  ) => ipcRenderer.invoke("updater:spawn-install", dmgPath, backendPid, targetVersion, dmgSize, dmgSha256),
+  updaterSpawnInstall: () => ipcRenderer.invoke("updater:spawn-install"),
   updaterInstallStatus: () => ipcRenderer.invoke("updater:install-status"),
   updaterClearStatus: () => ipcRenderer.invoke("updater:clear-status"),
-  backendGetPid: () => ipcRenderer.invoke("backend:get-pid"),
   migrateCheck: () => ipcRenderer.invoke("migrate:check"),
   migrateStart: () => ipcRenderer.invoke("migrate:start"),
   migrateProgress: () => ipcRenderer.invoke("migrate:progress"),

--- a/app/src/main/security.test.ts
+++ b/app/src/main/security.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { parseInstallDepsAction } from "./dependency-actions";
+import { isBackendRequestBody, validateBackendRequest } from "./ipc-security";
+import { validateDownloadedDmg } from "./updater-security";
+
+test("backend IPC only accepts allowlisted renderer routes and queries", () => {
+  assert.deepEqual(validateBackendRequest("GET", "/status"), {
+    ok: true,
+    method: "GET",
+    url: "/status",
+  });
+  assert.equal(validateBackendRequest("GET", "/diagnostics/m12/dry-run?appid=1583230").ok, true);
+  assert.equal(validateBackendRequest("GET", "/wine-mono/status?prefix=steam").ok, true);
+  assert.equal(validateBackendRequest("POST", "/processes/force-kill").ok, true);
+  assert.equal(validateBackendRequest("POST", "/update/start").ok, true);
+
+  assert.equal(validateBackendRequest("DELETE", "/status").ok, false);
+  assert.equal(validateBackendRequest("GET", "http://127.0.0.1/processes/force-kill").ok, false);
+  assert.equal(validateBackendRequest("GET", "/processes/force-kill").ok, false);
+  assert.equal(validateBackendRequest("GET", "/status?endpoint=/processes/force-kill").ok, false);
+  assert.equal(validateBackendRequest("GET", "/diagnostics/m12/dry-run?appid=not-a-number").ok, false);
+  assert.equal(validateBackendRequest("GET", "/wine-mono/status?prefix=other").ok, false);
+
+  assert.equal(validateBackendRequest("GET", "/update/migrate/check").ok, false);
+  assert.equal(validateBackendRequest("GET", "/update/migrate/check", "main").ok, true);
+});
+
+test("backend IPC bodies are plain JSON records", () => {
+  assert.equal(isBackendRequestBody(undefined), true);
+  assert.equal(isBackendRequestBody({ appid: 123 }), true);
+  assert.equal(isBackendRequestBody(Object.create(null)), true);
+  assert.equal(isBackendRequestBody(null), false);
+  assert.equal(isBackendRequestBody(["/processes/force-kill"]), false);
+});
+
+test("dependency IPC rejects free-form commands and unknown actions", () => {
+  assert.deepEqual(parseInstallDepsAction({ kind: "brew", package: "mono" }), {
+    kind: "brew",
+    package: "mono",
+  });
+  assert.deepEqual(parseInstallDepsAction({ kind: "script", name: "install-metalsharp-wine-runtime" }), {
+    kind: "script",
+    name: "install-metalsharp-wine-runtime",
+  });
+  assert.equal(parseInstallDepsAction("brew install --formula malicious"), null);
+  assert.equal(parseInstallDepsAction({ kind: "brew", package: "mono", args: ["--debug"] }), null);
+  assert.equal(parseInstallDepsAction({ kind: "script", name: "../../tmp/payload" }), null);
+  assert.equal(parseInstallDepsAction({ kind: "script", name: "toString" }), null);
+  assert.equal(parseInstallDepsAction({ kind: "script", name: "__proto__" }), null);
+  assert.equal(parseInstallDepsAction({ kind: "script", name: "constructor" }), null);
+});
+
+test("updater accepts only the backend-matched DMG in the update cache", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "metalsharp-447-"));
+  const updatesDir = path.join(root, "cache", "updates");
+  fs.mkdirSync(updatesDir, { recursive: true });
+  const dmgPath = path.join(updatesDir, "MetalSharp-1.2.3.dmg");
+  fs.writeFileSync(dmgPath, "dmg");
+
+  try {
+    const valid = validateDownloadedDmg(
+      {
+        ok: true,
+        path: dmgPath,
+        version: "1.2.3",
+        size: 3,
+        sha256: "00cbbd0ddbda2762798f7009838ed34ca1f12b93965813c7df22943bc62166d1",
+      },
+      updatesDir,
+    );
+    assert.equal(valid.ok, true);
+    if (valid.ok) assert.equal(valid.artifact.path, fs.realpathSync(dmgPath));
+
+    assert.equal(
+      validateDownloadedDmg(
+        {
+          ok: true,
+          path: path.join(root, "MetalSharp-1.2.3.dmg"),
+          version: "1.2.3",
+          size: 3,
+          sha256: "00cbbd0ddbda2762798f7009838ed34ca1f12b93965813c7df22943bc62166d1",
+        },
+        updatesDir,
+      ).ok,
+      false,
+    );
+    assert.equal(
+      validateDownloadedDmg(
+        {
+          ok: true,
+          path: dmgPath,
+          version: "1.2.4",
+          size: 3,
+          sha256: "00cbbd0ddbda2762798f7009838ed34ca1f12b93965813c7df22943bc62166d1",
+        },
+        updatesDir,
+      ).ok,
+      false,
+    );
+
+    const symlinkPath = path.join(updatesDir, "MetalSharp-1.2.3-arm64.dmg");
+    fs.symlinkSync(dmgPath, symlinkPath);
+    assert.equal(
+      validateDownloadedDmg(
+        {
+          ok: true,
+          path: symlinkPath,
+          version: "1.2.3",
+          size: 3,
+          sha256: "00cbbd0ddbda2762798f7009838ed34ca1f12b93965813c7df22943bc62166d1",
+        },
+        updatesDir,
+      ).ok,
+      false,
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/app/src/main/updater-bridge.ts
+++ b/app/src/main/updater-bridge.ts
@@ -4,12 +4,17 @@ import * as http from "http";
 import * as os from "os";
 import * as path from "path";
 import { BACKEND_TOKEN_HEADER } from "./rust-bridge";
+import { type VerifiedUpdateArtifact, validateDownloadedDmg } from "./updater-security";
 
 function getMetalsharpDir(): string {
   if (process.env.METALSHARP_HOME?.trim()) {
     return path.resolve(process.env.METALSHARP_HOME);
   }
   return path.join(os.homedir(), ".metalsharp");
+}
+
+function getUpdatesDir(): string {
+  return path.join(getMetalsharpDir(), "cache", "updates");
 }
 
 function getStatusFile(): string {
@@ -121,42 +126,59 @@ export class UpdaterBridge {
     });
   }
 
-  spawnInstallUpdater(
-    dmgPath: string,
-    backendPid: number,
-    targetVersion: string,
-    dmgSize: number,
-    dmgSha256: string,
-  ): { ok: boolean; error?: string } {
+  private async getDownloadedDmg(): Promise<
+    { ok: true; artifact: VerifiedUpdateArtifact } | { ok: false; error: string }
+  > {
+    return new Promise((resolve) => {
+      const token = this.authTokenProvider();
+      if (!token) {
+        resolve({ ok: false, error: "Could not authenticate with the MetalSharp backend" });
+        return;
+      }
+      const req = http.get(
+        {
+          hostname: "127.0.0.1",
+          port: this.backendPort,
+          path: "/update/dmg-path",
+          headers: { [BACKEND_TOKEN_HEADER]: token },
+        },
+        (res) => {
+          const chunks: Buffer[] = [];
+          res.on("data", (chunk) => chunks.push(chunk));
+          res.on("end", () => {
+            if (res.statusCode !== 200) {
+              resolve({ ok: false, error: "Backend did not provide a downloaded update" });
+              return;
+            }
+            try {
+              const data = JSON.parse(Buffer.concat(chunks).toString());
+              const validation = validateDownloadedDmg(data, getUpdatesDir());
+              resolve(validation);
+            } catch {
+              resolve({ ok: false, error: "Backend returned an invalid update artifact" });
+            }
+          });
+        },
+      );
+      req.on("error", () => resolve({ ok: false, error: "Could not verify the downloaded update with the backend" }));
+      req.setTimeout(1500, () => {
+        req.destroy();
+        resolve({ ok: false, error: "Timed out while verifying the downloaded update" });
+      });
+    });
+  }
+
+  async spawnInstallUpdater(): Promise<{ ok: boolean; error?: string }> {
     if (!this.scriptPath) {
       return { ok: false, error: "Updater not ready — update.sh missing" };
     }
 
-    if (typeof dmgPath !== "string" || typeof dmgSha256 !== "string") {
-      return { ok: false, error: "DMG path or integrity metadata is invalid" };
-    }
-    const updatesDir = path.resolve(getMetalsharpDir(), "cache", "updates");
-    const resolvedDmgPath = path.resolve(dmgPath);
-    if (!resolvedDmgPath.startsWith(`${updatesDir}${path.sep}`) || !fs.existsSync(resolvedDmgPath)) {
-      return { ok: false, error: `DMG file not found: ${dmgPath}` };
-    }
-    let realDmgPath: string;
-    try {
-      realDmgPath = fs.realpathSync(resolvedDmgPath);
-    } catch {
-      return { ok: false, error: `DMG file cannot be resolved: ${dmgPath}` };
-    }
-    let realUpdatesDir: string;
-    try {
-      realUpdatesDir = fs.realpathSync(updatesDir);
-    } catch {
-      return { ok: false, error: "MetalSharp update cache cannot be resolved" };
-    }
-    if (!realDmgPath.startsWith(`${realUpdatesDir}${path.sep}`)) {
-      return { ok: false, error: "DMG path must remain inside the MetalSharp update cache" };
-    }
-    if (!Number.isSafeInteger(dmgSize) || dmgSize <= 0 || !/^[0-9a-fA-F]{64}$/.test(dmgSha256)) {
-      return { ok: false, error: "DMG integrity metadata is missing or invalid" };
+    const downloaded = await this.getDownloadedDmg();
+    if (!downloaded.ok) return downloaded;
+
+    const backendPid = await this.getBackendPid();
+    if (!backendPid) {
+      return { ok: false, error: "Could not verify the MetalSharp backend process" };
     }
 
     fs.mkdirSync(getMetalsharpDir(), { recursive: true });
@@ -166,15 +188,15 @@ export class UpdaterBridge {
       [
         this.scriptPath,
         "--dmg",
-        resolvedDmgPath,
+        downloaded.artifact.path,
         "--dmg-size",
-        String(dmgSize),
+        String(downloaded.artifact.size),
         "--dmg-sha256",
-        dmgSha256,
+        downloaded.artifact.sha256,
         "--backend-pid",
         String(backendPid),
         "--target-version",
-        targetVersion,
+        downloaded.artifact.version,
         "--status-file",
         getStatusFile(),
         "--metalsharp-home",
@@ -195,7 +217,7 @@ export class UpdaterBridge {
 
     child.unref();
 
-    console.log(`Updater: spawned install script (pid=${child.pid}) for v${targetVersion}`);
+    console.log(`Updater: spawned install script (pid=${child.pid}) for v${downloaded.artifact.version}`);
 
     return { ok: true };
   }
@@ -233,7 +255,8 @@ export class UpdaterBridge {
 
   private static validateStatusPath(): boolean {
     const resolved = path.resolve(getStatusFile());
-    return resolved.startsWith(path.resolve(getMetalsharpDir()));
+    const root = path.resolve(getMetalsharpDir());
+    return resolved.startsWith(`${root}${path.sep}`);
   }
 
   readInstallStatus(): InstallStatus | null {

--- a/app/src/main/updater-security.ts
+++ b/app/src/main/updater-security.ts
@@ -1,0 +1,76 @@
+import * as fs from "fs";
+import * as path from "path";
+
+export interface VerifiedUpdateArtifact {
+  path: string;
+  version: string;
+  size: number;
+  sha256: string;
+}
+
+export type UpdateArtifactValidation = { ok: true; artifact: VerifiedUpdateArtifact } | { ok: false; error: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isWithinDirectory(candidate: string, directory: string): boolean {
+  return candidate.startsWith(`${directory}${path.sep}`);
+}
+
+export function validateDownloadedDmg(artifact: unknown, updatesDir: string): UpdateArtifactValidation {
+  if (
+    !isRecord(artifact) ||
+    artifact.ok !== true ||
+    typeof artifact.path !== "string" ||
+    typeof artifact.version !== "string" ||
+    typeof artifact.size !== "number" ||
+    !Number.isSafeInteger(artifact.size) ||
+    artifact.size <= 0 ||
+    typeof artifact.sha256 !== "string" ||
+    !/^[0-9a-fA-F]{64}$/.test(artifact.sha256)
+  ) {
+    return { ok: false, error: "Backend did not report a downloadable update with integrity metadata" };
+  }
+  if (!/^\d+(?:\.\d+){1,3}$/.test(artifact.version)) {
+    return { ok: false, error: "Backend reported an invalid update version" };
+  }
+
+  const updatesRoot = path.resolve(updatesDir);
+  const candidate = path.resolve(artifact.path);
+  if (!isWithinDirectory(candidate, updatesRoot)) {
+    return { ok: false, error: "Update DMG must be inside the MetalSharp update cache" };
+  }
+
+  const expectedNames = new Set([`MetalSharp-${artifact.version}.dmg`, `MetalSharp-${artifact.version}-arm64.dmg`]);
+  if (!expectedNames.has(path.basename(candidate))) {
+    return { ok: false, error: "Update DMG filename does not match the backend-reported version" };
+  }
+
+  try {
+    const linkStat = fs.lstatSync(candidate);
+    if (!linkStat.isFile() || linkStat.isSymbolicLink()) {
+      return { ok: false, error: "Update DMG is not a regular file" };
+    }
+    const resolvedRoot = fs.realpathSync(updatesRoot);
+    const resolvedCandidate = fs.realpathSync(candidate);
+    if (!isWithinDirectory(resolvedCandidate, resolvedRoot)) {
+      return { ok: false, error: "Update DMG resolves outside the MetalSharp update cache" };
+    }
+    const fileStat = fs.statSync(resolvedCandidate);
+    if (!fileStat.isFile() || fileStat.size === 0 || fileStat.size !== artifact.size) {
+      return { ok: false, error: "Update DMG is empty or does not match the reported size" };
+    }
+    return {
+      ok: true,
+      artifact: {
+        path: resolvedCandidate,
+        version: artifact.version,
+        size: artifact.size,
+        sha256: artifact.sha256.toLowerCase(),
+      },
+    };
+  } catch {
+    return { ok: false, error: "Update DMG is not available in the MetalSharp update cache" };
+  }
+}

--- a/app/src/renderer/App.vue
+++ b/app/src/renderer/App.vue
@@ -163,16 +163,6 @@ async function startUpdateDownload() {
     toast.show(ready?.error ?? "Updater not available", "error");
     return;
   }
-  const pid = await backend.backendGetPid();
-  if (!pid) {
-    toast.show("Cannot get backend PID", "error");
-    return;
-  }
-  const targetVersion = updateStatus.value?.latest_version ?? "";
-  if (!targetVersion) {
-    toast.show("Update version is unavailable", "error");
-    return;
-  }
   if (!updateStatus.value?.download_url) {
     toast.show("Update DMG asset is unavailable", "error");
     return;
@@ -203,28 +193,7 @@ async function startUpdateDownload() {
     if (progress.status === "downloaded" || progress.status === "complete") {
       if (updatePollTimer) clearInterval(updatePollTimer);
       updatePollTimer = null;
-      const dmgResult = await api<{ ok: boolean; path?: string; version?: string; size?: number; sha256?: string }>(
-        "GET",
-        "/update/dmg-path",
-      );
-      if (!dmgResult?.path) {
-        toast.show("Download complete but DMG not found", "error");
-        updateDownloading.value = false;
-        return;
-      }
-      if (!dmgResult.size || !dmgResult.sha256) {
-        toast.show("Download completed without integrity metadata", "error");
-        updateDownloading.value = false;
-        return;
-      }
-      const installVersion = dmgResult.version ?? targetVersion;
-      const spawnResult = await backend.updaterSpawnInstall(
-        dmgResult.path,
-        pid,
-        installVersion,
-        dmgResult.size,
-        dmgResult.sha256,
-      );
+      const spawnResult = await backend.updaterSpawnInstall();
       if (!spawnResult?.ok) {
         toast.show(spawnResult?.error ?? "Failed to start installer", "error");
         updateDownloading.value = false;

--- a/app/src/renderer/api-types.ts
+++ b/app/src/renderer/api-types.ts
@@ -75,6 +75,10 @@ interface UpdaterReadyResult {
   candidates?: string[];
 }
 
+type InstallDepsAction =
+  | { kind: "brew"; package: "game-porting-toolkit" | "molten-vk" | "mono" }
+  | { kind: "script"; name: "install-metalsharp-wine-runtime" };
+
 interface CrashReportSummary {
   id: string;
   timestamp: string;
@@ -220,7 +224,7 @@ type MetalsharpAPI = {
     launched?: string;
   }>;
   ejectDmg: () => Promise<void>;
-  installDeps: (command: string) => Promise<{ ok: boolean; error?: string }>;
+  installDeps: (action: InstallDepsAction) => Promise<{ ok: boolean; error?: string }>;
   installHomebrew: () => Promise<{ ok: boolean; installed?: boolean; path?: string; message?: string; error?: string }>;
   homebrewStatus: () => Promise<{ installed: boolean; path?: string }>;
   onSteamappsChanged: (callback: () => void) => void;
@@ -238,16 +242,9 @@ type MetalsharpAPI = {
   restartBackend: () => Promise<{ ok: boolean; error?: string }>;
   isBackendAlive: () => Promise<boolean>;
   updaterEnsureReady: () => Promise<UpdaterReadyResult>;
-  updaterSpawnInstall: (
-    dmgPath: string,
-    backendPid: number,
-    targetVersion: string,
-    dmgSize: number,
-    dmgSha256: string,
-  ) => Promise<{ ok: boolean; error?: string }>;
+  updaterSpawnInstall: () => Promise<{ ok: boolean; error?: string }>;
   updaterInstallStatus: () => Promise<InstallStatus | null>;
   updaterClearStatus: () => Promise<void>;
-  backendGetPid: () => Promise<number | null>;
   migrateCheck: () => Promise<BackendResponse>;
   migrateStart: () => Promise<BackendResponse>;
   migrateProgress: () => Promise<BackendResponse>;

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -14,5 +14,5 @@
     "sourceMap": true
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist", "src-rust"]
+  "exclude": ["node_modules", "dist", "src-rust", "src/**/*.test.ts"]
 }

--- a/app/tsconfig.test.json
+++ b/app/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": ".test-dist"
+  },
+  "include": ["src/main/security.test.ts"],
+  "exclude": []
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # MetalSharp Docs
-**Updated:** 2026-08-11
 
+**Updated:** 2026-08-11
 
 Use this page as the repo map before changing launch/runtime code.
 
@@ -34,6 +34,7 @@ Use this page as the repo map before changing launch/runtime code.
 
 - [Launch Architecture](architecture/launch-architecture.md) - pipeline selection and launch ownership.
 - [Backend HTTP Request Contract](architecture/backend-http-contract.md) - bounded JSON request bodies and client error responses.
+- [Electron IPC Security Contract](architecture/electron-ipc-security.md) - renderer trust boundary, backend allowlist, dependency actions, and updater validation.
 - [D3D12 Pipeline Map](architecture/m12-pipeline-map.md) - current M12 D3D12 path (vkd3d-proton default, DXMT rollback).
 - [D3D10 Pipeline Map](architecture/m10-pipeline-map.md) - current M10 D3D10/DXMT path.
 - [D3D9 Pipeline Map](architecture/m9-pipeline-map.md) - current M9 D3D9 route.

--- a/docs/architecture/electron-ipc-security.md
+++ b/docs/architecture/electron-ipc-security.md
@@ -1,0 +1,37 @@
+# Electron IPC Security Contract
+**Updated:** 2026-08-11
+
+MetalSharp's renderer is an untrusted caller. A renderer compromise must not
+turn the preload bridge into a generic command runner, arbitrary local HTTP
+client, or privileged installer launcher.
+
+## Trust-boundary rules
+
+- `backend:request` accepts only the exact `GET` and `POST` method/path pairs
+  used by the renderer. Query-bearing endpoints validate their query keys and
+  values (`appid`, `prefix`, and log offsets) instead of accepting arbitrary
+  URLs. Migration cleanup and update-cache cleanup are main-process-only
+  routes.
+- `app:install-deps` accepts a discriminated action union. Homebrew actions
+  select one of the checked-in package names; script actions select one of the
+  checked-in script names. The main process resolves scripts from the one
+  packaged/development `scripts` directory and never parses a renderer command
+  string.
+- `updater:spawn-install` takes no renderer-controlled path, PID, or version.
+  The main process asks the backend for the downloaded artifact, then requires
+  a regular, non-symlink DMG under the configured MetalSharp update cache whose
+  filename version exactly matches the backend-reported version. The backend
+  PID and application PID are obtained by trusted main-process code.
+
+The allowlist is intentionally explicit. Adding a renderer backend call
+requires adding its method/path and, when applicable, a query validator to
+`app/src/main/ipc-security.ts`, plus a renderer call-site test or review of the
+corresponding backend contract.
+
+## Compatibility
+
+The renderer's normal backend routes and update workflow remain unchanged from
+the user's perspective. The updater preload method is now parameterless, and
+the unused free-form dependency command interface is replaced by the typed
+action union. Backend route implementations remain the source of truth for
+their request bodies and existing process/PID containment checks.


### PR DESCRIPTION
## Summary

Fixes #447 by closing the renderer-to-main trust-boundary gaps in the Electron bridge and updater handoff.

## Changes

- Replace free-form `app:install-deps` command parsing with a discriminated, allowlisted action union for Homebrew packages and the pinned runtime script.
- Allow only the exact renderer backend method/path pairs and validated query parameters; keep migration/update cleanup routes main-process-only.
- Make updater installation parameterless from the renderer. The main process obtains the backend-reported DMG/version and backend PID, then verifies the regular non-symlink DMG is inside the configured update cache and matches its version before spawning the installer.
- Add focused security regression tests, exclude test modules from production builds, and document the IPC security contract.

## PR Readiness (MANDATORY)

<!-- This is a security-only trust-boundary change; the existing game route contract is preserved and full PR CI covers native/Metal compatibility gates. The checklist-exception label is applied for that item. -->

- [x] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

## Local toolchain (run before push)

- [ ] `cargo fmt --all -- --check` passes (Rust) — not applicable; no Rust files changed
- [ ] `cargo clippy --all-targets -- -D warnings` passes (Rust) — not applicable; no Rust files changed
- [ ] `cargo build --release` passes (Rust backend) — not applicable; no Rust files changed
- [ ] `cargo test` passes (Rust — 628+ tests) — not applicable; no Rust files changed
- [ ] C++ compiles if changed — not applicable; no native files changed
- [ ] `clang-format --dry-run --Werror` passes on any changed C/C++/Obj-C file — not applicable
- [ ] `ctest --test-dir build-native` passes if tests changed — not applicable
- [x] TypeScript compiles if changed: `cd app && npx tsc --noEmit`
- [x] Biome + Prettier pass if TS/JS changed
- [ ] Shell scripts lint if changed — no shell scripts changed
- [ ] `tools/ci/validate-rules-toml.py` passes if rules changed — no rules changed
- [x] `python3 tools/ci/verify-dmg-workflow.py` passes (packaging resources changed)
- [x] `git diff --check` passes
- [ ] Tested with at least one game — not applicable; no launch behavior changed
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files added at the repository root

## Test notes

- `npm ci`
- `npx tsc --noEmit`
- `npm run test:security` — 4 security regression subtests passed
- `npm run build` — production build passed; test modules excluded from `dist`
- `npx @biomejs/biome ci src/main src/shared` — passed
- `npx @biomejs/biome ci src/renderer` — passed with three pre-existing CSS specificity warnings
- `npx prettier --check 'src/renderer/**/*.{ts,js,html,css,json}' 'src/main/**/*.{ts,js,json}' 'src/shared/**/*.{ts,js,json}'` — passed
- `python3 tools/ci/verify-dmg-workflow.py` — passed
- `python3 tools/ci/check-doc-freshness.py` — warn-only pre-existing `docs/OPENGL-2-4-PLAN.md` header warning
- `git diff --check` — passed

## Risk

The renderer loses access to arbitrary backend routes, command strings, updater paths, versions, and PIDs. Existing allowlisted UI routes and backend body/PID containment contracts remain unchanged. If an allowlist entry is missing, the renderer receives a bounded error and the corresponding route can be explicitly added after review. Rollback is the single commit `4f28eddc`, although reverting would restore the reported IPC vulnerabilities.

