### PR TITLE
fix(runtime): protect crash report storage

### DIFF
--- a/src/runtime/CrashDiagnostics.cpp
+++ b/src/runtime/CrashDiagnostics.cpp
@@ -5,12 +5,12 @@
 /// flags, and instruction pointer — and formats them into a human-readable dump
 /// file. Complements CrashReporter with lower-level diagnostic detail.
 
+#include "PrivateStorage.h"
 #include <ctime>
 #include <fstream>
 #include <metalsharp/CrashDiagnostics.h>
 #include <metalsharp/Logger.h>
 #include <sstream>
-#include <sys/stat.h>
 
 namespace metalsharp {
 
@@ -21,11 +21,14 @@ CrashDiagnostics& CrashDiagnostics::instance() {
 
 void CrashDiagnostics::init(const std::string& diagDir) {
     m_diagDir = diagDir;
-    mkdir(m_diagDir.c_str(), 0755);
-    mkdir((m_diagDir + "/crashes").c_str(), 0755);
-    m_initialized = true;
+    const bool ready = runtime_detail::ensurePrivateDirectory(m_diagDir) &&
+                       runtime_detail::ensurePrivateDirectory(m_diagDir + "/crashes");
+    m_initialized = ready;
     m_crashCount = 0;
-    MS_INFO("CrashDiagnostics initialized: %s", m_diagDir.c_str());
+    if (m_initialized)
+        MS_INFO("CrashDiagnostics initialized: %s", m_diagDir.c_str());
+    else
+        MS_ERROR("CrashDiagnostics failed to initialize private directory: %s", m_diagDir.c_str());
 }
 
 void CrashDiagnostics::shutdown() {
@@ -44,10 +47,10 @@ void CrashDiagnostics::setGameId(const std::string& gameId) {
 
 std::string CrashDiagnostics::formatTimestamp(uint64_t epoch) {
     time_t t = static_cast<time_t>(epoch);
-    struct tm tm_buf;
-    localtime_r(&t, &tm_buf);
-    char buf[64];
-    strftime(buf, sizeof(buf), "%Y-%m-%d_%H-%M-%S", &tm_buf);
+    struct tm tm_buf{};
+    char buf[64] = {};
+    if (!localtime_r(&t, &tm_buf) || strftime(buf, sizeof(buf), "%Y-%m-%d_%H-%M-%S", &tm_buf) == 0)
+        return {};
     return buf;
 }
 
@@ -61,8 +64,8 @@ void CrashDiagnostics::writeCrashDump(const CrashInfo& info) {
     std::string ts = formatTimestamp(now);
     std::string filename = crashDir() + "/crash_" + ts + ".txt";
 
-    std::ofstream file(filename);
-    if (!file.is_open()) {
+    std::ofstream file;
+    if (!runtime_detail::openPrivateFile(file, filename)) {
         MS_ERROR("CrashDiagnostics: failed to write crash dump to %s", filename.c_str());
         return;
     }
@@ -125,8 +128,8 @@ void CrashDiagnostics::writeDiagnosticsBundle() {
         return;
 
     std::string bundlePath = m_diagDir + "/diagnostics.txt";
-    std::ofstream file(bundlePath);
-    if (!file.is_open())
+    std::ofstream file;
+    if (!runtime_detail::openPrivateFile(file, bundlePath))
         return;
 
     file << "=== MetalSharp Diagnostics Bundle ===\n";

--- a/src/runtime/CrashReporter.cpp
+++ b/src/runtime/CrashReporter.cpp
@@ -6,16 +6,54 @@
 /// be safe to call from signal handlers and other constrained contexts.
 
 #include "metalsharp/CrashReporter.h"
+#include "PrivateStorage.h"
 #include <cstdlib>
 #include <ctime>
 #include <filesystem>
 #include <fstream>
+#include <pwd.h>
 #include <random>
 #include <sstream>
+#include <unistd.h>
+#include <vector>
 
 namespace metalsharp {
 
 namespace fs = std::filesystem;
+
+namespace {
+
+// Launchers do not always inherit HOME. Resolve the account's home directory
+// without falling back to a shared, world-writable temporary directory.
+std::string passwdHomeDirectory() {
+    long bufferSize = sysconf(_SC_GETPW_R_SIZE_MAX);
+    if (bufferSize <= 0)
+        bufferSize = 16384;
+
+    std::vector<char> buffer(static_cast<size_t>(bufferSize));
+    struct passwd passwordEntry{};
+    struct passwd* result = nullptr;
+    if (getpwuid_r(getuid(), &passwordEntry, buffer.data(), buffer.size(), &result) == 0 && result && result->pw_dir) {
+        return result->pw_dir;
+    }
+    return {};
+}
+
+std::string applicationSupportDirectory() {
+    const std::string home = passwdHomeDirectory();
+    if (!home.empty())
+        return home + "/Library/Application Support/MetalSharp";
+    return "/Library/Application Support/MetalSharp";
+}
+
+std::string dataDirectory() {
+    const char* home = std::getenv("HOME");
+    if (home && *home)
+        return std::string(home) + "/.metalsharp";
+    return applicationSupportDirectory();
+}
+
+} // namespace
 
 CrashReporter& CrashReporter::instance() {
     static CrashReporter inst;
@@ -35,8 +73,9 @@ std::string CrashReporter::generateId() {
 std::string CrashReporter::formatTimestamp(int64_t epoch) {
     time_t t = static_cast<time_t>(epoch);
     struct tm* tm_info = localtime(&t);
-    char buf[64];
-    strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", tm_info);
+    char buf[64] = {};
+    if (!tm_info || strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", tm_info) == 0)
+        return {};
     return std::string(buf);
 }
 
@@ -59,10 +98,7 @@ void CrashReporter::endSession(int exitCode) {
 }
 
 std::string CrashReporter::getReportsDir() {
-    const char* home = std::getenv("HOME");
-    if (!home)
-        return "/tmp/metalsharp/crashes";
-    return std::string(home) + "/.metalsharp/crashes";
+    return dataDirectory() + "/crashes";
 }
 
 std::string CrashReporter::collectSystemInfo() {
@@ -83,10 +119,7 @@ std::string CrashReporter::collectSystemInfo() {
 
     ss << "Pointer size: " << sizeof(void*) * 8 << " bit\n";
 
-    const char* home = std::getenv("HOME");
-    if (home) {
-        ss << "Home: " << home << "\n";
-    }
+    ss << "Home: [redacted]\n";
 
     return ss.str();
 }
@@ -100,8 +133,7 @@ CrashReport CrashReporter::collectReport() {
     report.systemInfo = collectSystemInfo();
     report.collected = true;
 
-    const char* home = std::getenv("HOME");
-    std::string base = home ? std::string(home) + "/.metalsharp" : "/tmp/metalsharp";
+    const std::string base = dataDirectory();
 
     auto readFileIfExists = [&](const std::string& path) -> std::string {
         std::ifstream f(path);
@@ -202,12 +234,14 @@ std::vector<CrashReport> CrashReporter::getRecentReports(int count) {
 }
 
 bool CrashReporter::saveReport(const CrashReport& report) {
-    std::string dir = getReportsDir();
-    fs::create_directories(dir);
+    const fs::path base = dataDirectory();
+    const fs::path dir = base / "crashes";
+    if (!runtime_detail::ensurePrivateDirectory(base) || !runtime_detail::ensurePrivateDirectory(dir))
+        return false;
 
-    std::string path = dir + "/" + report.id + ".crash";
-    std::ofstream f(path);
-    if (!f.is_open())
+    const fs::path path = dir / (report.id + ".crash");
+    std::ofstream f;
+    if (!runtime_detail::openPrivateFile(f, path))
         return false;
 
     f << "id: " << report.id << "\n";

--- a/src/runtime/PrivateStorage.h
+++ b/src/runtime/PrivateStorage.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <filesystem>
+#include <fstream>
+#include <sys/stat.h>
+
+namespace metalsharp::runtime_detail {
+
+namespace fs = std::filesystem;
+
+class ScopedPrivateUmask final {
+  public:
+    ScopedPrivateUmask() : m_previous(umask(0077)) {}
+    ~ScopedPrivateUmask() { umask(m_previous); }
+
+    ScopedPrivateUmask(const ScopedPrivateUmask&) = delete;
+    ScopedPrivateUmask& operator=(const ScopedPrivateUmask&) = delete;
+
+  private:
+    mode_t m_previous;
+};
+
+// Apply the mode to both newly created and pre-existing paths. The latter is
+// important when a directory was created by an older, permissive build.
+inline bool ensurePrivateDirectory(const fs::path& directory) {
+    if (directory.empty())
+        return false;
+
+    std::error_code ec;
+    {
+        ScopedPrivateUmask privateUmask;
+        fs::create_directories(directory, ec);
+    }
+    if (ec || !fs::is_directory(directory, ec) || ec)
+        return false;
+
+    fs::permissions(directory, fs::perms::owner_all, fs::perm_options::replace, ec);
+    return !ec;
+}
+
+inline bool openPrivateFile(std::ofstream& file, const fs::path& path) {
+    {
+        ScopedPrivateUmask privateUmask;
+        file.open(path, std::ios::out | std::ios::trunc);
+    }
+    if (!file.is_open())
+        return false;
+
+    std::error_code ec;
+    fs::permissions(path, fs::perms::owner_read | fs::perms::owner_write, fs::perm_options::replace, ec);
+    if (ec) {
+        file.close();
+        return false;
+    }
+    return true;
+}
+
+} // namespace metalsharp::runtime_detail

--- a/tests/test_phase24.cpp
+++ b/tests/test_phase24.cpp
@@ -1,14 +1,19 @@
+#include "metalsharp/CrashDiagnostics.h"
 #include "metalsharp/CrashReporter.h"
 #include "metalsharp/GameDetector.h"
 #include "metalsharp/SettingsManager.h"
 #include "metalsharp/UpdateChecker.h"
 #include <cassert>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <string>
+#include <sys/stat.h>
+#include <unistd.h>
 #include <vector>
 
 namespace fs = std::filesystem;
@@ -96,6 +101,7 @@ static bool crash_reporter_generate_id() {
 static bool crash_reporter_format_timestamp() {
     std::string ts = metalsharp::CrashReporter::formatTimestamp(0);
     assert(!ts.empty());
+    assert(metalsharp::CrashReporter::formatTimestamp(std::numeric_limits<int64_t>::max()).empty());
     return true;
 }
 
@@ -105,6 +111,102 @@ static bool crash_reporter_collect_system_info() {
     assert(!info.empty());
     assert(info.find("Platform:") != std::string::npos);
     assert(info.find("Architecture:") != std::string::npos);
+    assert(info.find("Home: [redacted]") != std::string::npos);
+    const char* home = std::getenv("HOME");
+    if (home && *home)
+        assert(info.find(home) == std::string::npos);
+    return true;
+}
+
+static bool private_mode(const fs::path& path, mode_t expected) {
+    struct stat st{};
+    return stat(path.c_str(), &st) == 0 && (st.st_mode & 0777) == expected;
+}
+
+static bool crash_reporter_private_storage() {
+    auto& cr = metalsharp::CrashReporter::instance();
+    const char* previousHome = std::getenv("HOME");
+    const bool hadHome = previousHome != nullptr;
+    const std::string previousHomeValue = previousHome ? previousHome : "";
+    const fs::path tempHome = fs::temp_directory_path() / ("metalsharp-crash-reporter-" + std::to_string(getpid()));
+    fs::remove_all(tempHome);
+
+    if (setenv("HOME", tempHome.c_str(), 1) != 0)
+        return false;
+
+    metalsharp::CrashReport report;
+    report.id = "private-storage";
+    report.systemInfo = "test\n";
+    const bool saved = cr.saveReport(report);
+    const fs::path dataDir = tempHome / ".metalsharp";
+    const fs::path reportsDir = dataDir / "crashes";
+    const fs::path reportPath = reportsDir / "private-storage.crash";
+    const bool privateStorage =
+        saved && private_mode(dataDir, 0700) && private_mode(reportsDir, 0700) && private_mode(reportPath, 0600);
+
+    cr.deleteReport(report.id);
+    fs::remove_all(tempHome);
+    if (hadHome)
+        setenv("HOME", previousHomeValue.c_str(), 1);
+    else
+        unsetenv("HOME");
+    return privateStorage;
+}
+
+static bool crash_reporter_home_fallback() {
+    auto& cr = metalsharp::CrashReporter::instance();
+    const char* previousHome = std::getenv("HOME");
+    const bool hadHome = previousHome != nullptr;
+    const std::string previousHomeValue = previousHome ? previousHome : "";
+
+    unsetenv("HOME");
+    const std::string reportsDir = cr.getReportsDir();
+    if (hadHome)
+        setenv("HOME", previousHomeValue.c_str(), 1);
+    else
+        unsetenv("HOME");
+
+    return reportsDir.find("/tmp/") == std::string::npos && reportsDir.ends_with("/crashes");
+}
+
+static bool crash_diagnostics_private_storage() {
+    const fs::path diagDir = fs::temp_directory_path() / ("metalsharp-crash-diagnostics-" + std::to_string(getpid()));
+    fs::remove_all(diagDir);
+
+    auto& diagnostics = metalsharp::CrashDiagnostics::instance();
+    diagnostics.init(diagDir.string());
+    const bool privateDirectories = private_mode(diagDir, 0700) && private_mode(diagDir / "crashes", 0700);
+
+    if (!privateDirectories) {
+        diagnostics.shutdown();
+        fs::remove_all(diagDir);
+        return false;
+    }
+
+    metalsharp::CrashInfo info;
+    info.signal = 11;
+    diagnostics.setGameId("test-game");
+    diagnostics.setModuleInfo(0x1000, 0x1000, "/path/to/game.exe");
+    diagnostics.writeCrashDump(info);
+    diagnostics.writeDiagnosticsBundle();
+
+    bool privateFiles = private_mode(diagDir / "diagnostics.txt", 0600);
+    bool foundCrashDump = false;
+    for (const auto& entry : fs::directory_iterator(diagDir / "crashes")) {
+        if (entry.path().extension() == ".txt") {
+            foundCrashDump = true;
+            privateFiles = privateFiles && private_mode(entry.path(), 0600);
+        }
+    }
+
+    diagnostics.shutdown();
+    fs::remove_all(diagDir);
+    return privateDirectories && privateFiles && foundCrashDump;
+}
+
+static bool crash_diagnostics_format_timestamp() {
+    assert(!metalsharp::CrashDiagnostics::formatTimestamp(0).empty());
+    assert(metalsharp::CrashDiagnostics::formatTimestamp(std::numeric_limits<uint64_t>::max() / 2).empty());
     return true;
 }
 
@@ -345,8 +447,14 @@ int main() {
     TEST(crash_reporter_generate_id);
     TEST(crash_reporter_format_timestamp);
     TEST(crash_reporter_collect_system_info);
+    TEST(crash_reporter_private_storage);
+    TEST(crash_reporter_home_fallback);
     TEST(crash_reporter_save_and_load);
     TEST(crash_reporter_reports_dir);
+
+    printf("\n--- 24.2a Crash Diagnostics ---\n");
+    TEST(crash_diagnostics_private_storage);
+    TEST(crash_diagnostics_format_timestamp);
 
     printf("\n--- 24.3 Update Checker ---\n");
     TEST(version_parse);


### PR DESCRIPTION
## Summary

Fixes #425 by keeping crash reports and diagnostics private even when the launcher does not provide `HOME`.

## Changes

- Resolve `HOME`-unset storage through the account's macOS Application Support directory instead of shared `/tmp` paths.
- Create crash directories with owner-only `0700` permissions and report/dump files with owner-only `0600` permissions, including existing paths.
- Redact the home path from collected system information.
- Handle timestamp conversion failures without dereferencing an invalid `localtime` result.
- Add regression coverage for fallback selection, redaction, permissions, and timestamp failure handling.

## PR Readiness (MANDATORY)

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

The `checklist-exception` label is applied because this change is limited to native crash artifact storage and does not change a game or launch route, so real-game compatibility testing is not applicable. No user-facing documentation or compatibility matrix entry is needed.

## Local toolchain (run before push)

- [ ] `cargo fmt --all -- --check` passes (Rust)
- [ ] `cargo clippy --all-targets -- -D warnings` passes (Rust)
- [ ] `cargo build --release` passes (Rust backend)
- [ ] `cargo test` passes (Rust — 628+ tests)
- [x] C++ compiles if changed: `cmake -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON && cmake --build build-native --parallel $(sysctl -n hw.ncpu)`
- [x] `clang-format --dry-run --Werror` passes on any changed C/C++/Obj-C file
- [x] `ctest --test-dir build-native` passes if tests changed
- [ ] TypeScript compiles if changed: `cd app && npx tsc --noEmit`
- [ ] Biome + Prettier pass if TS/JS changed: `cd app && npx @biomejs/biome ci src/ && npx prettier --check 'src/**/*.{ts,js,html,css,json}'`
- [ ] Shell scripts lint if changed: `tools/ci/shellcheck.sh`
- [ ] `tools/ci/validate-rules-toml.py` passes if `configs/mtsp-rules.toml` changed
- [ ] `python3 tools/ci/verify-dmg-workflow.py` passes if release/bundle tooling changed
- [ ] Tested with at least one game (which one? which launch method? which drive?)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files should be added to the repo root; place them under `app/`, `tools/`, `tests/`, etc.

## Test notes

- `cmake -S . -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON`
- `cmake --build build-native --parallel $(sysctl -n hw.ncpu)`
- `./build-native/tests/test_phase24` — 26/26 passed
- `ctest --test-dir build-native --output-on-failure` — 31/31 passed
- `tools/ci/check-clang-format.sh`
- Targeted `clang++ -std=c++20 -fsyntax-only` checks for both runtime sources and `tests/test_phase24.cpp`

No real game was launched because this is a diagnostics-storage security fix with no game or route behavior change.

## Risk

The only behavior change is that crash artifacts are refused if private storage cannot be created or secured, rather than being written to an unsafe location. With `HOME` unavailable, the normal-user fallback is `~/Library/Application Support/MetalSharp`; there is no `/tmp` fallback. Rollback is a single commit revert if a platform-specific storage issue appears.
