### PR TITLE
fix(fna): terminate auto-length wide strings

### DIFF
--- a/src/fna/shims/kernel32_shim.c
+++ b/src/fna/shims/kernel32_shim.c
@@ -253,6 +253,8 @@ int MultiByteToWideChar(UINT CodePage, DWORD dwFlags, LPCSTR lpMultiByteStr, int
     uint16_t* out = (uint16_t*)lpWideCharStr;
     for (int i = 0; i < len && i < cchWideChar; i++)
         out[i] = (uint16_t)(unsigned char)lpMultiByteStr[i];
+    if (len >= 0 && len < cchWideChar)
+        out[len] = 0;
     return len < cchWideChar ? len : 0;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,6 +53,11 @@ add_executable(test_runtime
 )
 target_link_libraries(test_runtime PRIVATE metalsharp_core)
 
+add_executable(test_fna_kernel32_shim
+    test_fna_kernel32_shim.c
+    ../src/fna/shims/kernel32_shim.c
+)
+
 add_executable(test_host_runtime_abi
     test_host_runtime_abi.cpp
 )
@@ -100,6 +105,7 @@ add_test(NAME deferred_context COMMAND test_deferred_context)
 add_test(NAME d3d12 COMMAND test_d3d12)
 add_test(NAME d3d12_entrypoint COMMAND test_d3d12_entrypoint)
 add_test(NAME runtime COMMAND test_runtime)
+add_test(NAME fna_kernel32_shim COMMAND test_fna_kernel32_shim)
 add_test(NAME host_runtime_abi COMMAND test_host_runtime_abi)
 add_test(NAME mscoree_path_safety COMMAND test_mscoree_path_safety)
 add_test(NAME darwin_sync_map COMMAND test_darwin_sync_map)

--- a/tests/test_fna_kernel32_shim.c
+++ b/tests/test_fna_kernel32_shim.c
@@ -1,0 +1,36 @@
+#include <stdint.h>
+#include <stdio.h>
+
+int MultiByteToWideChar(uint32_t CodePage, uint32_t dwFlags, const char* lpMultiByteStr, int cbMultiByte,
+                        void* lpWideCharStr, int cchWideChar);
+
+static int passed;
+static int failed;
+
+#define CHECK(condition, message)                                                                                      \
+    do {                                                                                                               \
+        if (condition) {                                                                                               \
+            printf("  [OK] %s\n", message);                                                                            \
+            passed++;                                                                                                  \
+        } else {                                                                                                       \
+            printf("  [FAIL] %s\n", message);                                                                          \
+            failed++;                                                                                                  \
+        }                                                                                                              \
+    } while (0)
+
+int main(void) {
+    const char input[] = "FNA";
+    uint16_t output[sizeof(input) + 1];
+    for (size_t i = 0; i < sizeof(output) / sizeof(output[0]); i++)
+        output[i] = 0xA55A;
+
+    int converted = MultiByteToWideChar(0, 0, input, 0, output, (int)sizeof(input));
+
+    CHECK(converted == 3, "auto-length conversion reports payload length");
+    CHECK(output[0] == 'F' && output[1] == 'N' && output[2] == 'A', "auto-length conversion copies input");
+    CHECK(output[3] == 0, "auto-length conversion writes a UTF-16 terminator");
+    CHECK(output[4] == 0xA55A, "terminator write stays within the requested buffer");
+
+    printf("=== Results: %d passed, %d failed ===\n", passed, failed);
+    return failed != 0;
+}


### PR DESCRIPTION
Fixes #438

## Summary

Fix the FNA `kernel32` shim so auto-length `MultiByteToWideChar` calls leave a valid UTF-16 string terminator when the caller provides spare capacity.

## Changes

- Write `out[len] = 0` only when the output buffer has room, while guarding the computed length from negative inputs.
- Add and register a native regression test covering copied payload, terminator placement, and the adjacent sentinel.

## PR Readiness (MANDATORY)

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

## Local toolchain (run before push)

- [x] `cmake -S . -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON` completed
- [x] `cmake --build build-native --parallel $(sysctl -n hw.ncpu)` completed
- [x] `ctest --test-dir build-native --output-on-failure` passed (32/32)
- [x] `ctest --test-dir build-native --output-on-failure -V -R '^fna_kernel32_shim$'` passed (4/4 assertions)
- [x] `tools/ci/check-clang-format.sh` passed
- [x] `git diff --check` passed
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files should be added to the repo root; place them under `app/`, `tools/`, `tests/`, etc.

## Test notes

- Full native Release build and CTest suite passed: 32/32 tests.
- The focused `fna_kernel32_shim` test passed all four assertions, including the UTF-16 NUL and sentinel boundary checks.
- No real game was launched; this is an isolated native shim behavior fix and the repository's readiness exception is applied for the game-verification item.
- No user-facing documentation or compatibility matrix entry was needed.

## Risk

The change only writes the terminator when `cchWideChar` is larger than the copied payload and never changes the existing return value. Reverting commit `09bd2c59` restores the previous behavior without affecting runtime or bottle state.

