### PR TITLE
fix(sync): release handle table lock before waits

### DIFF
--- a/src/win32/kernel32/SyncContext.cpp
+++ b/src/win32/kernel32/SyncContext.cpp
@@ -396,20 +396,29 @@ uint32_t SyncContext::waitForThread(SyncThreadState* thr, uint32_t ms) {
 }
 
 uint32_t SyncContext::waitForSingleObject(void* handle, uint32_t milliseconds) {
-    std::lock_guard<std::mutex> lock(m_mutex);
-    auto it = m_handles.find((intptr_t)handle);
-    if (it == m_handles.end())
-        return 0xFFFFFFFF;
+    // The table lock only protects lookup. Wait helpers may block on the
+    // object's own mutex/condition variable, so release m_mutex before
+    // entering them or signal/release callers cannot make progress.
+    SyncHandleType type;
+    void* data;
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        auto it = m_handles.find((intptr_t)handle);
+        if (it == m_handles.end())
+            return 0xFFFFFFFF;
+        type = it->second.type;
+        data = it->second.data;
+    }
 
-    switch (it->second.type) {
+    switch (type) {
     case SyncHandleType::Event:
-        return waitForEvent(static_cast<SyncEventState*>(it->second.data), milliseconds);
+        return waitForEvent(static_cast<SyncEventState*>(data), milliseconds);
     case SyncHandleType::Mutex:
-        return waitForMutex(static_cast<SyncMutexState*>(it->second.data), milliseconds);
+        return waitForMutex(static_cast<SyncMutexState*>(data), milliseconds);
     case SyncHandleType::Semaphore:
-        return waitForSemaphore(static_cast<SyncSemaphoreState*>(it->second.data), milliseconds);
+        return waitForSemaphore(static_cast<SyncSemaphoreState*>(data), milliseconds);
     case SyncHandleType::Thread:
-        return waitForThread(static_cast<SyncThreadState*>(it->second.data), milliseconds);
+        return waitForThread(static_cast<SyncThreadState*>(data), milliseconds);
     default:
         return 0xFFFFFFFF;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,6 +69,11 @@ add_executable(test_darwin_sync_map
 )
 target_link_libraries(test_darwin_sync_map PRIVATE metalsharp_core)
 
+add_executable(test_sync_context
+    test_sync_context.cpp
+)
+target_link_libraries(test_sync_context PRIVATE metalsharp_core)
+
 add_executable(test_audio
     test_audio.cpp
 )
@@ -103,6 +108,7 @@ add_test(NAME runtime COMMAND test_runtime)
 add_test(NAME host_runtime_abi COMMAND test_host_runtime_abi)
 add_test(NAME mscoree_path_safety COMMAND test_mscoree_path_safety)
 add_test(NAME darwin_sync_map COMMAND test_darwin_sync_map)
+add_test(NAME sync_context COMMAND test_sync_context)
 add_test(NAME audio COMMAND test_audio)
 add_test(NAME input COMMAND test_input)
 add_test(NAME phase5 COMMAND test_phase5)

--- a/tests/test_sync_context.cpp
+++ b/tests/test_sync_context.cpp
@@ -1,0 +1,78 @@
+#include <atomic>
+#include <cerrno>
+#include <csignal>
+#include <cstdint>
+#include <cstdio>
+#include <thread>
+
+#include <metalsharp/SyncContext.h>
+
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+using metalsharp::win32::INFINITE;
+using metalsharp::win32::SyncContext;
+using metalsharp::win32::WAIT_FAILED;
+using metalsharp::win32::WAIT_OBJECT_0;
+
+namespace {
+
+int runEventSignalScenario() {
+    SyncContext& context = SyncContext::instance();
+    void* event = context.createEvent(true, false, "");
+    if (!event)
+        return 1;
+
+    std::atomic<bool> waiterStarted{false};
+    std::atomic<uint32_t> waitResult{WAIT_FAILED};
+    std::thread waiter([&]() {
+        waiterStarted.store(true, std::memory_order_release);
+        waitResult.store(context.waitForSingleObject(event, INFINITE), std::memory_order_release);
+    });
+
+    for (int i = 0; i < 1000 && !waiterStarted.load(std::memory_order_acquire); i++)
+        usleep(1000);
+
+    // Give the waiter time to enter the blocking path. On the buggy
+    // implementation, this call cannot acquire the global handle-table lock.
+    usleep(100000);
+    bool setResult = context.setEvent(event);
+    waiter.join();
+
+    uint32_t result = waitResult.load(std::memory_order_acquire);
+    context.destroyHandle(event);
+    return setResult && result == WAIT_OBJECT_0 ? 0 : 1;
+}
+
+bool test_event_wait_can_be_signaled() {
+    pid_t child = fork();
+    if (child < 0)
+        return false;
+    if (child == 0)
+        _exit(runEventSignalScenario());
+
+    int waitStatus = 0;
+    constexpr uint32_t timeoutMs = 2000;
+    for (uint32_t elapsed = 0; elapsed < timeoutMs; elapsed += 5) {
+        pid_t result = waitpid(child, &waitStatus, WNOHANG);
+        if (result == child)
+            return WIFEXITED(waitStatus) && WEXITSTATUS(waitStatus) == 0;
+        if (result < 0 && errno != EINTR)
+            break;
+        usleep(5000);
+    }
+
+    kill(child, SIGKILL);
+    waitpid(child, &waitStatus, 0);
+    return false;
+}
+
+} // namespace
+
+int main() {
+    printf("=== SyncContext Tests ===\n\n");
+    bool passed = test_event_wait_can_be_signaled();
+    printf("  [%s] WaitForSingleObject event can be released by SetEvent\n", passed ? "OK" : "FAIL");
+    return passed ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Fixes #415 by ensuring `SyncContext::waitForSingleObject` does not hold the global handle-table mutex while entering a potentially blocking per-object wait. This unblocks the canonical worker `SetEvent` / waiting-thread pattern.

## Changes

- Limit `m_mutex` to handle lookup and copy the handle type/state pointer before waiting.
- Run event, mutex, semaphore, and thread waits after releasing the global table lock so signal/release operations can acquire it.
- Add a regression test that exercises `WaitForSingleObject(event, INFINITE)` and `SetEvent` from another thread. The test runs the scenario in a child process so the pre-fix deadlock is bounded and cannot hang CTest.

## PR Readiness (MANDATORY)

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed (not applicable; neither changed)
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped (not applicable; no version changed)
- [x] Bottle/runtime migration and launch behavior preserved (internal synchronization-only change; no launch behavior changed)
- [ ] Docs / compatibility matrix updated for user-facing changes (not applicable; no user-facing surface changed; `docs/runtime/darwin-sync-map.md` was reviewed)
- [x] Regression test added for each bug fix

## Local toolchain (run before push)

- [ ] `cargo fmt --all -- --check` passes (Rust; no Rust files changed)
- [ ] `cargo clippy --all-targets -- -D warnings` passes (Rust; no Rust files changed)
- [ ] `cargo build --release` passes (Rust backend; no Rust files changed)
- [ ] `cargo test` passes (Rust; no Rust files changed)
- [x] C++ compiles if changed: `cmake -S . -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON && cmake --build build-native --parallel $(sysctl -n hw.ncpu)`
- [x] `clang-format --dry-run --Werror` passes on changed C++ files (also `tools/ci/check-clang-format.sh`)
- [x] `ctest --test-dir build-native` passes: 32/32
- [ ] TypeScript compiles if changed (not applicable; no TypeScript files changed)
- [ ] Biome + Prettier pass if TS/JS changed (not applicable; no TS/JS files changed)
- [ ] Shell scripts lint if changed (not applicable; no shell files changed)
- [ ] `tools/ci/validate-rules-toml.py` passes if rules changed (not applicable; no rules changed)
- [ ] `python3 tools/ci/verify-dmg-workflow.py` passes if release/bundle tooling changed (not applicable; no release tooling changed)
- [ ] Tested with at least one game (not applicable; this does not change launch behavior)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files added to the repo root; the regression test is under `tests/`

## Test notes

- Full native Release build passed: `cmake --build build-native --parallel 10`.
- Full CTest passed: 32/32, including `sync_context`.
- `tools/ci/check-clang-format.sh`, `git diff --check`, and the pre-commit hook passed.
- The new regression test passed 20 consecutive direct runs.
- Compiling the test against the pre-fix `origin/main` `SyncContext.cpp` causes the child scenario to time out and be killed; the fixed implementation passes.
- No real-game launch was run because this is an internal synchronization deadlock fix with no launch or compatibility-matrix change.

## Risk

Low. The change only narrows the global handle-table lock scope; each wait still uses the existing per-object synchronization primitive. No default, packaging, or launch behavior changes. The rollback is commit `574ec949`.

<!-- checklist-exception is used because real-game compatibility and user-facing documentation checks are intentionally not applicable to this internal synchronization fix. -->
