### PR TITLE
fix(audio): prevent DirectSound buffer double frees

### DIFF
--- a/include/metalsharp/DirectSoundBackend.h
+++ b/include/metalsharp/DirectSoundBackend.h
@@ -5,11 +5,14 @@
 /// creation with WAVEFORMAT, write cursor management, play/stop control, and per-buffer
 /// volume. Each DSBuffer wraps a std::vector ring buffer that feeds into CoreAudioBackend.
 /// Used by the dsound.dll shim to service games that use DirectSound for audio output.
+/// All public operations are serialized, and only buffers created by this backend are
+/// released by destroyBuffer; repeated or foreign destroy requests are ignored.
 
 #pragma once
 
 #include <cstdint>
 #include <metalsharp/Platform.h>
+#include <mutex>
 #include <vector>
 
 namespace metalsharp {
@@ -69,6 +72,7 @@ class DirectSoundBackend {
 
     std::vector<DSBuffer*> m_buffers;
     bool m_initialized = false;
+    mutable std::mutex m_mutex;
 };
 
 } // namespace metalsharp

--- a/src/audio/DirectSoundBackend.cpp
+++ b/src/audio/DirectSoundBackend.cpp
@@ -16,12 +16,14 @@ DirectSoundBackend& DirectSoundBackend::instance() {
 }
 
 bool DirectSoundBackend::init() {
+    std::lock_guard<std::mutex> lock(m_mutex);
     m_initialized = true;
     MS_INFO("DirectSoundBackend initialized");
     return true;
 }
 
 void DirectSoundBackend::shutdown() {
+    std::lock_guard<std::mutex> lock(m_mutex);
     for (auto* buf : m_buffers) {
         delete buf;
     }
@@ -30,6 +32,7 @@ void DirectSoundBackend::shutdown() {
 }
 
 void* DirectSoundBackend::createBuffer(uint32_t size, const WAVEFORMAT& format) {
+    std::lock_guard<std::mutex> lock(m_mutex);
     auto* buf = new DSBuffer();
     buf->data.resize(size, 0);
     buf->format = format;
@@ -45,18 +48,25 @@ void* DirectSoundBackend::createBuffer(uint32_t size, const WAVEFORMAT& format) 
 void DirectSoundBackend::destroyBuffer(void* buffer) {
     if (!buffer)
         return;
+
+    std::lock_guard<std::mutex> lock(m_mutex);
     auto* buf = static_cast<DSBuffer*>(buffer);
     auto it = std::find(m_buffers.begin(), m_buffers.end(), buf);
-    if (it != m_buffers.end()) {
-        m_buffers.erase(it);
-    }
+    if (it == m_buffers.end())
+        return;
+
+    m_buffers.erase(it);
     delete buf;
 }
 
 bool DirectSoundBackend::writeBuffer(void* buffer, const void* data, uint32_t offset, uint32_t size) {
     if (!buffer || !data)
         return false;
+
+    std::lock_guard<std::mutex> lock(m_mutex);
     auto* buf = static_cast<DSBuffer*>(buffer);
+    if (std::find(m_buffers.begin(), m_buffers.end(), buf) == m_buffers.end())
+        return false;
     if (offset + size > buf->data.size())
         return false;
     memcpy(buf->data.data() + offset, data, size);
@@ -66,7 +76,11 @@ bool DirectSoundBackend::writeBuffer(void* buffer, const void* data, uint32_t of
 bool DirectSoundBackend::playBuffer(void* buffer, uint32_t flags) {
     if (!buffer)
         return false;
+
+    std::lock_guard<std::mutex> lock(m_mutex);
     auto* buf = static_cast<DSBuffer*>(buffer);
+    if (std::find(m_buffers.begin(), m_buffers.end(), buf) == m_buffers.end())
+        return false;
     buf->playing = true;
     return true;
 }
@@ -74,7 +88,11 @@ bool DirectSoundBackend::playBuffer(void* buffer, uint32_t flags) {
 bool DirectSoundBackend::stopBuffer(void* buffer) {
     if (!buffer)
         return false;
+
+    std::lock_guard<std::mutex> lock(m_mutex);
     auto* buf = static_cast<DSBuffer*>(buffer);
+    if (std::find(m_buffers.begin(), m_buffers.end(), buf) == m_buffers.end())
+        return false;
     buf->playing = false;
     return true;
 }
@@ -82,14 +100,24 @@ bool DirectSoundBackend::stopBuffer(void* buffer) {
 bool DirectSoundBackend::setVolume(void* buffer, float volume) {
     if (!buffer)
         return false;
-    static_cast<DSBuffer*>(buffer)->volume = volume;
+
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto* buf = static_cast<DSBuffer*>(buffer);
+    if (std::find(m_buffers.begin(), m_buffers.end(), buf) == m_buffers.end())
+        return false;
+    buf->volume = volume;
     return true;
 }
 
 float DirectSoundBackend::getVolume(void* buffer) const {
     if (!buffer)
         return 0;
-    return static_cast<DSBuffer*>(buffer)->volume;
+
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto* buf = static_cast<DSBuffer*>(buffer);
+    if (std::find(m_buffers.begin(), m_buffers.end(), buf) == m_buffers.end())
+        return 0;
+    return buf->volume;
 }
 
 } // namespace metalsharp

--- a/tests/test_phase22.cpp
+++ b/tests/test_phase22.cpp
@@ -1,3 +1,4 @@
+#include <atomic>
 #include <cmath>
 #include <cstdio>
 #include <cstring>
@@ -5,6 +6,7 @@
 #include <metalsharp/DirectSoundBackend.h>
 #include <metalsharp/X3DAudioEngine.h>
 #include <metalsharp/XAudio2Engine.h>
+#include <thread>
 
 using namespace metalsharp;
 
@@ -313,6 +315,54 @@ static bool test_directsound_volume() {
     return std::abs(vol - 0.5f) < 0.01f;
 }
 
+static bool test_directsound_destroy_invalid_buffer() {
+    auto& ds = DirectSoundBackend::instance();
+    ds.init();
+
+    uint64_t foreignStorage = 0;
+    ds.destroyBuffer(&foreignStorage);
+
+    WAVEFORMAT fmt = {1, 2, 44100, 176400, 4, 16, 0};
+    void* buf = ds.createBuffer(1024, fmt);
+    ds.destroyBuffer(buf);
+    ds.destroyBuffer(buf);
+
+    ds.shutdown();
+    return true;
+}
+
+static bool test_directsound_concurrent_lifecycle() {
+    auto& ds = DirectSoundBackend::instance();
+    ds.init();
+
+    const WAVEFORMAT fmt = {1, 2, 44100, 176400, 4, 16, 0};
+    std::atomic<bool> ok{true};
+    auto exercise = [&]() {
+        uint8_t data[64] = {};
+        for (int i = 0; i < 64; ++i) {
+            void* buf = ds.createBuffer(256, fmt);
+            if (!buf) {
+                ok = false;
+                continue;
+            }
+
+            if (!ds.writeBuffer(buf, data, 0, sizeof(data)) || !ds.playBuffer(buf, 0) || !ds.stopBuffer(buf) ||
+                !ds.setVolume(buf, 0.5f) || std::abs(ds.getVolume(buf) - 0.5f) >= 0.01f) {
+                ok = false;
+            }
+            ds.destroyBuffer(buf);
+        }
+    };
+
+    std::thread workers[4] = {std::thread(exercise), std::thread(exercise), std::thread(exercise),
+                              std::thread(exercise)};
+    for (auto& worker : workers)
+        worker.join();
+
+    ds.shutdown();
+    return ok.load();
+}
+
 int main() {
     printf("=== Phase 22: Audio Pipeline ===\n\n");
 
@@ -340,6 +390,8 @@ int main() {
     TEST(directsound_create_buffer);
     TEST(directsound_write_play_stop);
     TEST(directsound_volume);
+    TEST(directsound_destroy_invalid_buffer);
+    TEST(directsound_concurrent_lifecycle);
 
     printf("\n%d/%d passed", testsPassed, testsPassed + testsFailed);
     if (testsFailed > 0)


### PR DESCRIPTION
## Summary

Fixes #435 by making DirectSound buffer ownership and lifetime checks safe under repeated, foreign, and concurrent API calls.

## Changes

- Add a mutex that serializes DirectSound backend lifecycle, registry, and buffer-state operations.
- Make `destroyBuffer` erase and delete only a buffer registered by this backend; null, foreign, and repeated destroy requests are no-ops.
- Reject operations on unregistered buffers so a concurrent destroy cannot race a buffer access.
- Document the ownership/thread-safety contract in `DirectSoundBackend.h`.
- Add Phase 22 regression coverage for foreign/repeated destruction and concurrent buffer lifecycles.

## PR Readiness (MANDATORY)

<!-- The checklist-exception label is used only for the intentionally inapplicable
     real-game and user-facing-documentation items. This is an internal native
     DirectSound lifetime fix and does not change launch routing or game behavior. -->

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
  - Not applicable: this change is an internal DirectSound registry/lifetime fix; no game launch or routing behavior changed.
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
  - Not applicable: no rules or DLL maps changed.
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped
  - Not applicable: no version surfaces changed.
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
  - No bottle, runtime, migration, or launch code changed.
- [ ] Docs / compatibility matrix updated for user-facing changes
  - Not applicable: no user-facing behavior changed; the native header contract was updated in the touched surface.
- [x] Regression test added for each bug fix

## Local toolchain (run before push)

- [ ] `cargo fmt --all -- --check` passes (Rust) — not applicable; no Rust files changed.
- [ ] `cargo clippy --all-targets -- -D warnings` passes — not applicable; no Rust files changed.
- [ ] `cargo build --release` passes — not applicable; no Rust files changed.
- [ ] `cargo test` passes — not applicable; no Rust files changed.
- [x] C++ compiles if changed: `cmake -S . -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON && cmake --build build-native --parallel $(sysctl -n hw.ncpu)`.
- [x] `clang-format --dry-run --Werror` passes on changed C++ files and `tools/ci/check-clang-format.sh` passes.
- [x] `ctest --test-dir build-native --output-on-failure` — 31/31 tests passed.
- [ ] TypeScript, Biome, and Prettier checks — not applicable; no app files changed.
- [ ] Shell, rules TOML, DMG workflow, and D3D12 contract checks — not applicable; those surfaces were not changed.
- [x] Native shim package contract: `tools/bundles/verify-native-shims.sh --eac-only app/native` passed.
- [ ] Tested with at least one game (which one? which launch method? which drive?) — not applicable; no game-launch behavior changed.
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths.
- [x] No new files were added to the repo root.

## Test notes

- `cmake -S . -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON` — passed.
- `cmake --build build-native --parallel $(sysctl -n hw.ncpu)` — passed.
- `ctest --test-dir build-native --output-on-failure -V -R '^phase22$'` — 20/20 Phase 22 checks passed, including the new invalid-destroy and concurrent-lifecycle checks.
- `ctest --test-dir build-native --output-on-failure` — 31/31 native tests passed.
- `tools/ci/check-clang-format.sh` — passed.
- `tools/bundles/verify-native-shims.sh --eac-only app/native` — passed.
- `git diff --check` — passed.
- No real-game launch was performed because this fix is isolated to native DirectSound buffer lifetime handling.

## Risk

Valid buffer creation and operations retain their existing behavior. Invalid or repeated destruction is now ignored instead of invoking `delete` on an unowned or already-freed pointer, and concurrent calls are serialized. Roll back commit `56dbed54` if a regression is found; no migration or runtime bundle changes are involved.

<!-- checklist-exception label applied; readiness is intentionally bypassed for this internal native fix. -->
