### PR TITLE
fix(win32): implement WSAWaitForMultipleEvents over real WSA events

### DIFF
--- a/include/metalsharp/NetworkContext.h
+++ b/include/metalsharp/NetworkContext.h
@@ -14,6 +14,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace metalsharp {
 namespace win32 {
@@ -47,6 +48,19 @@ constexpr uint32_t WSAECONNREFUSED = 10061;
 constexpr uint32_t WSAEHOSTDOWN = 10064;
 constexpr uint32_t WSAEHOSTUNREACH = 10065;
 constexpr uint32_t WSASYSCALLFAILURE = 10107;
+
+// WSA event-object wait results and limits (winsock2.h).
+constexpr uint32_t WSA_WAIT_OBJECT_0 = 0;
+constexpr uint32_t WSA_WAIT_IO_COMPLETION = 0x000000C0;
+constexpr uint32_t WSA_WAIT_TIMEOUT = 0x00000102;
+constexpr uint32_t WSA_WAIT_FAILED = 0xFFFFFFFF;
+constexpr uint32_t WSA_INFINITE = 0xFFFFFFFF;
+constexpr uint32_t WSA_MAXIMUM_WAIT_EVENTS = 64;
+
+// WSA error codes used by the event-object API (winsock2.h / winerror.h).
+constexpr uint32_t WSAEFAULT = 14;
+constexpr uint32_t WSA_INVALID_HANDLE = 6;
+constexpr uint32_t WSA_INVALID_PARAMETER = 87;
 
 constexpr uint32_t FD_READ_BIT = 0;
 constexpr uint32_t FD_WRITE_BIT = 1;
@@ -120,20 +134,69 @@ class NetworkContext {
     void setSocketEventMask(int handle, uint32_t mask, void* eventHandle);
     uint32_t getSocketEventMask(int handle) const;
 
+    // WSA event-object table (WSACreateEvent/WSACloseEvent/WSASetEvent/WSAResetEvent).
+    int allocEvent();
+    bool isValidEvent(int eventId) const;
+    void closeEvent(int eventId);
+    void setEventSignaled(int eventId, bool signaled);
+    bool isEventSignaled(int eventId) const;
+    std::vector<int> socketsForEvent(int eventId) const;
+    void associateSocketWithEvent(int socketHandle, int eventId);
+    void unassociateSocketFromEvent(int socketHandle);
+
+    // Cross-thread wake pipe: WSASetEvent writes a byte so a blocked
+    // WSAWaitForMultipleEvents poll() wakes and re-checks the signaled state.
+    int eventWakeReadFd();
+
+    // WSAEventSelect/FD_* edge tracking.
+    void markSocketConnecting(int handle, bool connecting);
+    // Starts a fresh recording period for the edge-triggered FD_CLOSE event
+    // after a new WSAEventSelect registration.
+    void resetSocketEventTracking(int handle);
+    // True once FD_CLOSE has been reported for the socket; such sockets are
+    // excluded from later waits (FD_CLOSE fires once, like Windows).
+    bool socketHasReportedClose(int handle) const;
+    // Classifies poll(2) results for a socket against its event mask, updates
+    // the FD_CONNECT/FD_CLOSE edge-tracking state, and returns the FD_* bits
+    // (masked by the socket's registered mask) that fired.
+    uint32_t applySocketPollResult(int handle, short revents, bool listening);
+    // Preserve edge-triggered notifications until WSAEnumNetworkEvents
+    // consumes the event record after WSAWaitForMultipleEvents returns.
+    void recordSocketEvents(int handle, uint32_t events);
+    uint32_t takeSocketEvents(int handle);
+
     void initialize();
 
   private:
+    // Must be called with m_mutex held.
+    void unassociateSocketFromEventLocked(int socketHandle);
     NetworkContext() = default;
 
     struct SocketEntry {
         int fd;
         uint32_t eventMask = 0;
         void* eventHandle = nullptr;
+        bool connecting = false;
+        bool closeReported = false;
+        uint32_t pendingEvents = 0;
+    };
+
+    struct EventEntry {
+        bool signaled = false;
+        std::vector<int> sockets;
     };
 
     mutable std::mutex m_mutex;
     std::unordered_map<int, SocketEntry> m_sockets;
     int m_nextHandle = 100;
+
+    std::unordered_map<int, EventEntry> m_events;
+    int m_nextEvent = 9000;
+
+    // Must be called with m_mutex held.
+    void ensureEventWakePipeLocked();
+    void wakePipeWriteLocked();
+    int m_eventWakePipe[2] = {-1, -1};
 
     std::unordered_map<int, PipeInstance> m_pipes;
     int m_nextPipe = 5000;

--- a/src/win32/extra/ExtraShims.cpp
+++ b/src/win32/extra/ExtraShims.cpp
@@ -34,9 +34,12 @@
 ///   only implemented where games actually depend on it.
 ///
 ///   Priority: prevent crashes > correct behavior > full API coverage.
+#include <algorithm>
 #include <arpa/inet.h>
 #include <cerrno>
+#include <chrono>
 #include <csignal>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <fcntl.h>
@@ -56,6 +59,7 @@
 #include <sys/socket.h>
 #include <unistd.h>
 #include <unordered_map>
+#include <vector>
 
 #if __has_include(<openssl/rand.h>)
 #include <openssl/rand.h>
@@ -494,18 +498,21 @@ static int MSABI ws2_32_closesocket(void* s) {
 }
 
 static int MSABI ws2_32_connect(void* s, const void* addr, int len) {
-    int fd = NetworkContext::instance().getFd((int)(intptr_t)s);
+    auto& ctx = NetworkContext::instance();
+    int handle = (int)(intptr_t)s;
+    int fd = ctx.getFd(handle);
     if (fd < 0) {
-        NetworkContext::instance().setWsaError(WSAENOTSOCK);
+        ctx.setWsaError(WSAENOTSOCK);
         return -1;
     }
     int ret = ::connect(fd, (const sockaddr*)addr, (socklen_t)len);
     if (ret < 0) {
         if (errno == EINPROGRESS) {
-            NetworkContext::instance().setWsaError(WSAEWOULDBLOCK);
+            ctx.setWsaError(WSAEWOULDBLOCK);
+            ctx.markSocketConnecting(handle, true);
             return -1;
         }
-        NetworkContext::instance().setWsaError(NetworkContext::instance().mapErrnoToWsa(errno));
+        ctx.setWsaError(ctx.mapErrnoToWsa(errno));
     }
     return ret;
 }
@@ -935,6 +942,28 @@ static int MSABI ws2_32_WSASendTo(void* s, void* lpBuffers, DWORD dwBufferCount,
     return 0;
 }
 
+// Winsock network-event constants (winsock2.h). FD_MAX_EVENTS is the size of
+// the WSANETWORKEVENTS::iErrorCode array.
+constexpr int WSA_FD_MAX_EVENTS = 10;
+constexpr int WSA_INVALID_EVENT = 0; // WSACreateEvent failure value (NULL)
+
+// Maps a WSAEventSelect FD_* mask to the poll(2) events that can satisfy it.
+static short wsaEventMaskToPoll(uint32_t mask) {
+    short events = 0;
+    if (mask & (FD_READ | FD_ACCEPT))
+        events |= POLLIN;
+    if (mask & (FD_WRITE | FD_CONNECT))
+        events |= POLLOUT;
+    return events;
+}
+
+// True when the socket is a listening socket (SO_ACCEPTCONN).
+static bool socketIsListening(int fd) {
+    int acceptConn = 0;
+    socklen_t acceptLen = sizeof(acceptConn);
+    return getsockopt(fd, SOL_SOCKET, SO_ACCEPTCONN, &acceptConn, &acceptLen) == 0 && acceptConn;
+}
+
 static int MSABI ws2_32_WSAEventSelect(void* s, void* hEventObject, uint32_t lNetworkEvents) {
     auto& ctx = NetworkContext::instance();
     int handle = (int)(intptr_t)s;
@@ -944,11 +973,22 @@ static int MSABI ws2_32_WSAEventSelect(void* s, void* hEventObject, uint32_t lNe
         return -1;
     }
 
-    ctx.setSocketEventMask(handle, lNetworkEvents, hEventObject);
-
+    int eventId = (int)(intptr_t)hEventObject;
     if (lNetworkEvents != 0) {
+        ctx.setSocketEventMask(handle, lNetworkEvents, hEventObject);
+        // Associate the socket with its event object so waits can watch it,
+        // and start a fresh recording period for the edge-triggered events.
+        if (ctx.isValidEvent(eventId)) {
+            ctx.associateSocketWithEvent(handle, eventId);
+            ctx.resetSocketEventTracking(handle);
+        }
         int flags = fcntl(fd, F_GETFL, 0);
         fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+    } else {
+        // A zero mask ends network-event recording and disassociates the
+        // socket from its event object.
+        ctx.setSocketEventMask(handle, 0, nullptr);
+        ctx.unassociateSocketFromEvent(handle);
     }
     return 0;
 }
@@ -983,45 +1023,237 @@ static int MSABI ws2_32_WSAGetOverlappedResult(void* s, void* lpOverlapped, DWOR
     return 1;
 }
 
-static int MSABI ws2_32_WSACreateEvent(void** lpEvent) {
-    if (lpEvent)
-        *lpEvent = reinterpret_cast<void*>(0xEE00);
-    return 0;
+static void* MSABI ws2_32_WSACreateEvent() {
+    int eventId = NetworkContext::instance().allocEvent();
+    if (eventId < 0)
+        return reinterpret_cast<void*>(static_cast<intptr_t>(WSA_INVALID_EVENT));
+    return reinterpret_cast<void*>(static_cast<intptr_t>(eventId));
 }
 
 static int MSABI ws2_32_WSACloseEvent(void* hEvent) {
-    (void)hEvent;
+    auto& ctx = NetworkContext::instance();
+    int eventId = (int)(intptr_t)hEvent;
+    if (!ctx.isValidEvent(eventId)) {
+        ctx.setWsaError(WSA_INVALID_HANDLE);
+        return 0;
+    }
+    ctx.closeEvent(eventId);
+    return 1;
+}
+
+static int MSABI ws2_32_WSASetEvent(void* hEvent) {
+    auto& ctx = NetworkContext::instance();
+    int eventId = (int)(intptr_t)hEvent;
+    if (!ctx.isValidEvent(eventId)) {
+        ctx.setWsaError(WSA_INVALID_HANDLE);
+        return 0;
+    }
+    ctx.setEventSignaled(eventId, true);
+    return 1;
+}
+
+static int MSABI ws2_32_WSAResetEvent(void* hEvent) {
+    auto& ctx = NetworkContext::instance();
+    int eventId = (int)(intptr_t)hEvent;
+    if (!ctx.isValidEvent(eventId)) {
+        ctx.setWsaError(WSA_INVALID_HANDLE);
+        return 0;
+    }
+    ctx.setEventSignaled(eventId, false);
     return 1;
 }
 
 static int MSABI ws2_32_WSAWaitForMultipleEvents(DWORD cEvents, void** lphEvents, BOOL fWaitAll, DWORD dwTimeout,
                                                  BOOL fAlertable) {
-    (void)fWaitAll;
     (void)fAlertable;
-    if (cEvents == 0)
-        return -1;
-    if (dwTimeout == 0xFFFFFFFF) {
-        pollfd pfd;
-        pfd.fd = 0;
-        pfd.events = POLLIN;
-        poll(&pfd, 1, -1);
-    } else {
-        pollfd pfd;
-        pfd.fd = 0;
-        pfd.events = POLLIN;
-        poll(&pfd, 1, (int)dwTimeout);
+    auto& ctx = NetworkContext::instance();
+    if (!lphEvents || cEvents == 0 || cEvents > WSA_MAXIMUM_WAIT_EVENTS) {
+        ctx.setWsaError(WSA_INVALID_PARAMETER);
+        return (int)WSA_WAIT_FAILED;
     }
-    return 0;
+    for (DWORD i = 0; i < cEvents; i++) {
+        if (!ctx.isValidEvent((int)(intptr_t)lphEvents[i])) {
+            ctx.setWsaError(WSA_INVALID_HANDLE);
+            return (int)WSA_WAIT_FAILED;
+        }
+    }
+
+    const bool infinite = dwTimeout == WSA_INFINITE;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(dwTimeout);
+
+    std::vector<pollfd> pfds;
+    std::vector<DWORD> pfdEventIndex;         // pfds[i] -> index into lphEvents
+    std::vector<int> pfdSocketHandle;         // pfds[i] -> shim socket handle
+    const int wakeFd = ctx.eventWakeReadFd(); // cross-thread WSASetEvent wake
+    size_t wakePfdIndex = SIZE_MAX;
+    bool everPolled = false;
+
+    for (;;) {
+        // 1. Already-signaled event objects satisfy the wait immediately.
+        bool anySignaled = false;
+        bool allSignaled = true;
+        DWORD firstSignaled = 0;
+        for (DWORD i = 0; i < cEvents; i++) {
+            if (ctx.isEventSignaled((int)(intptr_t)lphEvents[i])) {
+                if (!anySignaled)
+                    firstSignaled = i;
+                anySignaled = true;
+            } else {
+                allSignaled = false;
+            }
+        }
+        if (fWaitAll) {
+            if (allSignaled)
+                return (int)WSA_WAIT_OBJECT_0;
+        } else if (anySignaled) {
+            return (int)(WSA_WAIT_OBJECT_0 + firstSignaled);
+        }
+
+        // 2. Nothing satisfied yet: poll the sockets behind the remaining
+        //    events, honoring the remaining timeout. A zero timeout still
+        //    polls once (dwTimeout == 0 tests the current state, like
+        //    Windows); afterwards the deadline check takes over.
+        int timeoutMs = -1;
+        if (!infinite) {
+            const auto now = std::chrono::steady_clock::now();
+            const int64_t remainMs = std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now).count();
+            if (remainMs <= 0) {
+                if (everPolled)
+                    return (int)WSA_WAIT_TIMEOUT;
+                timeoutMs = 0;
+            } else {
+                timeoutMs = (int)std::min<int64_t>(remainMs, INT32_MAX);
+            }
+        }
+
+        pfds.clear();
+        pfdEventIndex.clear();
+        pfdSocketHandle.clear();
+        wakePfdIndex = SIZE_MAX;
+        for (DWORD i = 0; i < cEvents; i++) {
+            if (fWaitAll && ctx.isEventSignaled((int)(intptr_t)lphEvents[i]))
+                continue; // already satisfied; only the rest are outstanding
+            for (int socketHandle : ctx.socketsForEvent((int)(intptr_t)lphEvents[i])) {
+                int fd = ctx.getFd(socketHandle);
+                if (fd < 0 || ctx.socketHasReportedClose(socketHandle))
+                    continue; // closed sockets cannot fire again (FD_CLOSE is edge-triggered)
+                short pollEvents = wsaEventMaskToPoll(ctx.getSocketEventMask(socketHandle));
+                if (pollEvents == 0)
+                    continue;
+                pfds.push_back(pollfd{fd, pollEvents, 0});
+                pfdEventIndex.push_back(i);
+                pfdSocketHandle.push_back(socketHandle);
+            }
+        }
+        if (wakeFd >= 0) {
+            wakePfdIndex = pfds.size();
+            pfds.push_back(pollfd{wakeFd, POLLIN, 0});
+            pfdEventIndex.push_back(0);
+            pfdSocketHandle.push_back(-1);
+        }
+
+        if (pfds.empty()) {
+            // No watchable sockets and no wake pipe: only WSASetEvent (possibly
+            // from another thread) can satisfy the wait. Sleep and re-check.
+            if (!infinite && std::chrono::steady_clock::now() >= deadline)
+                return (int)WSA_WAIT_TIMEOUT;
+            usleep(1000);
+            continue;
+        }
+
+        int rc = ::poll(pfds.data(), static_cast<nfds_t>(pfds.size()), timeoutMs);
+        everPolled = true;
+        if (rc == 0)
+            return (int)WSA_WAIT_TIMEOUT;
+        if (rc < 0) {
+            if (errno == EINTR)
+                continue;
+            ctx.setWsaError(ctx.mapErrnoToWsa(errno));
+            return (int)WSA_WAIT_FAILED;
+        }
+
+        // 3. Classify the poll results against each socket's event mask and
+        //    signal the owning event objects.
+        bool firedAny = false;
+        bool wakeFired = false;
+        for (size_t k = 0; k < pfds.size(); k++) {
+            if (pfds[k].revents == 0)
+                continue;
+            if (k == wakePfdIndex) {
+                // Cross-thread WSASetEvent wrote a byte; drain it and let the
+                // signaled-state check at the top of the loop decide.
+                char byte;
+                while (::read(wakeFd, &byte, 1) > 0) {
+                }
+                wakeFired = true;
+                continue;
+            }
+            bool listening = socketIsListening(pfds[k].fd);
+            uint32_t firedEvents = ctx.applySocketPollResult(pfdSocketHandle[k], pfds[k].revents, listening);
+            if (firedEvents != 0) {
+                ctx.recordSocketEvents(pfdSocketHandle[k], firedEvents);
+                ctx.setEventSignaled((int)(intptr_t)lphEvents[pfdEventIndex[k]], true);
+                firedAny = true;
+            }
+        }
+        if (!firedAny && !wakeFired) {
+            // Ready fds that produced no fire (undeliverable POLLERR when no
+            // FD_CLOSE/FD_CONNECT is nominated, or data consumed between poll
+            // and classification) must not busy-loop the wait.
+            usleep(1000);
+        }
+        // Loop back: re-evaluate the signaled state (cheap when nothing fired).
+    }
 }
 
 static int MSABI ws2_32_WSAEnumNetworkEvents(void* s, void* hEvent, void* lpNetworkEvents) {
-    (void)s;
-    (void)hEvent;
-    if (lpNetworkEvents) {
-        auto* ne = reinterpret_cast<uint32_t*>(lpNetworkEvents);
-        ne[0] = FD_READ | FD_WRITE | FD_ACCEPT | FD_CONNECT;
-        ne[1] = 0;
+    auto& ctx = NetworkContext::instance();
+    int handle = (int)(intptr_t)s;
+    int fd = ctx.getFd(handle);
+    if (fd < 0) {
+        ctx.setWsaError(WSAENOTSOCK);
+        return -1;
     }
+    if (!lpNetworkEvents) {
+        ctx.setWsaError(WSAEFAULT);
+        return -1;
+    }
+
+    struct WsaNetworkEvents {
+        int32_t lNetworkEvents;
+        int32_t iErrorCode[WSA_FD_MAX_EVENTS];
+    };
+    auto* ne = reinterpret_cast<WsaNetworkEvents*>(lpNetworkEvents);
+    ne->lNetworkEvents = 0;
+
+    pollfd pfd{};
+    pfd.fd = fd;
+    pfd.events = wsaEventMaskToPoll(ctx.getSocketEventMask(handle));
+    ::poll(&pfd, 1, 0);
+
+    uint32_t events = ctx.takeSocketEvents(handle);
+    events |= ctx.applySocketPollResult(handle, pfd.revents, socketIsListening(fd));
+    ne->lNetworkEvents = static_cast<int32_t>(events);
+
+    if (events & FD_CONNECT) {
+        int err = 0;
+        socklen_t errLen = sizeof(err);
+        if (getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &errLen) == 0)
+            ne->iErrorCode[FD_CONNECT_BIT] = err == 0 ? 0 : (int)ctx.mapErrnoToWsa(err);
+    }
+    if (events & FD_CLOSE) {
+        int err = 0;
+        socklen_t errLen = sizeof(err);
+        if (getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &errLen) == 0)
+            ne->iErrorCode[FD_CLOSE_BIT] = err == 0 ? 0 : (int)ctx.mapErrnoToWsa(err);
+    }
+    // Remaining iErrorCode entries are left untouched, matching the documented
+    // behavior (only entries for set bits are modified).
+
+    // WSAEnumNetworkEvents resets the associated event object after copying
+    // and clearing the network event record.
+    if (hEvent && ctx.isValidEvent((int)(intptr_t)hEvent))
+        ctx.setEventSignaled((int)(intptr_t)hEvent, false);
     return 0;
 }
 
@@ -1162,6 +1394,8 @@ ShimLibrary createWs2_32Shim() {
     lib.functions["WSAGetOverlappedResult"] = fn((void*)ws2_32_WSAGetOverlappedResult);
     lib.functions["WSACreateEvent"] = fn((void*)ws2_32_WSACreateEvent);
     lib.functions["WSACloseEvent"] = fn((void*)ws2_32_WSACloseEvent);
+    lib.functions["WSASetEvent"] = fn((void*)ws2_32_WSASetEvent);
+    lib.functions["WSAResetEvent"] = fn((void*)ws2_32_WSAResetEvent);
     lib.functions["WSAWaitForMultipleEvents"] = fn((void*)ws2_32_WSAWaitForMultipleEvents);
     lib.functions["WSAEnumNetworkEvents"] = fn((void*)ws2_32_WSAEnumNetworkEvents);
     lib.functions["recvfrom"] = fn((void*)ws2_32_recvfrom);

--- a/src/win32/kernel32/NetworkContext.cpp
+++ b/src/win32/kernel32/NetworkContext.cpp
@@ -3,6 +3,7 @@
 ///
 /// Wraps POSIX socket operations behind Win32 SOCKET handles and implements Winsock initialization, socket creation,
 /// and named pipe pairs. Provides the networking layer that some games need for multiplayer or DRM.
+#include <algorithm>
 #include <arpa/inet.h>
 #include <cerrno>
 #include <cstdlib>
@@ -13,6 +14,8 @@
 #include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <poll.h>
+#include <sys/ioctl.h>
 #include <sys/select.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
@@ -61,6 +64,7 @@ int NetworkContext::releaseSocket(int handle) {
     auto it = m_sockets.find(handle);
     if (it == m_sockets.end())
         return -1;
+    unassociateSocketFromEventLocked(handle);
     int fd = it->second.fd;
     m_sockets.erase(it);
     return fd;
@@ -156,6 +160,198 @@ uint32_t NetworkContext::getSocketEventMask(int handle) const {
     std::lock_guard<std::mutex> lock(m_mutex);
     auto it = m_sockets.find(handle);
     return it != m_sockets.end() ? it->second.eventMask : 0;
+}
+
+int NetworkContext::allocEvent() {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    int eventId = m_nextEvent++;
+    m_events[eventId] = EventEntry{};
+    return eventId;
+}
+
+bool NetworkContext::isValidEvent(int eventId) const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_events.find(eventId) != m_events.end();
+}
+
+void NetworkContext::closeEvent(int eventId) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_events.erase(eventId);
+}
+
+void NetworkContext::setEventSignaled(int eventId, bool signaled) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto it = m_events.find(eventId);
+    if (it == m_events.end())
+        return;
+    if (signaled && !it->second.signaled)
+        wakePipeWriteLocked(); // cross-thread wake for blocked waits
+    it->second.signaled = signaled;
+}
+
+bool NetworkContext::isEventSignaled(int eventId) const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto it = m_events.find(eventId);
+    return it != m_events.end() && it->second.signaled;
+}
+
+std::vector<int> NetworkContext::socketsForEvent(int eventId) const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto it = m_events.find(eventId);
+    if (it == m_events.end())
+        return {};
+    return it->second.sockets;
+}
+
+void NetworkContext::associateSocketWithEvent(int socketHandle, int eventId) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto ev = m_events.find(eventId);
+    if (ev == m_events.end())
+        return;
+    // A socket belongs to at most one event object at a time.
+    unassociateSocketFromEventLocked(socketHandle);
+    ev->second.sockets.push_back(socketHandle);
+}
+
+void NetworkContext::unassociateSocketFromEventLocked(int socketHandle) {
+    for (auto& pair : m_events) {
+        auto& sockets = pair.second.sockets;
+        sockets.erase(std::remove(sockets.begin(), sockets.end(), socketHandle), sockets.end());
+    }
+}
+
+void NetworkContext::unassociateSocketFromEvent(int socketHandle) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    unassociateSocketFromEventLocked(socketHandle);
+}
+
+void NetworkContext::markSocketConnecting(int handle, bool connecting) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto it = m_sockets.find(handle);
+    if (it != m_sockets.end())
+        it->second.connecting = connecting;
+}
+
+void NetworkContext::resetSocketEventTracking(int handle) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto it = m_sockets.find(handle);
+    if (it != m_sockets.end())
+        it->second.closeReported = false;
+}
+
+bool NetworkContext::socketHasReportedClose(int handle) const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto it = m_sockets.find(handle);
+    return it != m_sockets.end() && it->second.closeReported;
+}
+
+int NetworkContext::eventWakeReadFd() {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    ensureEventWakePipeLocked();
+    return m_eventWakePipe[0];
+}
+
+void NetworkContext::ensureEventWakePipeLocked() {
+    if (m_eventWakePipe[0] >= 0)
+        return;
+    if (::pipe(m_eventWakePipe) != 0) {
+        m_eventWakePipe[0] = m_eventWakePipe[1] = -1;
+        return;
+    }
+    for (int end : {m_eventWakePipe[0], m_eventWakePipe[1]}) {
+        int flags = fcntl(end, F_GETFL, 0);
+        fcntl(end, F_SETFL, flags | O_NONBLOCK);
+    }
+}
+
+void NetworkContext::wakePipeWriteLocked() {
+    ensureEventWakePipeLocked();
+    if (m_eventWakePipe[1] < 0)
+        return;
+    char byte = 1;
+    (void)::write(m_eventWakePipe[1], &byte, 1); // EAGAIN when full: pending byte suffices
+}
+
+uint32_t NetworkContext::applySocketPollResult(int handle, short revents, bool listening) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto it = m_sockets.find(handle);
+    if (it == m_sockets.end())
+        return 0;
+    SocketEntry& entry = it->second;
+    const uint32_t mask = entry.eventMask;
+    if (mask == 0)
+        return 0;
+
+    uint32_t events = 0;
+    const bool sawPollOut = (revents & POLLOUT) != 0;
+
+    // FD_READ / FD_ACCEPT are level-triggered: report them whenever the
+    // condition still holds (data pending / connection pending).
+    if ((revents & POLLIN) && (mask & (FD_READ | FD_ACCEPT))) {
+        if (listening) {
+            if (mask & FD_ACCEPT)
+                events |= FD_ACCEPT;
+        } else if ((mask & FD_ACCEPT) && !(mask & FD_READ)) {
+            // macOS does not expose SO_ACCEPTCONN for every socket family;
+            // an FD_ACCEPT-only registration is itself an unambiguous listen
+            // request, so preserve the accept notification in that case.
+            events |= FD_ACCEPT;
+        } else {
+            int available = 0;
+            if (ioctl(entry.fd, FIONREAD, &available) == 0) {
+                if (available > 0 && (mask & FD_READ)) {
+                    events |= FD_READ;
+                } else if ((mask & FD_CLOSE) && !entry.closeReported) {
+                    // An orderly peer shutdown is reported by poll(2) as
+                    // readable EOF (POLLIN with no bytes), not necessarily
+                    // as POLLHUP. Windows surfaces that transition as
+                    // FD_CLOSE rather than a spurious FD_READ.
+                    events |= FD_CLOSE;
+                    entry.closeReported = true;
+                }
+            }
+        }
+    }
+
+    // FD_CONNECT fires once when a non-blocking connect completes (with or
+    // without error). FD_WRITE is polled level-triggered: reported whenever
+    // the socket is writable and FD_WRITE is nominated — a game's send-until-
+    // WSAEWOULDBLOCK loop makes progress, and the wait blocks once the send
+    // buffer fills (no POLLOUT).
+    if ((revents & (POLLOUT | POLLERR | POLLHUP)) && (mask & FD_CONNECT) && entry.connecting) {
+        events |= FD_CONNECT;
+        entry.connecting = false;
+    } else if (sawPollOut && (mask & FD_WRITE)) {
+        events |= FD_WRITE;
+    }
+
+    // FD_CLOSE fires once per close (edge-triggered, like Windows); the wait
+    // loop excludes sockets that already reported it, so a half-closed socket
+    // cannot keep a poll() round busy.
+    if ((revents & (POLLHUP | POLLERR)) && (mask & FD_CLOSE) && !entry.closeReported) {
+        events |= FD_CLOSE;
+        entry.closeReported = true;
+    }
+    return events;
+}
+
+void NetworkContext::recordSocketEvents(int handle, uint32_t events) {
+    if (events == 0)
+        return;
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto it = m_sockets.find(handle);
+    if (it != m_sockets.end())
+        it->second.pendingEvents |= events;
+}
+
+uint32_t NetworkContext::takeSocketEvents(int handle) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto it = m_sockets.find(handle);
+    if (it == m_sockets.end())
+        return 0;
+    uint32_t events = it->second.pendingEvents;
+    it->second.pendingEvents = 0;
+    return events;
 }
 
 bool NetworkContext::allocPipePair(const std::string& name, bool server, int outHandles[2]) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -147,6 +147,12 @@ if(APPLE)
     add_test(NAME kernel32_shim COMMAND test_kernel32_shim $<TARGET_FILE:kernel32_shim_testlib>)
 endif()
 
+# Regression test for #427: the ws2_32 event-object shim (WSAWaitForMultipleEvents
+# and friends) must wait on the real event handles/sockets, not poll stdin.
+add_executable(test_ws2_32_events test_ws2_32_events.cpp)
+target_link_libraries(test_ws2_32_events PRIVATE metalsharp_loader metalsharp_core)
+add_test(NAME ws2_32_events COMMAND test_ws2_32_events)
+
 add_executable(test_phase17
     test_phase17.cpp
 )

--- a/tests/test_ws2_32_events.cpp
+++ b/tests/test_ws2_32_events.cpp
@@ -1,0 +1,247 @@
+/// @file test_ws2_32_events.cpp
+/// @brief Regression tests for #427: WSAWaitForMultipleEvents must wait on the
+///        actual WSA event objects (and their sockets), not poll stdin and
+///        fabricate WAIT_OBJECT_0.
+///
+/// Before the fix, ws2_32_WSAWaitForMultipleEvents ignored lphEvents entirely,
+/// poll()ed fd 0 (stdin), and always returned WAIT_OBJECT_0 — so games waiting
+/// on socket events woke spuriously (or never) and always saw success. The
+/// event-object API (WSACreateEvent/WSASetEvent/WSAResetEvent) did not exist
+/// as real state, and WSAEnumNetworkEvents fabricated FD_READ|FD_WRITE|
+/// FD_ACCEPT|FD_CONNECT unconditionally.
+///
+/// The tests drive the shim through createWs2_32Shim() exactly as the PE
+/// loader resolves ws2_32.dll imports, over real loopback sockets.
+
+#include <arpa/inet.h>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <metalsharp/ExtraShims.h>
+#include <metalsharp/NetworkContext.h>
+#include <metalsharp/Win32Types.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <thread>
+
+using namespace metalsharp::win32;
+using metalsharp::ShimLibrary;
+
+#ifndef FALSE
+#define FALSE 0
+#define TRUE 1
+#endif
+
+// --- Function-pointer types matching the shim's MSABI exports ---------------
+
+typedef void*(MSABI* CreateEventFn)();
+typedef int(MSABI* CloseEventFn)(void*);
+typedef int(MSABI* SetEventFn)(void*);
+typedef int(MSABI* ResetEventFn)(void*);
+typedef int(MSABI* WaitFn)(DWORD cEvents, void** lphEvents, BOOL fWaitAll, DWORD dwTimeout, BOOL fAlertable);
+typedef int(MSABI* EventSelectFn)(void* s, void* hEvent, uint32_t lNetworkEvents);
+typedef int(MSABI* EnumNetworkEventsFn)(void* s, void* hEvent, void* lpNetworkEvents);
+typedef void*(MSABI* SocketFn)(int af, int type, int proto, void*, DWORD, DWORD);
+typedef int(MSABI* CloseSocketFn)(void* s);
+typedef int(MSABI* BindFn)(void* s, const void* addr, int len);
+typedef int(MSABI* ListenFn)(void* s, int backlog);
+typedef int(MSABI* ConnectFn)(void* s, const void* addr, int len);
+typedef int(MSABI* GetSockNameFn)(void* s, void* addr, int* len);
+typedef void*(MSABI* AcceptFn)(void* s, void* addr, int* len);
+typedef int(MSABI* SendFn)(void* s, const char* buf, int len, int flags);
+typedef int(MSABI* RecvFn)(void* s, char* buf, int len, int flags);
+typedef int(MSABI* ShutdownFn)(void* s, int how);
+typedef int(MSABI* GetLastErrorFn)();
+
+// WSANETWORKEVENTS layout (winsock2.h): LONG lNetworkEvents + iErrorCode[FD_MAX_EVENTS].
+struct WsaNetworkEvents {
+    int32_t lNetworkEvents;
+    int32_t iErrorCode[10];
+};
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                                                                  \
+    do {                                                                                                             \
+        if (!(cond)) {                                                                                                \
+            fprintf(stderr, "FAIL: %s:%d: %s\n", __FILE__, __LINE__, #cond);                                      \
+            ++g_failures;                                                                                            \
+        }                                                                                                            \
+    } while (0)
+
+static void* makeLoopbackSockaddr(sockaddr_in* out, uint16_t port) {
+    memset(out, 0, sizeof(*out));
+    out->sin_family = AF_INET;
+    out->sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    out->sin_port = htons(port);
+    return out;
+}
+
+int main() {
+    ShimLibrary shim = createWs2_32Shim();
+    auto getFn = [&](const char* name) -> void* { return shim.functions.at(name)(); };
+
+    CreateEventFn createEvent = reinterpret_cast<CreateEventFn>(getFn("WSACreateEvent"));
+    CloseEventFn closeEvent = reinterpret_cast<CloseEventFn>(getFn("WSACloseEvent"));
+    SetEventFn setEvent = reinterpret_cast<SetEventFn>(getFn("WSASetEvent"));
+    ResetEventFn resetEvent = reinterpret_cast<ResetEventFn>(getFn("WSAResetEvent"));
+    WaitFn wait = reinterpret_cast<WaitFn>(getFn("WSAWaitForMultipleEvents"));
+    EventSelectFn eventSelect = reinterpret_cast<EventSelectFn>(getFn("WSAEventSelect"));
+    EnumNetworkEventsFn enumNetworkEvents = reinterpret_cast<EnumNetworkEventsFn>(getFn("WSAEnumNetworkEvents"));
+    SocketFn socket = reinterpret_cast<SocketFn>(getFn("WSASocketA"));
+    CloseSocketFn closeSocket = reinterpret_cast<CloseSocketFn>(getFn("closesocket"));
+    BindFn bind = reinterpret_cast<BindFn>(getFn("bind"));
+    ListenFn listen = reinterpret_cast<ListenFn>(getFn("listen"));
+    ConnectFn connect = reinterpret_cast<ConnectFn>(getFn("connect"));
+    GetSockNameFn getSockName = reinterpret_cast<GetSockNameFn>(getFn("getsockname"));
+    AcceptFn accept = reinterpret_cast<AcceptFn>(getFn("accept"));
+    SendFn send = reinterpret_cast<SendFn>(getFn("send"));
+    RecvFn recv = reinterpret_cast<RecvFn>(getFn("recv"));
+    ShutdownFn shutdown = reinterpret_cast<ShutdownFn>(getFn("shutdown"));
+    GetLastErrorFn getLastError = reinterpret_cast<GetLastErrorFn>(getFn("WSAGetLastError"));
+
+    // --- 1. Event-object basics ---------------------------------------------
+    void* ev = createEvent();
+    CHECK(ev != nullptr);
+
+    // A fresh event is nonsignaled: a zero-timeout wait must time out, not
+    // fabricate WAIT_OBJECT_0 (the pre-fix behavior).
+    CHECK(wait(1, &ev, FALSE, 0, FALSE) == (int)WSA_WAIT_TIMEOUT);
+
+    CHECK(setEvent(ev) == 1);
+    CHECK(wait(1, &ev, FALSE, 0, FALSE) == (int)WSA_WAIT_OBJECT_0);
+    CHECK(resetEvent(ev) == 1);
+    CHECK(wait(1, &ev, FALSE, 0, FALSE) == (int)WSA_WAIT_TIMEOUT);
+
+    // --- 2. Multi-event indexing and fWaitAll --------------------------------
+    void* evs[2] = {createEvent(), createEvent()};
+    CHECK(evs[0] != nullptr && evs[1] != nullptr);
+
+    CHECK(setEvent(evs[1]) == 1);
+    CHECK(wait(2, evs, FALSE, 0, FALSE) == (int)(WSA_WAIT_OBJECT_0 + 1));
+    CHECK(setEvent(evs[0]) == 1);
+    // Lowest signaled index wins when several are signaled.
+    CHECK(wait(2, evs, FALSE, 0, FALSE) == (int)WSA_WAIT_OBJECT_0);
+    CHECK(resetEvent(evs[0]) == 1);
+    CHECK(resetEvent(evs[1]) == 1);
+
+    // fWaitAll: one signaled event is not enough...
+    CHECK(setEvent(evs[0]) == 1);
+    CHECK(wait(2, evs, TRUE, 50, FALSE) == (int)WSA_WAIT_TIMEOUT);
+    // ...but both are.
+    CHECK(setEvent(evs[1]) == 1);
+    CHECK(wait(2, evs, TRUE, 0, FALSE) == (int)WSA_WAIT_OBJECT_0);
+    CHECK(resetEvent(evs[0]) == 1);
+    CHECK(resetEvent(evs[1]) == 1);
+
+    // --- 3. Invalid handles fail the wait -------------------------------------
+    CHECK(closeEvent(evs[1]) == 1);
+    CHECK(wait(2, evs, FALSE, 0, FALSE) == (int)WSA_WAIT_FAILED);
+    CHECK(getLastError() == (int)WSA_INVALID_HANDLE);
+    CHECK(closeEvent(evs[0]) == 1);
+
+    CHECK(wait(0, nullptr, FALSE, 0, FALSE) == (int)WSA_WAIT_FAILED);
+    CHECK(getLastError() == (int)WSA_INVALID_PARAMETER);
+
+    // --- 4. A cross-thread WSASetEvent wakes a blocked infinite wait ----------
+    void* evX = createEvent();
+    CHECK(evX != nullptr);
+    std::thread signaller([&]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        setEvent(evX);
+    });
+    CHECK(wait(1, &evX, FALSE, WSA_INFINITE, FALSE) == (int)WSA_WAIT_OBJECT_0);
+    signaller.join();
+    CHECK(closeEvent(evX) == 1);
+
+    // --- 5. Real socket activity drives the wait (the core regression) --------
+    // Server side: loopback listener on an ephemeral port.
+    void* srv = socket(AF_INET, SOCK_STREAM, 0, nullptr, 0, 0);
+    CHECK(srv != reinterpret_cast<void*>(static_cast<intptr_t>(-1)));
+    sockaddr_in sa;
+    CHECK(bind(srv, makeLoopbackSockaddr(&sa, 0), sizeof(sa)) == 0);
+    sockaddr_in bound;
+    socklen_t boundLen = sizeof(bound);
+    CHECK(getSockName(srv, &bound, reinterpret_cast<int*>(&boundLen)) == 0);
+    CHECK(listen(srv, 2) == 0);
+
+    // Client side: connect (blocking loopback connect completes immediately).
+    void* cli = socket(AF_INET, SOCK_STREAM, 0, nullptr, 0, 0);
+    CHECK(cli != reinterpret_cast<void*>(static_cast<intptr_t>(-1)));
+    sockaddr_in csa;
+    CHECK(connect(cli, makeLoopbackSockaddr(&csa, ntohs(bound.sin_port)), sizeof(csa)) == 0);
+    void* acc = accept(srv, nullptr, nullptr);
+    CHECK(acc != reinterpret_cast<void*>(static_cast<intptr_t>(-1)));
+
+    // Watch the client socket for readable data only (FD_WRITE/FD_CONNECT are
+    // excluded so the wait cannot be satisfied by writability alone).
+    void* evR = createEvent();
+    CHECK(evR != nullptr);
+    CHECK(eventSelect(cli, evR, FD_READ | FD_CLOSE) == 0);
+
+    // No data yet: a bounded wait must time out (the old shim returned 0).
+    CHECK(wait(1, &evR, FALSE, 200, FALSE) == (int)WSA_WAIT_TIMEOUT);
+
+    // Deliver data: the wait must now be satisfied by the socket activity.
+    CHECK(send(acc, "hi", 2, 0) == 2);
+    CHECK(wait(1, &evR, FALSE, 2000, FALSE) == (int)WSA_WAIT_OBJECT_0);
+
+    // WSAEnumNetworkEvents reports the real, mask-nominated events only.
+    WsaNetworkEvents ne;
+    memset(&ne, 0, sizeof(ne));
+    CHECK(enumNetworkEvents(cli, evR, &ne) == 0);
+    CHECK((ne.lNetworkEvents & FD_READ) != 0);
+    CHECK((ne.lNetworkEvents & FD_WRITE) == 0);
+    CHECK((ne.lNetworkEvents & FD_ACCEPT) == 0);
+    CHECK((ne.lNetworkEvents & FD_CONNECT) == 0);
+    CHECK((ne.lNetworkEvents & FD_CLOSE) == 0);
+
+    // Enum resets the event; after draining the data the wait times out again.
+    char buf[16];
+    CHECK(recv(cli, buf, sizeof(buf), 0) == 2);
+    CHECK(wait(1, &evR, FALSE, 0, FALSE) == (int)WSA_WAIT_TIMEOUT);
+
+    // Peer close surfaces as FD_CLOSE (edge-triggered: reported once).
+    CHECK(shutdown(acc, 1 /*SD_SEND*/) == 0);
+    CHECK(wait(1, &evR, FALSE, 2000, FALSE) == (int)WSA_WAIT_OBJECT_0);
+    memset(&ne, 0, sizeof(ne));
+    CHECK(enumNetworkEvents(cli, evR, &ne) == 0);
+    CHECK((ne.lNetworkEvents & FD_CLOSE) != 0);
+    CHECK(wait(1, &evR, FALSE, 0, FALSE) == (int)WSA_WAIT_TIMEOUT);
+
+    // --- 6. FD_ACCEPT on a listening socket -----------------------------------
+    void* evL = createEvent();
+    CHECK(evL != nullptr);
+    int selectListenerResult = eventSelect(srv, evL, FD_ACCEPT);
+    CHECK(selectListenerResult == 0);
+
+    void* cli2 = socket(AF_INET, SOCK_STREAM, 0, nullptr, 0, 0);
+    CHECK(cli2 != reinterpret_cast<void*>(static_cast<intptr_t>(-1)));
+    sockaddr_in csa2;
+    CHECK(connect(cli2, makeLoopbackSockaddr(&csa2, ntohs(bound.sin_port)), sizeof(csa2)) == 0);
+
+    CHECK(wait(1, &evL, FALSE, 2000, FALSE) == (int)WSA_WAIT_OBJECT_0);
+    memset(&ne, 0, sizeof(ne));
+    CHECK(enumNetworkEvents(srv, evL, &ne) == 0);
+    CHECK((ne.lNetworkEvents & FD_ACCEPT) != 0);
+    void* acc2 = accept(srv, nullptr, nullptr);
+    CHECK(acc2 != reinterpret_cast<void*>(static_cast<intptr_t>(-1)));
+
+    // --- Cleanup --------------------------------------------------------------
+    closeSocket(acc2);
+    closeSocket(cli2);
+    closeSocket(acc);
+    closeSocket(cli);
+    closeSocket(srv);
+    closeEvent(evR);
+    closeEvent(evL);
+    closeEvent(ev);
+
+    if (g_failures == 0) {
+        printf("PASS: ws2_32 event-object shim (WSAWaitForMultipleEvents, WSAEnumNetworkEvents)\n");
+        return 0;
+    }
+    fprintf(stderr, "FAILED: %d check(s)\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Fixes #427: `ws2_32` shim's `WSAWaitForMultipleEvents` ignored `lphEvents`
entirely, `poll()`ed fd 0 (stdin), and always returned `WAIT_OBJECT_0` — so
games waiting on socket events woke spuriously (or never) and always saw
success. Socket event loops misbehaved with spurious wakes, missed events,
and busy loops.

## Changes

- `src/win32/extra/ExtraShims.cpp`:
  - `WSACreateEvent` now has the correct signature (returns a real event
    handle; the old shim took `void**` — a garbage-pointer write — and
    returned a fixed fake handle). New `WSACloseEvent`, `WSASetEvent`,
    `WSAResetEvent` exports validate handles per the Win32 contract
    (TRUE/FALSE + `WSA_INVALID_HANDLE`).
  - `WSAEventSelect` associates each socket with its event object; a zero
    mask ends recording and disassociates (per spec).
  - `WSAWaitForMultipleEvents` polls the sockets behind the actual event
    handles, honoring `fWaitAll`, `dwTimeout` (`WSA_INFINITE` and the
    zero-timeout state-test included), lowest-index return, `WSA_WAIT_TIMEOUT`,
    and `WSA_WAIT_FAILED` with `WSA_INVALID_HANDLE` / `WSA_INVALID_PARAMETER`.
    A self-pipe wakes the poll when another thread calls `WSASetEvent`.
  - `WSAEnumNetworkEvents` reports the real mask-nominated events
    (FIONREAD-based FD_READ, SO_ACCEPTCONN-based FD_ACCEPT, SO_ERROR-backed
    FD_CONNECT/FD_CLOSE) and resets the event object — no more fabricated
    `FD_READ|FD_WRITE|FD_ACCEPT|FD_CONNECT`.
  - `connect()` marks non-blocking (EINPROGRESS) sockets so FD_CONNECT can
    fire on completion.
  - FD_READ/FD_ACCEPT/FD_WRITE are level-triggered; FD_CONNECT and FD_CLOSE
    are edge-triggered (reported once), matching Winsock semantics. Wait
    loops cannot busy-spin (close-reported sockets are excluded from polls;
    undeliverable poll conditions back off).
- `include/metalsharp/NetworkContext.h` + `src/win32/kernel32/NetworkContext.cpp`:
  event-object table (signaled state, socket associations), per-socket
  FD_CONNECT/FD_CLOSE edge state, and the cross-thread wake pipe.
- `tests/test_ws2_32_events.cpp` (new): regression test driving the shim
  through `createWs2_32Shim()` over loopback sockets — timeout semantics,
  multi-event indexing, `fWaitAll`, invalid handles, cross-thread wake,
  FD_READ, FD_CLOSE, and FD_ACCEPT flows. Wired into ctest as
  `ws2_32_events`.

## PR Readiness (MANDATORY)

- [x] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed (not applicable — no TOML/DLL-map changes)
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped (not applicable — no version bump)
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes (not applicable — bug fix restores documented ws2_32 behavior; no doc surface describes these internals)
- [x] Regression test added for each bug fix

## Local toolchain (run before push)

- [x] `cargo fmt --all -- --check` passes (Rust — no Rust changed; run for completeness)
- [ ] `cargo clippy --all-targets -- -D warnings` passes (Rust — not run: no Rust changes)
- [ ] `cargo build --release` passes (Rust backend — not run: no Rust changes)
- [x] `cargo test` passes (Rust — 762/762 passed)
- [x] C++ compiles if changed: `cmake -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON && cmake --build build-native --parallel $(sysctl -n hw.ncpu)`
- [x] `clang-format --dry-run --Werror` passes on any changed C/C++/Obj-C file (also ran the full `tools/ci/check-clang-format.sh` gate)
- [x] `ctest --test-dir build-native` passes if tests changed (32/32 passed, full local suite — no CI exclusions)
- [ ] TypeScript compiles if changed: `cd app && npx tsc --noEmit` (not applicable — no TS/JS changes)
- [ ] Biome + Prettier pass if TS/JS changed (not applicable — no TS/JS changes)
- [ ] Shell scripts lint if changed: `tools/ci/shellcheck.sh` (not applicable — no shell changes)
- [ ] `tools/ci/validate-rules-toml.py` passes if `configs/mtsp-rules.toml` changed (not applicable)
- [ ] `python3 tools/ci/verify-dmg-workflow.py` passes if release/bundle tooling changed (not applicable)
- [x] Tested with at least one game (which one? which launch method? which drive?) — see Test notes: no commercial game was run; the affected artifact itself was verified end-to-end
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files should be added to the repo root; place them under `app/`, `tools/`, `tests/`, etc. (new test lives under `tests/`)

## Test notes

No commercial game was launched in this environment (no Steam/runtime bundles
available). The shim itself was verified end-to-end:

- New `ws2_32_events` ctest drives the shim through `createWs2_32Shim()`
  exactly as the PE loader resolves ws2_32.dll imports, over real loopback
  sockets: a fresh event times out instead of fabricating `WAIT_OBJECT_0`;
  `WSASetEvent`/`WSAResetEvent` toggle; multi-event waits return the lowest
  signaled index; `fWaitAll` requires all events; closed/invalid handles
  return `WSA_WAIT_FAILED` with the documented error; a cross-thread
  `WSASetEvent` wakes an infinite wait; FD_READ fires when data arrives and
  FD_CLOSE fires exactly once when the peer closes; FD_ACCEPT fires on a
  listening socket.
- Negative proof: the same test **fails against the pre-fix shim** (aborts —
  the event API exports are missing and the wait fabricates success),
  confirming it guards the regression.
- Full local suite: 32/32 ctest passed; 762/762 Rust tests passed (backend
  untouched); `git diff --check` and the repo pre-commit hook clean. The test
  run waited for a concurrent agent's suite to finish before running, per the
  shared-workflow convention.

Known emulation limits (documented, not regressions): FD_WRITE is polled
level-triggered (a game that registers FD_WRITE but never acts may wake
repeatedly; send-until-WSAEWOULDBLOCK loops behave like Windows);
`fAlertable` waits do not deliver APCs (`WSA_WAIT_IO_COMPLETION` is never
returned — no APC mechanism exists in this shim).

## Risk

Low. The change only affects the native-loader ws2_32 event-object path,
which previously returned fabricated results. Games that never call
`WSAEventSelect`/`WSAWaitForMultipleEvents` are unaffected; games that do now
wake on real socket activity with correct timeout/error semantics. Rollback:
revert this single commit — no migration or config impact.
