### PR TITLE
fix: align kernel32 environment variable shims (#421)

### DIFF
--- a/docs/runtime/metalsharp-host-shim-inventory.md
+++ b/docs/runtime/metalsharp-host-shim-inventory.md
@@ -1,6 +1,7 @@
 # MetalSharp Host Shim Inventory
 
 Created: 2026-05-19
+Updated: 2026-08-11
 
 Purpose: Phase 0 inventory of existing C, C++, and Objective-C host shims that can seed a formal MetalSharp Host Runtime ABI.
 
@@ -34,6 +35,28 @@ Purpose: Phase 0 inventory of existing C, C++, and Objective-C host shims that c
 | Offline EAC mode naming | `app/src-rust/src/installer.rs`, `app/src-rust/src/main.rs` | Installer/UI text now avoids bypass wording, but endpoint names still expose the legacy `eac-toggle` route. | legacy-risk | Audit behavior, keep naming explicit if legitimate compatibility flag, remove if bypass-like. |
 | Controller input shims (PR #375) | `tools/bundles/update-lib-metalsharp.py` (xinput/dinput PE shims), deployed per `controllerInput` config (`off`/`x`/`d`) | XInput shims (`xinput1_1.dll`…`xinput1_4.dll`, `xinput9_1_0.dll`) and DInput shims (`dinput.dll`, `dinput8.dll`) shipped in `lib/metalsharp` and copied into the game folder + Steam prefix `system32`/`syswow64` on launch; previous set removed on switch, pre-existing game files backed up/restored. | stable | Keep the shim set per-mode; extend the manifest pattern below to versioned selection. |
 | Runtime deploy glue | `app/src-rust/src/mtsp/launcher.rs`, `app/src-rust/src/setup.rs` | Copies shims into runtime/game folders and assembles launch env. The Mono/FNA launcher now has a native shim manifest for kernel32/user32/Carbon interpose plus bundled CoreAudio/GameController dylibs. | prototype | Extend the manifest pattern into versioned Host Runtime ABI asset selection and self-tests. |
+
+## Native-loader Environment Contract
+
+The C++ kernel32 environment exports in `src/win32/kernel32/Kernel32Extra.cpp`
+model the Windows environment block separately from the macOS process
+environment:
+
+- variable names are canonicalized to uppercase for both the A and W exports;
+- inherited macOS variables are discovered by a case-insensitive scan of the
+  host environment, rather than by the case-sensitive `getenv(name)` lookup;
+- `GetEnvironmentVariableA/W(name, nullptr, 0)` returns the required character
+  count including the terminator;
+- a non-zero-size buffer that cannot hold the value returns zero, sets
+  `ERROR_BUFFER_OVERFLOW`, and is left untouched; and
+- `SetEnvironmentVariableA/W` updates the Windows-side map without calling
+  `setenv` or `unsetenv`, so a PE mutation cannot leak a synthetic uppercase
+  variable into the launcher's POSIX namespace. A Windows-side deletion masks
+  an inherited host variable for subsequent PE lookups.
+
+The shared kernel32 last-error state is used by both the core exports and these
+extended exports, so callers observe buffer and missing-variable errors through
+the normal `GetLastError` path.
 
 ## Strongest Existing Pattern
 

--- a/include/metalsharp/Kernel32Shim.h
+++ b/include/metalsharp/Kernel32Shim.h
@@ -11,6 +11,7 @@
 
 #include "PELoader.h"
 #include <functional>
+#include <metalsharp/Win32Types.h>
 #include <string>
 #include <unordered_map>
 
@@ -18,6 +19,13 @@ namespace metalsharp {
 namespace win32 {
 
 void setExePath(const char* path);
+
+// GetLastError/SetLastError and the extended kernel32 shims share this
+// thread-local state. Keep the accessors outside the individual shim
+// translation units so an extra export can report an error through the
+// kernel32 GetLastError export.
+DWORD getKernel32LastError();
+void setKernel32LastError(DWORD error);
 
 class Kernel32Shim {
   public:

--- a/include/metalsharp/Win32Types.h
+++ b/include/metalsharp/Win32Types.h
@@ -34,6 +34,11 @@ typedef uint32_t ULONG;
 typedef uintptr_t DWORD_PTR;
 typedef int (*FARPROC)();
 
+// Error values used by the kernel32 compatibility surface.
+constexpr DWORD ERROR_INVALID_PARAMETER = 87;
+constexpr DWORD ERROR_BUFFER_OVERFLOW = 111;
+constexpr DWORD ERROR_ENVVAR_NOT_FOUND = 203;
+
 const HANDLE INVALID_HANDLE_VALUE = reinterpret_cast<HANDLE>(static_cast<intptr_t>(-1));
 constexpr DWORD DWORD_MAX_VAL = 0xFFFFFFFF;
 

--- a/src/win32/kernel32/Kernel32Extra.cpp
+++ b/src/win32/kernel32/Kernel32Extra.cpp
@@ -28,8 +28,8 @@
 ///
 /// Environment & Debug
 /// ===================
-///   shim_GetEnvironmentVariableA/W — Reads from real environment
-///   shim_SetEnvironmentVariableA/W — Sets in real environment
+///   shim_GetEnvironmentVariableA/W — Case-insensitive Windows-side environment lookup
+///   shim_SetEnvironmentVariableA/W — Updates the Windows-side environment map
 ///   shim_GetCommandLineA/W — Returns stored command line from launcher
 ///   shim_OutputDebugStringA — Forwards to MS_INFO log
 ///   shim_IsDebuggerPresent — Returns FALSE
@@ -45,6 +45,7 @@
 ///
 /// Status: ~70% of commonly-used kernel32 exports implemented. Games that call
 /// obscure kernel32 functions will log "MISSING" in the import resolver.
+#include <cctype>
 #include <cerrno>
 #include <chrono>
 #include <cstdio>
@@ -54,6 +55,7 @@
 #include <dirent.h>
 #include <dlfcn.h>
 #include <fcntl.h>
+#include <metalsharp/Kernel32Shim.h>
 #include <metalsharp/Logger.h>
 #include <metalsharp/NetworkContext.h>
 #include <metalsharp/PEHeader.h>
@@ -64,17 +66,23 @@
 #include <metalsharp/Win32Types.h>
 #include <mutex>
 #include <pthread.h>
+#include <string_view>
 #include <sys/mman.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/un.h>
 #include <unistd.h>
+#include <unordered_set>
+
+#if defined(__APPLE__)
+#include <crt_externs.h>
+#else
+extern char** environ;
+#endif
 
 namespace metalsharp {
 namespace win32 {
-
-static thread_local DWORD t_lastError = 0;
 
 static std::atomic<int> g_callCount{0};
 static thread_local int t_callDepth = 0;
@@ -267,14 +275,60 @@ static wchar_t* MSABI shim_GetCommandLineW() {
 }
 
 static std::unordered_map<std::string, std::string> s_envStore;
+static std::unordered_set<std::string> s_envHidden;
 static bool s_envInitialized = false;
+
+static std::string canonicalEnvironmentName(std::string_view name) {
+    std::string canonical;
+    canonical.reserve(name.size());
+    for (char character : name) {
+        canonical.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(character))));
+    }
+    return canonical;
+}
+
+static std::string narrowEnvironmentString(const wchar_t* value) {
+    std::string result;
+    if (!value)
+        return result;
+
+    for (size_t i = 0; value[i]; i++)
+        result.push_back(static_cast<char>(value[i] & 0x7F));
+    return result;
+}
+
+static char** hostEnvironment() {
+#if defined(__APPLE__)
+    return *_NSGetEnviron();
+#else
+    return environ;
+#endif
+}
+
+// macOS keeps environment names case-sensitive even though Windows does not.
+// Walk the process environment rather than calling getenv(name), so a PE
+// lookup cannot miss a host variable solely because its spelling differs.
+static const char* findHostEnvironmentValue(const std::string& canonicalName) {
+    char** environment = hostEnvironment();
+    if (!environment)
+        return nullptr;
+
+    for (char** entry = environment; *entry; entry++) {
+        const char* separator = strchr(*entry, '=');
+        if (!separator)
+            continue;
+
+        std::string entryName(*entry, static_cast<size_t>(separator - *entry));
+        if (canonicalEnvironmentName(entryName) == canonicalName)
+            return separator + 1;
+    }
+    return nullptr;
+}
 
 static void ensureEnvInit() {
     if (s_envInitialized)
         return;
     s_envInitialized = true;
-    const char* home = getenv("HOME");
-    std::string homeDir = home ? home : "/tmp";
     s_envStore["PATH"] = "C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem";
     s_envStore["APPDATA"] = "C:\\Users\\user\\AppData\\Roaming";
     s_envStore["USERPROFILE"] = "C:\\Users\\user";
@@ -308,95 +362,120 @@ static void ensureEnvInit() {
     s_envStore["FPS_BROWSER_APP_PROFILE"] = "chrome";
 }
 
+static const std::string* findEnvironmentValue(const std::string& canonicalName) {
+    auto cached = s_envStore.find(canonicalName);
+    if (cached != s_envStore.end())
+        return &cached->second;
+
+    // A Windows-side deletion must mask an inherited host variable without
+    // calling unsetenv(), which would mutate the launcher's POSIX namespace.
+    if (s_envHidden.find(canonicalName) != s_envHidden.end())
+        return nullptr;
+
+    const char* hostValue = findHostEnvironmentValue(canonicalName);
+    if (!hostValue)
+        return nullptr;
+
+    auto [inserted, unused] = s_envStore.emplace(canonicalName, hostValue);
+    (void)unused;
+    return &inserted->second;
+}
+
+static BOOL setEnvironmentValue(const std::string& name, const std::string* value) {
+    const std::string canonicalName = canonicalEnvironmentName(name);
+    if (canonicalName.empty()) {
+        setKernel32LastError(ERROR_INVALID_PARAMETER);
+        return 0;
+    }
+
+    if (value) {
+        s_envStore[canonicalName] = *value;
+        s_envHidden.erase(canonicalName);
+    } else {
+        s_envStore.erase(canonicalName);
+        s_envHidden.insert(canonicalName);
+    }
+    return 1;
+}
+
 static DWORD MSABI shim_GetEnvironmentVariableW(const wchar_t* lpName, wchar_t* lpBuffer, DWORD nSize) {
     ensureEnvInit();
-    if (!lpName)
+    if (!lpName) {
+        setKernel32LastError(ERROR_INVALID_PARAMETER);
         return 0;
-    char name[256];
-    int j = 0;
-    for (int i = 0; lpName[i] && j < 255; i++)
-        name[j++] = (char)(lpName[i] & 0x7F);
-    name[j] = 0;
-
-    std::string upper;
-    for (auto c : std::string(name))
-        upper += toupper(c);
-
-    auto it = s_envStore.find(upper);
-    if (it == s_envStore.end()) {
-        const char* env = getenv(name);
-        if (env)
-            it = s_envStore.insert({upper, env}).first;
-        else
-            return 0;
     }
 
-    const std::string& val = it->second;
-    DWORD needed = static_cast<DWORD>(val.size());
+    const std::string canonicalName = canonicalEnvironmentName(narrowEnvironmentString(lpName));
+    const std::string* value = findEnvironmentValue(canonicalName);
+    if (!value) {
+        setKernel32LastError(ERROR_ENVVAR_NOT_FOUND);
+        return 0;
+    }
+
+    const std::string& val = *value;
+    DWORD needed = static_cast<DWORD>(val.size() + 1);
     if (nSize == 0)
-        return needed + 1;
-    if (lpBuffer && nSize > needed) {
-        for (size_t i = 0; i <= needed; i++)
-            lpBuffer[i] = (wchar_t)(unsigned char)val[i];
+        return needed;
+    if (!lpBuffer || nSize < needed) {
+        setKernel32LastError(ERROR_BUFFER_OVERFLOW);
+        return 0;
     }
-    return needed;
+    if (lpBuffer) {
+        for (size_t i = 0; i < val.size(); i++)
+            lpBuffer[i] = (wchar_t)(unsigned char)val[i];
+        lpBuffer[val.size()] = L'\0';
+    }
+    return needed - 1;
 }
 
 static DWORD MSABI shim_GetEnvironmentVariableA(const char* lpName, char* lpBuffer, DWORD nSize) {
     ensureEnvInit();
-    if (!lpName)
+    if (!lpName) {
+        setKernel32LastError(ERROR_INVALID_PARAMETER);
         return 0;
-
-    std::string upper;
-    for (auto c : std::string(lpName))
-        upper += tolower(c);
-
-    auto it = s_envStore.find(upper);
-    if (it == s_envStore.end()) {
-        const char* env = getenv(lpName);
-        if (env)
-            it = s_envStore.insert({upper, env}).first;
-        else
-            return 0;
     }
 
-    const std::string& val = it->second;
-    DWORD needed = static_cast<DWORD>(val.size());
+    const std::string canonicalName = canonicalEnvironmentName(lpName);
+    const std::string* value = findEnvironmentValue(canonicalName);
+    if (!value) {
+        setKernel32LastError(ERROR_ENVVAR_NOT_FOUND);
+        return 0;
+    }
+
+    const std::string& val = *value;
+    DWORD needed = static_cast<DWORD>(val.size() + 1);
     if (nSize == 0)
-        return needed + 1;
-    if (lpBuffer && nSize > needed) {
-        memcpy(lpBuffer, val.c_str(), needed + 1);
+        return needed;
+    if (!lpBuffer || nSize < needed) {
+        setKernel32LastError(ERROR_BUFFER_OVERFLOW);
+        return 0;
     }
-    return needed;
+    if (lpBuffer) {
+        memcpy(lpBuffer, val.c_str(), needed);
+    }
+    return needed - 1;
 }
 
 static BOOL MSABI shim_SetEnvironmentVariableW(const wchar_t* lpName, const wchar_t* lpValue) {
     ensureEnvInit();
-    if (!lpName)
+    if (!lpName) {
+        setKernel32LastError(ERROR_INVALID_PARAMETER);
         return 0;
-    char name[256];
-    int j = 0;
-    for (int i = 0; lpName[i] && j < 255; i++)
-        name[j++] = (char)(lpName[i] & 0x7F);
-    name[j] = 0;
-
-    std::string upper;
-    for (auto c : std::string(name))
-        upper += toupper(c);
-
-    if (lpValue) {
-        char val[1024];
-        int k = 0;
-        for (int i = 0; lpValue[i] && k < 1023; i++)
-            val[k++] = (char)(lpValue[i] & 0x7F);
-        val[k] = 0;
-        s_envStore[upper] = val;
-        setenv(upper.c_str(), val, 1);
-    } else {
-        s_envStore.erase(upper);
-        unsetenv(upper.c_str());
     }
-    return 1;
+
+    std::string value = narrowEnvironmentString(lpValue);
+    return setEnvironmentValue(narrowEnvironmentString(lpName), lpValue ? &value : nullptr);
+}
+
+static BOOL MSABI shim_SetEnvironmentVariableA(const char* lpName, const char* lpValue) {
+    ensureEnvInit();
+    if (!lpName) {
+        setKernel32LastError(ERROR_INVALID_PARAMETER);
+        return 0;
+    }
+
+    std::string value = lpValue ? lpValue : "";
+    return setEnvironmentValue(lpName, lpValue ? &value : nullptr);
 }
 
 static DWORD MSABI shim_ExpandEnvironmentStringsW(const wchar_t* lpSrc, wchar_t* lpDst, DWORD nSize) {
@@ -415,19 +494,12 @@ static DWORD MSABI shim_ExpandEnvironmentStringsW(const wchar_t* lpSrc, wchar_t*
             size_t end = src.find('%', pos + 1);
             if (end != std::string::npos) {
                 std::string varName = src.substr(pos + 1, end - pos - 1);
-                std::string upper;
-                for (auto c : varName)
-                    upper += toupper(c);
-                auto it = s_envStore.find(upper);
-                if (it != s_envStore.end()) {
-                    result += it->second;
-                } else {
-                    const char* env = getenv(varName.c_str());
-                    if (env)
-                        result += env;
-                    else
-                        result += src.substr(pos, end - pos + 1);
-                }
+                const std::string canonicalName = canonicalEnvironmentName(varName);
+                const std::string* value = findEnvironmentValue(canonicalName);
+                if (value)
+                    result += *value;
+                else
+                    result += src.substr(pos, end - pos + 1);
                 pos = end + 1;
             } else {
                 result += src[pos++];
@@ -2065,6 +2137,7 @@ void addMissingKernel32(ShimLibrary& lib) {
     lib.functions["GetEnvironmentVariableW"] = fn((void*)shim_GetEnvironmentVariableW);
     lib.functions["GetEnvironmentVariableA"] = fn((void*)shim_GetEnvironmentVariableA);
     lib.functions["SetEnvironmentVariableW"] = fn((void*)shim_SetEnvironmentVariableW);
+    lib.functions["SetEnvironmentVariableA"] = fn((void*)shim_SetEnvironmentVariableA);
     lib.functions["ExpandEnvironmentStringsA"] = fn((void*)stub_zero_dword);
     lib.functions["ExpandEnvironmentStringsW"] = fn((void*)shim_ExpandEnvironmentStringsW);
     lib.functions["GetStartupInfoW"] = fn((void*)shim_GetStartupInfoW);

--- a/src/win32/kernel32/Kernel32Shim.cpp
+++ b/src/win32/kernel32/Kernel32Shim.cpp
@@ -60,14 +60,22 @@ uintptr_t Kernel32Shim::s_nextHandle = 0x00010000;
 
 static thread_local DWORD t_lastError = 0;
 
-static DWORD MSABI shim_GetLastError() {
-    MS_INFO("TRACE: GetLastError() -> %u", t_lastError);
+DWORD getKernel32LastError() {
     return t_lastError;
+}
+
+void setKernel32LastError(DWORD error) {
+    t_lastError = error;
+}
+
+static DWORD MSABI shim_GetLastError() {
+    MS_INFO("TRACE: GetLastError() -> %u", getKernel32LastError());
+    return getKernel32LastError();
 }
 
 static void MSABI shim_SetLastError(DWORD dwErrCode) {
     MS_INFO("TRACE: SetLastError(%u)", dwErrCode);
-    t_lastError = dwErrCode;
+    setKernel32LastError(dwErrCode);
 }
 
 static void* MSABI shim_VirtualAlloc(void* lpAddress, SIZE_T dwSize, DWORD flAllocationType, DWORD flProtect) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -270,3 +270,9 @@ target_compile_options(test_eac_substrate PRIVATE -Wno-deprecated-declarations)
 # dynamic lookup; keep the same link contract as metalsharp_eac_substrate.
 target_link_options(test_eac_substrate PRIVATE "-Wl,-undefined,dynamic_lookup")
 add_test(NAME eac_substrate COMMAND test_eac_substrate)
+
+add_executable(test_kernel32_environment
+    test_kernel32_environment.cpp
+)
+target_link_libraries(test_kernel32_environment PRIVATE metalsharp_loader metalsharp_core)
+add_test(NAME kernel32_environment COMMAND test_kernel32_environment)

--- a/tests/test_kernel32_environment.cpp
+++ b/tests/test_kernel32_environment.cpp
@@ -1,0 +1,143 @@
+#include <metalsharp/ExtraShims.h>
+#include <metalsharp/Kernel32Shim.h>
+#include <metalsharp/Win32Types.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+using metalsharp::ShimLibrary;
+using metalsharp::win32::BOOL;
+using metalsharp::win32::DWORD;
+using metalsharp::win32::ERROR_BUFFER_OVERFLOW;
+using metalsharp::win32::ERROR_ENVVAR_NOT_FOUND;
+
+using GetEnvironmentVariableA = DWORD(MSABI*)(const char*, char*, DWORD);
+using GetEnvironmentVariableW = DWORD(MSABI*)(const wchar_t*, wchar_t*, DWORD);
+using SetEnvironmentVariableA = BOOL(MSABI*)(const char*, const char*);
+using SetEnvironmentVariableW = BOOL(MSABI*)(const wchar_t*, const wchar_t*);
+using GetLastError = DWORD(MSABI*)();
+
+struct Kernel32EnvironmentApi {
+    ShimLibrary library;
+    GetEnvironmentVariableA getA;
+    GetEnvironmentVariableW getW;
+    SetEnvironmentVariableA setA;
+    SetEnvironmentVariableW setW;
+    GetLastError getLastError;
+};
+
+Kernel32EnvironmentApi makeApi() {
+    Kernel32EnvironmentApi api;
+    api.library = metalsharp::win32::Kernel32Shim::create();
+    metalsharp::win32::addMissingKernel32(api.library);
+    api.getA = reinterpret_cast<GetEnvironmentVariableA>(api.library.functions.at("GetEnvironmentVariableA")());
+    api.getW = reinterpret_cast<GetEnvironmentVariableW>(api.library.functions.at("GetEnvironmentVariableW")());
+    api.setA = reinterpret_cast<SetEnvironmentVariableA>(api.library.functions.at("SetEnvironmentVariableA")());
+    api.setW = reinterpret_cast<SetEnvironmentVariableW>(api.library.functions.at("SetEnvironmentVariableW")());
+    api.getLastError = reinterpret_cast<GetLastError>(api.library.functions.at("GetLastError")());
+    return api;
+}
+
+bool expect(bool condition, const char* message) {
+    if (!condition)
+        std::cerr << "FAIL: " << message << '\n';
+    return condition;
+}
+
+bool testCaseInsensitiveHostLookup(Kernel32EnvironmentApi& api) {
+    constexpr const char* hostName = "MetalSharpIssue421HostCase";
+    constexpr const char* hostValue = "host-case-value";
+    setenv(hostName, hostValue, 1);
+
+    char aBuffer[64] = {};
+    wchar_t wBuffer[64] = {};
+    DWORD aLength = api.getA("METALSHARPISSUE421HOSTCASE", aBuffer, sizeof(aBuffer));
+    DWORD wLength = api.getW(L"metalsharpissue421hostcase", wBuffer, sizeof(wBuffer) / sizeof(wBuffer[0]));
+
+    bool result = true;
+    result &= expect(aLength == strlen(hostValue), "A lookup finds mixed-case host environment names");
+    result &= expect(strcmp(aBuffer, hostValue) == 0, "A lookup returns the host value");
+    result &= expect(wLength == strlen(hostValue), "W lookup finds mixed-case host environment names");
+    result &= expect(std::wstring(wBuffer) == L"host-case-value", "W lookup returns the host value");
+
+    unsetenv(hostName);
+    return result;
+}
+
+bool testCanonicalSetAndCrossEncoding(Kernel32EnvironmentApi& api) {
+    constexpr const char* name = "MetalSharpIssue421SetCase";
+    bool result = true;
+    result &= expect(api.setW(L"MetalSharpIssue421SetCase", L"set-by-w"), "SetEnvironmentVariableW succeeds");
+
+    char aBuffer[64] = {};
+    DWORD aLength = api.getA("metalsharpissue421setcase", aBuffer, sizeof(aBuffer));
+    result &= expect(aLength == strlen("set-by-w"), "A reads a W-set variable case-insensitively");
+    result &= expect(strcmp(aBuffer, "set-by-w") == 0, "A reads the W-set value");
+
+    result &= expect(api.setA("METALSHARPISSUE421SETCASE", "set-by-a"), "SetEnvironmentVariableA succeeds");
+    wchar_t wBuffer[64] = {};
+    DWORD wLength = api.getW(L"metalsharpissue421setcase", wBuffer, sizeof(wBuffer) / sizeof(wBuffer[0]));
+    result &= expect(wLength == strlen("set-by-a"), "W reads an A-set variable case-insensitively");
+    result &= expect(std::wstring(wBuffer) == L"set-by-a", "W reads the A-set value");
+
+    // The Windows-side map must not create or delete a POSIX variable.
+    result &= expect(getenv(name) == nullptr, "Windows-side set does not leak into the POSIX environment");
+    result &= expect(api.setW(L"metalsharpissue421setcase", nullptr), "SetEnvironmentVariableW deletes the variable");
+    result &= expect(api.getA("METALSHARPISSUE421SETCASE", aBuffer, sizeof(aBuffer)) == 0,
+                     "Deleted variables are not returned");
+    result &= expect(api.getLastError() == ERROR_ENVVAR_NOT_FOUND, "Deleted variables report not found");
+    return result;
+}
+
+bool testSmallBufferContract(Kernel32EnvironmentApi& api) {
+    constexpr const char* value = "0123456789";
+    bool result = true;
+    result &= expect(api.setA("METALSHARPISSUE421BUFFER", value), "Set buffer test variable");
+
+    char aBuffer[sizeof("0123456789")] = {};
+    memset(aBuffer, 'x', sizeof(aBuffer));
+    DWORD aRequired = api.getA("metalsharpissue421buffer", nullptr, 0);
+    result &= expect(aRequired == strlen(value) + 1, "A zero-sized query returns the required size");
+    DWORD aResult = api.getA("metalsharpissue421buffer", aBuffer, aRequired - 1);
+    result &= expect(aResult == 0, "A short buffer returns zero");
+    result &= expect(api.getLastError() == ERROR_BUFFER_OVERFLOW, "A short buffer reports ERROR_BUFFER_OVERFLOW");
+    result &= expect(aBuffer[0] == 'x', "A short buffer is left untouched");
+
+    wchar_t wBuffer[sizeof("0123456789")] = {};
+    for (wchar_t& character : wBuffer)
+        character = L'x';
+    DWORD wRequired = api.getW(L"METALSHARPISSUE421BUFFER", nullptr, 0);
+    result &= expect(wRequired == strlen(value) + 1, "W zero-sized query returns the required size");
+    DWORD wResult = api.getW(L"METALSHARPISSUE421BUFFER", wBuffer, wRequired - 1);
+    result &= expect(wResult == 0, "W short buffer returns zero");
+    result &= expect(api.getLastError() == ERROR_BUFFER_OVERFLOW, "W short buffer reports ERROR_BUFFER_OVERFLOW");
+    result &= expect(wBuffer[0] == L'x', "W short buffer is left untouched");
+
+    std::vector<char> exactBuffer(aRequired);
+    std::vector<wchar_t> exactWideBuffer(wRequired);
+    result &= expect(api.getA("METALSHARPISSUE421BUFFER", exactBuffer.data(), aRequired) == strlen(value),
+                     "A exact-sized buffer succeeds");
+    result &= expect(api.getW(L"METALSHARPISSUE421BUFFER", exactWideBuffer.data(), wRequired) == strlen(value),
+                     "W exact-sized buffer succeeds");
+    result &= expect(strcmp(exactBuffer.data(), value) == 0, "A exact-sized buffer is null-terminated");
+    result &= expect(std::wstring(exactWideBuffer.data()) == L"0123456789", "W exact-sized buffer is null-terminated");
+    return result;
+}
+
+} // namespace
+
+int main() {
+    Kernel32EnvironmentApi api = makeApi();
+    bool passed = true;
+    passed &= testCaseInsensitiveHostLookup(api);
+    passed &= testCanonicalSetAndCrossEncoding(api);
+    passed &= testSmallBufferContract(api);
+
+    api.setA("METALSHARPISSUE421BUFFER", nullptr);
+    return passed ? 0 : 1;
+}


### PR DESCRIPTION
Fixes #421

<!-- Issue #421 -->
## Summary

Fix the native-loader `kernel32` environment-variable shims so ANSI and Unicode callers share Windows-compatible, case-insensitive state and cannot consume stale output after a short-buffer failure.

## Changes

- Canonicalize A and W variable names to one uppercase key.
- Scan the inherited macOS environment case-insensitively instead of relying on macOS's case-sensitive `getenv` lookup.
- Keep `SetEnvironmentVariableA/W` mutations in the Windows-side map and mask deletions without polluting the POSIX environment.
- Return zero with `ERROR_BUFFER_OVERFLOW` for non-zero buffers that are too small, while preserving the zero-size required-length query.
- Share the kernel32 last-error state between core and extended exports.
- Add regression coverage for cross-encoding lookups, host fallback, POSIX isolation, deletion, and short-buffer behavior.
- Document the native-loader environment contract.

## PR Readiness (MANDATORY)

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

The real-game compatibility item is intentionally not applicable: this is an isolated native kernel32 shim contract fix with deterministic regression coverage and no route, bottle, or game-launch behavior change. The `checklist-exception` label is applied for that exception.

## Local toolchain

- [ ] `cargo fmt --all -- --check` (not applicable; no Rust changes)
- [ ] `cargo clippy --all-targets -- -D warnings` (not applicable; no Rust changes)
- [ ] `cargo build --release` (not applicable; no Rust changes)
- [ ] `cargo test` (not applicable; no Rust changes)
- [x] C++ compiles: `cmake -S . -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON && cmake --build build-native --parallel $(sysctl -n hw.ncpu)`
- [x] `tools/ci/check-clang-format.sh`
- [x] `ctest --test-dir build-native --output-on-failure` (32/32)
- [ ] TypeScript compiles (not applicable; no TypeScript changes)
- [ ] Biome + Prettier (not applicable; no TypeScript/JavaScript changes)
- [ ] Shell scripts lint (not applicable; no shell changes)
- [ ] Rules TOML validation (not applicable; no rules/DLL map changes)
- [ ] DMG workflow validation (not applicable; no release tooling changes)
- [ ] Tested with at least one game (intentionally not applicable; see exception above)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files added to the repository root

## Test notes

- Configured and built the native Release test tree.
- Ran the focused `kernel32_environment` regression test.
- Ran the full CTest suite: 32/32 passed.
- Ran `clang-format --dry-run --Werror` on changed C++ files and `tools/ci/check-clang-format.sh`.
- Ran `python3 -B tools/ci/check-doc-freshness.py`; it returned success with the existing warning for `docs/OPENGL-2-4-PLAN.md`.
- No real game was launched because this change does not alter a game route or runtime bundle.

## Risk

The change is isolated to the native PE loader's environment shims and their shared last-error state. The rollback is a single commit revert: `d24bc336`. No Rust routes, bottle migration, release bundles, or launch defaults changed.

