### PR TITLE
fix(fna): prevent CloseHandle from closing borrowed descriptors

### DIFF
--- a/src/fna/README.md
+++ b/src/fna/README.md
@@ -29,6 +29,15 @@ builds, so these stubs allow the game to run silently without audio.
 
 Build: `./build_fmod_stubs.sh` (outputs `libfmod.dylib`, `libfmodstudio.dylib`)
 
+### Kernel32 Shim Handle Ownership (`kernel32_shim.c`)
+
+`GetStdHandle` exposes the host process's standard POSIX descriptors as
+borrowed handles. `CloseHandle` does not close arbitrary numeric descriptor
+values: this shim has no fd-backed handle creator to establish ownership, so
+closing an untracked handle is intentionally a no-op. This prevents a game
+from closing the process's real stdin/stdout/stderr or another library's
+descriptor by passing its number to `CloseHandle`.
+
 ## Game Setup (Celeste example)
 
 1. Install the game through Windows Steam in MetalSharp.

--- a/src/fna/shims/kernel32_shim.c
+++ b/src/fna/shims/kernel32_shim.c
@@ -293,11 +293,16 @@ BOOL IsDebuggerPresent(void) {
 BOOL CloseHandle(HANDLE hObject) {
     if (!hObject)
         return 0;
-    int fd = (int)(intptr_t)hObject;
-    if (fd >= 0 && fd < 1024) {
-        close(fd);
-        return 1;
-    }
+
+    /*
+     * GetStdHandle returns borrowed POSIX descriptors in this shim. A file
+     * descriptor is process-global, so treating every small HANDLE value as
+     * owned would let CloseHandle(GetStdHandle(...)) close the host's stdio
+     * (or an unrelated descriptor that has since reused the same number).
+     * This shim currently has no API that creates fd-backed HANDLEs; until
+     * such an API can register its owned handles, CloseHandle must not infer
+     * ownership from the numeric value.
+     */
     return 1;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -131,7 +131,6 @@ add_test(NAME input COMMAND test_input)
 add_test(NAME network_context COMMAND test_network_context)
 add_test(NAME phase5 COMMAND test_phase5)
 add_test(NAME tiled_resources COMMAND test_tiled_resources)
-
 # Regression test for #441: the FNA kernel32 shim is macOS-only (it uses
 # mach headers) and ships as a dylib compiled from src/fna/shims, so build
 # it the same way and exercise GetModuleFileNameA through dlopen.

--- a/tests/test_fna_kernel32_shim.c
+++ b/tests/test_fna_kernel32_shim.c
@@ -1,8 +1,16 @@
+#include <fcntl.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <unistd.h>
+
+typedef uint32_t DWORD;
+typedef int32_t BOOL;
+typedef void* HANDLE;
 
 int MultiByteToWideChar(uint32_t CodePage, uint32_t dwFlags, const char* lpMultiByteStr, int cbMultiByte,
                         void* lpWideCharStr, int cchWideChar);
+extern HANDLE GetStdHandle(DWORD nStdHandle);
+extern BOOL CloseHandle(HANDLE hObject);
 
 static int passed;
 static int failed;
@@ -18,6 +26,22 @@ static int failed;
         }                                                                                                              \
     } while (0)
 
+static int check_standard_handle(DWORD selector, int expected_fd) {
+    int backup = dup(expected_fd);
+    if (backup < 0)
+        return 0;
+
+    HANDLE handle = GetStdHandle(selector);
+    int handle_matches = (int)(intptr_t)handle == expected_fd;
+    (void)CloseHandle(handle);
+    int remains_open = fcntl(expected_fd, F_GETFD) != -1;
+
+    int restored = dup2(backup, expected_fd) == expected_fd;
+    close(backup);
+
+    return handle_matches && remains_open && restored;
+}
+
 int main(void) {
     const char input[] = "FNA";
     uint16_t output[sizeof(input) + 1];
@@ -30,6 +54,19 @@ int main(void) {
     CHECK(output[0] == 'F' && output[1] == 'N' && output[2] == 'A', "auto-length conversion copies input");
     CHECK(output[3] == 0, "auto-length conversion writes a UTF-16 terminator");
     CHECK(output[4] == 0xA55A, "terminator write stays within the requested buffer");
+
+    CHECK(check_standard_handle((DWORD)-10, STDIN_FILENO), "CloseHandle preserves borrowed stdin");
+    CHECK(check_standard_handle((DWORD)-11, STDOUT_FILENO), "CloseHandle preserves borrowed stdout");
+    CHECK(check_standard_handle((DWORD)-12, STDERR_FILENO), "CloseHandle preserves borrowed stderr");
+
+    int unowned_fd = open("/dev/null", O_RDONLY);
+    CHECK(unowned_fd >= 0, "open an unowned descriptor");
+    if (unowned_fd >= 0) {
+        CHECK(CloseHandle((HANDLE)(intptr_t)unowned_fd), "CloseHandle accepts an unowned descriptor");
+        CHECK(CloseHandle((HANDLE)(intptr_t)unowned_fd), "repeated CloseHandle remains harmless");
+        CHECK(fcntl(unowned_fd, F_GETFD) != -1, "CloseHandle does not close an unowned descriptor");
+        close(unowned_fd);
+    }
 
     printf("=== Results: %d passed, %d failed ===\n", passed, failed);
     return failed != 0;


### PR DESCRIPTION
## Summary

Fix the FNA `kernel32` shim so `CloseHandle` cannot close borrowed POSIX descriptors returned by `GetStdHandle` or unrelated descriptors that happen to share a small numeric value.

Fixes #439

## Changes

- Make `CloseHandle` leave non-null, untracked handles untouched; the shim currently has no fd-backed handle creator that can establish ownership.
- Add `fna_kernel32_shim` coverage for stdin/stdout/stderr preservation, unrelated descriptors, and repeated close attempts.
- Document the borrowed-handle ownership contract in `src/fna/README.md`.

## PR Readiness (MANDATORY)

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

The `checklist-exception` label is applied for the real-game item: this is an isolated native shim regression with a dedicated runtime test, and no FNA game/runtime is staged in this clean checkout. No launch or compatibility route changed.

## Local toolchain

- [ ] `cargo fmt --all -- --check` (not applicable; no Rust changes)
- [ ] `cargo clippy --all-targets -- -D warnings` (not applicable; no Rust changes)
- [ ] `cargo build --release` (not applicable; no Rust changes)
- [ ] `cargo test` (not applicable; no Rust changes)
- [x] C++/C/Obj-C configured and built with `cmake -S . -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON && cmake --build build-native --parallel $(sysctl -n hw.ncpu)`
- [x] `clang-format --dry-run --Werror` / `tools/ci/check-clang-format.sh`
- [x] `ctest --test-dir build-native --output-on-failure`
- [ ] TypeScript, Biome, and Prettier (not applicable; no app changes)
- [ ] ShellCheck (not applicable; no shell changes)
- [ ] Rules TOML validation (not applicable; no rules changes)
- [ ] DMG workflow validation (not applicable; no release tooling changes)
- [ ] Tested with at least one game (intentionally excepted above)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files added to the repository root

## Test notes

- The new `fna_kernel32_shim` CTest passed as part of the full native suite: **32/32 tests passed**.
- The regression harness also passed as a standalone `clang -Wall -Wextra -Werror` build/run.
- `tools/bundles/verify-native-shims.sh --eac-only app/native` passed after the clean native build.
- `git diff --check` and the full clang-format gate passed.
- `python3 tools/ci/check-doc-freshness.py` completed with the repository's existing warning for `docs/OPENGL-2-4-PLAN.md` (missing `Updated:` header).
- No real game launch was performed; this is covered by the documented checklist exception.

## Risk

This is intentionally scoped to the FNA `kernel32` shim. `CloseHandle` no longer guesses ownership from an integer descriptor, preventing process-wide stdio/unrelated-fd closure. The current shim exposes no fd-backed handle creator, so no owned fd-close path is removed. If one is added later, it must register explicit ownership before `CloseHandle` is extended. Rollback is a single-commit revert.
