### PR TITLE
fix: scope Process Manager Wine shutdown

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -10,7 +10,7 @@
   "main": "dist/main/index.js",
   "scripts": {
     "build": "tsc && vite build && cp src/renderer/icon.png src/renderer/pressstart2p.ttf dist/renderer/",
-    "test": "tsc && node --test test/dmg-eject.test.js",
+    "test": "npm run build && node --test test/dmg-eject.test.js tests/process-manager.test.js",
     "start": "npm run build && electron .",
     "dev": "tsc -w & vite build --watch & electron .",
     "dev:vite": "vite",

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -4,6 +4,13 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import { ejectDmgVolume } from "./dmg-eject";
+import {
+  createProcessManagerScope,
+  isNonSteamMetalSharpWineProcess,
+  isSteamWineProcess,
+  type ProcessRow,
+  stopMetalSharpWineProcesses,
+} from "./process-manager";
 import type { ProcessManagerAction, ProcessManagerActionResult, ProcessManagerSample } from "./process-manager-types";
 import { RustBridge } from "./rust-bridge";
 import { validateUninstallTarget } from "./uninstall-safety";
@@ -306,8 +313,6 @@ function forceKillBackendProcesses() {
   }
 }
 
-type ProcessRow = { pid: number; comm: string; command: string };
-
 function parseProcessRows(output: string): ProcessRow[] {
   return output
     .split(/\r?\n/)
@@ -447,24 +452,6 @@ async function processManagerSample(): Promise<ProcessManagerSample> {
   return jsProcessManagerFallback();
 }
 
-function isNonSteamWineProcess(row: ProcessRow): boolean {
-  const command = row.command.toLowerCase();
-  const comm = path.basename(row.comm).toLowerCase();
-  const haystack = `${comm} ${command}`;
-  const isSteam = haystack.includes("steam");
-  const isWine =
-    comm === "wine" ||
-    comm === "wineserver" ||
-    comm.startsWith("wine") ||
-    command.includes("/wine") ||
-    command.includes("wineserver") ||
-    command.includes("wine-preloader") ||
-    command.includes("wine64-preloader") ||
-    command.includes("wineboot") ||
-    command.includes("drive_c/");
-  return row.pid > 0 && row.pid !== process.pid && isWine && !isSteam;
-}
-
 async function processManagerQuitGame(): Promise<ProcessManagerActionResult> {
   let rows: ProcessRow[] = [];
   try {
@@ -477,24 +464,29 @@ async function processManagerQuitGame(): Promise<ProcessManagerActionResult> {
       errors: [],
     };
   }
-  const targets = rows.filter(isNonSteamWineProcess);
-  const killed: number[] = [];
-  const errors: string[] = [];
-  for (const row of targets) {
-    try {
-      process.kill(row.pid, "SIGKILL");
-      killed.push(row.pid);
-    } catch (error) {
-      const code =
-        typeof error === "object" && error && "code" in error ? String((error as { code?: unknown }).code) : "";
-      if (code !== "ESRCH") errors.push(`${row.pid}: ${error instanceof Error ? error.message : String(error)}`);
-    }
-  }
-  const skippedSteamWinePids = rows.filter((row) => {
-    const haystack = `${path.basename(row.comm).toLowerCase()} ${row.command.toLowerCase()}`;
-    return haystack.includes("wine") && haystack.includes("steam");
-  }).length;
-  return { ok: errors.length === 0, killed, errors, skippedSteamWinePids };
+  const scope = createProcessManagerScope(getMetalsharpDir());
+  const targets = rows.filter((row) => isNonSteamMetalSharpWineProcess(row, scope, process.pid));
+  const skippedSteamWinePids = rows.filter(isSteamWineProcess).length;
+  const useGracefulStop =
+    targets.length > 0 &&
+    skippedSteamWinePids === 0 &&
+    fs.existsSync(scope.wineServer) &&
+    fs.existsSync(scope.managedPrefix);
+  const result = stopMetalSharpWineProcesses(
+    targets,
+    scope,
+    {
+      stopWithWineserver: (wineServer, prefix) => {
+        execFileSync(wineServer, ["-k"], {
+          env: { ...process.env, WINEPREFIX: prefix },
+          stdio: "ignore",
+        });
+      },
+      kill: (pid) => process.kill(pid, "SIGKILL"),
+    },
+    useGracefulStop,
+  );
+  return { ok: result.errors.length === 0, ...result, skippedSteamWinePids };
 }
 
 async function createProcessManagerWindow(): Promise<BrowserWindow> {

--- a/app/src/main/process-manager.ts
+++ b/app/src/main/process-manager.ts
@@ -1,0 +1,136 @@
+import * as path from "path";
+
+export interface ProcessRow {
+  pid: number;
+  comm: string;
+  command: string;
+}
+
+export interface ProcessManagerScope {
+  home: string;
+  managedPrefix: string;
+  wineServer: string;
+}
+
+export interface ProcessManagerStopOperations {
+  stopWithWineserver: (wineServer: string, prefix: string) => void;
+  kill: (pid: number) => void;
+}
+
+export interface ProcessManagerStopResult {
+  killed: number[];
+  errors: string[];
+  mode: "no-targets" | "wineserver" | "scoped-sigkill";
+}
+
+export function createProcessManagerScope(home: string): ProcessManagerScope {
+  const resolvedHome = path.resolve(home);
+  return {
+    home: resolvedHome,
+    managedPrefix: path.join(resolvedHome, "prefix-steam"),
+    wineServer: path.join(resolvedHome, "runtime", "wine", "bin", "wineserver"),
+  };
+}
+
+function processName(row: ProcessRow): string {
+  return path.basename(row.comm).toLowerCase();
+}
+
+function normalizedPath(value: string): string {
+  return value.replaceAll("\\", "/").toLowerCase();
+}
+
+function pathReference(command: string, candidate: string): boolean {
+  const haystack = normalizedPath(command);
+  const needle = normalizedPath(path.resolve(candidate)).replace(/\/+$/, "");
+  if (!needle || needle === "/") return false;
+
+  let offset = haystack.indexOf(needle);
+  while (offset !== -1) {
+    const before = offset === 0 ? "" : haystack[offset - 1];
+    const after = haystack[offset + needle.length] ?? "";
+    const isPathBoundary = (value: string) => value === "" || !/[a-z0-9._-]/.test(value);
+    if (isPathBoundary(before) && isPathBoundary(after)) return true;
+    offset = haystack.indexOf(needle, offset + needle.length);
+  }
+  return false;
+}
+
+export function isWineProcess(row: ProcessRow): boolean {
+  const command = normalizedPath(row.command);
+  const comm = processName(row);
+  return (
+    comm === "wine" ||
+    comm === "wineserver" ||
+    comm.startsWith("wine") ||
+    command.includes("/wine") ||
+    command.includes("wineserver") ||
+    command.includes("wine-preloader") ||
+    command.includes("wine64-preloader") ||
+    command.includes("wineboot") ||
+    command.includes("drive_c/")
+  );
+}
+
+export function isSteamWineProcess(row: ProcessRow): boolean {
+  if (!isWineProcess(row)) return false;
+
+  const haystack = normalizedPath(`${row.comm} ${row.command}`);
+  return (
+    /(?:^|[/\s"'=])steam(?:\.exe)?(?:$|[/\s"'])/.test(haystack) ||
+    /(?:^|[/\s"'=])steamwebhelper(?:_real)?\.exe(?:$|[/\s"'])/.test(haystack) ||
+    /(?:^|[/\s"'=])steam(?:service|errorreporter)\.exe(?:$|[/\s"'])/.test(haystack)
+  );
+}
+
+export function isMetalSharpOwnedWineProcess(row: ProcessRow, scope: ProcessManagerScope, currentPid: number): boolean {
+  if (row.pid <= 0 || row.pid === currentPid || !isWineProcess(row)) return false;
+
+  // A Wine executable name is not an ownership proof: CrossOver, Whisky,
+  // GPTK, and Homebrew Wine all expose the same wine/wineserver helpers.
+  // Require a path reference to MetalSharp's resolved data root or its
+  // managed prefix before a row can be considered safe to stop.
+  const command = `${row.comm} ${row.command}`;
+  return pathReference(command, scope.home) || pathReference(command, scope.managedPrefix);
+}
+
+export function isNonSteamMetalSharpWineProcess(
+  row: ProcessRow,
+  scope: ProcessManagerScope,
+  currentPid: number,
+): boolean {
+  return isMetalSharpOwnedWineProcess(row, scope, currentPid) && !isSteamWineProcess(row);
+}
+
+export function stopMetalSharpWineProcesses(
+  targets: ProcessRow[],
+  scope: ProcessManagerScope,
+  operations: ProcessManagerStopOperations,
+  useGracefulStop: boolean,
+): ProcessManagerStopResult {
+  if (targets.length === 0) return { killed: [], errors: [], mode: "no-targets" };
+
+  if (useGracefulStop) {
+    try {
+      operations.stopWithWineserver(scope.wineServer, scope.managedPrefix);
+      return { killed: targets.map((row) => row.pid), errors: [], mode: "wineserver" };
+    } catch {
+      // Fall through to the already-scoped PID fallback when the runtime is
+      // unavailable or wineserver cannot connect to the managed prefix.
+    }
+  }
+
+  const killed: number[] = [];
+  const errors: string[] = [];
+  for (const row of targets) {
+    try {
+      operations.kill(row.pid);
+      killed.push(row.pid);
+    } catch (error) {
+      const code =
+        typeof error === "object" && error && "code" in error ? String((error as { code?: unknown }).code) : "";
+      if (code !== "ESRCH") errors.push(`${row.pid}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  return { killed, errors, mode: "scoped-sigkill" };
+}

--- a/app/src/renderer/components/ProcessManagerOverlay.vue
+++ b/app/src/renderer/components/ProcessManagerOverlay.vue
@@ -71,8 +71,8 @@ const fpsLabel = computed(() => (sample.value?.fps == null ? "WAIT" : Math.round
 const tempLabel = computed(() => {
   const s = sample.value;
   if (s?.gpu_mem_used_bytes != null && s.gpu_mem_used_bytes > 0) {
-    const gb = s.gpu_mem_used_bytes / (1024*1024*1024);
-    return gb >= 1 ? `${gb.toFixed(1)}GB` : `${Math.round(s.gpu_mem_used_bytes/(1024*1024))}MB`;
+    const gb = s.gpu_mem_used_bytes / (1024 * 1024 * 1024);
+    return gb >= 1 ? `${gb.toFixed(1)}GB` : `${Math.round(s.gpu_mem_used_bytes / (1024 * 1024))}MB`;
   }
   return s?.cpu_temp_c != null ? `${Math.round(s.cpu_temp_c)}°C` : "VRAM";
 });
@@ -124,7 +124,7 @@ async function runAction(action: ProcessManagerAction): Promise<void> {
     gpuAccelArmed.value = !gpuAccelArmed.value;
     status.value = `GPU acceleration visual surface ${gpuAccelArmed.value ? "armed" : "parked"}; runtime hook pending`;
   } else if (action === "quit-game") {
-    status.value = "Force-killing non-Steam Wine game PIDs...";
+    status.value = "Stopping MetalSharp-owned Wine game processes...";
   } else {
     status.value = "Bringing Steam forward...";
   }
@@ -137,7 +137,12 @@ async function runAction(action: ProcessManagerAction): Promise<void> {
   }
   if (result?.ok) {
     if (action === "quit-game") {
-      status.value = "Non-Steam Wine game kill signal sent";
+      status.value =
+        result.mode === "wineserver"
+          ? "MetalSharp Wine game stopped via its managed wineserver"
+          : result.killed?.length
+            ? `Stopped ${result.killed.length} MetalSharp-owned Wine process${result.killed.length === 1 ? "" : "es"}`
+            : "No MetalSharp-owned non-Steam Wine game processes found";
       await refresh();
     }
   } else {
@@ -185,13 +190,19 @@ onBeforeUnmount(() => {
           <span class="pm-label">Active FPS</span>
           <strong>{{ fpsLabel }}</strong>
           <small>{{
-            sample?.fps == null ? "waiting for non-Steam Wine FPS" : sample?.fps_source ?? "frames/sec"
+            sample?.fps == null ? "waiting for non-Steam Wine FPS" : (sample?.fps_source ?? "frames/sec")
           }}</small>
         </article>
         <article class="pm-stat">
           <span class="pm-label">GPU Memory</span>
           <strong>{{ tempLabel }}</strong>
-          <small>{{ sample?.gpu_mem_used_bytes ? "allocated VRAM" : sample?.cpu_temp_c == null ? "unavailable" : sample?.cpu_temp_source ?? "PMU sensor" }}</small>
+          <small>{{
+            sample?.gpu_mem_used_bytes
+              ? "allocated VRAM"
+              : sample?.cpu_temp_c == null
+                ? "unavailable"
+                : (sample?.cpu_temp_source ?? "PMU sensor")
+          }}</small>
         </article>
         <article class="pm-stat">
           <span class="pm-label">Cores Used</span>
@@ -246,8 +257,8 @@ onBeforeUnmount(() => {
         </div>
         <button class="pm-action danger" type="button" @click="runAction('quit-game')">
           <span>Quit Game</span>
-          <strong>Force Kill</strong>
-          <small>non-Steam Wine PIDs</small>
+          <strong>Stop</strong>
+          <small>MetalSharp-owned Wine game</small>
         </button>
         <button
           class="pm-action"
@@ -299,8 +310,7 @@ onBeforeUnmount(() => {
   height: 100vh;
   color: var(--text-primary);
   background:
-    radial-gradient(circle at 18% 0, #ff2ef738, #0000 36%),
-    radial-gradient(circle at 88% 14%, #00f5ff2e, #0000 34%),
+    radial-gradient(circle at 18% 0, #ff2ef738, #0000 36%), radial-gradient(circle at 88% 14%, #00f5ff2e, #0000 34%),
     radial-gradient(circle at 50% 100%, #b9ff4d21, #0000 42%);
   justify-content: center;
   align-items: center;
@@ -315,7 +325,10 @@ onBeforeUnmount(() => {
   width: min(720px, 100vw - 18px);
   max-height: calc(100vh - 18px);
   overflow: auto;
-  box-shadow: inset 0 0 0 1px #ffffff0d, 0 0 42px #b9ff4d1f, 0 30px 90px #00000094;
+  box-shadow:
+    inset 0 0 0 1px #ffffff0d,
+    0 0 42px #b9ff4d1f,
+    0 30px 90px #00000094;
 }
 .pm-header {
   -webkit-app-region: drag;

--- a/app/tests/process-manager.test.js
+++ b/app/tests/process-manager.test.js
@@ -1,0 +1,129 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+const {
+  createProcessManagerScope,
+  isMetalSharpOwnedWineProcess,
+  isNonSteamMetalSharpWineProcess,
+  isSteamWineProcess,
+  stopMetalSharpWineProcesses,
+} = require("../dist/main/process-manager.js");
+
+const scope = createProcessManagerScope("/tmp/metalsharp-process-manager-test");
+const currentPid = 999;
+
+function row(pid, comm, command) {
+  return { pid, comm, command };
+}
+
+test("only MetalSharp-owned Wine rows are eligible for process-manager cleanup", () => {
+  assert.equal(
+    isNonSteamMetalSharpWineProcess(
+      row(100, "wine", "/Applications/CrossOver.app/Contents/SharedSupport/CrossOver/bin/wine game.exe"),
+      scope,
+      currentPid,
+    ),
+    false,
+  );
+  assert.equal(
+    isNonSteamMetalSharpWineProcess(row(101, "wineserver", "/opt/homebrew/bin/wineserver -f"), scope, currentPid),
+    false,
+  );
+  assert.equal(
+    isNonSteamMetalSharpWineProcess(
+      row(102, "wine-preloader", "/tmp/metalsharp-process-manager-test-other/runtime/wine/bin/wine-preloader game.exe"),
+      scope,
+      currentPid,
+    ),
+    false,
+  );
+  assert.equal(
+    isNonSteamMetalSharpWineProcess(
+      row(103, "metalsharp-wine", "/tmp/metalsharp-process-manager-test/runtime/wine/bin/metalsharp-wine game.exe"),
+      scope,
+      currentPid,
+    ),
+    true,
+  );
+  assert.equal(
+    isNonSteamMetalSharpWineProcess(
+      row(104, "wineboot", "/tmp/metalsharp-process-manager-test/prefix-steam/drive_c/windows/wineboot.exe --init"),
+      scope,
+      currentPid,
+    ),
+    true,
+  );
+  assert.equal(
+    isNonSteamMetalSharpWineProcess(
+      row(105, "wine", "/tmp/metalsharp-process-manager-test/runtime/wine/bin/wine Steam.exe"),
+      scope,
+      currentPid,
+    ),
+    false,
+  );
+  assert.equal(
+    isMetalSharpOwnedWineProcess(
+      row(currentPid, "wine", "/tmp/metalsharp-process-manager-test/runtime/wine/bin/wine game.exe"),
+      scope,
+      currentPid,
+    ),
+    false,
+  );
+});
+
+test("wineserver shutdown receives the MetalSharp runtime and managed prefix", () => {
+  const calls = [];
+  const result = stopMetalSharpWineProcesses(
+    [row(200, "wine", "/tmp/metalsharp-process-manager-test/runtime/wine/bin/metalsharp-wine game.exe")],
+    scope,
+    {
+      stopWithWineserver: (wineServer, prefix) => calls.push({ wineServer, prefix }),
+      kill: () => assert.fail("scoped SIGKILL should not run after wineserver succeeds"),
+    },
+    true,
+  );
+
+  assert.deepEqual(calls, [{ wineServer: scope.wineServer, prefix: scope.managedPrefix }]);
+  assert.deepEqual(result.killed, [200]);
+  assert.equal(result.mode, "wineserver");
+});
+
+test("scoped SIGKILL is only the fallback when wineserver cannot stop the prefix", () => {
+  const killed = [];
+  const result = stopMetalSharpWineProcesses(
+    [row(201, "wine", "/tmp/metalsharp-process-manager-test/runtime/wine/bin/metalsharp-wine game.exe")],
+    scope,
+    {
+      stopWithWineserver: () => {
+        throw new Error("wineserver unavailable");
+      },
+      kill: (pid) => killed.push(pid),
+    },
+    true,
+  );
+
+  assert.deepEqual(killed, [201]);
+  assert.deepEqual(result.killed, [201]);
+  assert.equal(result.mode, "scoped-sigkill");
+  assert.deepEqual(result.errors, []);
+});
+
+test("the graceful path can be disabled when the shared Steam prefix must remain alive", () => {
+  const killed = [];
+  const result = stopMetalSharpWineProcesses(
+    [row(202, "wine", "/tmp/metalsharp-process-manager-test/runtime/wine/bin/metalsharp-wine game.exe")],
+    scope,
+    {
+      stopWithWineserver: () => assert.fail("shared Steam prefix should use the scoped fallback"),
+      kill: (pid) => killed.push(pid),
+    },
+    false,
+  );
+
+  assert.deepEqual(killed, [202]);
+  assert.equal(result.mode, "scoped-sigkill");
+  assert.equal(
+    isSteamWineProcess(row(203, "wine", "/tmp/metalsharp-process-manager-test/runtime/wine/bin/wine Steam.exe")),
+    true,
+  );
+});

--- a/docs/runtime/wine-architecture.md
+++ b/docs/runtime/wine-architecture.md
@@ -1,5 +1,5 @@
 # Wine Architecture
-**Updated:** 2026-07-08
+**Updated:** 2026-08-11
 
 
 MetalSharp ships a self-contained Wine runtime at:
@@ -177,6 +177,22 @@ Rules:
 5. **Vulkan ICD**: `VK_ICD_FILENAMES` must resolve inside the runtime
    (`$MS_ROOT/etc/vulkan/icd.d/MoltenVK_icd.json`) or be unset — never a
    hardcoded Homebrew path, which is absent on CrossOver-only machines.
+
+### Process Manager stop behavior
+
+The Process Manager's **Quit Game** action follows the same ownership boundary
+as the rest of the Wine lifecycle. It considers only non-Steam Wine rows whose
+command line references the resolved MetalSharp data root or the managed
+`prefix-steam` prefix. A bare `wine`, `wineserver`, `wineboot`, or
+`drive_c/` match is never enough to stop a process from CrossOver, Whisky,
+GPTK, or another Wine installation.
+
+When the shared Steam prefix is not active, the action first invokes
+MetalSharp's bundled `runtime/wine/bin/wineserver -k` with `WINEPREFIX` set to
+the managed prefix. If the prefix is shared with Wine Steam, or the bundled
+server is unavailable, it falls back to SIGKILL only for the already-scoped
+MetalSharp game PIDs. This preserves the live Wine Steam client while keeping
+foreign Wine games outside the kill scope.
 
 The GPTK lane is the working model for isolation: it owns its prefix
 (`prefix-gptk`), its DYLD paths (`gptk_seed_dyld`), and its route DLLs. The


### PR DESCRIPTION
## Summary

Fixes #449 by making the Process Manager's **Quit Game** action ownership-aware and prefix-scoped instead of treating every non-Steam Wine-looking process on the host as MetalSharp-owned.

## Changes

- Extract the process ownership and stop strategy into a tested main-process module.
- Require a path reference to the resolved MetalSharp data root or managed prefix before selecting a Wine PID.
- Prefer MetalSharp's bundled `wineserver -k` with `WINEPREFIX` set to `prefix-steam`; use SIGKILL only as a scoped fallback when the managed server is unavailable or Wine Steam shares the prefix.
- Preserve Wine Steam and foreign CrossOver/Whisky/GPTK processes, and report the stop mode in the overlay.
- Document the process-manager isolation contract and add Node regression tests for foreign helpers, path-boundary matching, Steam detection, and fallback behavior.

## PR Readiness (MANDATORY)

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

The compatibility item is intentionally not applicable to this process-ownership-only change; the `checklist-exception` label is applied for the readiness workflow.

## Local toolchain (run before push)

- [ ] `cargo fmt --all -- --check` passes (Rust) — not applicable; no Rust files changed.
- [ ] `cargo clippy --all-targets -- -D warnings` passes (Rust) — not applicable; no Rust files changed.
- [ ] `cargo build --release` passes (Rust backend) — not applicable; no Rust files changed.
- [ ] `cargo test` passes (Rust — 628+ tests) — not applicable; no Rust files changed.
- [ ] C++ compiles if changed — not applicable; no native files changed.
- [ ] `clang-format --dry-run --Werror` passes on any changed C/C++/Obj-C file — not applicable; no native files changed.
- [ ] `ctest --test-dir build-native` passes if tests changed — not applicable; no native tests changed.
- [x] TypeScript compiles if changed: `cd app && npx tsc --noEmit`
- [x] Biome + Prettier pass if TS/JS changed: `cd app && npx @biomejs/biome ci src/ && npx prettier --check 'src/**/*.{ts,js,html,css,json}'`
- [ ] Shell scripts lint if changed — not applicable; no shell scripts changed.
- [ ] `tools/ci/validate-rules-toml.py` passes if `configs/mtsp-rules.toml` changed — not applicable; rules unchanged.
- [ ] `python3 tools/ci/verify-dmg-workflow.py` passes if release/bundle tooling changed — not applicable; release tooling unchanged.
- [ ] Tested with at least one game (which one? which launch method? which drive?) — intentionally not applicable; this fix is isolated to host process ownership and was exercised with synthetic process rows.
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files should be added to the repo root; place them under `app/`, `tools/`, `tests/`, etc.

## Test notes

- `npm ci`
- `npm test` (production TypeScript/Vite build plus 4 Node regression tests)
- `npx tsc --noEmit`
- `npx @biomejs/biome ci src/main src/shared`
- `npx @biomejs/biome ci src/renderer` (passes with three pre-existing CSS specificity warnings)
- `npx prettier --check 'src/main/**/*.{ts,js,json}' 'src/shared/**/*.{ts,js,json}' 'src/renderer/**/*.{ts,js,html,css,json}' 'tests/**/*.js'`
- `python3 tools/ci/check-doc-freshness.py` (warn-only existing warning: `docs/OPENGL-2-4-PLAN.md` has no `Updated:` header)
- `git diff --check`

## Risk

The primary behavior change is that the Quit Game action can no longer signal foreign Wine processes. The graceful path uses only MetalSharp's runtime and managed prefix. If that path is unavailable, rollback is a single revert of this PR; the fallback remains restricted to the process rows that passed the ownership check.

<!-- pr-readiness-checklist: process-manager-only -->
