### PR TITLE
fix(drm): bound GetAdaptersAddresses output

### DIFF
--- a/src/win32/kernel32/DRMShims.cpp
+++ b/src/win32/kernel32/DRMShims.cpp
@@ -3,7 +3,9 @@
 ///
 /// Spoofs volume serial numbers, MAC addresses, and system timing to bypass DRM checks that validate hardware
 /// fingerprints. Also provides anti-debug detection shims to hide the Wine environment from copy protection.
+#include <cassert>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -25,6 +27,45 @@ namespace win32 {
 
 static const uint8_t STABLE_MAC[6] = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E};
 static const uint32_t STABLE_DISK_SERIAL = 0xABCDEF12;
+static char STABLE_ADAPTER_NAME[] = "eth0";
+static uint16_t STABLE_ADAPTER_DESCRIPTION[] = {
+    'M', 'e', 't', 'a', 'l', 'S', 'h', 'a', 'r', 'p', ' ', 'V', 'i', 'r',
+    't', 'u', 'a', 'l', ' ', 'E', 't', 'h', 'e', 'r', 'n', 'e', 't', 0,
+};
+
+// IP_ADAPTER_ADDRESSES_LH's x86_64 prefix through Ipv6IfIndex.  Keep this
+// layout explicit because the guest reads these fields through Windows ABI
+// pointers, not as an inline buffer.  The remaining linked-list fields are
+// intentionally null for this single synthetic adapter.
+struct IP_ADAPTER_ADDRESSES_LAYOUT {
+    uint32_t Length;
+    uint32_t IfIndex;
+    void* Next;
+    char* AdapterName;
+    void* FirstUnicastAddress;
+    void* FirstAnycastAddress;
+    void* FirstMulticastAddress;
+    void* FirstDnsServerAddress;
+    uint16_t* DnsSuffix;
+    uint16_t* Description;
+    uint16_t* FriendlyName;
+    uint8_t PhysicalAddress[8];
+    uint32_t PhysicalAddressLength;
+    uint32_t Flags;
+    uint32_t Mtu;
+    uint32_t IfType;
+    uint32_t OperStatus;
+    uint32_t Ipv6IfIndex;
+};
+
+static_assert(sizeof(IP_ADAPTER_ADDRESSES_LAYOUT) == 112);
+static_assert(offsetof(IP_ADAPTER_ADDRESSES_LAYOUT, AdapterName) == 16);
+static_assert(offsetof(IP_ADAPTER_ADDRESSES_LAYOUT, PhysicalAddress) == 80);
+static_assert(offsetof(IP_ADAPTER_ADDRESSES_LAYOUT, PhysicalAddressLength) == 88);
+static_assert(offsetof(IP_ADAPTER_ADDRESSES_LAYOUT, IfType) == 100);
+static_assert(offsetof(IP_ADAPTER_ADDRESSES_LAYOUT, OperStatus) == 104);
+static_assert(offsetof(IP_ADAPTER_ADDRESSES_LAYOUT, OperStatus) + sizeof(uint32_t) <=
+              sizeof(IP_ADAPTER_ADDRESSES_LAYOUT));
 
 static BOOL MSABI shim_GetSystemFirmwareTable(DWORD FirmwareTableProviderSignature, DWORD FirmwareTableID,
                                               void* pFirmwareTableBuffer, DWORD BufferSize) {
@@ -123,40 +164,34 @@ static uint32_t MSABI shim_GetAdaptersInfo(void* pAdapterInfo, uint32_t* pOutBuf
 
 static uint32_t MSABI shim_GetAdaptersAddresses(uint32_t Family, uint32_t Flags, void* Reserved,
                                                 void* pAdapterAddresses, uint32_t* pOutBufLen) {
+    (void)Family;
+    (void)Flags;
+
     if (!pOutBufLen)
         return 111;
     if (Reserved)
         return 87;
 
-    uint32_t needed = 256;
+    constexpr uint32_t needed = static_cast<uint32_t>(sizeof(IP_ADAPTER_ADDRESSES_LAYOUT));
     if (!pAdapterAddresses || *pOutBufLen < needed) {
         *pOutBufLen = needed;
         return 111;
     }
 
-    memset(pAdapterAddresses, 0, *pOutBufLen);
-    auto* out = static_cast<uint8_t*>(pAdapterAddresses);
+    assert(needed <= *pOutBufLen);
+    memset(pAdapterAddresses, 0, needed);
+    auto* adapter = static_cast<IP_ADAPTER_ADDRESSES_LAYOUT*>(pAdapterAddresses);
 
-    auto** pNext = reinterpret_cast<void**>(out);
-    *pNext = nullptr;
-
-    uint32_t* pComboIndex = reinterpret_cast<uint32_t*>(out + 8);
-    *pComboIndex = 0;
-
-    char* name = reinterpret_cast<char*>(out + 12);
-    memcpy(name, "eth0\0", 5);
-
-    uint32_t* pPhysAddrLen = reinterpret_cast<uint32_t*>(out + 280);
-    *pPhysAddrLen = 6;
-
-    uint8_t* physAddr = out + 284;
-    memcpy(physAddr, STABLE_MAC, 6);
-
-    uint32_t* pIfType = reinterpret_cast<uint32_t*>(out + 296);
-    *pIfType = 6;
-
-    uint32_t* pOperStatus = reinterpret_cast<uint32_t*>(out + 300);
-    *pOperStatus = 1;
+    adapter->Length = needed;
+    adapter->IfIndex = 1;
+    adapter->AdapterName = STABLE_ADAPTER_NAME;
+    adapter->Description = STABLE_ADAPTER_DESCRIPTION;
+    adapter->FriendlyName = STABLE_ADAPTER_DESCRIPTION;
+    memcpy(adapter->PhysicalAddress, STABLE_MAC, sizeof(STABLE_MAC));
+    adapter->PhysicalAddressLength = sizeof(STABLE_MAC);
+    adapter->Mtu = 1500;
+    adapter->IfType = 6;
+    adapter->OperStatus = 1;
 
     return 0;
 }

--- a/tests/test_phase20.cpp
+++ b/tests/test_phase20.cpp
@@ -1,9 +1,42 @@
+#include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <metalsharp/AntiCheatDB.h>
+#include <metalsharp/ExtraShims.h>
+#include <metalsharp/Win32Types.h>
+#include <vector>
 
 using namespace metalsharp::win32;
+
+struct AdapterAddressesLayout {
+    uint32_t Length;
+    uint32_t IfIndex;
+    void* Next;
+    char* AdapterName;
+    void* FirstUnicastAddress;
+    void* FirstAnycastAddress;
+    void* FirstMulticastAddress;
+    void* FirstDnsServerAddress;
+    uint16_t* DnsSuffix;
+    uint16_t* Description;
+    uint16_t* FriendlyName;
+    uint8_t PhysicalAddress[8];
+    uint32_t PhysicalAddressLength;
+    uint32_t Flags;
+    uint32_t Mtu;
+    uint32_t IfType;
+    uint32_t OperStatus;
+    uint32_t Ipv6IfIndex;
+};
+
+using GetAdaptersAddressesFn = uint32_t(MSABI*)(uint32_t, uint32_t, void*, void*, uint32_t*);
+
+static_assert(sizeof(AdapterAddressesLayout) == 112);
+static_assert(offsetof(AdapterAddressesLayout, AdapterName) == 16);
+static_assert(offsetof(AdapterAddressesLayout, PhysicalAddressLength) == 88);
+static_assert(offsetof(AdapterAddressesLayout, IfType) == 100);
+static_assert(offsetof(AdapterAddressesLayout, OperStatus) == 104);
 
 static int testsPassed = 0;
 static int testsFailed = 0;
@@ -77,6 +110,49 @@ static bool test_mac_address_stable() {
     return true;
 }
 
+static bool test_adapters_addresses_layout() {
+    metalsharp::ShimLibrary kernel32;
+    metalsharp::ShimLibrary winmm;
+    addDRMShims(kernel32, winmm);
+
+    auto it = kernel32.functions.find("GetAdaptersAddresses");
+    if (it == kernel32.functions.end())
+        return false;
+
+    auto getAdaptersAddresses = reinterpret_cast<GetAdaptersAddressesFn>(it->second());
+    uint32_t needed = 0;
+    if (getAdaptersAddresses(0, 0, nullptr, nullptr, &needed) != 111)
+        return false;
+    if (needed != sizeof(AdapterAddressesLayout))
+        return false;
+
+    std::vector<uint8_t> tooSmall(needed - 1, 0xCD);
+    uint32_t tooSmallLength = needed - 1;
+    if (getAdaptersAddresses(0, 0, nullptr, tooSmall.data(), &tooSmallLength) != 111 || tooSmallLength != needed)
+        return false;
+    for (uint8_t byte : tooSmall) {
+        if (byte != 0xCD)
+            return false;
+    }
+
+    constexpr size_t kCanarySize = 32;
+    std::vector<uint8_t> buffer(needed + kCanarySize, 0xCD);
+    uint32_t bufferLength = needed;
+    if (getAdaptersAddresses(0, 0, nullptr, buffer.data(), &bufferLength) != 0)
+        return false;
+    for (size_t i = needed; i < buffer.size(); ++i) {
+        if (buffer[i] != 0xCD)
+            return false;
+    }
+
+    auto* adapter = reinterpret_cast<const AdapterAddressesLayout*>(buffer.data());
+    return adapter->Length == sizeof(AdapterAddressesLayout) && adapter->IfIndex == 1 && adapter->Next == nullptr &&
+           adapter->AdapterName != nullptr && strcmp(adapter->AdapterName, "eth0") == 0 &&
+           adapter->PhysicalAddressLength == 6 &&
+           memcmp(adapter->PhysicalAddress, "\x00\x1A\x2B\x3C\x4D\x5E", 6) == 0 && adapter->Mtu == 1500 &&
+           adapter->IfType == 6 && adapter->OperStatus == 1 && adapter->Ipv6IfIndex == 0;
+}
+
 static bool test_local_time() {
     return true;
 }
@@ -126,6 +202,7 @@ int main() {
     printf("\n--- 20.2 DRM Shims (Firmware, MAC, Disk) ---\n");
     TEST(smbios_firmware_table);
     TEST(mac_address_stable);
+    TEST(adapters_addresses_layout);
     TEST(device_io_control_disk);
 
     printf("\n--- 20.3 SEH & Exception Hardening ---\n");


### PR DESCRIPTION
## Summary

Fix the `GetAdaptersAddresses` DRM shim so its reported buffer size matches the Windows x86-64 adapter-addresses layout and its output cannot overwrite the caller's buffer.

Fixes #417

## Changes

- Model the `IP_ADAPTER_ADDRESSES` prefix through `Ipv6IfIndex` with compile-time ABI offset and size checks.
- Return the 112-byte size required by the fields the shim provides, populate the real pointer and adapter-field offsets, and bound the output initialization to that size.
- Add a debug assertion that the required output size fits the caller-provided length.
- Add a Phase 20 regression test covering size negotiation, undersized-buffer behavior, a post-buffer canary, and the corrected adapter values.

## PR Readiness (MANDATORY)

<!-- The checklist-exception label is used only for the intentionally inapplicable
     real-game and user-facing-documentation items; this is an internal native
     DRM-shim memory-safety fix and does not change launch behavior. -->

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
  - Not applicable: this is a focused native shim safety fix; no game launch behavior changed.
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
  - Not applicable: no rules or DLL maps changed.
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped
  - Not applicable: no version surfaces changed.
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
  - No bottle, runtime, migration, or game launch behavior changed.
- [ ] Docs / compatibility matrix updated for user-facing changes
  - Not applicable: this is an internal memory-safety correction with no user-facing contract change.
- [x] Regression test added for each bug fix

## Local toolchain

- [x] `cmake -S . -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON && cmake --build build-native --parallel $(sysctl -n hw.ncpu)` — native build passed.
- [x] `clang-format --dry-run --Werror` and `tools/ci/check-clang-format.sh` — native formatting passed.
- [x] `ctest --test-dir build-native --output-on-failure -R '^phase20$'` — targeted regression passed.
- [x] `ctest --test-dir build-native --output-on-failure` — all 31 native tests passed.
- [x] `git diff --check` passed.
- Rust, Electron/TypeScript, shell, rules, DMG, and real-game suites were intentionally skipped because no files in those surfaces changed.
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced.
- No new files were added to the repo root.

## Test notes

The Phase 20 regression calls the shim through its registered export, verifies the required-size query and `ERROR_BUFFER_OVERFLOW` behavior, confirms an undersized buffer remains untouched, checks a canary immediately after the exact allocation, and validates the corrected `IP_ADAPTER_ADDRESSES` fields. No real game launch was performed because this change only adjusts the native DRM shim and does not alter launch behavior.

## Risk

The change narrows the synthetic adapter output to the documented x86-64 structure prefix and corrects field addresses; it does not change other DRM shims or runtime/launch paths. Revert commit `83fdcf04` to restore the previous implementation if needed.
