### PR TITLE
fix(kernel32): handle null ImageBase in RtlLookupFunctionEntry

### DIFF
--- a/src/win32/kernel32/Kernel32Extra.cpp
+++ b/src/win32/kernel32/Kernel32Extra.cpp
@@ -1951,6 +1951,7 @@ static void* MSABI shim_RtlCaptureStackBackTrace(DWORD FramesToSkip, DWORD Frame
 }
 static uint32_t s_fakeRuntimeFunc[3] = {0, 0, 0};
 static uint8_t s_fakeUnwindInfo[8] = {1, 0, 0, 0, 0, 0, 0, 0};
+static std::mutex s_fakeRuntimeFuncMutex;
 
 static void* MSABI shim_RtlLookupFunctionEntry(uint64_t ControlPoint, uint64_t* ImageBase, void* HistoryTable) {
     MS_INFO("TRACE: RtlLookupFunctionEntry(0x%llX)", (unsigned long long)ControlPoint);
@@ -1961,14 +1962,17 @@ static void* MSABI shim_RtlLookupFunctionEntry(uint64_t ControlPoint, uint64_t* 
     void* result = PELoader::instance()->lookupFunctionEntry(ControlPoint, ImageBase);
     if (!result) {
         MS_INFO("TRACE: RtlLookupFunctionEntry -> returning fake entry");
-        s_fakeRuntimeFunc[0] = 0;
-        s_fakeRuntimeFunc[1] = 0x1000;
-        auto* base = reinterpret_cast<uint8_t*>(*ImageBase);
+        auto* base = ImageBase ? reinterpret_cast<uint8_t*>(*ImageBase) : nullptr;
         if (!base)
             base = reinterpret_cast<uint8_t*>(PELoader::instance()->getMainModule()->base);
-        s_fakeRuntimeFunc[2] =
-            static_cast<uint32_t>(reinterpret_cast<uintptr_t>(s_fakeUnwindInfo) - reinterpret_cast<uintptr_t>(base));
-        result = s_fakeRuntimeFunc;
+        {
+            std::lock_guard<std::mutex> lock(s_fakeRuntimeFuncMutex);
+            s_fakeRuntimeFunc[0] = 0;
+            s_fakeRuntimeFunc[1] = 0x1000;
+            s_fakeRuntimeFunc[2] = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(s_fakeUnwindInfo) -
+                                                         reinterpret_cast<uintptr_t>(base));
+            result = s_fakeRuntimeFunc;
+        }
     }
     return result;
 }

--- a/tests/test_phase20.cpp
+++ b/tests/test_phase20.cpp
@@ -1,13 +1,19 @@
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <metalsharp/AntiCheatDB.h>
 #include <metalsharp/ExtraShims.h>
+#include <metalsharp/Kernel32Shim.h>
+#include <metalsharp/Logger.h>
+#include <metalsharp/PELoader.h>
 #include <metalsharp/Win32Types.h>
+#include <thread>
 #include <vector>
 
 using namespace metalsharp::win32;
+using metalsharp::PELoader;
 
 struct AdapterAddressesLayout {
     uint32_t Length;
@@ -185,6 +191,48 @@ static bool test_veh_chain_registration() {
     return true;
 }
 
+static bool test_rtl_lookup_function_entry_allows_null_image_base() {
+    PELoader loader;
+    auto kernel32 = Kernel32Shim::create();
+    addMissingKernel32(kernel32);
+
+    auto function = kernel32.functions.find("RtlLookupFunctionEntry");
+    if (function == kernel32.functions.end())
+        return false;
+
+    using LookupFunctionEntry = void*(MSABI*)(uint64_t, uint64_t*, void*);
+    auto lookup = reinterpret_cast<LookupFunctionEntry>(function->second());
+    if (!lookup)
+        return false;
+
+    metalsharp::Logger::setLevel(metalsharp::LogLevel::Error);
+    void* result = lookup(0, nullptr, nullptr);
+    if (!result)
+        return false;
+
+    auto* runtimeFunction = static_cast<const uint32_t*>(result);
+    if (runtimeFunction[0] != 0 || runtimeFunction[1] != 0x1000)
+        return false;
+
+    std::atomic<bool> allCallsReturned{true};
+    std::vector<std::thread> callers;
+    callers.reserve(8);
+    for (int i = 0; i < 8; ++i) {
+        callers.emplace_back([&] {
+            for (int call = 0; call < 100; ++call) {
+                if (!lookup(0, nullptr, nullptr)) {
+                    allCallsReturned = false;
+                    return;
+                }
+            }
+        });
+    }
+    for (auto& caller : callers)
+        caller.join();
+
+    return allCallsReturned;
+}
+
 int main() {
     printf("=== Phase 20: Anti-Cheat & DRM Compatibility ===\n\n");
 
@@ -210,6 +258,7 @@ int main() {
     TEST(ki_user_exception_dispatcher);
     TEST(rtl_raise_exception);
     TEST(veh_chain_registration);
+    TEST(rtl_lookup_function_entry_allows_null_image_base);
 
     printf("\n--- 20.4 Timing & Hardware Fingerprinting ---\n");
     TEST(local_time);


### PR DESCRIPTION
## Summary

Fix the `RtlLookupFunctionEntry` fallback crash when callers omit the optional `ImageBase` output pointer, and serialize construction of the shared fake runtime-function record.

Fixes #430

## Changes

- Treat a null `ImageBase` as an empty base and preserve the main-module fallback.
- Protect `s_fakeRuntimeFunc` initialization with a mutex.
- Add a Phase 20 regression test covering the null-pointer call and concurrent fallback calls.

## PR Readiness (MANDATORY)

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed (no config or DLL-map changes)
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped (no version bump)
- [x] Bottle/runtime migration and launch behavior preserved (no launch or runtime migration changes)
- [x] Docs / compatibility matrix updated for user-facing changes (no user-facing behavior changed)
- [x] Regression test added for each bug fix

The `checklist-exception` label is applied because this is a low-level native exception-shim regression with no launch behavior change; real-game compatibility testing is not applicable to the fix.

## Local toolchain

- [x] `cmake -S . -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON`
- [x] `cmake --build build-native --parallel $(sysctl -n hw.ncpu)`
- [x] `ctest --test-dir build-native --output-on-failure` — 31/31 passed
- [x] `build-native/tests/test_phase20` — 20/20 passed, including the new regression
- [x] `tools/ci/check-clang-format.sh`
- [x] `clang-format --dry-run --Werror` on changed files
- [x] `git diff --check`
- [x] shared pre-commit hook — passed

## Test notes

Build and tests ran from the clean `/Volumes/AverySSD/MetalSharp-430-clean` checkout on the Apple Silicon macOS development host. No real game was launched because the change is confined to the native exception-shim fallback and does not alter a launch route.

## Risk

The change only affects the fallback used when no runtime-function entry is found. The existing entry lookup and main-module fallback remain unchanged. Reverting commit `afcd9bbe` restores the previous behavior if needed.
