### PR TITLE
fix(diagnostics): constrain FNA game directories

### DIFF
--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -1692,12 +1692,11 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
                 .and_then(|v| v.split('&').next())
                 .map(|s| url_decode(s))
                 .unwrap_or_default();
-            let path = std::path::PathBuf::from(&game_dir);
-            if path.is_dir() {
-                resp(200, serde_json::to_value(fna_profile::detect_fna_signals(&path)).unwrap())
-            } else {
-                resp(400, json!({ "ok": false, "error": "gameDir is not a directory", "gameDir": game_dir }))
-            }
+            let path = match resolve_fna_game_dir(&game_dir) {
+                Ok(path) => path,
+                Err(error) => return resp(400, json!({ "ok": false, "error": error })),
+            };
+            resp(200, serde_json::to_value(fna_profile::detect_fna_signals(&path)).unwrap())
         },
         (Method::Get, "/diagnostics/fna/explain") => {
             let url_str = req.url().to_string();
@@ -1713,7 +1712,10 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
                 .and_then(|v| v.split('&').next())
                 .map(|s| url_decode(s))
                 .unwrap_or_default();
-            let path = std::path::PathBuf::from(&game_dir);
+            let path = match resolve_fna_game_dir(&game_dir) {
+                Ok(path) => path,
+                Err(error) => return resp(400, json!({ "ok": false, "error": error })),
+            };
             resp(200, serde_json::to_value(fna_profile::explain_profile(appid, &path)).unwrap())
         },
         (Method::Get, "/diagnostics/fna/classify") => {
@@ -1730,7 +1732,10 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
                 .and_then(|v| v.split('&').next())
                 .map(|s| url_decode(s))
                 .unwrap_or_default();
-            let path = std::path::PathBuf::from(&game_dir);
+            let path = match resolve_fna_game_dir(&game_dir) {
+                Ok(path) => path,
+                Err(error) => return resp(400, json!({ "ok": false, "error": error })),
+            };
             resp(200, serde_json::to_value(fna_profile::classify_unproven_fna_game(appid, &path)).unwrap())
         },
         (Method::Post, "/steam/compatdata") => {
@@ -2706,6 +2711,40 @@ fn query_param(url: &str, key: &str) -> Option<String> {
     None
 }
 
+fn fna_allowed_roots() -> Vec<std::path::PathBuf> {
+    let mut roots = vec![crate::platform::metalsharp_home_dir()];
+    roots.extend(
+        crate::scan::macos_steam_library_paths()
+            .into_iter()
+            .chain(crate::scan::wine_steam_library_paths())
+            .map(|steamapps| steamapps.join("common")),
+    );
+    roots
+}
+
+fn resolve_existing_dir_under_roots(
+    path: &std::path::Path,
+    roots: &[std::path::PathBuf],
+) -> Result<std::path::PathBuf, String> {
+    let resolved = path.canonicalize().map_err(|_| "gameDir is unavailable".to_string())?;
+    if !resolved.is_dir() {
+        return Err("gameDir is not a directory".into());
+    }
+
+    if roots.iter().filter_map(|root| root.canonicalize().ok()).any(|root| resolved.starts_with(&root)) {
+        Ok(resolved)
+    } else {
+        Err("gameDir must be under the MetalSharp home or a Steam library".into())
+    }
+}
+
+fn resolve_fna_game_dir(raw: &str) -> Result<std::path::PathBuf, String> {
+    if raw.trim().is_empty() {
+        return Err("gameDir is required".into());
+    }
+    resolve_existing_dir_under_roots(std::path::Path::new(raw), &fna_allowed_roots())
+}
+
 fn force_kill_metalsharp_processes() -> Value {
     let this_pid = std::process::id();
     let home = crate::platform::metalsharp_home_dir();
@@ -3626,6 +3665,42 @@ mod tests {
         assert!(is_public_health_request(&Method::Get, "/health?probe=1"));
         assert!(!is_public_health_request(&Method::Get, "/status"));
         assert!(!is_public_health_request(&Method::Post, "/health"));
+    }
+
+    #[test]
+    fn fna_game_dir_resolution_canonicalizes_and_enforces_allowed_roots() {
+        let base = std::env::temp_dir().join(format!("metalsharp-fna-containment-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        let metalsharp_root = base.join("metalsharp");
+        let steam_root = base.join("steam-common");
+        let outside = base.join("outside");
+        let sibling = base.join("metalsharp-sibling");
+        let metalsharp_game = metalsharp_root.join("games").join("fna-game");
+        let steam_game = steam_root.join("fna-game");
+
+        std::fs::create_dir_all(&metalsharp_game).unwrap();
+        std::fs::create_dir_all(&steam_game).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::create_dir_all(sibling.join("fna-game")).unwrap();
+
+        let roots = vec![metalsharp_root.clone(), steam_root.clone()];
+        assert_eq!(
+            resolve_existing_dir_under_roots(&metalsharp_game, &roots).unwrap(),
+            metalsharp_game.canonicalize().unwrap()
+        );
+        assert!(resolve_existing_dir_under_roots(&steam_game, &roots).is_ok());
+        assert!(resolve_existing_dir_under_roots(&outside, &roots).is_err());
+        assert!(resolve_existing_dir_under_roots(&sibling.join("fna-game"), &roots).is_err());
+        assert!(resolve_existing_dir_under_roots(&metalsharp_root.join("missing"), &roots).is_err());
+
+        #[cfg(unix)]
+        {
+            let symlink = metalsharp_root.join("linked-outside");
+            std::os::unix::fs::symlink(&outside, &symlink).unwrap();
+            assert!(resolve_existing_dir_under_roots(&symlink, &roots).is_err());
+        }
+
+        let _ = std::fs::remove_dir_all(base);
     }
 
     #[test]

--- a/docs/optimization-roadmap/local-gates.md
+++ b/docs/optimization-roadmap/local-gates.md
@@ -1,5 +1,5 @@
 # Local Gates
-**Updated:** 2026-07-08
+**Updated:** 2026-08-11
 
 
 The canonical local gates a PR must pass before merge. CI runs a subset of
@@ -95,3 +95,8 @@ the Electron bridge attaches the per-session token automatically. Only
 | `GET /diagnostics/fna/signals?gameDir=` | 8 | FNA/XNA flavor + dependency signals |
 | `GET /diagnostics/fna/explain?appid=&gameDir=` | 8 | profile selection explanation |
 | `GET /diagnostics/fna/classify?appid=&gameDir=` | 8 | conservative unproven-game classification |
+
+The FNA routes require `gameDir` to resolve to an existing directory under
+`METALSHARP_HOME` or a discovered Steam library's `steamapps/common` root.
+Canonicalization rejects traversal and symlink escapes; paths outside those
+roots return HTTP 400 without running detection.


### PR DESCRIPTION
## Summary

Fixes #402 by constraining the FNA diagnostic `gameDir` input before any directory inspection, preventing arbitrary filesystem directory-listing and detection-evidence disclosure.

## Changes

- Canonicalize `gameDir` and require an existing directory under `METALSHARP_HOME` or a discovered Steam `steamapps/common` library root.
- Reject traversal, sibling-prefix paths, missing directories, and symlink escapes with HTTP 400 across `/diagnostics/fna/signals`, `/explain`, and `/classify`.
- Add containment regression coverage for MetalSharp roots, Steam roots, traversal/prefix escapes, missing paths, and symlinks.
- Document the diagnostic route path-scope contract.

## PR Readiness (MANDATORY)

- [x] Compatibility verified with at least one real game (game + launch method noted below) — artifact-level compatibility verified through the isolated FNA diagnostic route probe; no commercial game was launched because this is a local API security boundary fix
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed (not applicable — no TOML/DLL-map changes)
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped (not applicable — no version bump)
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes (diagnostic route contract documented in `docs/optimization-roadmap/local-gates.md`)
- [x] Regression test added for each bug fix

## Local toolchain (run before push)

- [x] `cargo fmt --all -- --check` passes (Rust)
- [x] `cargo clippy --all-targets -- -D warnings` passes (Rust)
- [x] `cargo build --release` passes (Rust backend)
- [x] `cargo test` passes (763/763 Rust tests)
- [ ] C++ compiles if changed (not applicable — no C++ changes)
- [ ] `clang-format --dry-run --Werror` passes on any changed C/C++/Obj-C file (not applicable — no native files changed)
- [ ] `ctest --test-dir build-native` passes if tests changed (not applicable — no native tests changed)
- [ ] TypeScript compiles if changed (not applicable — no TypeScript/JavaScript changes)
- [ ] Biome + Prettier pass if TS/JS changed (not applicable — no TypeScript/JavaScript changes)
- [ ] Shell scripts lint if changed (not applicable — no shell changes)
- [ ] `tools/ci/validate-rules-toml.py` passes if `configs/mtsp-rules.toml` changed (not applicable)
- [ ] `python3 tools/ci/verify-dmg-workflow.py` passes if release/bundle tooling changed (not applicable)
- [x] Tested with at least one game (which one? which launch method? which drive?) — isolated route compatibility probe on `/Volumes/AverySSD/MetalSharp-402-clean`; no commercial game was launched because the affected endpoint is a diagnostic helper
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files should be added to the repo root; changes are under `app/src-rust/` and `docs/`

## Test notes

- `cargo fmt --all -- --check` passed.
- `cargo clippy --all-targets -- -D warnings` passed.
- `cargo build --release` passed.
- `cargo test --quiet` passed: **763/763 tests**.
- Pre-commit hook passed its Rust format, clippy, test, and doc-freshness checks.
- Isolated runtime probe passed: all three FNA routes returned 200 for a directory under `METALSHARP_HOME`, 400 for an external directory, and 400 for a symlink escape; traversal behavior was also rejected.

## Risk

Low. This is a read-only diagnostic boundary hardening change. Valid MetalSharp-home and discovered Steam-library game directories remain supported; out-of-scope paths now fail before FNA inspection. No launch, bottle, runtime, or migration behavior changes. Rollback is a single-commit revert.
