### PR TITLE
fix(update-checker): compare prerelease versions correctly

### DIFF
--- a/src/runtime/UpdateChecker.cpp
+++ b/src/runtime/UpdateChecker.cpp
@@ -7,20 +7,109 @@
 
 #include "metalsharp/UpdateChecker.h"
 #include <algorithm>
+#include <cerrno>
+#include <spawn.h>
 #include <sstream>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <vector>
+
+extern char** environ;
 
 namespace metalsharp {
+
+namespace {
+
+std::vector<std::string> splitPrerelease(const std::string& value) {
+    std::vector<std::string> identifiers;
+    size_t start = 0;
+    while (start <= value.size()) {
+        size_t end = value.find('.', start);
+        if (end == std::string::npos) {
+            identifiers.push_back(value.substr(start));
+            break;
+        }
+        identifiers.push_back(value.substr(start, end - start));
+        start = end + 1;
+    }
+    return identifiers;
+}
+
+bool isNumericIdentifier(const std::string& identifier) {
+    return !identifier.empty() &&
+           std::all_of(identifier.begin(), identifier.end(), [](char c) { return c >= '0' && c <= '9'; });
+}
+
+int compareNumericIdentifiers(const std::string& left, const std::string& right) {
+    const auto leftFirst = left.find_first_not_of('0');
+    const auto rightFirst = right.find_first_not_of('0');
+    const std::string leftNormalized = leftFirst == std::string::npos ? "0" : left.substr(leftFirst);
+    const std::string rightNormalized = rightFirst == std::string::npos ? "0" : right.substr(rightFirst);
+
+    if (leftNormalized.size() != rightNormalized.size())
+        return leftNormalized.size() < rightNormalized.size() ? -1 : 1;
+    if (leftNormalized == rightNormalized)
+        return 0;
+    return leftNormalized < rightNormalized ? -1 : 1;
+}
+
+int comparePrerelease(const std::string& left, const std::string& right) {
+    if (left.empty() || right.empty()) {
+        if (left.empty() && right.empty())
+            return 0;
+        return left.empty() ? 1 : -1;
+    }
+
+    const auto leftIdentifiers = splitPrerelease(left);
+    const auto rightIdentifiers = splitPrerelease(right);
+    const size_t sharedCount = std::min(leftIdentifiers.size(), rightIdentifiers.size());
+    for (size_t i = 0; i < sharedCount; ++i) {
+        const std::string& leftIdentifier = leftIdentifiers[i];
+        const std::string& rightIdentifier = rightIdentifiers[i];
+        if (leftIdentifier == rightIdentifier)
+            continue;
+
+        const bool leftNumeric = isNumericIdentifier(leftIdentifier);
+        const bool rightNumeric = isNumericIdentifier(rightIdentifier);
+        if (leftNumeric && rightNumeric)
+            return compareNumericIdentifiers(leftIdentifier, rightIdentifier);
+        if (leftNumeric != rightNumeric)
+            return leftNumeric ? -1 : 1;
+        return leftIdentifier < rightIdentifier ? -1 : 1;
+    }
+
+    if (leftIdentifiers.size() == rightIdentifiers.size())
+        return 0;
+    return leftIdentifiers.size() < rightIdentifiers.size() ? -1 : 1;
+}
+
+bool isValidRepository(const std::string& repo) {
+    const size_t slash = repo.find('/');
+    if (slash == std::string::npos || slash == 0 || slash + 1 >= repo.size() ||
+        repo.find('/', slash + 1) != std::string::npos)
+        return false;
+
+    return std::all_of(repo.begin(), repo.end(), [](char c) {
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_' ||
+               c == '.' || c == '/';
+    });
+}
+
+} // namespace
 
 bool Version::operator>(const Version& o) const {
     if (major != o.major)
         return major > o.major;
     if (minor != o.minor)
         return minor > o.minor;
-    return patch > o.patch;
+    if (patch != o.patch)
+        return patch > o.patch;
+    return comparePrerelease(prerelease, o.prerelease) > 0;
 }
 
 bool Version::operator==(const Version& o) const {
-    return major == o.major && minor == o.minor && patch == o.patch;
+    return major == o.major && minor == o.minor && patch == o.patch && comparePrerelease(prerelease, o.prerelease) == 0;
 }
 
 bool Version::operator>=(const Version& o) const {
@@ -39,6 +128,10 @@ Version Version::parse(const std::string& s) {
     std::string input = s;
     if (input.size() > 0 && input[0] == 'v')
         input = input.substr(1);
+
+    size_t buildPos = input.find('+');
+    if (buildPos != std::string::npos)
+        input = input.substr(0, buildPos);
 
     size_t dashPos = input.find('-');
     std::string versionPart = (dashPos != std::string::npos) ? input.substr(0, dashPos) : input;
@@ -74,7 +167,100 @@ std::string UpdateChecker::getUserAgent() {
 }
 
 std::string UpdateChecker::fetchLatestRelease(const std::string& repo) {
-    return "";
+    // The GitHub REST endpoint has no detached signature for its JSON response.
+    // Keep the request limited to a validated repository over CA-verified HTTPS;
+    // signed/package asset verification remains the release/installer's contract.
+    if (!isValidRepository(repo))
+        return "";
+
+    const std::string url = "https://api.github.com/repos/" + repo + "/releases/latest";
+    const std::string userAgent = getUserAgent();
+    std::vector<std::string> arguments = {
+        "/usr/bin/curl",
+        "--fail",
+        "--silent",
+        "--proto",
+        "=https",
+        "--tlsv1.2",
+        "--connect-timeout",
+        "5",
+        "--max-time",
+        "15",
+        "--header",
+        "Accept: application/vnd.github+json",
+        "--header",
+        "X-GitHub-Api-Version: 2022-11-28",
+        "--user-agent",
+        userAgent,
+        url,
+    };
+    std::vector<char*> argv;
+    argv.reserve(arguments.size() + 1);
+    for (auto& argument : arguments)
+        argv.push_back(argument.data());
+    argv.push_back(nullptr);
+
+    int outputPipe[2];
+    if (pipe(outputPipe) != 0)
+        return "";
+
+    posix_spawn_file_actions_t actions;
+    if (posix_spawn_file_actions_init(&actions) != 0) {
+        close(outputPipe[0]);
+        close(outputPipe[1]);
+        return "";
+    }
+    int actionResult = posix_spawn_file_actions_adddup2(&actions, outputPipe[1], STDOUT_FILENO);
+    if (actionResult == 0)
+        actionResult = posix_spawn_file_actions_addclose(&actions, outputPipe[0]);
+    if (actionResult == 0)
+        actionResult = posix_spawn_file_actions_addclose(&actions, outputPipe[1]);
+    if (actionResult != 0) {
+        posix_spawn_file_actions_destroy(&actions);
+        close(outputPipe[0]);
+        close(outputPipe[1]);
+        return "";
+    }
+
+    pid_t child = 0;
+    const int spawnResult = posix_spawn(&child, arguments[0].c_str(), &actions, nullptr, argv.data(), environ);
+    posix_spawn_file_actions_destroy(&actions);
+    close(outputPipe[1]);
+    if (spawnResult != 0) {
+        close(outputPipe[0]);
+        return "";
+    }
+
+    constexpr size_t maxResponseBytes = 4 * 1024 * 1024;
+    std::string response;
+    char buffer[4096];
+    bool tooLarge = false;
+    bool readFailed = false;
+    while (true) {
+        const ssize_t bytesRead = read(outputPipe[0], buffer, sizeof(buffer));
+        if (bytesRead == 0)
+            break;
+        if (bytesRead < 0) {
+            if (errno == EINTR)
+                continue;
+            readFailed = true;
+            break;
+        }
+        if (response.size() + static_cast<size_t>(bytesRead) <= maxResponseBytes)
+            response.append(buffer, static_cast<size_t>(bytesRead));
+        else
+            tooLarge = true;
+    }
+    close(outputPipe[0]);
+
+    int status = 0;
+    pid_t waited;
+    do {
+        waited = waitpid(child, &status, 0);
+    } while (waited < 0 && errno == EINTR);
+    if (readFailed || tooLarge || waited < 0 || !WIFEXITED(status) || WEXITSTATUS(status) != 0)
+        return "";
+    return response;
 }
 
 UpdateInfo UpdateChecker::parseGitHubRelease(const std::string& json, const Version& current) {
@@ -89,13 +275,59 @@ UpdateInfo UpdateChecker::parseGitHubRelease(const std::string& json, const Vers
         auto colon = j.find(':', pos + search.length());
         if (colon == std::string::npos)
             return "";
-        auto openQuote = j.find('"', colon + 1);
-        if (openQuote == std::string::npos)
+        auto openQuote = colon + 1;
+        while (openQuote < j.size() &&
+               (j[openQuote] == ' ' || j[openQuote] == '\n' || j[openQuote] == '\r' || j[openQuote] == '\t'))
+            ++openQuote;
+        if (openQuote >= j.size() || j[openQuote] != '"')
             return "";
-        auto closeQuote = j.find('"', openQuote + 1);
-        if (closeQuote == std::string::npos)
-            return "";
-        return j.substr(openQuote + 1, closeQuote - openQuote - 1);
+
+        std::string value;
+        bool escaped = false;
+        for (size_t i = openQuote + 1; i < j.size(); ++i) {
+            const char c = j[i];
+            if (escaped) {
+                escaped = false;
+                switch (c) {
+                case '"':
+                case '\\':
+                case '/':
+                    value += c;
+                    break;
+                case 'b':
+                    value += '\b';
+                    break;
+                case 'f':
+                    value += '\f';
+                    break;
+                case 'n':
+                    value += '\n';
+                    break;
+                case 'r':
+                    value += '\r';
+                    break;
+                case 't':
+                    value += '\t';
+                    break;
+                case 'u':
+                    if (i + 4 >= j.size())
+                        return "";
+                    value += "\\u";
+                    value.append(j, i + 1, 4);
+                    i += 4;
+                    break;
+                default:
+                    return "";
+                }
+            } else if (c == '\\') {
+                escaped = true;
+            } else if (c == '"') {
+                return value;
+            } else {
+                value += c;
+            }
+        }
+        return "";
     };
 
     std::string tag = extractJsonString(json, "tag_name");

--- a/tests/test_phase24.cpp
+++ b/tests/test_phase24.cpp
@@ -292,6 +292,26 @@ static bool version_comparison() {
     return true;
 }
 
+static bool version_prerelease_comparison() {
+    auto stable = metalsharp::Version::parse("1.0.1");
+    auto releaseCandidate = metalsharp::Version::parse("1.0.1-rc1");
+    assert(stable > releaseCandidate);
+    assert(!(releaseCandidate > stable));
+    assert(!(stable == releaseCandidate));
+
+    assert(metalsharp::Version::parse("1.0.0-alpha.1") > metalsharp::Version::parse("1.0.0-alpha"));
+    assert(metalsharp::Version::parse("1.0.0-alpha.beta") > metalsharp::Version::parse("1.0.0-alpha.1"));
+    assert(metalsharp::Version::parse("1.0.0-beta") > metalsharp::Version::parse("1.0.0-alpha.beta"));
+    assert(metalsharp::Version::parse("1.0.0-beta.2") > metalsharp::Version::parse("1.0.0-beta.1"));
+    assert(metalsharp::Version::parse("1.0.0-beta.11") > metalsharp::Version::parse("1.0.0-beta.2"));
+    assert(metalsharp::Version::parse("1.0.0-rc.1") > metalsharp::Version::parse("1.0.0-beta.11"));
+    assert(stable > metalsharp::Version::parse("1.0.1-rc.1"));
+
+    assert(metalsharp::Version::parse("1.0.0+build.1") == metalsharp::Version::parse("1.0.0"));
+    assert(metalsharp::Version::parse("1.0.0-alpha+build.1") == metalsharp::Version::parse("1.0.0-alpha"));
+    return true;
+}
+
 static bool version_to_string() {
     auto v = metalsharp::Version::parse("1.2.3");
     assert(v.toString() == "1.2.3");
@@ -318,7 +338,7 @@ static bool update_checker_user_agent() {
 
 static bool update_checker_parse_release() {
     std::string json =
-        R"({"tag_name":"v0.2.0","html_url":"https://github.com/test/repo/releases/tag/v0.2.0","zipball_url":"https://github.com/test/repo/zipball/v0.2.0","body":"Release notes here"})";
+        R"({"tag_name":"v0.2.0","html_url":"https://github.com/test/repo/releases/tag/v0.2.0","zipball_url":"https://github.com/test/repo/zipball/v0.2.0","body":"Release notes with a \"quoted\" line\n"})";
 
     auto current = metalsharp::Version::parse("0.1.0");
     auto info = metalsharp::UpdateChecker::parseGitHubRelease(json, current);
@@ -328,7 +348,7 @@ static bool update_checker_parse_release() {
     assert(info.latestVersion.minor == 2);
     assert(info.latestVersion.patch == 0);
     assert(info.currentVersion == "0.1.0");
-    assert(info.releaseNotes == "Release notes here");
+    assert(info.releaseNotes == "Release notes with a \"quoted\" line\n");
     assert(!info.downloadUrl.empty());
     assert(!info.htmlUrl.empty());
     return true;
@@ -343,6 +363,13 @@ static bool update_checker_no_update() {
 
     assert(!info.available);
     assert(info.latestVersion == current);
+    return true;
+}
+
+static bool update_checker_rejects_invalid_repo() {
+    auto info = metalsharp::UpdateChecker::checkForUpdates("not a repository");
+    assert(!info.available);
+    assert(info.currentVersion == metalsharp::UpdateChecker::getCurrentVersion().toString());
     return true;
 }
 
@@ -515,11 +542,13 @@ int main() {
     printf("\n--- 24.3 Update Checker ---\n");
     TEST(version_parse);
     TEST(version_comparison);
+    TEST(version_prerelease_comparison);
     TEST(version_to_string);
     TEST(update_checker_current_version);
     TEST(update_checker_user_agent);
     TEST(update_checker_parse_release);
     TEST(update_checker_no_update);
+    TEST(update_checker_rejects_invalid_repo);
 
     printf("\n--- 24.4 Settings Manager ---\n");
     TEST(settings_manager_defaults);


### PR DESCRIPTION
## Summary

Fix the native update checker so Semantic Versioning prerelease tags participate in version ordering, and make its latest-release request path functional and bounded.

Fixes #428

## Changes

- Compare prerelease identifiers using SemVer precedence: stable releases sort after prereleases, numeric identifiers sort numerically before nonnumeric identifiers, and longer equal prefixes sort later.
- Include prerelease state in equality and ignore build metadata when parsing precedence.
- Implement the GitHub `releases/latest` fetch with strict repository validation, direct `posix_spawn` argument passing, CA-verified HTTPS/TLS, bounded response reads, timeout limits, and child-status handling.
- Decode escaped JSON strings so release notes survive normal GitHub JSON escaping.
- Add Phase 24 regression coverage for the SemVer precedence examples, build metadata, escaped release notes, and invalid repository input.

## PR Readiness (MANDATORY)

<!-- The checklist-exception label covers the intentionally inapplicable real-game
     and user-facing-documentation items. This change is isolated to the native
     update-checker contract and does not alter a game launch route. -->

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
  - Not applicable: update-checker comparison/fetch behavior only; no game launch path changed.
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
  - Not applicable: no rules or DLL maps changed.
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped
  - Not applicable: no version surfaces changed.
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
  - No bottle, migration, or game launch code changed.
- [ ] Docs / compatibility matrix updated for user-facing changes
  - Not applicable: the checker is an internal native contract and is not wired to a current user-facing route.
- [x] Regression test added for each bug fix

## Local checks

- [x] `cmake -S . -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON` passed.
- [x] `cmake --build build-native --parallel $(sysctl -n hw.ncpu)` passed.
- [x] `ctest --test-dir build-native --output-on-failure` — 31/31 passed.
- [x] `ctest --test-dir build-native --output-on-failure -R '^phase24$'` — passed after the final comparator change.
- [x] `tools/ci/check-clang-format.sh` passed.
- [x] Valid HTTPS smoke probe against `metalsharp/MetalSharp` returned `available=1`, `latest=0.59.1`, and a download URL.
- [x] `git diff --check` passed.
- Rust, Electron/TypeScript, and real-game suites were intentionally skipped because no files in those surfaces changed.

## Test notes

Phase 24 covers the SemVer precedence chain from `alpha` through `rc.1` to stable, the reported `1.0.1-rc1` versus `1.0.1` regression, numeric/non-numeric identifier ordering, build metadata equality, escaped release-note JSON, and invalid repository rejection.

The GitHub `/releases/latest` endpoint does not publish a detached signature for its JSON response. The implementation therefore uses direct CA-verified HTTPS with no shell interpolation and leaves signed/package asset verification to the existing release/installer contract rather than inventing an untrusted public key.

## Risk

Only update metadata comparison/fetching changes. Network failure, invalid repositories, oversized responses, nonzero curl exits, and malformed responses return no update; no installer is started by this code. Revert commit `965e5d16` to restore the previous checker behavior if needed.

Validation used the existing Phase 24 native test target and a temporary valid-repository HTTPS smoke probe.
