### PR TITLE
fix(kernel32): populate find data filenames correctly

### DIFF
--- a/src/win32/kernel32/VirtualFileSystem.cpp
+++ b/src/win32/kernel32/VirtualFileSystem.cpp
@@ -420,9 +420,14 @@ static void fillWin32FindData(void* lpFindFileData, const char* name, bool isDir
     uint64_t fsize = static_cast<uint64_t>(fileSize);
     memcpy(data + 28, &fsize, 8);
 
-    memset(data + 36, 0, 14 * 2);
-    for (int i = 0; name[i] && i < 13; i++) {
-        reinterpret_cast<uint16_t*>(data + 36)[i] = static_cast<uint16_t>(static_cast<unsigned char>(name[i]));
+    // WIN32_FIND_DATAW places cFileName after dwReserved0 and dwReserved1 at byte 44.
+    // Leave those reserved fields untouched and initialize the complete file-name field.
+    constexpr size_t cFileNameOffset = 44;
+    constexpr size_t cFileNameCapacity = 260;
+    memset(data + cFileNameOffset, 0, cFileNameCapacity * sizeof(uint16_t));
+    for (size_t i = 0; name[i] && i + 1 < cFileNameCapacity; i++) {
+        uint16_t codeUnit = static_cast<uint16_t>(static_cast<unsigned char>(name[i]));
+        memcpy(data + cFileNameOffset + i * sizeof(codeUnit), &codeUnit, sizeof(codeUnit));
     }
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -210,6 +210,13 @@ add_executable(test_pe_loader_relocations
 target_link_libraries(test_pe_loader_relocations PRIVATE metalsharp_loader metalsharp_core)
 add_test(NAME pe_loader_relocations COMMAND test_pe_loader_relocations)
 
+add_executable(test_virtual_file_system
+    test_virtual_file_system.cpp
+)
+target_link_libraries(test_virtual_file_system PRIVATE metalsharp_loader metalsharp_core)
+
+add_test(NAME virtual_file_system COMMAND test_virtual_file_system)
+
 add_executable(test_phase21
     test_phase21.cpp
 )

--- a/tests/test_virtual_file_system.cpp
+++ b/tests/test_virtual_file_system.cpp
@@ -1,0 +1,139 @@
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <metalsharp/VirtualFileSystem.h>
+#include <string>
+#include <sys/stat.h>
+#include <unistd.h>
+
+using metalsharp::win32::HANDLE;
+using metalsharp::win32::INVALID_HANDLE_VALUE;
+using metalsharp::win32::VirtualFileSystem;
+
+namespace {
+
+constexpr size_t kFindDataFileNameOffset = 44;
+constexpr size_t kFindDataFileNameCapacity = 260;
+constexpr size_t kFindDataSize =
+    kFindDataFileNameOffset + kFindDataFileNameCapacity * sizeof(uint16_t) + 14 * sizeof(uint16_t);
+constexpr uint32_t kReserved0 = 0x13579BDF;
+constexpr uint32_t kReserved1 = 0x2468ACE0;
+
+uint16_t readCodeUnit(const std::array<uint8_t, kFindDataSize>& data, size_t index) {
+    uint16_t codeUnit = 0;
+    memcpy(&codeUnit, data.data() + kFindDataFileNameOffset + index * sizeof(codeUnit), sizeof(codeUnit));
+    return codeUnit;
+}
+
+std::string readFileName(const std::array<uint8_t, kFindDataSize>& data) {
+    std::string name;
+    for (size_t i = 0; i < kFindDataFileNameCapacity; i++) {
+        uint16_t codeUnit = readCodeUnit(data, i);
+        if (codeUnit == 0)
+            break;
+        if (codeUnit > 0x7F)
+            return {};
+        name.push_back(static_cast<char>(codeUnit));
+    }
+    return name;
+}
+
+bool hasZeroTail(const std::array<uint8_t, kFindDataSize>& data, size_t nameLength) {
+    for (size_t i = nameLength + 1; i < kFindDataFileNameCapacity; i++) {
+        if (readCodeUnit(data, i) != 0)
+            return false;
+    }
+    return true;
+}
+
+} // namespace
+
+int main() {
+    int passed = 0;
+    int failed = 0;
+
+#define CHECK(condition, message)                                                                                      \
+    do {                                                                                                               \
+        if (condition) {                                                                                               \
+            printf("  [OK] %s\n", message);                                                                            \
+            passed++;                                                                                                  \
+        } else {                                                                                                       \
+            printf("  [FAIL] %s\n", message);                                                                          \
+            failed++;                                                                                                  \
+        }                                                                                                              \
+    } while (0)
+
+    printf("=== VirtualFileSystem Find Data Tests ===\n\n");
+
+    char directoryTemplate[] = "/tmp/metalsharp-find-data-XXXXXX";
+    char* directoryPath = mkdtemp(directoryTemplate);
+    CHECK(directoryPath != nullptr, "Create temporary directory");
+    if (!directoryPath)
+        return 1;
+
+    const std::array<const char*, 2> expectedNames = {{"config.ini", "long-file-name-for-find-data.ini"}};
+    bool filesCreated = true;
+    for (const char* name : expectedNames) {
+        std::string path = std::string(directoryPath) + "/" + name;
+        int fd = open(path.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0600);
+        if (fd < 0) {
+            filesCreated = false;
+            continue;
+        }
+        constexpr char contents[] = "test";
+        if (write(fd, contents, sizeof(contents) - 1) != static_cast<ssize_t>(sizeof(contents) - 1))
+            filesCreated = false;
+        close(fd);
+    }
+    CHECK(filesCreated, "Create find-data fixtures");
+
+    std::string pattern = std::string(directoryPath) + "/*";
+    std::array<uint8_t, kFindDataSize> findData;
+    findData.fill(0xA5);
+    memcpy(findData.data() + 36, &kReserved0, sizeof(kReserved0));
+    memcpy(findData.data() + 40, &kReserved1, sizeof(kReserved1));
+
+    HANDLE findHandle = VirtualFileSystem::instance().findFirstFileW(pattern.c_str(), findData.data());
+    bool enumerationSucceeded = findHandle != INVALID_HANDLE_VALUE;
+    bool reservedFieldsPreserved = true;
+    bool configNameFound = false;
+    bool longNameFound = false;
+    bool namesAreComplete = true;
+
+    while (enumerationSucceeded) {
+        uint32_t reserved0 = 0;
+        uint32_t reserved1 = 0;
+        memcpy(&reserved0, findData.data() + 36, sizeof(reserved0));
+        memcpy(&reserved1, findData.data() + 40, sizeof(reserved1));
+        reservedFieldsPreserved &= reserved0 == kReserved0 && reserved1 == kReserved1;
+
+        std::string name = readFileName(findData);
+        if (name == expectedNames[0])
+            configNameFound = true;
+        if (name == expectedNames[1])
+            longNameFound = true;
+        if (name == expectedNames[0] || name == expectedNames[1])
+            namesAreComplete &= hasZeroTail(findData, name.size());
+
+        enumerationSucceeded = VirtualFileSystem::instance().findNextFileW(findHandle, findData.data()) != 0;
+    }
+
+    CHECK(findHandle != INVALID_HANDLE_VALUE, "FindFirstFile returns a handle");
+    CHECK(configNameFound, "cFileName contains config.ini at offset 44");
+    CHECK(longNameFound, "cFileName is not limited to the alternate-name length");
+    CHECK(reservedFieldsPreserved, "dwReserved0 and dwReserved1 remain untouched");
+    CHECK(namesAreComplete, "cFileName is zeroed after the terminator");
+    if (findHandle != INVALID_HANDLE_VALUE)
+        CHECK(VirtualFileSystem::instance().findClose(findHandle) != 0, "Close find handle");
+
+    for (const char* name : expectedNames) {
+        std::string path = std::string(directoryPath) + "/" + name;
+        unlink(path.c_str());
+    }
+    rmdir(directoryPath);
+
+    printf("\n=== Results: %d passed, %d failed ===\n", passed, failed);
+    return failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Fixes #419 by populating `WIN32_FIND_DATAW.cFileName` at its ABI-defined offset instead of overwriting the reserved fields.

## Changes

- Write file names at byte offset 44, where `cFileName` begins.
- Preserve `dwReserved0` and `dwReserved1`.
- Initialize the complete 260-code-unit `cFileName` field and support names up to 259 characters.
- Add a native regression test covering `config.ini`, longer names, reserved-field preservation, and null termination.
- Verified the layout against the Windows-compatible `WIN32_FIND_DATAW` definition: reserved fields at offsets 36/40 and `cFileName` at offset 44.

## PR Readiness (MANDATORY)

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed (not applicable; neither changed)
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped (not applicable; no version bump)
- [x] Bottle/runtime migration and launch behavior preserved (native VFS layout fix only)
- [x] Docs / compatibility matrix updated for user-facing changes (not applicable; no user-facing contract changed)
- [x] Regression test added for each bug fix

## Local toolchain (run before push)

- [ ] `cargo fmt --all -- --check` passes (Rust; not applicable)
- [ ] `cargo clippy --all-targets -- -D warnings` passes (Rust; not applicable)
- [ ] `cargo build --release` passes (Rust backend; not applicable)
- [ ] `cargo test` passes (Rust; not applicable)
- [x] C++ compiles if changed: `cmake -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON && cmake --build build-native --parallel $(sysctl -n hw.ncpu)`
- [x] `clang-format --dry-run --Werror` passes on any changed C/C++/Obj-C file
- [x] `ctest --test-dir build-native` passes if tests changed
- [ ] TypeScript compiles if changed (not applicable)
- [ ] Biome + Prettier pass if TS/JS changed (not applicable)
- [ ] Shell scripts lint if changed (not applicable)
- [ ] `tools/ci/validate-rules-toml.py` passes if `configs/mtsp-rules.toml` changed (not applicable)
- [ ] `python3 tools/ci/verify-dmg-workflow.py` passes if release/bundle tooling changed (not applicable)
- [ ] Tested with at least one game (which one? which launch method? which drive?)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files should be added to the repo root; place them under `app/`, `tools/`, `tests/`, etc.

## Test notes

- Checkout: `/Volumes/AverySSD/MetalSharp-419-fix`
- Base: latest `origin/main` at `5afc4edc72bb30377e6702e30ad61425c15ebd0f`
- `cmake -S . -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON`
- `cmake --build build-native --parallel "$(sysctl -n hw.ncpu)"`
- `ctest --test-dir build-native --output-on-failure -R '^virtual_file_system$'`
- `ctest --test-dir build-native --output-on-failure` — 32/32 passed
- `tools/ci/check-clang-format.sh`
- `git diff --check`
- No commercial game was launched; the isolated native regression test exercises the affected VFS buffer directly. The `checklist-exception` label is applied for the unavailable real-game check.

## Risk

Low. The change only alters the serialized `WIN32_FIND_DATAW` name field and prevents reserved-field corruption. Reverting commit `94c527e4` restores the prior behavior if needed.
