### PR TITLE
fix(kernel32): bound PE resource directory walks

### DIFF
--- a/src/win32/kernel32/Kernel32Extra.cpp
+++ b/src/win32/kernel32/Kernel32Extra.cpp
@@ -1530,78 +1530,182 @@ static DWORD MSABI shim_SetErrorMode(DWORD uMode) {
     return 0;
 }
 
-static void* findResourceEntry(uint8_t* base, IMAGE_RESOURCE_DIRECTORY* dir, uint32_t id) {
-    auto* entries = reinterpret_cast<IMAGE_RESOURCE_DIRECTORY_ENTRY*>(dir + 1);
-    uint16_t count = dir->NumberOfNamedEntries + dir->NumberOfIdEntries;
+static bool resourceImageRangeValid(const LoadedModule& module, uint32_t rva, size_t length) {
+    if (!module.base || rva > module.size)
+        return false;
+    return length <= static_cast<size_t>(module.size - rva);
+}
 
-    for (uint16_t i = 0; i < count; i++) {
-        if (entries[i].Name == id) {
-            if (entries[i].OffsetToData & 0x80000000) {
-                uint32_t dirRVA = entries[i].OffsetToData & 0x7FFFFFFF;
-                return base + dirRVA;
-            }
-            return base + entries[i].OffsetToData;
-        }
+static bool resourcePointerRangeValid(const LoadedModule& module, const void* pointer, size_t length) {
+    if (!module.base || !pointer)
+        return false;
+
+    uintptr_t imageBase = reinterpret_cast<uintptr_t>(module.base);
+    uintptr_t address = reinterpret_cast<uintptr_t>(pointer);
+    if (address < imageBase)
+        return false;
+
+    uintptr_t rva = address - imageBase;
+    return rva <= module.size && length <= static_cast<size_t>(module.size - rva);
+}
+
+static bool resourceRangeValid(const LoadedModule& module, uint32_t resourceRVA, uint32_t resourceSize, uint32_t offset,
+                               size_t length) {
+    if (!resourceImageRangeValid(module, resourceRVA, resourceSize) || offset > resourceSize)
+        return false;
+    return length <= static_cast<size_t>(resourceSize - offset);
+}
+
+static uint8_t* resourcePtr(const LoadedModule& module, uint32_t resourceRVA, uint32_t resourceSize, uint32_t offset,
+                            size_t length) {
+    if (!resourceRangeValid(module, resourceRVA, resourceSize, offset, length))
+        return nullptr;
+    return module.base + static_cast<size_t>(resourceRVA) + offset;
+}
+
+// Directory-entry offsets are relative to the resource data directory; the
+// OffsetToData in a leaf IMAGE_RESOURCE_DATA_ENTRY is an image RVA.
+static const IMAGE_RESOURCE_DATA_ENTRY* validatedResourceDataEntry(const LoadedModule& module,
+                                                                   const void* resourceHandle) {
+    if (!resourcePointerRangeValid(module, resourceHandle, sizeof(IMAGE_RESOURCE_DATA_ENTRY)))
+        return nullptr;
+
+    auto* dataEntry = static_cast<const IMAGE_RESOURCE_DATA_ENTRY*>(resourceHandle);
+    if (dataEntry->OffsetToData >= module.size ||
+        !resourceImageRangeValid(module, dataEntry->OffsetToData, dataEntry->Size))
+        return nullptr;
+
+    return dataEntry;
+}
+
+static void* findResourceEntry(const LoadedModule& module, uint32_t resourceRVA, uint32_t resourceSize,
+                               uint32_t directoryOffset, uint32_t id, bool expectDirectory, uint32_t* targetOffset) {
+    auto* dir = reinterpret_cast<const IMAGE_RESOURCE_DIRECTORY*>(
+        resourcePtr(module, resourceRVA, resourceSize, directoryOffset, sizeof(IMAGE_RESOURCE_DIRECTORY)));
+    if (!dir)
+        return nullptr;
+
+    uint32_t count = static_cast<uint32_t>(dir->NumberOfNamedEntries) + dir->NumberOfIdEntries;
+    size_t entriesSize = static_cast<size_t>(count) * sizeof(IMAGE_RESOURCE_DIRECTORY_ENTRY);
+    if (!resourceRangeValid(module, resourceRVA, resourceSize, directoryOffset,
+                            sizeof(IMAGE_RESOURCE_DIRECTORY) + entriesSize))
+        return nullptr;
+
+    auto* entries = reinterpret_cast<const IMAGE_RESOURCE_DIRECTORY_ENTRY*>(reinterpret_cast<const uint8_t*>(dir) +
+                                                                            sizeof(IMAGE_RESOURCE_DIRECTORY));
+    for (uint32_t i = 0; i < count; i++) {
+        if (entries[i].Name != id)
+            continue;
+
+        uint32_t entryOffset = entries[i].OffsetToData & 0x7FFFFFFF;
+        bool isDirectory = (entries[i].OffsetToData & 0x80000000) != 0;
+        if (isDirectory != expectDirectory)
+            return nullptr;
+
+        size_t targetSize = expectDirectory ? sizeof(IMAGE_RESOURCE_DIRECTORY) : sizeof(IMAGE_RESOURCE_DATA_ENTRY);
+        void* entry = resourcePtr(module, resourceRVA, resourceSize, entryOffset, targetSize);
+        if (!entry)
+            return nullptr;
+
+        if (!expectDirectory && !validatedResourceDataEntry(module, entry))
+            return nullptr;
+
+        if (targetOffset)
+            *targetOffset = entryOffset;
+        return entry;
     }
     return nullptr;
 }
 
 static void* MSABI shim_FindResourceA(HMODULE hModule, const char* lpName, const char* lpType) {
-    auto* mod = PELoader::instance()->getMainModule();
-    if (!mod || !mod->base)
+    (void)hModule;
+
+    auto* loader = PELoader::instance();
+    if (!loader)
+        return nullptr;
+    auto* mod = loader->getMainModule();
+    if (!mod || !resourceImageRangeValid(*mod, 0, sizeof(IMAGE_DOS_HEADER)))
         return nullptr;
 
-    uint8_t* base = mod->base;
+    auto* base = mod->base;
     auto* dos = reinterpret_cast<const IMAGE_DOS_HEADER*>(base);
-    auto* opt = reinterpret_cast<const IMAGE_OPTIONAL_HEADER64*>(base + dos->e_lfanew + 4 + sizeof(IMAGE_FILE_HEADER));
-
-    if (opt->DataDirectory[DIRECTORY_RESOURCE].Size == 0)
+    if (dos->e_magic != IMAGE_DOS_SIGNATURE || dos->e_lfanew < 0)
         return nullptr;
 
-    uint32_t rsrcRVA = opt->DataDirectory[DIRECTORY_RESOURCE].VirtualAddress;
-    auto* rsrcDir = reinterpret_cast<IMAGE_RESOURCE_DIRECTORY*>(base + rsrcRVA);
+    uint64_t ntHeaderRVA = static_cast<uint32_t>(dos->e_lfanew);
+    if (ntHeaderRVA > UINT32_MAX || !resourceImageRangeValid(*mod, static_cast<uint32_t>(ntHeaderRVA),
+                                                             sizeof(uint32_t) + sizeof(IMAGE_FILE_HEADER)))
+        return nullptr;
+
+    auto* peSignature = reinterpret_cast<const uint32_t*>(base + ntHeaderRVA);
+    if (*peSignature != IMAGE_PE_SIGNATURE)
+        return nullptr;
+
+    auto* fileHeader = reinterpret_cast<const IMAGE_FILE_HEADER*>(peSignature + 1);
+    if (fileHeader->SizeOfOptionalHeader < sizeof(IMAGE_OPTIONAL_HEADER64))
+        return nullptr;
+
+    uint64_t optionalHeaderRVA = ntHeaderRVA + sizeof(uint32_t) + sizeof(IMAGE_FILE_HEADER);
+    if (optionalHeaderRVA > UINT32_MAX ||
+        !resourceImageRangeValid(*mod, static_cast<uint32_t>(optionalHeaderRVA), sizeof(IMAGE_OPTIONAL_HEADER64)))
+        return nullptr;
+
+    auto* opt = reinterpret_cast<const IMAGE_OPTIONAL_HEADER64*>(base + optionalHeaderRVA);
+    if (opt->Magic != IMAGE_OPTIONAL_MAGIC_PE32PLUS || opt->NumberOfRvaAndSizes <= DIRECTORY_RESOURCE)
+        return nullptr;
+
+    const auto& resourceDirectory = opt->DataDirectory[DIRECTORY_RESOURCE];
+    if (!resourceDirectory.VirtualAddress || !resourceDirectory.Size ||
+        !resourceImageRangeValid(*mod, resourceDirectory.VirtualAddress, resourceDirectory.Size))
+        return nullptr;
 
     uint32_t typeId = (reinterpret_cast<uintptr_t>(lpType) >= 0x10000)
                           ? 0
                           : static_cast<uint32_t>(reinterpret_cast<uintptr_t>(lpType));
-
-    auto* typeDir = reinterpret_cast<IMAGE_RESOURCE_DIRECTORY*>(findResourceEntry(base, rsrcDir, typeId));
-    if (!typeDir)
+    uint32_t typeOffset = 0;
+    if (!findResourceEntry(*mod, resourceDirectory.VirtualAddress, resourceDirectory.Size, 0, typeId, true,
+                           &typeOffset))
         return nullptr;
 
     uint32_t nameId = (reinterpret_cast<uintptr_t>(lpName) >= 0x10000)
                           ? 0
                           : static_cast<uint32_t>(reinterpret_cast<uintptr_t>(lpName));
-
-    auto* nameDir = reinterpret_cast<IMAGE_RESOURCE_DIRECTORY*>(findResourceEntry(base, typeDir, nameId));
-    if (!nameDir)
+    uint32_t nameOffset = 0;
+    if (!findResourceEntry(*mod, resourceDirectory.VirtualAddress, resourceDirectory.Size, typeOffset, nameId, true,
+                           &nameOffset))
         return nullptr;
 
-    auto* langEntry = reinterpret_cast<IMAGE_RESOURCE_DATA_ENTRY*>(findResourceEntry(base, nameDir, 0));
-    if (!langEntry)
-        return nullptr;
-
-    return langEntry;
+    return findResourceEntry(*mod, resourceDirectory.VirtualAddress, resourceDirectory.Size, nameOffset, 0, false,
+                             nullptr);
 }
+
 static void* MSABI shim_LoadResource(HMODULE hModule, void* hResInfo) {
     (void)hModule;
+
+    auto* loader = PELoader::instance();
+    if (!loader || !validatedResourceDataEntry(*loader->getMainModule(), hResInfo))
+        return nullptr;
     return hResInfo;
 }
 static void* MSABI shim_LockResource(void* hResData) {
-    if (!hResData)
+    auto* loader = PELoader::instance();
+    if (!loader)
         return nullptr;
-    auto* dataEntry = static_cast<IMAGE_RESOURCE_DATA_ENTRY*>(hResData);
-    auto* mod = PELoader::instance()->getMainModule();
-    if (!mod || !mod->base)
+
+    auto* mod = loader->getMainModule();
+    auto* dataEntry = validatedResourceDataEntry(*mod, hResData);
+    if (!dataEntry)
         return nullptr;
     return mod->base + dataEntry->OffsetToData;
 }
 static DWORD MSABI shim_SizeofResource(HMODULE hModule, void* hResInfo) {
     (void)hModule;
-    if (!hResInfo)
+
+    auto* loader = PELoader::instance();
+    if (!loader)
         return 0;
-    auto* dataEntry = static_cast<IMAGE_RESOURCE_DATA_ENTRY*>(hResInfo);
-    return dataEntry->Size;
+    auto* dataEntry = validatedResourceDataEntry(*loader->getMainModule(), hResInfo);
+    return dataEntry ? dataEntry->Size : 0;
 }
 
 static int MSABI shim_MulDiv(int nNumber, int nNumerator, int nDenominator) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -164,6 +164,14 @@ add_executable(test_ws2_select
 target_link_libraries(test_ws2_select PRIVATE metalsharp_loader metalsharp_core)
 add_test(NAME ws2_select COMMAND test_ws2_select)
 
+add_executable(test_resource_bounds
+    test_resource_bounds.cpp
+)
+target_link_libraries(test_resource_bounds PRIVATE metalsharp_loader metalsharp_core)
+target_compile_options(test_resource_bounds PRIVATE -fobjc-arc)
+
+add_test(NAME resource_bounds COMMAND test_resource_bounds)
+
 add_executable(test_phase21
     test_phase21.cpp
 )

--- a/tests/test_resource_bounds.cpp
+++ b/tests/test_resource_bounds.cpp
@@ -1,0 +1,244 @@
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <metalsharp/ExtraShims.h>
+#include <metalsharp/PEHeader.h>
+#include <metalsharp/PELoader.h>
+#include <metalsharp/Win32Types.h>
+#include <sys/mman.h>
+
+using namespace metalsharp;
+using namespace metalsharp::win32;
+
+namespace {
+
+constexpr uint32_t kImageSize = 0x1000;
+constexpr uint32_t kResourceRVA = 0x200;
+constexpr uint32_t kResourceSize = 0x80;
+constexpr uint32_t kTypeID = 10;
+constexpr uint32_t kNameID = 20;
+constexpr uint32_t kTypeDirectoryOffset = 0x20;
+constexpr uint32_t kNameDirectoryOffset = 0x40;
+constexpr uint32_t kDataEntryOffset = 0x60;
+constexpr uint32_t kResourceDataRVA = 0x500;
+
+using FindResourceA = void*(MSABI*)(metalsharp::win32::HMODULE, const char*, const char*);
+using LoadResource = void*(MSABI*)(metalsharp::win32::HMODULE, void*);
+using LockResource = void*(MSABI*)(void*);
+using SizeofResource = metalsharp::win32::DWORD(MSABI*)(metalsharp::win32::HMODULE, void*);
+
+struct ResourceApi {
+    FindResourceA find;
+    LoadResource load;
+    LockResource lock;
+    SizeofResource size;
+};
+
+struct TestImage {
+    PELoader loader;
+    uint8_t* base = nullptr;
+
+    TestImage() {
+        base = static_cast<uint8_t*>(
+            mmap(nullptr, kImageSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+        if (base == MAP_FAILED) {
+            base = nullptr;
+            return;
+        }
+
+        memset(base, 0, kImageSize);
+        auto* module = loader.getMainModule();
+        module->base = base;
+        module->size = kImageSize;
+        module->isPE = true;
+        initializeHeaders();
+    }
+
+    ~TestImage() {
+        if (base) {
+            loader.getMainModule()->base = nullptr;
+            munmap(base, kImageSize);
+        }
+    }
+
+    bool valid() const { return base != nullptr; }
+
+    void initializeHeaders() {
+        auto* dos = reinterpret_cast<IMAGE_DOS_HEADER*>(base);
+        dos->e_magic = IMAGE_DOS_SIGNATURE;
+        dos->e_lfanew = 0x80;
+
+        auto* peSignature = reinterpret_cast<uint32_t*>(base + dos->e_lfanew);
+        *peSignature = IMAGE_PE_SIGNATURE;
+
+        auto* fileHeader = reinterpret_cast<IMAGE_FILE_HEADER*>(peSignature + 1);
+        fileHeader->Machine = IMAGE_FILE_MACHINE_AMD64;
+        fileHeader->SizeOfOptionalHeader = sizeof(IMAGE_OPTIONAL_HEADER64);
+
+        auto* optionalHeader = reinterpret_cast<IMAGE_OPTIONAL_HEADER64*>(fileHeader + 1);
+        optionalHeader->Magic = IMAGE_OPTIONAL_MAGIC_PE32PLUS;
+        optionalHeader->SizeOfImage = kImageSize;
+        optionalHeader->NumberOfRvaAndSizes = 16;
+        optionalHeader->DataDirectory[DIRECTORY_RESOURCE].VirtualAddress = kResourceRVA;
+        optionalHeader->DataDirectory[DIRECTORY_RESOURCE].Size = kResourceSize;
+    }
+
+    IMAGE_OPTIONAL_HEADER64* optionalHeader() {
+        auto* dos = reinterpret_cast<IMAGE_DOS_HEADER*>(base);
+        auto* fileHeader = reinterpret_cast<IMAGE_FILE_HEADER*>(base + dos->e_lfanew + sizeof(uint32_t));
+        return reinterpret_cast<IMAGE_OPTIONAL_HEADER64*>(fileHeader + 1);
+    }
+
+    void clearResource() { memset(base + kResourceRVA, 0, kResourceSize); }
+
+    void buildValidResource() {
+        initializeHeaders();
+        clearResource();
+
+        auto* root = reinterpret_cast<IMAGE_RESOURCE_DIRECTORY*>(base + kResourceRVA);
+        root->NumberOfIdEntries = 1;
+        auto* rootEntry = reinterpret_cast<IMAGE_RESOURCE_DIRECTORY_ENTRY*>(root + 1);
+        rootEntry->Name = kTypeID;
+        rootEntry->OffsetToData = 0x80000000u | kTypeDirectoryOffset;
+
+        auto* typeDirectory = reinterpret_cast<IMAGE_RESOURCE_DIRECTORY*>(base + kResourceRVA + kTypeDirectoryOffset);
+        typeDirectory->NumberOfIdEntries = 1;
+        auto* typeEntry = reinterpret_cast<IMAGE_RESOURCE_DIRECTORY_ENTRY*>(typeDirectory + 1);
+        typeEntry->Name = kNameID;
+        typeEntry->OffsetToData = 0x80000000u | kNameDirectoryOffset;
+
+        auto* nameDirectory = reinterpret_cast<IMAGE_RESOURCE_DIRECTORY*>(base + kResourceRVA + kNameDirectoryOffset);
+        nameDirectory->NumberOfIdEntries = 1;
+        auto* nameEntry = reinterpret_cast<IMAGE_RESOURCE_DIRECTORY_ENTRY*>(nameDirectory + 1);
+        nameEntry->OffsetToData = kDataEntryOffset;
+
+        auto* dataEntry = reinterpret_cast<IMAGE_RESOURCE_DATA_ENTRY*>(base + kResourceRVA + kDataEntryOffset);
+        dataEntry->OffsetToData = kResourceDataRVA;
+        dataEntry->Size = 4;
+        memcpy(base + kResourceDataRVA, "rsrc", 4);
+    }
+
+    IMAGE_RESOURCE_DIRECTORY_ENTRY* rootEntry() {
+        auto* root = reinterpret_cast<IMAGE_RESOURCE_DIRECTORY*>(base + kResourceRVA);
+        return reinterpret_cast<IMAGE_RESOURCE_DIRECTORY_ENTRY*>(root + 1);
+    }
+
+    IMAGE_RESOURCE_DATA_ENTRY* dataEntry() {
+        return reinterpret_cast<IMAGE_RESOURCE_DATA_ENTRY*>(base + kResourceRVA + kDataEntryOffset);
+    }
+};
+
+const char* resourceID(uint32_t id) {
+    return reinterpret_cast<const char*>(static_cast<uintptr_t>(id));
+}
+
+ResourceApi createResourceApi() {
+    ShimLibrary kernel32;
+    addMissingKernel32(kernel32);
+    return {
+        reinterpret_cast<FindResourceA>(kernel32.functions.at("FindResourceA")()),
+        reinterpret_cast<LoadResource>(kernel32.functions.at("LoadResource")()),
+        reinterpret_cast<LockResource>(kernel32.functions.at("LockResource")()),
+        reinterpret_cast<SizeofResource>(kernel32.functions.at("SizeofResource")()),
+    };
+}
+
+bool testValidResource(const ResourceApi& api, TestImage& image) {
+    image.buildValidResource();
+    void* resource = api.find(nullptr, resourceID(kNameID), resourceID(kTypeID));
+    if (resource != image.base + kResourceRVA + kDataEntryOffset)
+        return false;
+
+    void* loaded = api.load(nullptr, resource);
+    if (loaded != resource)
+        return false;
+    if (api.size(nullptr, loaded) != 4)
+        return false;
+
+    void* data = api.lock(loaded);
+    return data == image.base + kResourceDataRVA && memcmp(data, "rsrc", 4) == 0;
+}
+
+bool testDirectoryEntryCountIsBounded(const ResourceApi& api, TestImage& image) {
+    image.clearResource();
+    auto* root = reinterpret_cast<IMAGE_RESOURCE_DIRECTORY*>(image.base + kResourceRVA);
+    root->NumberOfNamedEntries = UINT16_MAX;
+    root->NumberOfIdEntries = UINT16_MAX;
+    return api.find(nullptr, resourceID(kNameID), resourceID(kTypeID)) == nullptr;
+}
+
+bool testDirectoryOffsetIsBounded(const ResourceApi& api, TestImage& image) {
+    image.buildValidResource();
+    image.rootEntry()->OffsetToData = 0x80000000u | kResourceSize;
+    return api.find(nullptr, resourceID(kNameID), resourceID(kTypeID)) == nullptr;
+}
+
+bool testDataRvaAndSizeAreBounded(const ResourceApi& api, TestImage& image) {
+    image.buildValidResource();
+    image.dataEntry()->OffsetToData = kImageSize - 1;
+    image.dataEntry()->Size = 2;
+    if (api.find(nullptr, resourceID(kNameID), resourceID(kTypeID)) != nullptr)
+        return false;
+
+    image.buildValidResource();
+    image.dataEntry()->Size = kImageSize;
+    void* resource = api.find(nullptr, resourceID(kNameID), resourceID(kTypeID));
+    return resource == nullptr && api.lock(image.dataEntry()) == nullptr && api.size(nullptr, image.dataEntry()) == 0;
+}
+
+bool testImageAndHeaderBoundsAreChecked(const ResourceApi& api, TestImage& image) {
+    image.buildValidResource();
+    image.optionalHeader()->DataDirectory[DIRECTORY_RESOURCE].VirtualAddress = kImageSize - 4;
+    image.optionalHeader()->DataDirectory[DIRECTORY_RESOURCE].Size = 16;
+    if (api.find(nullptr, resourceID(kNameID), resourceID(kTypeID)) != nullptr)
+        return false;
+
+    image.buildValidResource();
+    auto* dos = reinterpret_cast<IMAGE_DOS_HEADER*>(image.base);
+    dos->e_lfanew = static_cast<int32_t>(kImageSize - sizeof(uint32_t) + 1);
+    if (api.find(nullptr, resourceID(kNameID), resourceID(kTypeID)) != nullptr)
+        return false;
+
+    image.buildValidResource();
+    image.optionalHeader()->NumberOfRvaAndSizes = DIRECTORY_RESOURCE;
+    if (api.find(nullptr, resourceID(kNameID), resourceID(kTypeID)) != nullptr)
+        return false;
+
+    image.buildValidResource();
+    auto* invalidHandle = image.base + kImageSize - sizeof(IMAGE_RESOURCE_DATA_ENTRY) + 1;
+    return api.load(nullptr, invalidHandle) == nullptr && api.lock(invalidHandle) == nullptr &&
+           api.size(nullptr, invalidHandle) == 0;
+}
+
+} // namespace
+
+int main() {
+    TestImage image;
+    if (!image.valid()) {
+        fprintf(stderr, "resource_bounds: failed to allocate test image\n");
+        return 1;
+    }
+
+    ResourceApi api = createResourceApi();
+    struct TestCase {
+        const char* name;
+        bool (*run)(const ResourceApi&, TestImage&);
+    };
+    const TestCase tests[] = {
+        {"valid resource tree", testValidResource},
+        {"directory entry count", testDirectoryEntryCountIsBounded},
+        {"directory offset", testDirectoryOffsetIsBounded},
+        {"resource data RVA and size", testDataRvaAndSizeAreBounded},
+        {"image, directory, and handle bounds", testImageAndHeaderBoundsAreChecked},
+    };
+
+    int failed = 0;
+    for (const auto& test : tests) {
+        bool passed = test.run(api, image);
+        printf("  [%s] %s\n", passed ? "PASS" : "FAIL", test.name);
+        failed += passed ? 0 : 1;
+    }
+
+    printf("resource_bounds: %zu tests, %d failed\n", sizeof(tests) / sizeof(tests[0]), failed);
+    return failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Fixes #431 by making the native kernel32 resource loader reject malformed resource trees before reading outside the mapped PE image.

## Changes

- Bound-check the DOS/PE headers, resource data directory, directory-entry table size, and every resource-relative directory/data-entry offset against the loaded module image.
- Treat `IMAGE_RESOURCE_DIRECTORY_ENTRY` offsets as relative to the resource directory, while validating leaf `IMAGE_RESOURCE_DATA_ENTRY::OffsetToData` as an image RVA.
- Validate resource handles and payload ranges in `LoadResource`, `LockResource`, and `SizeofResource`.
- Add `resource_bounds`, a focused regression test covering valid lookup plus oversized counts, invalid directory offsets, invalid payload RVAs/sizes, truncated headers, and invalid handles.

## PR Readiness (MANDATORY)

<!-- The checklist-exception label is used only for the intentionally inapplicable
     real-game and user-facing-documentation items; this is an internal PE parser
     hardening fix with no launch/configuration behavior change. -->

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
  - Not applicable: this change is isolated to malformed PE resource parsing; no game launch behavior or graphics path changed.
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
  - Not applicable: no rules, configuration, or DLL maps changed.
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped
  - Not applicable: no version was bumped.
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
  - No bottle, runtime, migration, or launch code changed.
- [ ] Docs / compatibility matrix updated for user-facing changes
  - Not applicable: no user-facing behavior or compatibility claim changed.
- [x] Regression test added for each bug fix

## Local toolchain (run before push)

- [x] `cargo fmt --all -- --check` — passed.
- [x] `cargo clippy --all-targets -- -D warnings` — passed.
- [x] `cargo build --release` — passed.
- [x] `cargo test` — 762/762 passed.
- [x] C++ compiles if changed: `cmake -S . -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON && cmake --build build-native --parallel 10` — passed.
- [x] `clang-format --dry-run --Werror` — full `tools/ci/check-clang-format.sh` passed.
- [x] `ctest --test-dir build-native` — 32/32 passed, including `resource_bounds`.
- [x] TypeScript compiles if changed: `cd app && npx tsc --noEmit` — passed.
- [x] Biome + Prettier pass if TS/JS changed — renderer, main, and shared checks passed.
- [x] Shell scripts lint if changed: `tools/ci/shellcheck.sh` — passed.
- [x] `tools/ci/validate-rules-toml.py` passes if `configs/mtsp-rules.toml` changed — passed (not changed).
- [x] `python3 tools/ci/verify-dmg-workflow.py` passes if release/bundle tooling changed — passed (not changed).
- [ ] Tested with at least one game (which one? which launch method? which drive?)
  - No commercial game was launched; the focused parser regression suite is the relevant verification for this isolated hardening change.
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files should be added to the repo root; the regression test is under `tests/`.

## Test notes

The implementation follows the Microsoft PE/COFF resource specification: directory-entry offsets are relative to the resource data directory, and leaf data RVAs are validated against the mapped image. The focused `resource_bounds` test exercises both valid lookup/locking and malformed-count, malformed-offset, truncated-header, invalid-payload, and invalid-handle cases.

Final verification on the clean external-drive worktree:

- Native release build completed successfully.
- Full native CTest: 32/32 passed.
- Rust formatting, clippy, release build, and 762 Rust tests passed.
- Vue/Electron checks passed: npm install, Biome, Prettier, Vite build, and TypeScript compilation.
- ShellCheck, rules TOML, DMG workflow, clang-format, and `git diff --check` passed.
- Doc freshness completed with the repository's existing warning for `docs/OPENGL-2-4-PLAN.md`; that file is unchanged.
- No live game launch was performed because the fix does not alter game launch or user-facing compatibility behavior.

## Risk

Low. Invalid resource structures now fail closed (`FindResourceA`/`LoadResource` return null and `SizeofResource` returns zero) instead of being dereferenced. Valid resource trees use the PE-specified relative directory offsets and image-relative leaf data RVA. No configuration, migration, runtime packaging, or launch path changed. Rollback is `git revert d3a47f6b`.
