### PR TITLE
fix(loader): bound PE header and file reads

### DIFF
--- a/include/metalsharp/PELoader.h
+++ b/include/metalsharp/PELoader.h
@@ -16,6 +16,9 @@
 ///   7. applySectionProtections() — Set mprotect based on section characteristics
 ///   8. processTLS()           — Run TLS callbacks for DLL_PROCESS_ATTACH
 ///
+/// File-backed loads reject empty or 512 MiB-and-larger inputs. Header and
+/// section-table extents must remain within the raw file before mapping.
+///
 /// Import resolution priority: registered shim → loaded PE DLL → load from search path.
 /// Export forwarding is handled recursively.
 /// Shims are registered via registerShim() and take priority over native loading.

--- a/src/loader/PELoader.cpp
+++ b/src/loader/PELoader.cpp
@@ -71,12 +71,39 @@
 ///   is set in the constructor and cleared in the destructor.
 #include <cstring>
 #include <fstream>
+#include <limits>
 #include <metalsharp/Logger.h>
 #include <metalsharp/PEHeader.h>
 #include <metalsharp/PELoader.h>
 #include <sys/mman.h>
 
 namespace metalsharp {
+
+namespace {
+
+constexpr std::streamoff kMaxPEFileSize = 512 * 1024 * 1024;
+
+bool readPEFile(const std::string& path, std::vector<uint8_t>& data) {
+    std::ifstream file(path, std::ios::binary | std::ios::ate);
+    if (!file.is_open())
+        return false;
+
+    const std::streamoff fileSize = file.tellg();
+    if (fileSize <= 0 || fileSize >= kMaxPEFileSize)
+        return false;
+    if (!file.seekg(0, std::ios::beg))
+        return false;
+
+    data.resize(static_cast<size_t>(fileSize));
+    return static_cast<bool>(
+        file.read(reinterpret_cast<char*>(data.data()), static_cast<std::streamsize>(data.size())));
+}
+
+bool rangeWithin(size_t offset, size_t length, size_t total) {
+    return offset <= total && length <= total - offset;
+}
+
+} // namespace
 
 PELoader* PELoader::s_instance = nullptr;
 
@@ -111,20 +138,12 @@ bool PELoader::load(const std::string& path) {
 
     m_mainModule.name = path;
 
-    std::ifstream file(path, std::ios::binary | std::ios::ate);
-    if (!file.is_open()) {
-        MS_INFO("PELoader: failed to open %s", path.c_str());
-        return false;
-    }
-
-    size_t fileSize = file.tellg();
-    file.seekg(0);
-
-    std::vector<uint8_t> data(fileSize);
-    if (!file.read(reinterpret_cast<char*>(data.data()), fileSize)) {
+    std::vector<uint8_t> data;
+    if (!readPEFile(path, data)) {
         MS_INFO("PELoader: failed to read %s", path.c_str());
         return false;
     }
+    const size_t fileSize = data.size();
 
     if (!parsePE(m_mainModule, data.data(), fileSize))
         return false;
@@ -159,7 +178,7 @@ bool PELoader::loadFromMemory(const uint8_t* data, size_t size) {
 }
 
 bool PELoader::parsePE(LoadedModule& module, const uint8_t* rawData, size_t rawSize) {
-    if (rawSize < sizeof(IMAGE_DOS_HEADER)) {
+    if (!rawData || rawSize < sizeof(IMAGE_DOS_HEADER)) {
         MS_INFO("PELoader: file too small for DOS header");
         return false;
     }
@@ -170,7 +189,12 @@ bool PELoader::parsePE(LoadedModule& module, const uint8_t* rawData, size_t rawS
         return false;
     }
 
-    if (dos->e_lfanew < 0 || (size_t)dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER) > rawSize) {
+    const auto headerRangeWithin = [rawSize](size_t offset, size_t length) {
+        return rangeWithin(offset, length, rawSize);
+    };
+
+    if (dos->e_lfanew < 0 ||
+        !headerRangeWithin(static_cast<size_t>(dos->e_lfanew), sizeof(uint32_t) + sizeof(IMAGE_FILE_HEADER))) {
         MS_INFO("PELoader: invalid e_lfanew offset");
         return false;
     }
@@ -193,11 +217,36 @@ bool PELoader::parsePE(LoadedModule& module, const uint8_t* rawData, size_t rawS
         return false;
     }
 
+    const size_t optionalHeaderOffset =
+        static_cast<size_t>(dos->e_lfanew) + sizeof(uint32_t) + sizeof(IMAGE_FILE_HEADER);
+    if (!headerRangeWithin(optionalHeaderOffset, fileHeader->SizeOfOptionalHeader)) {
+        MS_INFO("PELoader: optional header extends past end of file");
+        return false;
+    }
+
+    const size_t sectionTableOffset = optionalHeaderOffset + fileHeader->SizeOfOptionalHeader;
+    const size_t sectionTableSize = static_cast<size_t>(fileHeader->NumberOfSections) * sizeof(IMAGE_SECTION_HEADER);
+    if (!headerRangeWithin(sectionTableOffset, sectionTableSize)) {
+        MS_INFO("PELoader: section table extends past end of file");
+        return false;
+    }
+
     auto* optHeader =
         reinterpret_cast<const IMAGE_OPTIONAL_HEADER64*>(rawData + dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER));
 
     if (optHeader->Magic != IMAGE_OPTIONAL_MAGIC_PE32PLUS) {
         MS_INFO("PELoader: not PE32+ (magic: 0x%04X)", optHeader->Magic);
+        return false;
+    }
+
+    if (optHeader->SectionAlignment == 0 || optHeader->FileAlignment == 0) {
+        MS_INFO("PELoader: invalid section or file alignment");
+        return false;
+    }
+
+    const size_t sectionTableEnd = sectionTableOffset + sectionTableSize;
+    if (optHeader->SizeOfHeaders < sectionTableEnd || optHeader->SizeOfHeaders > rawSize) {
+        MS_INFO("PELoader: headers extend past declared or actual file bounds");
         return false;
     }
 
@@ -222,7 +271,12 @@ bool PELoader::mapSections(LoadedModule& module, const uint8_t* rawData, size_t 
     auto* sections = reinterpret_cast<const IMAGE_SECTION_HEADER*>(
         rawData + dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER) + fileHeader->SizeOfOptionalHeader);
 
-    uint32_t imageSize = alignUp(optHeader->SizeOfImage, 0x1000);
+    const uint64_t imageSize64 = alignUp(optHeader->SizeOfImage, 0x1000);
+    if (imageSize64 == 0 || imageSize64 > std::numeric_limits<size_t>::max()) {
+        MS_INFO("PELoader: invalid image size");
+        return false;
+    }
+    const size_t imageSize = static_cast<size_t>(imageSize64);
 
 #ifdef __APPLE__
     int mmapFlags = MAP_PRIVATE | MAP_ANONYMOUS | MAP_JIT;
@@ -234,16 +288,19 @@ bool PELoader::mapSections(LoadedModule& module, const uint8_t* rawData, size_t 
         reinterpret_cast<uint8_t*>(mmap(nullptr, imageSize, PROT_READ | PROT_WRITE | PROT_EXEC, mmapFlags, -1, 0));
 
     if (mem == MAP_FAILED) {
-        MS_INFO("PELoader: mmap failed for image (%u bytes), errno=%d", imageSize, errno);
+        MS_INFO("PELoader: mmap failed for image (%zu bytes), errno=%d", imageSize, errno);
         return false;
     }
 
     memset(mem, 0, imageSize);
 
-    uint32_t headerSize = alignUp(optHeader->SizeOfHeaders, m_fileAlignment);
-    if (headerSize > rawSize)
-        headerSize = rawSize;
-    memcpy(mem, rawData, headerSize);
+    const uint64_t headerSize64 = alignUp(optHeader->SizeOfHeaders, m_fileAlignment);
+    if (headerSize64 > imageSize || headerSize64 > rawSize) {
+        MS_INFO("PELoader: header copy exceeds image or file bounds");
+        munmap(mem, imageSize);
+        return false;
+    }
+    memcpy(mem, rawData, static_cast<size_t>(headerSize64));
 
     for (uint16_t i = 0; i < fileHeader->NumberOfSections; i++) {
         const auto& sec = sections[i];
@@ -254,11 +311,17 @@ bool PELoader::mapSections(LoadedModule& module, const uint8_t* rawData, size_t 
         uint32_t srcOffset = sec.PointerToRawData;
         uint32_t copySize = sec.SizeOfRawData;
 
-        if (srcOffset + copySize > rawSize) {
-            copySize = rawSize - srcOffset;
+        if (static_cast<size_t>(srcOffset) > rawSize ||
+            static_cast<size_t>(copySize) > rawSize - static_cast<size_t>(srcOffset)) {
+            MS_INFO("PELoader: section raw data exceeds file bounds");
+            munmap(mem, imageSize);
+            return false;
         }
-        if (dstOffset + copySize > imageSize) {
-            copySize = imageSize - dstOffset;
+        if (static_cast<size_t>(dstOffset) > imageSize ||
+            static_cast<size_t>(copySize) > imageSize - static_cast<size_t>(dstOffset)) {
+            MS_INFO("PELoader: section virtual data exceeds image bounds");
+            munmap(mem, imageSize);
+            return false;
         }
 
         if (copySize > 0) {
@@ -880,15 +943,10 @@ void* PELoader::getProcAddress(HMODULE hModule, const std::string& funcName) {
 bool PELoader::loadDLL(const std::string& path, const std::string& dllName) {
     MS_INFO("PELoader: loading DLL %s from %s", dllName.c_str(), path.c_str());
 
-    std::ifstream file(path, std::ios::binary | std::ios::ate);
-    if (!file.is_open())
+    std::vector<uint8_t> data;
+    if (!readPEFile(path, data))
         return false;
-
-    size_t fileSize = file.tellg();
-    file.seekg(0);
-    std::vector<uint8_t> data(fileSize);
-    if (!file.read(reinterpret_cast<char*>(data.data()), fileSize))
-        return false;
+    const size_t fileSize = data.size();
 
     LoadedModule mod;
     mod.name = dllName;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -172,6 +172,14 @@ target_compile_options(test_resource_bounds PRIVATE -fobjc-arc)
 
 add_test(NAME resource_bounds COMMAND test_resource_bounds)
 
+add_executable(test_pe_loader
+    test_pe_loader.cpp
+)
+target_link_libraries(test_pe_loader PRIVATE metalsharp_loader metalsharp_core)
+target_compile_options(test_pe_loader PRIVATE -fobjc-arc)
+
+add_test(NAME pe_loader COMMAND test_pe_loader)
+
 add_executable(test_phase21
     test_phase21.cpp
 )

--- a/tests/test_pe_loader.cpp
+++ b/tests/test_pe_loader.cpp
@@ -1,0 +1,187 @@
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <metalsharp/PEHeader.h>
+#include <metalsharp/PELoader.h>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+using namespace metalsharp;
+
+static int testsPassed = 0;
+static int testsFailed = 0;
+
+#define TEST(name)                                                                                                     \
+    printf("  TEST: %-55s", #name);                                                                                    \
+    if (test_##name()) {                                                                                               \
+        printf("PASS\n");                                                                                              \
+        testsPassed++;                                                                                                 \
+    } else {                                                                                                           \
+        printf("FAIL\n");                                                                                              \
+        testsFailed++;                                                                                                 \
+    }
+
+namespace {
+
+constexpr size_t kNtHeadersOffset = 0x80;
+constexpr size_t kOptionalHeaderOffset = kNtHeadersOffset + sizeof(uint32_t) + sizeof(IMAGE_FILE_HEADER);
+constexpr size_t kSectionTableOffset = kOptionalHeaderOffset + sizeof(IMAGE_OPTIONAL_HEADER64);
+constexpr size_t kMinimumHeadersSize = 0x200;
+constexpr size_t kMaxPEFileSize = 512ull * 1024ull * 1024ull;
+
+std::vector<uint8_t> makeMinimalPE() {
+    const size_t fileSize = std::max(kMinimumHeadersSize, kSectionTableOffset + sizeof(IMAGE_SECTION_HEADER));
+    std::vector<uint8_t> data(fileSize);
+
+    auto* dos = reinterpret_cast<IMAGE_DOS_HEADER*>(data.data());
+    dos->e_magic = IMAGE_DOS_SIGNATURE;
+    dos->e_lfanew = kNtHeadersOffset;
+
+    auto* signature = reinterpret_cast<uint32_t*>(data.data() + kNtHeadersOffset);
+    *signature = IMAGE_PE_SIGNATURE;
+
+    auto* fileHeader = reinterpret_cast<IMAGE_FILE_HEADER*>(signature + 1);
+    fileHeader->Machine = IMAGE_FILE_MACHINE_AMD64;
+    fileHeader->NumberOfSections = 1;
+    fileHeader->SizeOfOptionalHeader = sizeof(IMAGE_OPTIONAL_HEADER64);
+
+    auto* optionalHeader = reinterpret_cast<IMAGE_OPTIONAL_HEADER64*>(data.data() + kOptionalHeaderOffset);
+    optionalHeader->Magic = IMAGE_OPTIONAL_MAGIC_PE32PLUS;
+    optionalHeader->ImageBase = 0x140000000ULL;
+    optionalHeader->SectionAlignment = 0x1000;
+    optionalHeader->FileAlignment = 0x200;
+    optionalHeader->SizeOfImage = 0x2000;
+    optionalHeader->SizeOfHeaders = kMinimumHeadersSize;
+
+    auto* section = reinterpret_cast<IMAGE_SECTION_HEADER*>(data.data() + kSectionTableOffset);
+    section->Name[0] = '.';
+    section->Name[1] = 't';
+    section->Name[2] = 'e';
+    section->Name[3] = 's';
+    section->Name[4] = 't';
+    section->VirtualSize = 0x10;
+    section->VirtualAddress = 0x1000;
+    section->Characteristics = IMAGE_SCN_MEM_READ;
+
+    return data;
+}
+
+IMAGE_FILE_HEADER* fileHeader(std::vector<uint8_t>& data) {
+    return reinterpret_cast<IMAGE_FILE_HEADER*>(data.data() + kNtHeadersOffset + sizeof(uint32_t));
+}
+
+IMAGE_SECTION_HEADER* firstSection(std::vector<uint8_t>& data) {
+    return reinterpret_cast<IMAGE_SECTION_HEADER*>(data.data() + kSectionTableOffset);
+}
+
+std::string temporaryPath(const char* suffix) {
+    const char* tempDirectory = getenv("TMPDIR");
+    return std::string(tempDirectory ? tempDirectory : "/tmp") + "/metalsharp-pe-loader-" + std::to_string(getpid()) +
+           suffix;
+}
+
+static bool test_accepts_minimal_pe() {
+    auto data = makeMinimalPE();
+    PELoader loader;
+    return loader.loadFromMemory(data.data(), data.size()) && loader.getBase() != nullptr;
+}
+
+static bool test_rejects_optional_header_past_file() {
+    auto data = makeMinimalPE();
+    data.resize(kOptionalHeaderOffset + sizeof(IMAGE_OPTIONAL_HEADER64));
+    fileHeader(data)->SizeOfOptionalHeader = sizeof(IMAGE_OPTIONAL_HEADER64) + 1;
+
+    PELoader loader;
+    return !loader.loadFromMemory(data.data(), data.size());
+}
+
+static bool test_rejects_truncated_section_table() {
+    auto data = makeMinimalPE();
+    data.resize(kSectionTableOffset + sizeof(IMAGE_SECTION_HEADER));
+    fileHeader(data)->NumberOfSections = 2;
+
+    PELoader loader;
+    return !loader.loadFromMemory(data.data(), data.size());
+}
+
+static bool test_rejects_raw_section_past_file() {
+    auto data = makeMinimalPE();
+    auto* section = firstSection(data);
+    section->PointerToRawData = static_cast<uint32_t>(data.size() - 1);
+    section->SizeOfRawData = 2;
+
+    PELoader loader;
+    return !loader.loadFromMemory(data.data(), data.size());
+}
+
+static bool test_rejects_virtual_section_past_image() {
+    auto data = makeMinimalPE();
+    data.resize(kMinimumHeadersSize + 2);
+    auto* section = firstSection(data);
+    section->VirtualAddress = 0x1FFF;
+    section->PointerToRawData = kMinimumHeadersSize;
+    section->SizeOfRawData = 2;
+
+    PELoader loader;
+    return !loader.loadFromMemory(data.data(), data.size());
+}
+
+static bool test_rejects_empty_file() {
+    const std::string path = temporaryPath("-empty.bin");
+    {
+        std::ofstream file(path, std::ios::binary);
+        if (!file)
+            return false;
+    }
+
+    PELoader loader;
+    const bool rejectedByLoad = !loader.load(path);
+    PELoader dllLoader;
+    const bool rejectedByLoadDLL = !dllLoader.loadDLL(path, "empty.dll");
+    std::remove(path.c_str());
+    return rejectedByLoad && rejectedByLoadDLL;
+}
+
+static bool test_rejects_oversized_file() {
+    const std::string path = temporaryPath("-oversized.bin");
+    {
+        std::ofstream file(path, std::ios::binary);
+        if (!file)
+            return false;
+        file.seekp(static_cast<std::streamoff>(kMaxPEFileSize - 1));
+        file.put('\0');
+        if (!file)
+            return false;
+    }
+
+    PELoader loader;
+    const bool rejectedByLoad = !loader.load(path);
+    PELoader dllLoader;
+    const bool rejectedByLoadDLL = !dllLoader.loadDLL(path, "oversized.dll");
+    std::remove(path.c_str());
+    return rejectedByLoad && rejectedByLoadDLL;
+}
+
+} // namespace
+
+int main() {
+    printf("=== PE Loader Bounds Tests ===\n\n");
+
+    TEST(accepts_minimal_pe);
+    TEST(rejects_optional_header_past_file);
+    TEST(rejects_truncated_section_table);
+    TEST(rejects_raw_section_past_file);
+    TEST(rejects_virtual_section_past_image);
+    TEST(rejects_empty_file);
+    TEST(rejects_oversized_file);
+
+    printf("\n%d/%d passed", testsPassed, testsPassed + testsFailed);
+    if (testsFailed > 0)
+        printf(" (%d FAILED)", testsFailed);
+    printf("\n");
+
+    return testsFailed > 0 ? 1 : 0;
+}


### PR DESCRIPTION
Fixes #414

## Summary

Harden PE file loading against malformed headers, truncated section tables, invalid section ranges, and unsafe file-size handling reported in #414.

## Changes

- Validate the optional-header and section-table extents before dereferencing or mapping them.
- Bound file-backed `load()` and `loadDLL()` reads to non-empty inputs smaller than 512 MiB, including failed `tellg()` results.
- Reject section raw/virtual ranges that would read past the file or write past the mapped image.
- Add focused PE loader regression coverage and document the file-backed input limit.

## PR Readiness (MANDATORY)

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

The real-game compatibility item is intentionally not applicable to this malformed-input/security-boundary fix; the PR carries the `checklist-exception` label.

## Local toolchain (run before push)

- [ ] `cargo fmt --all -- --check` passes (Rust) — not run; no Rust files changed
- [ ] `cargo clippy --all-targets -- -D warnings` passes (Rust) — not run; no Rust files changed
- [ ] `cargo build --release` passes (Rust backend) — not run; no Rust files changed
- [ ] `cargo test` passes (Rust — 628+ tests) — not run; no Rust files changed
- [x] C++ compiles if changed: `cmake -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON && cmake --build build-native --parallel $(sysctl -n hw.ncpu)`
- [x] `clang-format --dry-run --Werror` passes on any changed C/C++/Obj-C file
- [x] `ctest --test-dir build-native` passes if tests changed
- [ ] TypeScript compiles if changed: `cd app && npx tsc --noEmit` — not run; no TypeScript files changed
- [ ] Biome + Prettier pass if TS/JS changed: `cd app && npx @biomejs/biome ci src/ && npx prettier --check 'src/**/*.{ts,js,html,css,json}'` — not run; no TS/JS files changed
- [ ] Shell scripts lint if changed: `tools/ci/shellcheck.sh` — not run; no shell scripts changed
- [ ] `tools/ci/validate-rules-toml.py` passes if `configs/mtsp-rules.toml` changed — not run; no rules changed
- [ ] `python3 tools/ci/verify-dmg-workflow.py` passes if release/bundle tooling changed — not run; no release tooling changed
- [ ] Tested with at least one game (which one? which launch method? which drive?) — not applicable; this PR tests malformed PE inputs
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files should be added to the repo root; place them under `app/`, `tools/`, `tests/`, etc.

## Test notes

From a clean external-drive checkout at `/Volumes/AverySSD/MetalSharp-414-clean`, based on the fetched latest `origin/main` (`5afc4edc`):

- Waited for concurrent native build/test processes to finish before running this checkout's validation.
- `cmake -S . -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON` — passed.
- `cmake --build build-native --parallel $(sysctl -n hw.ncpu)` — passed.
- `ctest --test-dir build-native --output-on-failure` — 32/32 passed.
- `./build-native/tests/test_pe_loader` — 7/7 passed, covering valid PE loading, optional-header and section-table truncation, raw/virtual section bounds, empty files, and the 512 MiB file limit.
- `tools/ci/check-clang-format.sh`, `git diff --check`, and the pre-commit hook — passed.
- No real-game launch was performed because the regression scope is pre-mapping malformed-input validation; this is covered by the `checklist-exception` label.

## Risk

Valid file-backed PE inputs below 512 MiB retain the existing path. Empty, failed-size, or 512 MiB-and-larger file-backed inputs now fail early, and malformed header/section extents fail instead of being mapped. No bottle, runtime migration, launch behavior, configuration, or version files changed. Rollback is `git revert 42b28938` if the boundary policy needs to be revisited.

