### PR TITLE
fix(security): verify downloaded installer artifacts

### DIFF
--- a/app/src-rust/src/diagnostics.rs
+++ b/app/src-rust/src/diagnostics.rs
@@ -20,6 +20,7 @@
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -35,10 +36,39 @@ const TIMING_LATEST_NAME: &str = "launch-timing-latest.json";
 /// Returns `None` if the file cannot be read. This is intentional: the
 /// diagnostic reports presence/absence explicitly rather than panicking.
 pub fn file_sha256(path: &Path) -> Option<String> {
-    let bytes = fs::read(path).ok()?;
+    let mut file = fs::File::open(path).ok()?;
     let mut hasher = Sha256::new();
-    hasher.update(&bytes);
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        let bytes_read = file.read(&mut buffer).ok()?;
+        if bytes_read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..bytes_read]);
+    }
     Some(bytes_to_hex(&hasher.finalize()))
+}
+
+/// True when a regular file has exactly the expected non-zero size and
+/// SHA-256. Callers use this for downloaded artifacts before staging or
+/// executing them; a missing size or malformed hash fails closed.
+pub fn file_matches_sha256(path: &Path, expected_size: u64, expected_sha256: &str) -> bool {
+    let expected_sha256 = expected_sha256.trim();
+    if expected_size == 0
+        || expected_sha256.len() != 64
+        || !expected_sha256.chars().all(|character| character.is_ascii_hexdigit())
+    {
+        return false;
+    }
+
+    let Ok(metadata) = fs::metadata(path) else {
+        return false;
+    };
+    if !metadata.is_file() || metadata.len() != expected_size {
+        return false;
+    }
+
+    file_sha256(path).is_some_and(|actual| actual.eq_ignore_ascii_case(expected_sha256))
 }
 
 fn bytes_to_hex(bytes: &[u8]) -> String {
@@ -432,6 +462,24 @@ mod tests {
         let path = std::env::temp_dir().join("ms-diag-sha-missing-nope.bin");
         let _ = fs::remove_file(&path);
         assert_eq!(file_sha256(&path), None);
+    }
+
+    #[test]
+    fn file_matches_sha256_requires_size_and_hash() {
+        let dir = std::env::temp_dir().join("ms-diag-sha-verify-test");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("blob.bin");
+        fs::write(&path, b"abc").unwrap();
+        let known = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+
+        assert!(file_matches_sha256(&path, 3, known));
+        assert!(!file_matches_sha256(&path, 0, known));
+        assert!(!file_matches_sha256(&path, 3, "not-a-sha256"));
+        assert!(!file_matches_sha256(&path, 4, known));
+        assert!(!file_matches_sha256(&path, 3, "0000000000000000000000000000000000000000000000000000000000000000"));
+
+        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/app/src-rust/src/installer.rs
+++ b/app/src-rust/src/installer.rs
@@ -2480,22 +2480,7 @@ fn install_windows_steam(home: &PathBuf) -> Result<bool, String> {
     let installer = crate::platform::metalsharp_home_dir_for(&home).join("SteamSetup.exe");
 
     let _ = fs::remove_file(&installer);
-
-    let output = mac_cmd("curl")
-        .args(["-sL", "-o"])
-        .arg(&installer)
-        .arg("https://steamcdn-a.akamaihd.net/client/installer/SteamSetup.exe")
-        .output()
-        .map_err(|e| format!("curl failed: {}", e))?;
-    if !output.status.success() {
-        let bundled = find_bundled_file("SteamSetup.exe");
-        if let Some(bundled) = bundled {
-            let _ = fs::copy(&bundled, &installer);
-        }
-        if !installer.exists() {
-            return Err("failed to download SteamSetup.exe and no bundled fallback".into());
-        }
-    }
+    crate::steam::stage_verified_steam_setup(&installer)?;
 
     let prefix = crate::platform::metalsharp_home_dir_for(&home).join("prefix-steam");
     let _ = fs::create_dir_all(&prefix);
@@ -2512,6 +2497,7 @@ fn install_windows_steam(home: &PathBuf) -> Result<bool, String> {
         .stderr(std::process::Stdio::null());
     crate::platform::set_runtime_library_env(&mut wineboot_cmd, &ms_root);
     let _ = wineboot_cmd.status();
+    crate::steam::stage_verified_steam_setup(&installer)?;
 
     let mut install_cmd = Command::new(&ms_wine);
     install_cmd
@@ -2783,22 +2769,6 @@ fn download_bundled_file(name: &str) -> Option<PathBuf> {
     }
 
     None
-}
-
-fn find_bundled_file(name: &str) -> Option<PathBuf> {
-    if let Some(resources) = crate::platform::app_resources_dir() {
-        let file = resources.join(format!("bundles/{}", name));
-        if file.exists() && bundled_artifact_valid(name, &file) {
-            return Some(file);
-        }
-    }
-
-    let dev = PathBuf::from(format!("app/bundles/{}", name));
-    if dev.exists() && bundled_artifact_valid(name, &dev) {
-        return Some(dev);
-    }
-
-    download_bundled_file(name)
 }
 
 fn download_from_github_release(filename: &str) -> Option<PathBuf> {

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -360,7 +360,16 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
         },
         (Method::Get, "/update/progress") => resp(200, updater::read_update_progress()),
         (Method::Get, "/update/dmg-path") => match updater::get_downloaded_dmg() {
-            Some((path, version)) => resp(200, json!({"ok": true, "path": path, "version": version})),
+            Some(download) => resp(
+                200,
+                json!({
+                    "ok": true,
+                    "path": download.path,
+                    "version": download.version,
+                    "size": download.size,
+                    "sha256": download.sha256,
+                }),
+            ),
             None => resp(200, json!({"ok": false, "error": "no downloaded DMG"})),
         },
         (Method::Post, "/update/cleanup") => resp(200, updater::cleanup_downloaded_dmgs()),

--- a/app/src-rust/src/mono.rs
+++ b/app/src-rust/src/mono.rs
@@ -32,12 +32,14 @@ use std::process::{Child, Command, Stdio};
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
-/// Pinned "latest" Wine Mono release. Bumping this (version + msi filename +
-/// expected install dir) is the only change needed to ship a new mono.
+/// Pinned "latest" Wine Mono release. Bump the version, MSI filename,
+/// install directory, expected size, and SHA-256 together for a new release.
 pub const WINE_MONO_LATEST_VERSION: &str = "11.2.0";
 const WINE_MONO_LATEST_MSI_FILENAME: &str = "wine-mono-11.2.0-x86.msi";
 const WINE_MONO_RELEASE_TAG: &str = "wine-mono-11.2.0";
 const WINE_MONO_INSTALL_DIR_NAME: &str = "wine-mono-11.2.0";
+const WINE_MONO_LATEST_MSI_SIZE: u64 = 83_324_416;
+const WINE_MONO_LATEST_MSI_SHA256: &str = "b4525679e7da30d4658ceb85739cbc55c771791054abbb4b3152fe96ded0b897";
 
 fn wine_mono_msi_url() -> &'static str {
     "https://github.com/wine-mono/wine-mono/releases/download/wine-mono-11.2.0/wine-mono-11.2.0-x86.msi"
@@ -55,6 +57,10 @@ fn mono_cache_dir() -> PathBuf {
 
 fn mono_cache_msi_path() -> PathBuf {
     mono_cache_dir().join(WINE_MONO_LATEST_MSI_FILENAME)
+}
+
+fn mono_cache_msi_part_path() -> PathBuf {
+    mono_cache_msi_path().with_extension("msi.part")
 }
 
 /// In-flight install state so the renderer can poll a single status endpoint
@@ -336,27 +342,36 @@ fn download_msi_to_cache(url: &str, cache_dir: &Path, cache_path: &Path) -> Resu
     });
 
     let tmp = cache_path.with_extension("msi.part");
-    let mut file = fs::File::create(&tmp).map_err(|e| format!("create wine-mono msi: {}", e))?;
-    let mut reader = response.into_body().into_reader();
-    let mut buf = [0u8; 65536];
-    let mut downloaded: u64 = 0;
-    loop {
-        let n = reader.read(&mut buf).map_err(|e| format!("wine-mono read: {}", e))?;
-        if n == 0 {
-            break;
+    let result = (|| {
+        let mut file = fs::File::create(&tmp).map_err(|e| format!("create wine-mono msi: {}", e))?;
+        let mut reader = response.into_body().into_reader();
+        let mut buf = [0u8; 65536];
+        let mut downloaded: u64 = 0;
+        loop {
+            let n = reader.read(&mut buf).map_err(|e| format!("wine-mono read: {}", e))?;
+            if n == 0 {
+                break;
+            }
+            file.write_all(&buf[..n]).map_err(|e| format!("wine-mono write: {}", e))?;
+            downloaded += n as u64;
+            mutate_download_state(|s| {
+                s.download_bytes = downloaded;
+            });
+            if total > 0 && downloaded >= total {
+                break;
+            }
         }
-        file.write_all(&buf[..n]).map_err(|e| format!("wine-mono write: {}", e))?;
-        downloaded += n as u64;
-        mutate_download_state(|s| {
-            s.download_bytes = downloaded;
-        });
-        if total > 0 && downloaded >= total {
-            break;
+        drop(file);
+        if !crate::diagnostics::file_matches_sha256(&tmp, WINE_MONO_LATEST_MSI_SIZE, WINE_MONO_LATEST_MSI_SHA256) {
+            return Err("downloaded Wine Mono MSI failed size/SHA-256 verification".to_string());
         }
+        fs::rename(&tmp, cache_path).map_err(|e| format!("finalize wine-mono msi: {}", e))?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&tmp);
     }
-    drop(file);
-    fs::rename(&tmp, cache_path).map_err(|e| format!("finalize wine-mono msi: {}", e))?;
-    Ok(())
+    result
 }
 
 // ---------------------------------------------------------------------------
@@ -497,12 +512,14 @@ fn cleanup_prefix_for_mono_install(prefix: &Path) {
     // REINSTALLMODE=vomus below handles it without external cleanup).
 }
 
-/// True when the cached MSI exists and is plausibly intact (the real
-/// wine-mono x86 MSI is ~60MB; anything under 1MB is a truncated/partial
-/// download). Corrupt caches are deleted so the next install re-downloads.
+/// True when the cached MSI matches the pinned Wine Mono release size and
+/// SHA-256. Corrupt caches are deleted so the next install re-downloads.
 pub fn cached_msi_is_valid() -> bool {
-    let path = mono_cache_msi_path();
-    path.is_file() && path.metadata().map(|m| m.len() >= 1_000_000).unwrap_or(false)
+    cached_msi_path_is_valid(&mono_cache_msi_path())
+}
+
+fn cached_msi_path_is_valid(path: &Path) -> bool {
+    crate::diagnostics::file_matches_sha256(path, WINE_MONO_LATEST_MSI_SIZE, WINE_MONO_LATEST_MSI_SHA256)
 }
 
 pub fn install_wine_mono_latest(prefix: &Path, prefix_kind: &str) -> Result<u32, String> {
@@ -524,14 +541,19 @@ pub fn install_wine_mono_latest(prefix: &Path, prefix_kind: &str) -> Result<u32,
 
     // 3. Verify the cached MSI is present and intact.
     if !cached_msi_is_valid() {
-        // Corrupt (<1MB) or missing: delete the stale file so the next
+        // Corrupt or missing: delete the stale file so the next
         // handle_install call re-downloads instead of erroring forever.
         let _ = fs::remove_file(mono_cache_msi_path());
+        let _ = fs::remove_file(mono_cache_msi_part_path());
         return Err("Wine Mono MSI not downloaded yet or corrupt — re-downloading".to_string());
     }
 
     // 4. Re-stage the MSI into the prefix (each install gets a fresh copy).
     let staged_msi = stage_msi_into_prefix(&mono_cache_msi_path(), prefix)?;
+    if !crate::diagnostics::file_matches_sha256(&staged_msi, WINE_MONO_LATEST_MSI_SIZE, WINE_MONO_LATEST_MSI_SHA256) {
+        let _ = fs::remove_file(&staged_msi);
+        return Err("staged Wine Mono MSI failed size/SHA-256 verification".to_string());
+    }
 
     // 5. Log setup — single open, clone handle for stdout (match sharp)
     let log_dir = crate::platform::metalsharp_home_dir_for(&home).join("logs");
@@ -731,6 +753,7 @@ pub fn handle_install(prefix_kind: &str) -> Value {
     // download.
     if !cached_msi_is_valid() {
         let _ = fs::remove_file(mono_cache_msi_path());
+        let _ = fs::remove_file(mono_cache_msi_part_path());
         spawn_msi_download();
         return json!({
             "ok": true,
@@ -812,6 +835,7 @@ mod tests {
         assert!(WINE_MONO_LATEST_VERSION.contains('.'));
         assert!(WINE_MONO_LATEST_MSI_FILENAME.contains(WINE_MONO_LATEST_VERSION));
         assert!(WINE_MONO_INSTALL_DIR_NAME.contains(WINE_MONO_LATEST_VERSION));
+        assert_eq!(WINE_MONO_LATEST_MSI_SHA256.len(), 64);
         assert!(wine_mono_msi_url().contains(WINE_MONO_RELEASE_TAG));
         assert!(wine_mono_msi_url().ends_with(WINE_MONO_LATEST_MSI_FILENAME));
     }
@@ -898,14 +922,11 @@ mod tests {
     }
 
     #[test]
-    fn cached_msi_validity_requires_plausible_size() {
-        // The cache path is fixed under the user home; use the helper's
-        // predicate logic against a temp file by testing the threshold rule
-        // directly through a fake: write a small file and confirm the real
-        // cache path check returns false when no MSI is cached.
-        assert!(
-            !cached_msi_is_valid() || mono_cache_msi_path().metadata().map(|m| m.len() >= 1_000_000).unwrap_or(false)
-        );
+    fn cached_msi_validation_rejects_partial_files() {
+        let path = std::env::temp_dir().join(format!("ms-mono-partial-{}", std::process::id()));
+        std::fs::write(&path, b"partial MSI").unwrap();
+        assert!(!cached_msi_path_is_valid(&path));
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]

--- a/app/src-rust/src/steam.rs
+++ b/app/src-rust/src/steam.rs
@@ -6,6 +6,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 static STEAM_INSTALLING: AtomicBool = AtomicBool::new(false);
 const STEAMWEBHELPER_WRAPPER_MAX_BYTES: u64 = 100_000;
 const STEAMWEBHELPER_WRAPPER_SHA256: &str = "3f33958020f6c987b94cc1a7790222b1efc2e3775e3cddd711cdff99143bc182";
+const STEAMSETUP_SIZE: u64 = 2_380_800;
+const STEAMSETUP_SHA256: &str = "7d3654531c32d941b8cae81c4137fc542172bfa9635f169cb392f245a0a12bcb";
+const STEAM_BUNDLE_ARCHIVE_SIZE: u64 = 2_327_667;
+const STEAM_BUNDLE_ARCHIVE_SHA256: &str = "5090e08bdd2edbf7e550726e79c9c9b12c2fdaa501776024fe6d0cb18d2a983e";
 const STEAM_D3D12_GUARD_APPS: &[&str] = &["Steam.exe", "steamwebhelper.exe", "steamwebhelper_real.exe"];
 const STEAM_D3D12_GUARD_DLLS: &[&str] = &["d3d12", "d3d12core", "d3d12SDKLayers", "dxcore"];
 const STEAM_LAUNCH_ARGS: &[&str] = &["-no-cef-sandbox", "-noverifyfiles", "-no-dwrite"];
@@ -843,11 +847,27 @@ fn find_bundled_steamwebhelper_wrapper() -> Option<PathBuf> {
     find_bundled_steam_asset("steamwebhelper.exe").filter(|path| steamwebhelper_wrapper_valid(path))
 }
 
+fn steam_setup_valid(path: &Path) -> bool {
+    crate::diagnostics::file_matches_sha256(path, STEAMSETUP_SIZE, STEAMSETUP_SHA256)
+}
+
+fn steam_bundle_archive_valid(path: &Path) -> bool {
+    crate::diagnostics::file_matches_sha256(path, STEAM_BUNDLE_ARCHIVE_SIZE, STEAM_BUNDLE_ARCHIVE_SHA256)
+}
+
+fn steam_asset_valid(filename: &str, path: &Path) -> bool {
+    match filename {
+        "SteamSetup.exe" => steam_setup_valid(path),
+        "steamwebhelper.exe" => steamwebhelper_wrapper_valid(path),
+        _ => path.is_file() && path.metadata().map(|metadata| metadata.len() > 0).unwrap_or(false),
+    }
+}
+
 fn find_bundled_steam_asset(filename: &str) -> Option<PathBuf> {
     let home = dirs::home_dir()?;
     let cache_dir = crate::platform::metalsharp_home_dir_for(&home).join("cache").join("steam");
     let cached = cache_dir.join(filename);
-    if cached.exists() {
+    if cached.exists() && steam_asset_valid(filename, &cached) {
         return Some(cached);
     }
 
@@ -876,19 +896,19 @@ fn find_bundled_steam_asset(filename: &str) -> Option<PathBuf> {
     }
     let _ = std::fs::remove_dir_all(&tmp);
 
-    cached.exists().then_some(cached)
+    steam_asset_valid(filename, &cached).then_some(cached)
 }
 
 fn find_steam_bundle_archive() -> Option<PathBuf> {
     let filename = "metalsharp-steam.tar.zst";
     if let Some(resources) = crate::platform::app_resources_dir() {
         let archive = resources.join("bundles").join(filename);
-        if archive.exists() {
+        if steam_bundle_archive_valid(&archive) {
             return Some(archive);
         }
     }
     let dev = PathBuf::from("app/bundles").join(filename);
-    if dev.exists() {
+    if steam_bundle_archive_valid(&dev) {
         return Some(dev);
     }
 
@@ -896,19 +916,27 @@ fn find_steam_bundle_archive() -> Option<PathBuf> {
     let cache_dir = crate::platform::metalsharp_home_dir_for(&home).join("cache").join("bundles");
     let _ = std::fs::create_dir_all(&cache_dir);
     let cached = cache_dir.join(filename);
-    if cached.exists() {
+    if steam_bundle_archive_valid(&cached) {
         return Some(cached);
     }
+    let _ = std::fs::remove_file(&cached);
 
     let url = format!("https://github.com/aaf2tbz/metalsharp/releases/download/bundles/{}", filename);
     let tmp = cached.with_extension("download");
-    let output = Command::new("curl")
+    let _ = std::fs::remove_file(&tmp);
+    let output = match Command::new("curl")
         .args(["--fail", "--location", "--silent", "--show-error", "--retry", "3", "-o"])
         .arg(&tmp)
         .arg(url)
         .output()
-        .ok()?;
-    if output.status.success() && tmp.exists() && std::fs::rename(&tmp, &cached).is_ok() {
+    {
+        Ok(output) => output,
+        Err(_) => {
+            let _ = std::fs::remove_file(&tmp);
+            return None;
+        },
+    };
+    if output.status.success() && steam_bundle_archive_valid(&tmp) && std::fs::rename(&tmp, &cached).is_ok() {
         return Some(cached);
     }
     let _ = std::fs::remove_file(&tmp);
@@ -994,29 +1022,24 @@ fn copy_dir_recursive_steam(src: &Path, dst: &Path) -> std::io::Result<()> {
 }
 
 fn steamwebhelper_wrapper_valid(path: &Path) -> bool {
-    let size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
-    if size == 0 || size > STEAMWEBHELPER_WRAPPER_MAX_BYTES {
-        return false;
-    }
-
-    file_sha256(path).as_deref() == Some(STEAMWEBHELPER_WRAPPER_SHA256)
+    let size = std::fs::metadata(path).map(|metadata| metadata.len()).unwrap_or(0);
+    size > 0
+        && size <= STEAMWEBHELPER_WRAPPER_MAX_BYTES
+        && crate::diagnostics::file_sha256(path).as_deref() == Some(STEAMWEBHELPER_WRAPPER_SHA256)
 }
 
-fn file_sha256(path: &Path) -> Option<String> {
-    for (program, args) in [("shasum", vec!["-a", "256"]), ("sha256sum", Vec::new())] {
-        let Ok(output) = Command::new(program).args(args).arg(path).output() else {
-            continue;
-        };
-        if !output.status.success() {
-            continue;
-        }
-        let stdout = String::from_utf8(output.stdout).ok()?;
-        let hash = stdout.split_whitespace().next()?.to_string();
-        if hash.len() == 64 {
-            return Some(hash);
-        }
+pub(crate) fn stage_verified_steam_setup(destination: &Path) -> Result<(), String> {
+    let source = find_bundled_steam_asset("SteamSetup.exe")
+        .ok_or_else(|| "no verified SteamSetup.exe bundle is available".to_string())?;
+    if let Some(parent) = destination.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| format!("create Steam installer directory: {}", error))?;
     }
-    None
+    std::fs::copy(&source, destination).map_err(|error| format!("stage verified SteamSetup.exe: {}", error))?;
+    if !steam_setup_valid(destination) {
+        let _ = std::fs::remove_file(destination);
+        return Err("staged SteamSetup.exe failed size/SHA-256 verification".to_string());
+    }
+    Ok(())
 }
 
 pub fn get_game_name_from_manifest(appid: u32) -> Option<String> {
@@ -1548,21 +1571,13 @@ fn run_install_steam() -> Result<String, Box<dyn std::error::Error>> {
 
     let steam_dir = steam_prefix().join("drive_c").join("Program Files (x86)").join("Steam");
 
-    let _ = std::fs::remove_dir_all(steam_prefix());
-
     let installer = metalsharp_dir.join("SteamSetup.exe");
     let _ = std::fs::remove_file(&installer);
+    stage_verified_steam_setup(&installer).map_err(|error| format!("Failed to stage Steam installer: {}", error))?;
 
-    let url = "https://steamcdn-a.akamaihd.net/client/installer/SteamSetup.exe";
-    let output = Command::new("curl").args(["-sL", "-o", &installer.to_string_lossy(), url]).status()?;
-    if !output.success() {
-        if let Some(bundled) = find_bundled_steam_asset("SteamSetup.exe") {
-            let _ = std::fs::copy(&bundled, &installer);
-        }
-    }
-    if !installer.exists() {
-        return Err("Failed to download Steam installer".into());
-    }
+    // Do not destroy an existing prefix until the installer has been obtained
+    // and verified against the pinned Steam bundle artifact.
+    let _ = std::fs::remove_dir_all(steam_prefix());
 
     let wine = ms_wine();
     if !wine.exists() {
@@ -1608,6 +1623,11 @@ fn run_install_steam() -> Result<String, Box<dyn std::error::Error>> {
 
     let seed_log = prefix.join("drive_c").join("metalsharp-post-wineboot.log");
     let _ = crate::bottles::seed_post_wineboot_config(&prefix, &seed_log);
+
+    // Re-stage and re-verify immediately before Wine opens the installer so
+    // a replacement of the user-writable cache file cannot reach msiexec.
+    stage_verified_steam_setup(&installer)
+        .map_err(|error| format!("Steam installer changed before launch: {}", error))?;
 
     let mut install_cmd = Command::new(&wine);
     install_cmd
@@ -1885,6 +1905,16 @@ mod tests {
         let fields: Vec<&str> = steam_row.split('\t').collect();
 
         assert_eq!(fields.get(1).copied(), Some("steam"));
+        assert_eq!(STEAMSETUP_SHA256.len(), 64);
+        assert_eq!(STEAM_BUNDLE_ARCHIVE_SHA256.len(), 64);
         assert_eq!(STEAMWEBHELPER_WRAPPER_SHA256.len(), 64);
+    }
+
+    #[test]
+    fn steam_setup_validation_rejects_size_only_cache_entries() {
+        let path = std::env::temp_dir().join(format!("metalsharp-steam-setup-{}", std::process::id()));
+        std::fs::write(&path, b"crafted installer").unwrap();
+        assert!(!steam_setup_valid(&path));
+        let _ = std::fs::remove_file(path);
     }
 }

--- a/app/src-rust/src/updater.rs
+++ b/app/src-rust/src/updater.rs
@@ -58,10 +58,60 @@ struct GithubAsset {
     name: String,
     browser_download_url: String,
     size: u64,
+    digest: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct DmgMetadata {
+    version: String,
+    source_url: String,
+    size: u64,
+    sha256: String,
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+struct DmgCacheManifest {
+    version: String,
+    source_url: String,
+    expected_size: u64,
+    sha256: String,
+}
+
+pub struct DownloadedDmg {
+    pub path: String,
+    pub version: String,
+    pub size: u64,
+    pub sha256: String,
 }
 
 fn find_dmg_asset(assets: &[GithubAsset]) -> Option<&GithubAsset> {
     assets.iter().find(|a| a.name.ends_with("-arm64.dmg") || a.name.ends_with(".dmg"))
+}
+
+fn normalize_sha256(value: &str) -> Option<String> {
+    let value = value.trim().strip_prefix("sha256:").unwrap_or(value.trim());
+    (value.len() == 64 && value.chars().all(|character| character.is_ascii_hexdigit()))
+        .then(|| value.to_ascii_lowercase())
+}
+
+fn dmg_metadata(asset: &GithubAsset, version: &str) -> Result<DmgMetadata, String> {
+    if asset.size == 0 {
+        return Err("release DMG has no non-zero size".to_string());
+    }
+    let sha256 = asset
+        .digest
+        .as_deref()
+        .and_then(normalize_sha256)
+        .ok_or_else(|| "release DMG has no valid SHA-256 digest".to_string())?;
+    if asset.browser_download_url.is_empty() {
+        return Err("release DMG has no download URL".to_string());
+    }
+    Ok(DmgMetadata {
+        version: version.to_string(),
+        source_url: asset.browser_download_url.clone(),
+        size: asset.size,
+        sha256,
+    })
 }
 
 pub fn check_for_update() -> serde_json::Value {
@@ -95,8 +145,26 @@ pub fn check_for_update() -> serde_json::Value {
     let current = CURRENT_VERSION.to_string();
     let available = semver_gt(&latest, &current);
 
-    let download_url = find_dmg_asset(&release.assets).map(|a| a.browser_download_url.clone()).unwrap_or_default();
-    let download_size = find_dmg_asset(&release.assets).map(|a| a.size).unwrap_or(0);
+    let dmg_asset = match find_dmg_asset(&release.assets) {
+        Some(asset) => asset,
+        None => {
+            return json!({
+                "ok": false,
+                "error": "latest release has no DMG asset",
+                "current_version": CURRENT_VERSION,
+            })
+        },
+    };
+    let metadata = match dmg_metadata(dmg_asset, &latest) {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            return json!({
+                "ok": false,
+                "error": format!("latest release DMG failed integrity metadata validation: {}", error),
+                "current_version": CURRENT_VERSION,
+            })
+        },
+    };
 
     let release_notes = release.body.unwrap_or_default();
     let release_name = release.name.unwrap_or_else(|| release.tag_name.clone());
@@ -111,8 +179,9 @@ pub fn check_for_update() -> serde_json::Value {
         "current_version": current,
         "latest_version": latest,
         "available": available,
-        "download_url": download_url,
-        "download_size": download_size,
+        "download_url": metadata.source_url,
+        "download_size": metadata.size,
+        "download_sha256": metadata.sha256,
         "release_notes": release_notes,
         "release_name": release_name,
     })
@@ -166,7 +235,26 @@ fn run_download() {
     };
 
     let latest_version = update_info.get("latest_version").and_then(|v| v.as_str()).unwrap_or("unknown").to_string();
-    let expected_size = update_info.get("download_size").and_then(|v| v.as_u64()).unwrap_or(0);
+    let expected_size = match update_info.get("download_size").and_then(|v| v.as_u64()) {
+        Some(size) if size > 0 => size,
+        _ => {
+            write_update_progress("error", 0, "Release DMG has no expected size", Some("dmg_size_missing"));
+            return;
+        },
+    };
+    let expected_sha256 = match update_info.get("download_sha256").and_then(|v| v.as_str()).and_then(normalize_sha256) {
+        Some(sha256) => sha256,
+        None => {
+            write_update_progress("error", 0, "Release DMG has no valid SHA-256", Some("dmg_hash_missing"));
+            return;
+        },
+    };
+    let metadata = DmgMetadata {
+        version: latest_version.clone(),
+        source_url: download_url.clone(),
+        size: expected_size,
+        sha256: expected_sha256,
+    };
 
     let home = match dirs::home_dir() {
         Some(h) => h,
@@ -180,24 +268,29 @@ fn run_download() {
     let _ = fs::create_dir_all(&cache_dir);
     let dmg_path = cache_dir.join(format!("MetalSharp-{}.dmg", latest_version));
 
-    if cached_dmg_ready(&dmg_path, expected_size) {
+    if cached_dmg_ready(&dmg_path, &metadata) {
         app_log(&format!("Using cached DMG: {}", dmg_path.display()));
     } else {
-        let _ = fs::remove_file(&dmg_path);
+        remove_cached_dmg(&dmg_path);
         write_update_progress("downloading", 10, &format!("Downloading v{}...", latest_version), None);
         if let Err(e) = download_with_progress(&download_url, &dmg_path) {
             write_update_progress("error", 0, &format!("Download failed: {}", e), Some(&e.to_string()));
-            let _ = fs::remove_file(&dmg_path);
+            remove_cached_dmg(&dmg_path);
             return;
         }
-        if !cached_dmg_ready(&dmg_path, expected_size) {
+        if !crate::diagnostics::file_matches_sha256(&dmg_path, metadata.size, &metadata.sha256) {
             write_update_progress(
                 "error",
                 0,
-                "Downloaded DMG size did not match the latest release asset",
-                Some("dmg_size_mismatch"),
+                "Downloaded DMG did not match the latest release size and SHA-256",
+                Some("dmg_integrity_mismatch"),
             );
-            let _ = fs::remove_file(&dmg_path);
+            remove_cached_dmg(&dmg_path);
+            return;
+        }
+        if let Err(error) = write_dmg_cache_manifest(&dmg_path, &metadata) {
+            write_update_progress("error", 0, "Could not record DMG provenance", Some(&error));
+            remove_cached_dmg(&dmg_path);
             return;
         }
     }
@@ -205,14 +298,51 @@ fn run_download() {
     write_update_progress("downloaded", 80, &format!("Download complete — ready to install v{}", latest_version), None);
 }
 
-fn cached_dmg_ready(path: &PathBuf, expected_size: u64) -> bool {
-    let Ok(meta) = fs::metadata(path) else {
+fn dmg_cache_manifest_path(path: &Path) -> PathBuf {
+    PathBuf::from(format!("{}.json", path.display()))
+}
+
+fn remove_cached_dmg(path: &Path) {
+    let _ = fs::remove_file(path);
+    let _ = fs::remove_file(dmg_cache_manifest_path(path));
+    let _ = fs::remove_file(path.with_extension("dmg.tmp"));
+    let _ = fs::remove_file(path.with_extension("dmg.json.tmp"));
+}
+
+fn cached_dmg_ready(path: &Path, expected: &DmgMetadata) -> bool {
+    let Ok(manifest_contents) = fs::read_to_string(dmg_cache_manifest_path(path)) else {
         return false;
     };
-    if !meta.is_file() || meta.len() == 0 {
+    let Ok(manifest) = serde_json::from_str::<DmgCacheManifest>(&manifest_contents) else {
+        return false;
+    };
+    if manifest.version != expected.version
+        || manifest.source_url != expected.source_url
+        || manifest.expected_size != expected.size
+        || manifest.sha256 != expected.sha256
+    {
         return false;
     }
-    expected_size == 0 || meta.len() == expected_size
+    crate::diagnostics::file_matches_sha256(path, expected.size, &expected.sha256)
+}
+
+fn write_dmg_cache_manifest(dmg_path: &Path, metadata: &DmgMetadata) -> Result<(), String> {
+    let manifest = DmgCacheManifest {
+        version: metadata.version.clone(),
+        source_url: metadata.source_url.clone(),
+        expected_size: metadata.size,
+        sha256: metadata.sha256.clone(),
+    };
+    let manifest_path = dmg_cache_manifest_path(dmg_path);
+    let tmp = dmg_path.with_extension("dmg.json.tmp");
+    let contents =
+        serde_json::to_vec_pretty(&manifest).map_err(|error| format!("serialize DMG manifest: {}", error))?;
+    fs::write(&tmp, contents).map_err(|error| format!("write DMG manifest: {}", error))?;
+    fs::rename(&tmp, manifest_path).map_err(|error| {
+        let _ = fs::remove_file(&tmp);
+        format!("finalize DMG manifest: {}", error)
+    })?;
+    Ok(())
 }
 
 fn download_with_progress(url: &str, dest: &PathBuf) -> Result<(), String> {
@@ -229,36 +359,41 @@ fn download_with_progress(url: &str, dest: &PathBuf) -> Result<(), String> {
         .unwrap_or(0);
 
     let tmp_path = dest.with_extension("dmg.tmp");
-    let mut file = fs::File::create(&tmp_path).map_err(|e| format!("create file: {}", e))?;
+    let result = (|| {
+        let mut file = fs::File::create(&tmp_path).map_err(|e| format!("create file: {}", e))?;
 
-    let mut reader = resp.into_body().into_reader();
-    let mut buf = [0u8; 65536];
-    let mut downloaded: u64 = 0;
-    let mut last_percent: u32 = 10;
+        let mut reader = resp.into_body().into_reader();
+        let mut buf = [0u8; 65536];
+        let mut downloaded: u64 = 0;
+        let mut last_percent: u32 = 10;
 
-    loop {
-        let n = reader.read(&mut buf).map_err(|e| format!("read error: {}", e))?;
-        if n == 0 {
-            break;
-        }
-        use std::io::Write;
-        file.write_all(&buf[..n]).map_err(|e| format!("write error: {}", e))?;
-        downloaded += n as u64;
+        loop {
+            let n = reader.read(&mut buf).map_err(|e| format!("read error: {}", e))?;
+            if n == 0 {
+                break;
+            }
+            use std::io::Write;
+            file.write_all(&buf[..n]).map_err(|e| format!("write error: {}", e))?;
+            downloaded += n as u64;
 
-        if total_size > 0 {
-            let pct = 10 + ((downloaded as f64 / total_size as f64) * 70.0) as u32;
-            if pct > last_percent {
-                last_percent = pct;
-                DOWNLOAD_PERCENT.store(pct, Ordering::SeqCst);
-                write_update_progress("downloading", pct, &format!("Downloading... {}%", pct), None);
+            if total_size > 0 {
+                let pct = 10 + ((downloaded as f64 / total_size as f64) * 70.0) as u32;
+                if pct > last_percent {
+                    last_percent = pct;
+                    DOWNLOAD_PERCENT.store(pct, Ordering::SeqCst);
+                    write_update_progress("downloading", pct, &format!("Downloading... {}%", pct), None);
+                }
             }
         }
+
+        drop(file);
+        fs::rename(&tmp_path, dest).map_err(|e| format!("rename: {}", e))?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&tmp_path);
     }
-
-    drop(file);
-    fs::rename(&tmp_path, dest).map_err(|e| format!("rename: {}", e))?;
-
-    Ok(())
+    result
 }
 
 pub fn cleanup_downloaded_dmgs() -> serde_json::Value {
@@ -278,11 +413,24 @@ pub fn cleanup_downloaded_dmgs() -> serde_json::Value {
     if let Ok(entries) = fs::read_dir(&cache_dir) {
         for entry in entries.flatten() {
             let path = entry.path();
-            if path.extension().map(|e| e == "dmg").unwrap_or(false) {
+            let is_dmg = path.extension().map(|e| e == "dmg").unwrap_or(false);
+            let is_manifest = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .map(|name| name.ends_with(".dmg.json"))
+                .unwrap_or(false);
+            let is_partial = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .map(|name| name.ends_with(".dmg.tmp") || name.ends_with(".dmg.json.tmp"))
+                .unwrap_or(false);
+            if is_dmg || is_manifest || is_partial {
                 let size = fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
                 if fs::remove_file(&path).is_ok() {
                     bytes_freed += size;
-                    removed += 1;
+                    if is_dmg {
+                        removed += 1;
+                    }
                 }
             }
         }
@@ -295,52 +443,36 @@ pub fn cleanup_downloaded_dmgs() -> serde_json::Value {
     json!({"ok": true, "removed": removed, "bytes_freed": bytes_freed})
 }
 
-pub fn get_downloaded_dmg() -> Option<(String, String)> {
+pub fn get_downloaded_dmg() -> Option<DownloadedDmg> {
     let update_info = check_for_update();
     let latest_version = update_info.get("latest_version").and_then(|v| v.as_str())?;
+    let source_url = update_info.get("download_url").and_then(|v| v.as_str())?;
+    let size = update_info.get("download_size").and_then(|v| v.as_u64()).filter(|size| *size > 0)?;
+    let sha256 = update_info.get("download_sha256").and_then(|v| v.as_str()).and_then(normalize_sha256)?;
+    let metadata = DmgMetadata {
+        version: latest_version.to_string(),
+        source_url: source_url.to_string(),
+        size,
+        sha256: sha256.clone(),
+    };
     let home = dirs::home_dir()?;
     let cache_dir = crate::platform::metalsharp_home_dir_for(&home).join("cache").join("updates");
     let dmg_path = cache_dir.join(format!("MetalSharp-{}.dmg", latest_version));
 
-    let expected_size = update_info.get("download_size").and_then(|v| v.as_u64()).unwrap_or(0);
-
-    if cached_dmg_ready(&dmg_path, expected_size) {
-        Some((dmg_path.to_string_lossy().to_string(), latest_version.to_string()))
+    if cached_dmg_ready(&dmg_path, &metadata) {
+        Some(DownloadedDmg {
+            path: dmg_path.to_string_lossy().to_string(),
+            version: latest_version.to_string(),
+            size,
+            sha256,
+        })
     } else {
-        newest_cached_update_dmg(&cache_dir, CURRENT_VERSION)
-            .map(|(version, path)| (path.to_string_lossy().to_string(), version))
+        None
     }
 }
 
 pub fn get_downloaded_dmg_path() -> Option<String> {
-    get_downloaded_dmg().map(|(path, _version)| path)
-}
-
-fn newest_cached_update_dmg(cache_dir: &Path, current_version: &str) -> Option<(String, PathBuf)> {
-    let mut candidates = Vec::new();
-    for entry in fs::read_dir(cache_dir).ok()?.flatten() {
-        let path = entry.path();
-        if !cached_dmg_ready(&path, 0) {
-            continue;
-        }
-        let Some(version) = dmg_filename_version(&path) else {
-            continue;
-        };
-        if semver_gt(&version, current_version) {
-            candidates.push((version, path));
-        }
-    }
-
-    candidates.sort_by(|(left, _), (right, _)| compare_versions(left, right));
-    candidates.pop()
-}
-
-fn dmg_filename_version(path: &Path) -> Option<String> {
-    let name = path.file_name()?.to_str()?;
-    let raw = name.strip_prefix("MetalSharp-")?.strip_suffix(".dmg")?;
-    let raw = raw.strip_suffix("-arm64").unwrap_or(raw);
-    let version = clean_version(raw);
-    (!version.is_empty()).then_some(version)
+    get_downloaded_dmg().map(|download| download.path)
 }
 
 fn compare_versions(left: &str, right: &str) -> std::cmp::Ordering {
@@ -417,48 +549,50 @@ mod tests {
     }
 
     #[test]
-    fn cached_dmg_requires_nonempty_expected_size_match() {
+    fn cached_dmg_requires_manifest_size_and_sha256_match() {
         let home = test_home("cached-dmg-size");
         fs::create_dir_all(&home).expect("create test dir");
         let dmg = home.join("MetalSharp-0.1.0.dmg");
+        let metadata = DmgMetadata {
+            version: "0.1.0".to_string(),
+            source_url: "https://github.com/metalsharp/MetalSharp/releases/download/v0.1.0/MetalSharp-0.1.0-arm64.dmg"
+                .to_string(),
+            size: 4,
+            sha256: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08".to_string(),
+        };
 
-        assert!(!cached_dmg_ready(&dmg, 4));
+        assert!(!cached_dmg_ready(&dmg, &metadata));
 
         fs::write(&dmg, b"test").expect("write dmg");
+        assert!(!cached_dmg_ready(&dmg, &metadata), "a DMG without provenance is not installable");
+        write_dmg_cache_manifest(&dmg, &metadata).expect("write manifest");
+        assert!(cached_dmg_ready(&dmg, &metadata));
 
-        assert!(cached_dmg_ready(&dmg, 0));
-        assert!(cached_dmg_ready(&dmg, 4));
-        assert!(!cached_dmg_ready(&dmg, 5));
+        let mut wrong_size = metadata.clone();
+        wrong_size.size = 0;
+        assert!(!cached_dmg_ready(&dmg, &wrong_size));
+
+        let mut wrong_hash = metadata.clone();
+        wrong_hash.sha256 = "0000000000000000000000000000000000000000000000000000000000000000".to_string();
+        assert!(!cached_dmg_ready(&dmg, &wrong_hash));
+
+        fs::write(&dmg, b"evil").expect("replace cached dmg");
+        assert!(!cached_dmg_ready(&dmg, &metadata), "tampered cached DMG must be rejected");
 
         let _ = fs::remove_dir_all(home);
     }
 
     #[test]
-    fn cached_update_selection_requires_newer_versioned_dmg() {
-        let home = test_home("cached-dmg-version");
-        fs::create_dir_all(&home).expect("create test dir");
-        fs::write(home.join("MetalSharp-0.37.0.dmg"), b"old").expect("write old dmg");
-        fs::write(home.join("MetalSharp-0.37.1.dmg"), b"same").expect("write same dmg");
-        fs::write(home.join("MetalSharp-0.37.2.dmg"), b"new").expect("write new dmg");
-        fs::write(home.join("MetalSharp-0.37.3-arm64.dmg"), b"newer").expect("write newer dmg");
-        fs::write(home.join("MetalSharp-not-a-version.dmg"), b"junk").expect("write junk dmg");
-
-        let (version, selected) = newest_cached_update_dmg(&home, "0.37.1").expect("newer dmg selected");
-
-        assert_eq!(version, "0.37.3");
-        assert_eq!(selected.file_name().and_then(|name| name.to_str()), Some("MetalSharp-0.37.3-arm64.dmg"));
-        let _ = fs::remove_dir_all(home);
-    }
-
-    #[test]
-    fn cached_update_selection_rejects_old_or_current_dmgs() {
-        let home = test_home("cached-dmg-no-newer");
-        fs::create_dir_all(&home).expect("create test dir");
-        fs::write(home.join("MetalSharp-0.36.9.dmg"), b"old").expect("write old dmg");
-        fs::write(home.join("MetalSharp-0.37.1.dmg"), b"same").expect("write same dmg");
-
-        assert!(newest_cached_update_dmg(&home, "0.37.1").is_none());
-        let _ = fs::remove_dir_all(home);
+    fn release_dmg_metadata_requires_a_digest() {
+        let asset = GithubAsset {
+            name: "MetalSharp-0.1.0-arm64.dmg".to_string(),
+            browser_download_url:
+                "https://github.com/metalsharp/MetalSharp/releases/download/v0.1.0/MetalSharp-0.1.0-arm64.dmg"
+                    .to_string(),
+            size: 4,
+            digest: None,
+        };
+        assert!(dmg_metadata(&asset, "0.1.0").is_err());
     }
 
     fn test_home(name: &str) -> PathBuf {

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -1169,10 +1169,13 @@ function registerIpc() {
     return updaterBridge.ensureReady();
   });
 
-  ipcMain.handle("updater:spawn-install", async (_e, dmgPath: string, backendPid: number, targetVersion: string) => {
-    if (isUiOnlyRuntime()) return { ok: false, error: "Updater is disabled in UI-only preview mode." };
-    return updaterBridge.spawnInstallUpdater(dmgPath, backendPid, targetVersion);
-  });
+  ipcMain.handle(
+    "updater:spawn-install",
+    async (_e, dmgPath: string, backendPid: number, targetVersion: string, dmgSize: number, dmgSha256: string) => {
+      if (isUiOnlyRuntime()) return { ok: false, error: "Updater is disabled in UI-only preview mode." };
+      return updaterBridge.spawnInstallUpdater(dmgPath, backendPid, targetVersion, dmgSize, dmgSha256);
+    },
+  );
 
   ipcMain.handle("updater:install-status", async () => {
     if (isUiOnlyRuntime()) return null;

--- a/app/src/main/preload.ts
+++ b/app/src/main/preload.ts
@@ -25,8 +25,13 @@ contextBridge.exposeInMainWorld("metalsharp", {
   restartBackend: () => ipcRenderer.invoke("backend:restart"),
   isBackendAlive: () => ipcRenderer.invoke("backend:is-alive"),
   updaterEnsureReady: () => ipcRenderer.invoke("updater:ensure-ready"),
-  updaterSpawnInstall: (dmgPath: string, backendPid: number, targetVersion: string) =>
-    ipcRenderer.invoke("updater:spawn-install", dmgPath, backendPid, targetVersion),
+  updaterSpawnInstall: (
+    dmgPath: string,
+    backendPid: number,
+    targetVersion: string,
+    dmgSize: number,
+    dmgSha256: string,
+  ) => ipcRenderer.invoke("updater:spawn-install", dmgPath, backendPid, targetVersion, dmgSize, dmgSha256),
   updaterInstallStatus: () => ipcRenderer.invoke("updater:install-status"),
   updaterClearStatus: () => ipcRenderer.invoke("updater:clear-status"),
   backendGetPid: () => ipcRenderer.invoke("backend:get-pid"),

--- a/app/src/main/updater-bridge.ts
+++ b/app/src/main/updater-bridge.ts
@@ -100,13 +100,42 @@ export class UpdaterBridge {
     });
   }
 
-  spawnInstallUpdater(dmgPath: string, backendPid: number, targetVersion: string): { ok: boolean; error?: string } {
+  spawnInstallUpdater(
+    dmgPath: string,
+    backendPid: number,
+    targetVersion: string,
+    dmgSize: number,
+    dmgSha256: string,
+  ): { ok: boolean; error?: string } {
     if (!this.scriptPath) {
       return { ok: false, error: "Updater not ready — update.sh missing" };
     }
 
-    if (!fs.existsSync(dmgPath)) {
+    if (typeof dmgPath !== "string" || typeof dmgSha256 !== "string") {
+      return { ok: false, error: "DMG path or integrity metadata is invalid" };
+    }
+    const updatesDir = path.resolve(getMetalsharpDir(), "cache", "updates");
+    const resolvedDmgPath = path.resolve(dmgPath);
+    if (!resolvedDmgPath.startsWith(`${updatesDir}${path.sep}`) || !fs.existsSync(resolvedDmgPath)) {
       return { ok: false, error: `DMG file not found: ${dmgPath}` };
+    }
+    let realDmgPath: string;
+    try {
+      realDmgPath = fs.realpathSync(resolvedDmgPath);
+    } catch {
+      return { ok: false, error: `DMG file cannot be resolved: ${dmgPath}` };
+    }
+    let realUpdatesDir: string;
+    try {
+      realUpdatesDir = fs.realpathSync(updatesDir);
+    } catch {
+      return { ok: false, error: "MetalSharp update cache cannot be resolved" };
+    }
+    if (!realDmgPath.startsWith(`${realUpdatesDir}${path.sep}`)) {
+      return { ok: false, error: "DMG path must remain inside the MetalSharp update cache" };
+    }
+    if (!Number.isSafeInteger(dmgSize) || dmgSize <= 0 || !/^[0-9a-fA-F]{64}$/.test(dmgSha256)) {
+      return { ok: false, error: "DMG integrity metadata is missing or invalid" };
     }
 
     fs.mkdirSync(getMetalsharpDir(), { recursive: true });
@@ -116,7 +145,11 @@ export class UpdaterBridge {
       [
         this.scriptPath,
         "--dmg",
-        dmgPath,
+        resolvedDmgPath,
+        "--dmg-size",
+        String(dmgSize),
+        "--dmg-sha256",
+        dmgSha256,
         "--backend-pid",
         String(backendPid),
         "--target-version",

--- a/app/src/renderer/App.vue
+++ b/app/src/renderer/App.vue
@@ -203,14 +203,28 @@ async function startUpdateDownload() {
     if (progress.status === "downloaded" || progress.status === "complete") {
       if (updatePollTimer) clearInterval(updatePollTimer);
       updatePollTimer = null;
-      const dmgResult = await api<{ ok: boolean; path?: string; version?: string }>("GET", "/update/dmg-path");
+      const dmgResult = await api<{ ok: boolean; path?: string; version?: string; size?: number; sha256?: string }>(
+        "GET",
+        "/update/dmg-path",
+      );
       if (!dmgResult?.path) {
         toast.show("Download complete but DMG not found", "error");
         updateDownloading.value = false;
         return;
       }
+      if (!dmgResult.size || !dmgResult.sha256) {
+        toast.show("Download completed without integrity metadata", "error");
+        updateDownloading.value = false;
+        return;
+      }
       const installVersion = dmgResult.version ?? targetVersion;
-      const spawnResult = await backend.updaterSpawnInstall(dmgResult.path, pid, installVersion);
+      const spawnResult = await backend.updaterSpawnInstall(
+        dmgResult.path,
+        pid,
+        installVersion,
+        dmgResult.size,
+        dmgResult.sha256,
+      );
       if (!spawnResult?.ok) {
         toast.show(spawnResult?.error ?? "Failed to start installer", "error");
         updateDownloading.value = false;

--- a/app/src/renderer/api-types.ts
+++ b/app/src/renderer/api-types.ts
@@ -234,6 +234,8 @@ type MetalsharpAPI = {
     dmgPath: string,
     backendPid: number,
     targetVersion: string,
+    dmgSize: number,
+    dmgSha256: string,
   ) => Promise<{ ok: boolean; error?: string }>;
   updaterInstallStatus: () => Promise<InstallStatus | null>;
   updaterClearStatus: () => Promise<void>;

--- a/app/updater/update.py
+++ b/app/updater/update.py
@@ -8,11 +8,13 @@ Communication: writes JSON status to ~/.metalsharp/update_install_status.json
 The new MetalSharp instance reads this file on launch to show success/failure.
 
 Usage:
-    python3 update.py --dmg <path> --backend-pid <pid> --target-version <ver> \
+    python3 update.py --dmg <path> --dmg-size <bytes> --dmg-sha256 <sha256> \
+                      --backend-pid <pid> --target-version <ver> \
                       [--status-file <path>] [--python <path>]
 """
 
 import argparse
+import hashlib
 import json
 import os
 import signal
@@ -307,6 +309,28 @@ def verify_app_bundle(app_path):
     return "Mach-O" in substrate_type and "x86_64" in substrate_type and "ELF 64-bit" in symbol_type and "x86-64" in symbol_type
 
 
+def verify_dmg_integrity(dmg_path, expected_size, expected_sha256):
+    try:
+        expected_size = int(expected_size)
+    except (TypeError, ValueError):
+        return False
+    if expected_size <= 0 or not isinstance(expected_sha256, str):
+        return False
+    expected_sha256 = expected_sha256.strip().lower()
+    if len(expected_sha256) != 64 or any(c not in "0123456789abcdef" for c in expected_sha256):
+        return False
+    try:
+        if not os.path.isfile(dmg_path) or os.path.getsize(dmg_path) != expected_size:
+            return False
+        digest = hashlib.sha256()
+        with open(dmg_path, "rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest() == expected_sha256
+    except (OSError, IOError):
+        return False
+
+
 def admin_rm_rf(path):
     r = run(["rm", "-rf", path])
     if r.returncode == 0:
@@ -382,6 +406,8 @@ def report_update_result(status_file, version, target_version):
 def main():
     parser = argparse.ArgumentParser(description="MetalSharp Updater")
     parser.add_argument("--dmg", required=True)
+    parser.add_argument("--dmg-size", required=True, type=int)
+    parser.add_argument("--dmg-sha256", required=True)
     parser.add_argument("--backend-pid", required=True, type=int)
     parser.add_argument("--target-version", required=True)
     parser.add_argument(
@@ -396,11 +422,24 @@ def main():
     tv = args.target_version
     global UPDATE_DMG_PATH
     dmg = args.dmg
+    dmg_size = args.dmg_size
+    dmg_sha256 = args.dmg_sha256
     UPDATE_DMG_PATH = dmg
     bpid = args.backend_pid
     app_pid = args.app_pid
 
     write_status(sf, "starting", 0, "Starting update...", new_version=tv)
+
+    if not verify_dmg_integrity(dmg, dmg_size, dmg_sha256):
+        write_status(
+            sf,
+            "error",
+            0,
+            "Downloaded DMG failed size/SHA-256 verification",
+            error="dmg_integrity_failed",
+            new_version=tv,
+        )
+        sys.exit(1)
 
     # ── 1. Force-stop old app/backend before touching the update image ───────
     force_stop_old_runtime(sf, bpid, app_pid, tv)
@@ -425,13 +464,13 @@ def main():
     )
 
     # ── 3. Verify DMG exists ─────────────────────────────────────────
-    if not os.path.exists(dmg):
+    if not verify_dmg_integrity(dmg, dmg_size, dmg_sha256):
         write_status(
             sf,
             "error",
             20,
-            "DMG not found: {}".format(dmg),
-            error="dmg_not_found",
+            "Downloaded DMG failed size/SHA-256 verification",
+            error="dmg_integrity_failed",
             new_version=tv,
         )
         sys.exit(1)

--- a/app/updater/update.sh
+++ b/app/updater/update.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 DMG_PATH=""
+DMG_SIZE=""
+DMG_SHA256=""
 BACKEND_PID=""
 TARGET_VERSION=""
 STATUS_FILE=""
@@ -95,6 +97,8 @@ force_stop_old_runtime() {
 while [ "$#" -gt 0 ]; do
     case "$1" in
         --dmg) shift; DMG_PATH="${1:-}"; shift ;;
+        --dmg-size) shift; DMG_SIZE="${1:-}"; shift ;;
+        --dmg-sha256) shift; DMG_SHA256="${1:-}"; shift ;;
         --backend-pid) shift; BACKEND_PID="${1:-}"; shift ;;
         --target-version) shift; TARGET_VERSION="${1:-}"; shift ;;
         --status-file) shift; STATUS_FILE="${1:-}"; shift ;;
@@ -108,6 +112,8 @@ done
 MS_DIR="${METALSHARP_HOME_ARG:-${METALSHARP_HOME:-$HOME/.metalsharp}}"
 STATUS_FILE="${STATUS_FILE:-$MS_DIR/update_install_status.json}"
 DMG_PATH="${DMG_PATH:?--dmg required}"
+DMG_SIZE="${DMG_SIZE:?--dmg-size required}"
+DMG_SHA256="${DMG_SHA256:?--dmg-sha256 required}"
 BACKEND_PID="${BACKEND_PID:?--backend-pid required}"
 TARGET_VERSION="${TARGET_VERSION:?--target-version required}"
 APP_PATH="/Applications/MetalSharp.app"
@@ -160,6 +166,19 @@ verify_app_bundle() {
         return 1
     fi
     return 0
+}
+
+verify_dmg_integrity() {
+    if [ ! -f "$DMG_PATH" ] || [[ ! "$DMG_SIZE" =~ ^[1-9][0-9]*$ ]] || [[ ! "$DMG_SHA256" =~ ^[0-9a-fA-F]{64}$ ]]; then
+        return 1
+    fi
+
+    local actual_size actual_sha256 expected_sha256
+    actual_size="$(wc -c < "$DMG_PATH" | tr -d '[:space:]')"
+    [ "$actual_size" = "$DMG_SIZE" ] || return 1
+    actual_sha256="$(shasum -a 256 "$DMG_PATH" | awk '{print tolower($1)}')" || return 1
+    expected_sha256="$(printf '%s' "$DMG_SHA256" | tr '[:upper:]' '[:lower:]')"
+    [ "$actual_sha256" = "$expected_sha256" ]
 }
 
 normalize_version() {
@@ -226,6 +245,11 @@ fi
 
 write_status "starting" 0 "Starting update..."
 
+if ! verify_dmg_integrity; then
+    write_status "error" 0 "Downloaded DMG failed size/SHA-256 verification" "dmg_integrity_failed"
+    exit 1
+fi
+
 force_stop_old_runtime
 
 write_status "killing_steam" 15 "Stopping Steam and Wine processes..."
@@ -246,8 +270,8 @@ sleep 1
 force_stop_old_runtime
 
 write_status "verifying_dmg" 30 "Verifying DMG..."
-if [ ! -f "$DMG_PATH" ]; then
-    write_status "error" 30 "DMG not found: $DMG_PATH" "dmg_not_found"
+if ! verify_dmg_integrity; then
+    write_status "error" 30 "Downloaded DMG failed size/SHA-256 verification" "dmg_integrity_failed"
     exit 1
 fi
 if ! hdiutil verify "$DMG_PATH" >/dev/null 2>&1; then

--- a/docs/runtime/runtime-bundles-and-steam-routing.md
+++ b/docs/runtime/runtime-bundles-and-steam-routing.md
@@ -65,6 +65,26 @@ Installed DXMT runtime state is recorded in:
 
 Do not trust a runtime by version string alone. Check the manifest, required DLLs, the vkd3d-proton/DXVK/MoltenVK lane artifacts (for the default M12 backend) or the `dxmt-m12` sidecars (for the DXMT rollback), and source archive hash when diagnosing deployment drift.
 
+## Downloaded Installer Artifact Integrity
+
+Every downloaded installer that can reach an install or privileged update path
+must have a non-zero expected size and a SHA-256 digest before it is accepted:
+
+- Update DMGs use the GitHub release asset digest and URL/size/hash sidecar in
+  `~/.metalsharp/cache/updates/`. A cache entry is usable only when the
+  sidecar exactly matches the current release metadata and the DMG is hashed
+  again.
+- Wine Mono 11.2.0 uses the pinned MSI size and SHA-256 in
+  `app/src-rust/src/mono.rs`. Partial or mismatched `.msi.part` files are
+  removed before retrying.
+- SteamSetup.exe is staged only from the verified `metalsharp-steam` bundle;
+  the bundle archive and extracted installer are both pinned by size and
+  SHA-256 in `app/src-rust/src/steam.rs`.
+
+The detached updater receives the DMG size and digest from the backend and
+rechecks them immediately before mounting. `hdiutil verify` remains an
+additional structural check, not a replacement for the content hash.
+
 ## Steam Launch Route
 
 The app launches Wine Steam through:

--- a/tools/ci/verify-dmg-workflow.py
+++ b/tools/ci/verify-dmg-workflow.py
@@ -109,6 +109,9 @@ def check_updater_handoff() -> None:
         for needle in ["hdiutil", "attach", "-mountpoint", "metalsharp-update-mount", "detach_mount(mount_point" if path.endswith(".py") else "detach_mount"]:
             if needle not in updater:
                 fail(f"{path} no longer mounts the downloaded DMG on a private update mount point before install")
+        for needle in ["verify_dmg_integrity", "dmg-sha256", "dmg-size"]:
+            if needle not in updater:
+                fail(f"{path} must require DMG size and SHA-256 verification before installation")
 
 
 def check_create_dmg_version() -> None:


### PR DESCRIPTION
## Summary

Fixes #405 by making every affected installer artifact fail closed unless its expected non-zero size and SHA-256 match. Cached DMGs now carry provenance metadata and the detached updater re-verifies the DMG immediately before mounting it.

## Changes

- Verify GitHub release DMG digests and sizes, reject releases without integrity metadata, and remove the size-zero cached-DMG fallback.
- Write and validate a DMG sidecar containing the release version, source URL, expected size, and SHA-256; remove mismatched and partial files.
- Pass DMG integrity metadata through the backend/Electron updater bridge and verify it in both updater implementations before install.
- Pin and verify the Wine Mono MSI and SteamSetup.exe/bundle hashes, including validation after staging and before Wine opens the installers.
- Add streaming SHA-256 file verification and document the artifact trust contract.
- Add CI contract checks so both detached updater scripts retain the hash handoff.

## PR Readiness (MANDATORY)

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed (not applicable; neither changed)
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped (not applicable; no version changed)
- [x] Bottle/runtime migration and launch behavior preserved (installer integrity only; no game launch route changed)
- [x] Docs / compatibility matrix updated for user-facing changes (`docs/runtime/runtime-bundles-and-steam-routing.md` updated)
- [x] Regression test added for each bug fix

## Local toolchain (run before push)

- [x] `cargo fmt --all -- --check` passes (Rust)
- [x] `cargo clippy --all-targets -- -D warnings` passes (Rust)
- [x] `cargo build --release` passes (Rust backend)
- [x] `cargo test` passes (Rust — 763 tests)
- [ ] C++ compiles if changed (not applicable; no native C++ files changed)
- [ ] `clang-format --dry-run --Werror` passes on any changed C/C++/Obj-C file (not applicable)
- [ ] `ctest --test-dir build-native` passes if tests changed (not applicable; no native tests changed)
- [x] TypeScript compiles if changed: `cd app && npx tsc --noEmit`
- [x] Biome + Prettier pass if TS/JS changed
- [x] Shell scripts lint if changed: `tools/ci/shellcheck.sh`
- [ ] `tools/ci/validate-rules-toml.py` passes if `configs/mtsp-rules.toml` changed (not applicable)
- [x] `python3 tools/ci/verify-dmg-workflow.py` passes (updated updater contract)
- [ ] Tested with at least one game (not applicable; no game launch behavior changed)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files added to the repo root; no generated files are tracked

## Test notes

- `cargo test --quiet`: 763 passed.
- `cargo clippy --all-targets -- -D warnings`, `cargo build --release`, and `cargo fmt --all -- --check` passed.
- `npx tsc --noEmit`, `npm run build`, Biome, and Prettier passed. Biome reports three pre-existing CSS specificity warnings without failing.
- `tools/ci/shellcheck.sh`, `python3 tools/ci/verify-dmg-workflow.py`, `bash -n app/updater/update.sh`, Python compilation, and updater integrity helper checks passed.
- The pinned values were checked against the current upstream GitHub assets: Wine Mono 11.2.0 MSI, SteamSetup.exe, and `metalsharp-steam.tar.zst`.
- No real-game launch was run because this is a fail-closed installer/download security fix.

## Risk

Low-to-medium. Missing or changed release metadata now blocks installation instead of accepting an unverified artifact. Steam and Wine Mono hashes must be updated together with their pinned release constants when those upstream payloads intentionally change. Rollback is commit `35501f90`.

<!-- checklist-exception is used because real-game compatibility is intentionally not applicable to this internal installer-integrity fix. -->
