### PR TITLE
fix(kernel32): preserve null terminators in string conversions

### DIFF
--- a/src/win32/kernel32/Kernel32Shim.cpp
+++ b/src/win32/kernel32/Kernel32Shim.cpp
@@ -362,12 +362,15 @@ static int MSABI shim_MultiByteToWideChar(UINT CodePage, DWORD dwFlags, const ch
                                           wchar_t* lpWideCharStr, int cchWideChar) {
     (void)CodePage;
     (void)dwFlags;
-    if (!lpMultiByteStr)
+    if (!lpMultiByteStr || cbMultiByte == 0 || cbMultiByte < -1 || cchWideChar < 0)
         return 0;
 
-    int len = cbMultiByte > 0 ? cbMultiByte : static_cast<int>(strlen(lpMultiByteStr));
+    const bool includeNull = cbMultiByte == -1;
+    int len = includeNull ? static_cast<int>(strlen(lpMultiByteStr)) + 1 : cbMultiByte;
     if (cchWideChar == 0)
         return len;
+    if (!lpWideCharStr)
+        return 0;
 
     int copyLen = len < cchWideChar ? len : cchWideChar;
     for (int i = 0; i < copyLen; i++) {
@@ -382,13 +385,17 @@ static int MSABI shim_WideCharToMultiByte(UINT CodePage, DWORD dwFlags, const wc
     (void)CodePage;
     (void)dwFlags;
     (void)lpDefaultChar;
-    (void)lpUsedDefaultChar;
-    if (!lpWideCharStr)
+    if (lpUsedDefaultChar)
+        *lpUsedDefaultChar = 0;
+    if (!lpWideCharStr || cchWideChar == 0 || cchWideChar < -1 || cbMultiByte < 0)
         return 0;
 
-    int len = cchWideChar > 0 ? cchWideChar : static_cast<int>(wcslen(lpWideCharStr));
+    const bool includeNull = cchWideChar == -1;
+    int len = includeNull ? static_cast<int>(wcslen(lpWideCharStr)) + 1 : cchWideChar;
     if (cbMultiByte == 0)
         return len;
+    if (!lpMultiByteStr)
+        return 0;
 
     int copyLen = len < cbMultiByte ? len : cbMultiByte;
     for (int i = 0; i < copyLen; i++) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -308,3 +308,9 @@ add_executable(test_kernel32_environment
 )
 target_link_libraries(test_kernel32_environment PRIVATE metalsharp_loader metalsharp_core)
 add_test(NAME kernel32_environment COMMAND test_kernel32_environment)
+
+add_executable(test_kernel32
+    test_kernel32.cpp
+)
+target_link_libraries(test_kernel32 PRIVATE metalsharp_loader metalsharp_core)
+add_test(NAME kernel32 COMMAND test_kernel32)

--- a/tests/test_kernel32.cpp
+++ b/tests/test_kernel32.cpp
@@ -1,0 +1,110 @@
+#include <array>
+#include <cstdio>
+#include <metalsharp/Kernel32Shim.h>
+#include <metalsharp/Win32Types.h>
+
+using metalsharp::ShimLibrary;
+using metalsharp::win32::BOOL;
+using metalsharp::win32::DWORD;
+using metalsharp::win32::Kernel32Shim;
+using metalsharp::win32::UINT;
+
+using MultiByteToWideCharFn = int(MSABI*)(UINT, DWORD, const char*, int, wchar_t*, int);
+using WideCharToMultiByteFn = int(MSABI*)(UINT, DWORD, const wchar_t*, int, char*, int, const char*, BOOL*);
+
+static int testsPassed = 0;
+static int testsFailed = 0;
+
+#define TEST(name)                                                                                                     \
+    printf("  TEST: %-55s", #name);                                                                                    \
+    if (test_##name()) {                                                                                               \
+        printf("PASS\n");                                                                                              \
+        testsPassed++;                                                                                                 \
+    } else {                                                                                                           \
+        printf("FAIL\n");                                                                                              \
+        testsFailed++;                                                                                                 \
+    }
+
+static MultiByteToWideCharFn getMultiByteToWideChar() {
+    ShimLibrary library = Kernel32Shim::create();
+    return reinterpret_cast<MultiByteToWideCharFn>(library.functions.at("MultiByteToWideChar")());
+}
+
+static WideCharToMultiByteFn getWideCharToMultiByte() {
+    ShimLibrary library = Kernel32Shim::create();
+    return reinterpret_cast<WideCharToMultiByteFn>(library.functions.at("WideCharToMultiByte")());
+}
+
+static bool test_multibyte_null_terminator_and_size() {
+    const char input[] = "abc";
+    auto convert = getMultiByteToWideChar();
+
+    int required = convert(65001, 0, input, -1, nullptr, 0);
+    std::array<wchar_t, 4> output = {L'?', L'?', L'?', L'?'};
+    int written = convert(65001, 0, input, -1, output.data(), static_cast<int>(output.size()));
+
+    return required == 4 && written == 4 && output[0] == L'a' && output[1] == L'b' && output[2] == L'c' &&
+           output[3] == L'\0';
+}
+
+static bool test_multibyte_explicit_length_stays_unterminated() {
+    const char input[] = "abc";
+    auto convert = getMultiByteToWideChar();
+    std::array<wchar_t, 4> output = {L'?', L'?', L'?', L'?'};
+
+    int written = convert(65001, 0, input, 3, output.data(), static_cast<int>(output.size()));
+
+    return written == 3 && output[0] == L'a' && output[1] == L'b' && output[2] == L'c' && output[3] == L'?';
+}
+
+static bool test_wide_null_terminator_and_size() {
+    const wchar_t input[] = L"abc";
+    auto convert = getWideCharToMultiByte();
+
+    int required = convert(65001, 0, input, -1, nullptr, 0, nullptr, nullptr);
+    std::array<char, 4> output = {'?', '?', '?', '?'};
+    int written = convert(65001, 0, input, -1, output.data(), static_cast<int>(output.size()), nullptr, nullptr);
+
+    return required == 4 && written == 4 && output[0] == 'a' && output[1] == 'b' && output[2] == 'c' &&
+           output[3] == '\0';
+}
+
+static bool test_wide_explicit_length_stays_unterminated() {
+    const wchar_t input[] = L"abc";
+    auto convert = getWideCharToMultiByte();
+    std::array<char, 4> output = {'?', '?', '?', '?'};
+
+    int written = convert(65001, 0, input, 3, output.data(), static_cast<int>(output.size()), nullptr, nullptr);
+
+    return written == 3 && output[0] == 'a' && output[1] == 'b' && output[2] == 'c' && output[3] == '?';
+}
+
+static bool test_zero_lengths_are_rejected() {
+    const char narrowInput[] = "abc";
+    const wchar_t wideInput[] = L"abc";
+    auto multiByteToWide = getMultiByteToWideChar();
+    auto wideToMultiByte = getWideCharToMultiByte();
+    std::array<wchar_t, 4> wideOutput{};
+    std::array<char, 4> narrowOutput{};
+
+    return multiByteToWide(65001, 0, narrowInput, 0, wideOutput.data(), static_cast<int>(wideOutput.size())) == 0 &&
+           wideToMultiByte(65001, 0, wideInput, 0, narrowOutput.data(), static_cast<int>(narrowOutput.size()), nullptr,
+                           nullptr) == 0;
+}
+
+int main() {
+    printf("=== Kernel32 String Conversion Tests ===\n\n");
+
+    TEST(multibyte_null_terminator_and_size);
+    TEST(multibyte_explicit_length_stays_unterminated);
+    TEST(wide_null_terminator_and_size);
+    TEST(wide_explicit_length_stays_unterminated);
+    TEST(zero_lengths_are_rejected);
+
+    printf("\n%d/%d passed", testsPassed, testsPassed + testsFailed);
+    if (testsFailed > 0)
+        printf(" (%d FAILED)", testsFailed);
+    printf("\n");
+
+    return testsFailed > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

Fixes #420 by bringing the Kernel32 string-conversion shims in line with the documented Win32 `-1` length contract. Null-terminated conversions now size and write the terminating NUL instead of silently dropping it.

## Changes

- Make `MultiByteToWideChar` treat `cbMultiByte == -1` as an inclusive, NUL-terminated input and report the terminator in size queries and writes.
- Make `WideCharToMultiByte` apply the same inclusive behavior for `cchWideChar == -1`.
- Preserve the explicit-length contract: positive lengths copy exactly that many elements and do not add an implicit terminator.
- Reject invalid zero/negative length combinations and safely handle missing output buffers.
- Add a native CTest regression covering size queries, terminator writes, explicit lengths, and zero-length validation.

## Specification notes

The implementation follows the Win32 API contracts documented in:

- [MultiByteToWideChar](https://learn.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-multibytetowidechar)
- [WideCharToMultiByte](https://learn.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte)

In particular, `-1` includes the source NUL in the processed length, while a positive input length processes exactly the requested range.

## PR Readiness (MANDATORY)

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

The `checklist-exception` label is applied because this is an internal native Win32 shim fix; real-game launch validation is not applicable to the focused API behavior. No user-facing compatibility matrix change is required.

## Local toolchain (run before push)

- [x] `cargo fmt --all -- --check` / Rust checks — N/A; no Rust files changed
- [x] `cargo clippy --all-targets -- -D warnings` — N/A; no Rust files changed
- [x] `cargo build --release` — N/A; no Rust files changed
- [x] `cargo test` — N/A; no Rust files changed
- [x] Native CMake configure and Release build with `BUILD_TESTS=ON`
- [x] `clang-format --dry-run --Werror` on changed native files
- [x] Full `ctest --test-dir build-native --output-on-failure` (32/32 passed)
- [x] Focused `ctest --test-dir build-native -R '^kernel32$' --output-on-failure` (1/1 passed)
- [x] `tools/ci/check-clang-format.sh`
- [x] `git diff --check`
- [x] TypeScript, Biome, and Prettier checks — N/A; no app files changed
- [x] Shell and rules checks — N/A; no shell or rules files changed
- [x] No new files added to the repository root

## Test notes

- Clean native checkout from latest `main` was used on the external drive.
- Native Release build completed successfully.
- Full native CTest suite passed: 32/32 tests.
- The new `kernel32` regression passed both directly and through CTest.
- Clang-format and whitespace checks passed.
- No real game was launched because the change is isolated to the internal conversion shim; existing launch/runtime code was not modified.

## Risk

The only behavior change is the documented handling of `-1` lengths and invalid zero/negative length combinations. Positive explicit lengths retain their prior byte-for-byte conversion behavior and remain unterminated unless the caller includes a NUL. If a regression appears, revert commit `aace0361` to restore the prior shim behavior without affecting runtime or migration code.

<!-- Readiness checklist re-evaluated after applying checklist-exception. -->
