### PR TITLE
fix(settings): make settings persistence atomic and thread-safe

### DIFF
--- a/include/metalsharp/SettingsManager.h
+++ b/include/metalsharp/SettingsManager.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <cstdint>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -59,8 +60,10 @@ class SettingsManager {
     bool load(const std::string& path = "");
     bool save(const std::string& path = "");
 
-    SettingsState& state();
-    const SettingsState& state() const;
+    /// Return a consistent snapshot of the current settings.
+    SettingsState state() const;
+    /// Replace the current settings as one synchronized update.
+    void setState(SettingsState state);
 
     static std::string defaultSettingsPath();
     static std::string upscalingToString(UpscalingQuality q);
@@ -74,6 +77,7 @@ class SettingsManager {
 
   private:
     SettingsManager() = default;
+    mutable std::mutex m_mutex;
     SettingsState m_state;
     std::string m_path;
 };

--- a/src/runtime/SettingsManager.cpp
+++ b/src/runtime/SettingsManager.cpp
@@ -6,14 +6,34 @@
 /// clearing the cache to force a re-read from disk on next access.
 
 #include "metalsharp/SettingsManager.h"
+#include <cerrno>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <sstream>
+#include <unistd.h>
+#include <utility>
 
 namespace metalsharp {
 
 namespace fs = std::filesystem;
+
+namespace {
+
+bool writeAll(int fd, const std::string& contents) {
+    size_t offset = 0;
+    while (offset < contents.size()) {
+        ssize_t written = ::write(fd, contents.data() + offset, contents.size() - offset);
+        if (written < 0 && errno == EINTR)
+            continue;
+        if (written <= 0)
+            return false;
+        offset += static_cast<size_t>(written);
+    }
+    return true;
+}
+
+} // namespace
 
 SettingsManager& SettingsManager::instance() {
     static SettingsManager inst;
@@ -78,6 +98,8 @@ WindowMode SettingsManager::windowModeFromString(const std::string& s) {
 }
 
 bool SettingsManager::load(const std::string& path) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+
     std::string p = path.empty() ? defaultSettingsPath() : path;
     m_path = p;
 
@@ -87,6 +109,8 @@ bool SettingsManager::load(const std::string& path) {
 
     std::ostringstream buf;
     buf << f.rdbuf();
+    if (f.bad())
+        return false;
     std::string json = buf.str();
 
     auto extractValue = [](const std::string& j, const std::string& key) -> std::string {
@@ -167,41 +191,74 @@ bool SettingsManager::load(const std::string& path) {
 }
 
 bool SettingsManager::save(const std::string& path) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+
     std::string p = path.empty() ? (m_path.empty() ? defaultSettingsPath() : m_path) : path;
     m_path = p;
 
-    fs::create_directories(fs::path(p).parent_path());
-
-    std::ofstream f(p);
-    if (!f.is_open())
+    fs::path target(p);
+    fs::path parent = target.parent_path();
+    if (parent.empty())
+        parent = ".";
+    if (!target.has_filename())
         return false;
 
-    f << "{\n";
-    f << "  \"render_width\": " << m_state.render.renderWidth << ",\n";
-    f << "  \"render_height\": " << m_state.render.renderHeight << ",\n";
-    f << "  \"window_mode\": \"" << windowModeToString(m_state.render.windowMode) << "\",\n";
-    f << "  \"upscaling_quality\": \"" << upscalingToString(m_state.render.upscaling) << "\",\n";
-    f << "  \"vsync\": " << (m_state.render.vsync ? "true" : "false") << ",\n";
-    f << "  \"metal_validation\": " << (m_state.render.metalValidation ? "true" : "false") << ",\n";
-    f << "  \"metal_gpu_capture\": " << (m_state.render.metalgpuCapture ? "true" : "false") << ",\n";
-    f << "  \"shader_cache_max_mb\": " << m_state.render.shaderCacheMaxMB << ",\n";
-    f << "  \"shader_cache_enabled\": " << (m_state.render.shaderCacheEnabled ? "true" : "false") << ",\n";
-    f << "  \"pipeline_cache_enabled\": " << (m_state.render.pipelineCacheEnabled ? "true" : "false") << ",\n";
-    f << "  \"max_frame_rate\": " << m_state.render.maxFrameRate << ",\n";
-    f << "  \"wine_prefix\": \"" << m_state.winePrefix << "\",\n";
-    f << "  \"launch_mode\": \"" << m_state.launchMode << "\",\n";
-    f << "  \"crash_reporting\": " << (m_state.crashReporting ? "true" : "false") << ",\n";
-    f << "  \"auto_check_updates\": " << (m_state.autoCheckUpdates ? "true" : "false") << "\n";
-    f << "}\n";
+    std::error_code ec;
+    fs::create_directories(parent, ec);
+    if (ec || !fs::is_directory(parent, ec) || ec)
+        return false;
+
+    std::ostringstream output;
+    output << "{\n";
+    output << "  \"render_width\": " << m_state.render.renderWidth << ",\n";
+    output << "  \"render_height\": " << m_state.render.renderHeight << ",\n";
+    output << "  \"window_mode\": \"" << windowModeToString(m_state.render.windowMode) << "\",\n";
+    output << "  \"upscaling_quality\": \"" << upscalingToString(m_state.render.upscaling) << "\",\n";
+    output << "  \"vsync\": " << (m_state.render.vsync ? "true" : "false") << ",\n";
+    output << "  \"metal_validation\": " << (m_state.render.metalValidation ? "true" : "false") << ",\n";
+    output << "  \"metal_gpu_capture\": " << (m_state.render.metalgpuCapture ? "true" : "false") << ",\n";
+    output << "  \"shader_cache_max_mb\": " << m_state.render.shaderCacheMaxMB << ",\n";
+    output << "  \"shader_cache_enabled\": " << (m_state.render.shaderCacheEnabled ? "true" : "false") << ",\n";
+    output << "  \"pipeline_cache_enabled\": " << (m_state.render.pipelineCacheEnabled ? "true" : "false") << ",\n";
+    output << "  \"max_frame_rate\": " << m_state.render.maxFrameRate << ",\n";
+    output << "  \"wine_prefix\": \"" << m_state.winePrefix << "\",\n";
+    output << "  \"launch_mode\": \"" << m_state.launchMode << "\",\n";
+    output << "  \"crash_reporting\": " << (m_state.crashReporting ? "true" : "false") << ",\n";
+    output << "  \"auto_check_updates\": " << (m_state.autoCheckUpdates ? "true" : "false") << "\n";
+    output << "}\n";
+
+    std::string temporaryPath = (parent / (target.filename().string() + ".tmp.XXXXXX")).string();
+    int fd = ::mkstemp(temporaryPath.data());
+    if (fd == -1)
+        return false;
+
+    bool success = writeAll(fd, output.str());
+    if (success && ::fsync(fd) != 0)
+        success = false;
+    if (::close(fd) != 0)
+        success = false;
+
+    if (!success) {
+        ::unlink(temporaryPath.c_str());
+        return false;
+    }
+
+    if (::rename(temporaryPath.c_str(), p.c_str()) != 0) {
+        ::unlink(temporaryPath.c_str());
+        return false;
+    }
 
     return true;
 }
 
-SettingsState& SettingsManager::state() {
+SettingsState SettingsManager::state() const {
+    std::lock_guard<std::mutex> lock(m_mutex);
     return m_state;
 }
-const SettingsState& SettingsManager::state() const {
-    return m_state;
+
+void SettingsManager::setState(SettingsState state) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_state = std::move(state);
 }
 
 void SettingsManager::clearShaderCache() {

--- a/tests/test_phase24.cpp
+++ b/tests/test_phase24.cpp
@@ -3,7 +3,9 @@
 #include "metalsharp/GameDetector.h"
 #include "metalsharp/SettingsManager.h"
 #include "metalsharp/UpdateChecker.h"
+#include <atomic>
 #include <cassert>
+#include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -14,6 +16,9 @@
 #include <string>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <iterator>
+#include <thread>
+#include <utility>
 #include <vector>
 
 namespace fs = std::filesystem;
@@ -343,7 +348,7 @@ static bool update_checker_no_update() {
 
 static bool settings_manager_defaults() {
     auto& sm = metalsharp::SettingsManager::instance();
-    auto& s = sm.state();
+    const auto s = sm.state();
     assert(s.render.renderWidth == 1920);
     assert(s.render.renderHeight == 1080);
     assert(s.render.windowMode == metalsharp::WindowMode::Fullscreen);
@@ -384,44 +389,95 @@ static bool settings_manager_string_conversions() {
 
 static bool settings_manager_save_load() {
     auto& sm = metalsharp::SettingsManager::instance();
-    auto& s = sm.state();
+    auto s = sm.state();
     s.render.renderWidth = 2560;
     s.render.renderHeight = 1440;
     s.render.windowMode = metalsharp::WindowMode::Borderless;
     s.render.upscaling = metalsharp::UpscalingQuality::High;
     s.render.vsync = false;
     s.launchMode = "wine";
+    sm.setState(s);
 
-    std::string testPath = "/tmp/metalsharp_test_settings.json";
-    bool saved = sm.save(testPath);
+    const auto testPath = fs::temp_directory_path() / "metalsharp_test_settings.json";
+    bool saved = sm.save(testPath.string());
     assert(saved);
-    assert(fs::exists(testPath));
+    const bool fileExists = fs::exists(testPath);
+    if (!saved || !fileExists) {
+        fs::remove(testPath);
+        sm.setState({});
+        return false;
+    }
 
-    s.render.renderWidth = 1920;
-    s.render.renderHeight = 1080;
-    s.render.windowMode = metalsharp::WindowMode::Fullscreen;
-    s.render.upscaling = metalsharp::UpscalingQuality::Off;
-    s.render.vsync = true;
-    s.launchMode = "native";
-
-    bool loaded = sm.load(testPath);
+    bool loaded = sm.load(testPath.string());
     assert(loaded);
-    assert(s.render.renderWidth == 2560);
-    assert(s.render.renderHeight == 1440);
-    assert(s.render.windowMode == metalsharp::WindowMode::Borderless);
-    assert(s.render.upscaling == metalsharp::UpscalingQuality::High);
-    assert(s.render.vsync == false);
-    assert(s.launchMode == "wine");
+    const auto loadedState = sm.state();
+    const bool valuesMatch = loadedState.render.renderWidth == 2560 && loadedState.render.renderHeight == 1440 &&
+                             loadedState.render.windowMode == metalsharp::WindowMode::Borderless &&
+                             loadedState.render.upscaling == metalsharp::UpscalingQuality::High &&
+                             !loadedState.render.vsync && loadedState.launchMode == "wine";
 
     fs::remove(testPath);
 
-    s.render.renderWidth = 1920;
-    s.render.renderHeight = 1080;
-    s.render.windowMode = metalsharp::WindowMode::Fullscreen;
-    s.render.upscaling = metalsharp::UpscalingQuality::Off;
-    s.render.vsync = true;
-    s.launchMode = "native";
-    return true;
+    sm.setState({});
+    return loaded && valuesMatch;
+}
+
+static bool settings_manager_concurrent_access() {
+    auto& sm = metalsharp::SettingsManager::instance();
+    const auto uniqueSuffix = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto testDir = fs::temp_directory_path() / ("metalsharp_settings_" + std::to_string(uniqueSuffix));
+    const auto testPath = testDir / "settings.json";
+
+    auto initial = sm.state();
+    initial.render.renderWidth = 1920;
+    initial.render.renderHeight = 1080;
+    sm.setState(initial);
+    if (!sm.save(testPath.string())) {
+        fs::remove_all(testDir);
+        return false;
+    }
+
+    std::atomic<bool> failed{false};
+    std::vector<std::thread> workers;
+    for (int worker = 0; worker < 4; ++worker) {
+        workers.emplace_back([&, worker] {
+            for (int iteration = 0; iteration < 25 && !failed.load(); ++iteration) {
+                if (worker == 0) {
+                    if (!sm.load(testPath.string())) {
+                        failed.store(true);
+                        return;
+                    }
+                    continue;
+                }
+
+                auto snapshot = sm.state();
+                snapshot.render.renderWidth = 1280 + static_cast<uint32_t>(worker * 100 + iteration);
+                snapshot.render.renderHeight = 720 + static_cast<uint32_t>(iteration);
+                snapshot.launchMode = "worker-" + std::to_string(worker);
+                sm.setState(std::move(snapshot));
+                if (!sm.save(testPath.string())) {
+                    failed.store(true);
+                    return;
+                }
+                if (iteration % 5 == 0 && !sm.load(testPath.string())) {
+                    failed.store(true);
+                    return;
+                }
+            }
+        });
+    }
+
+    for (auto& worker : workers)
+        worker.join();
+
+    std::ifstream savedFile(testPath);
+    std::string savedJson((std::istreambuf_iterator<char>(savedFile)), std::istreambuf_iterator<char>());
+    const bool validFile = !savedJson.empty() && savedJson.front() == '{' && savedJson.back() == '\n';
+    savedFile.close();
+    const auto finalState = sm.state();
+    fs::remove_all(testDir);
+    sm.setState({});
+    return !failed.load() && validFile && finalState.render.renderWidth >= 1280;
 }
 
 static bool settings_manager_default_path() {
@@ -469,6 +525,7 @@ int main() {
     TEST(settings_manager_defaults);
     TEST(settings_manager_string_conversions);
     TEST(settings_manager_save_load);
+    TEST(settings_manager_concurrent_access);
     TEST(settings_manager_default_path);
 
     printf("\n%d/%d passed (%d FAILED)\n\n", g_pass, g_pass + g_fail, g_fail);


### PR DESCRIPTION
## Summary

Fixes #429 by making settings persistence crash-safe and synchronizing all in-memory settings access.

## Changes

- Serialize settings to a same-directory temporary file, `fsync` it, and atomically `rename()` it over `settings.json`.
- Protect load, save, snapshot, and state replacement operations with a mutex.
- Replace the mutable `state()` reference with a synchronized snapshot API and add `setState()` for atomic updates.
- Add a concurrent save/load/state regression test.

## PR Readiness (MANDATORY)

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed (not applicable; no config/rules files changed)
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped (not applicable; no version bump)
- [x] Bottle/runtime migration and launch behavior preserved (not applicable; persistence-only native change)
- [x] Docs / compatibility matrix updated for user-facing changes (not applicable; no user-facing behavior or compatibility route changed)
- [x] Regression test added for each bug fix

## Local toolchain (run before push)

- [x] C++ native build completed with `cmake -S . -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON` and `cmake --build build-native --parallel $(sysctl -n hw.ncpu)`
- [x] `ctest --test-dir build-native --output-on-failure` — 31/31 passed
- [x] `tools/ci/check-clang-format.sh`
- [x] `git diff --check`
- [x] Pre-commit hook checks passed

## Test notes

- Full native CTest suite passed on the Apple Silicon macOS host: 31/31 tests, including `phase24`.
- No real game launch was run because this is an isolated native settings persistence/concurrency fix; the `checklist-exception` label records that intentional scope exception.

## Risk

The on-disk JSON schema and settings keys are unchanged. The main behavioral change is that callers receive a synchronized snapshot and must use `setState()` to publish mutations. Reverting commit `db105099` restores the previous implementation if needed.


