### PR TITLE
fix: restrict force-kill to MetalSharp-owned executables (#404)

### DIFF
--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -2800,6 +2800,78 @@ fn parse_process_line_owned(line: &str) -> Option<(u32, String)> {
     Some((pid, command))
 }
 
+const METALSHARP_WINE_EXECUTABLES: &[&str] = &[
+    "metalsharp-wine",
+    "wine",
+    "wine64",
+    "wine32",
+    "wineserver",
+    "wineboot",
+    "wineboot.exe",
+    "wineloader",
+    "wine-preloader",
+    "wine64-preloader",
+    "wine32-preloader",
+    "winedevice",
+    "winedevice.exe",
+    "winedbg",
+];
+
+const METALSHARP_RUNTIME_HELPERS: &[&str] = &["gogdl", "heroic_gogdl", "heroic-gogdl"];
+
+fn command_executable(command: &str) -> &str {
+    let command = command.trim_start();
+    for quote in ['"', '\''] {
+        if let Some(quoted) = command.strip_prefix(quote) {
+            return quoted.split(quote).next().unwrap_or("");
+        }
+    }
+    command.split_whitespace().next().unwrap_or("")
+}
+
+fn is_metalsharp_wine_executable(command: &str, home: &std::path::Path) -> bool {
+    let executable = std::path::Path::new(command_executable(command));
+    let runtime_bin = home.join("runtime").join("wine").join("bin");
+    if !executable.starts_with(&runtime_bin) {
+        return false;
+    }
+
+    let name = executable.file_name().and_then(|value| value.to_str()).map(|value| value.to_ascii_lowercase());
+    name.as_deref().is_some_and(|name| METALSHARP_WINE_EXECUTABLES.contains(&name))
+}
+
+fn is_metalsharp_runtime_helper(command: &str, home: &std::path::Path) -> bool {
+    let executable = std::path::Path::new(command_executable(command));
+    let runtime_root = home.join("runtime");
+    let tools_root = home.join("tools");
+    let owned_helper_path =
+        executable.parent() == Some(runtime_root.as_path()) || executable.parent() == Some(tools_root.as_path());
+    if !owned_helper_path {
+        return false;
+    }
+
+    let name = executable.file_name().and_then(|value| value.to_str()).map(|value| value.to_ascii_lowercase());
+    name.as_deref().is_some_and(|name| METALSHARP_RUNTIME_HELPERS.contains(&name))
+}
+
+fn is_metalsharp_owned_prefix_executable(command: &str, home: &std::path::Path) -> bool {
+    let executable = std::path::Path::new(command_executable(command));
+    let Ok(relative) = executable.strip_prefix(home) else {
+        return false;
+    };
+    let Some(root) = relative.components().next() else {
+        return false;
+    };
+    let root = root.as_os_str().to_string_lossy();
+
+    root == "bottles"
+        || root == "games"
+        || root == "prefix-gptk"
+        || root == "prefix-steam"
+        || root == "sharp-prefix"
+        || root.starts_with("prefix-")
+}
+
 fn is_metalsharp_game_command(command: &str, home: &std::path::Path) -> bool {
     if is_force_kill_target(command, home) {
         return true;
@@ -2832,41 +2904,14 @@ fn is_force_kill_target(command: &str, home: &std::path::Path) -> bool {
         return false;
     }
 
-    let home_text = home.to_string_lossy();
-    let under_metalsharp_home = !home_text.is_empty() && command.contains(home_text.as_ref());
-    let wine_process = lower.contains("metalsharp-wine")
-        || lower.contains("wineserver")
-        || lower.contains("wineloader")
-        || lower.contains("wineboot")
-        || lower.contains("wine64")
-        || lower.contains("winedevice.exe")
-        || lower.contains("steamwebhelper")
-        || lower.contains("c:\\windows\\")
-        || lower.contains(".exe");
-
-    // Isolation contract: MetalSharp must only ever kill processes it owns.
-    // A bare `wine`/`wineserver`/`wineloader` match is NOT enough — that
-    // would kill a foreign Wine (CrossOver, SakuraGiri, Whisky, GPTK) that
-    // happens to be running. Ownership is proven by the process command
-    // referencing the MetalSharp home, an MS prefix/bottle path, or the
-    // metalsharp-wine wrapper itself.
-    if wine_process {
-        let owned = under_metalsharp_home
-            || command.contains("metalsharp-wine")
-            || lower.contains("prefix-steam")
-            || lower.contains("sharp-prefix")
-            || lower.contains("/bottles/")
-            || lower.contains("gogdl")
-            || lower.contains("heroic_gogdl");
-        return owned;
-    }
-
-    under_metalsharp_home
-        && (lower.contains("/runtime/")
-            || lower.contains("/bottles/")
-            || lower.contains("/prefix-steam/")
-            || lower.contains("gogdl")
-            || lower.contains("heroic_gogdl"))
+    // `ps` returns the executable followed by its arguments. Only the
+    // executable may establish ownership; paths in arguments are untrusted.
+    // This prevents commands such as `open <home>/runtime/.../some.exe` or
+    // `vim <home>/games/.../game.exe` from becoming kill targets merely by
+    // mentioning a MetalSharp path or a `.exe` suffix.
+    is_metalsharp_wine_executable(command, home)
+        || is_metalsharp_runtime_helper(command, home)
+        || is_metalsharp_owned_prefix_executable(command, home)
 }
 
 /// Minimal percent-decoding for URL query values (e.g. gameDir paths with
@@ -3502,17 +3547,30 @@ mod tests {
     }
 
     #[test]
-    fn force_kill_targets_metalsharp_wine_helpers_but_not_app_processes() {
-        let home = std::path::Path::new("/Users/test/.metalsharp");
+    fn force_kill_targets_owned_executables_but_not_path_arguments() {
+        let home = std::env::temp_dir().join("metalsharp-force-kill-test");
+        let runtime = |name: &str| home.join("runtime/wine/bin").join(name).to_string_lossy().into_owned();
+        let game = || home.join("games/620/game.exe").to_string_lossy().into_owned();
 
-        assert!(is_force_kill_target("/Users/test/.metalsharp/runtime/wine/bin/wineserver", home));
+        assert!(is_force_kill_target(&runtime("wineserver"), &home));
+        assert!(is_force_kill_target(&format!(r#"{} C:\windows\system32\wineboot.exe"#, runtime("wine64")), &home));
+        assert!(is_force_kill_target(&format!("{} Steam.exe", runtime("wine")), &home));
         assert!(is_force_kill_target(
-            "/Users/test/.metalsharp/runtime/wine/bin/wine64 C:\\windows\\system32\\wineboot.exe",
-            home
+            &home.join("prefix-steam/drive_c/Program Files (x86)/Steam/bin/steamwebhelper.exe").to_string_lossy(),
+            &home
         ));
-        assert!(is_force_kill_target("/Users/test/.metalsharp/runtime/wine/bin/wine Steam.exe", home));
-        assert!(!is_force_kill_target("/Applications/MetalSharp.app/Contents/MacOS/MetalSharp", home));
-        assert!(!is_force_kill_target("/Applications/Steam.app/Contents/MacOS/steam_osx", home));
+        assert!(is_force_kill_target(&game(), &home));
+        assert!(is_force_kill_target(&format!("{} --version", home.join("tools/gogdl").display()), &home));
+        assert!(!is_force_kill_target(&runtime("other.exe"), &home));
+        assert!(!is_force_kill_target(&format!("{}-evil/runtime/wine/bin/wine64", home.display()), &home));
+
+        // A path in an argument does not identify the executable that would
+        // be terminated. These are the false positives from issue #404.
+        assert!(!is_force_kill_target(&format!("vim {}.metalsharp-original", game()), &home));
+        assert!(!is_force_kill_target(&format!("open {}", runtime("some.exe")), &home));
+        assert!(!is_force_kill_target(&format!("/usr/local/bin/wine64 {}", game()), &home));
+        assert!(!is_force_kill_target("/Applications/MetalSharp.app/Contents/MacOS/MetalSharp", &home));
+        assert!(!is_force_kill_target("/Applications/Steam.app/Contents/MacOS/steam_osx", &home));
     }
 
     #[test]
@@ -3520,26 +3578,34 @@ mod tests {
         // Isolation contract: a foreign Wine launcher (CrossOver, SakuraGiri,
         // Whisky, GPTK) must never be killed by MetalSharp cleanup, even when
         // its command line contains wine/wineserver/wineloader tokens.
-        let home = std::path::Path::new("/Users/test/.metalsharp");
+        let home = std::env::temp_dir().join("metalsharp-force-kill-test");
+        let runtime = |name: &str| home.join("runtime/wine/bin").join(name).to_string_lossy().into_owned();
 
         assert!(!is_force_kill_target(
             "/Applications/CrossOver.app/Contents/SharedSupport/CrossOver/bin/wineserver -f",
-            home
+            &home
         ));
         assert!(!is_force_kill_target(
             "/Applications/CrossOver.app/Contents/SharedSupport/CrossOver/bin/wine64 C:\\windows\\system32\\wineboot.exe",
-            home
+            &home
         ));
         assert!(!is_force_kill_target(
-            "/Users/test/Library/Application Support/SakuraGiri/engine/wine/bin/wineloader",
-            home
+            "/Applications/SakuraGiri.app/Contents/Resources/engine/wine/bin/wineloader",
+            &home
         ));
-        assert!(!is_force_kill_target("/opt/homebrew/bin/wineserver", home));
-        assert!(!is_force_kill_target("/usr/local/bin/wine", home));
+        assert!(!is_force_kill_target("/opt/homebrew/bin/wineserver", &home));
+        assert!(!is_force_kill_target("/usr/local/bin/wine", &home));
+        assert!(!is_force_kill_target(
+            &format!(
+                "/Applications/CrossOver.app/Contents/SharedSupport/CrossOver/bin/wine64 {}",
+                home.join("games/620/game.exe").display()
+            ),
+            &home
+        ));
 
         // MS-owned processes must still be targeted.
-        assert!(is_force_kill_target("/Users/test/.metalsharp/runtime/wine/bin/wineserver -f", home));
-        assert!(is_force_kill_target("/Users/test/.metalsharp/runtime/wine/bin/metalsharp-wine Steam.exe", home));
+        assert!(is_force_kill_target(&format!("{} -f", runtime("wineserver")), &home));
+        assert!(is_force_kill_target(&format!("{} Steam.exe", runtime("metalsharp-wine")), &home));
     }
 
     #[test]

--- a/docs/runtime/wine-architecture.md
+++ b/docs/runtime/wine-architecture.md
@@ -164,11 +164,16 @@ Rules:
 3. **No foreign identity**: never export `CX_ROOT` (CrossOver's identity
    variable) or mimic another launcher's env vars.
 4. **Process ownership**: kill/cleanup logic (`stop_wine_steam`,
-   `is_force_kill_target`, `update.sh`, process-manager helper) targets only
-   processes whose command line references the MetalSharp home
-   (`~/.metalsharp/`), an MS prefix/bottle path, or `metalsharp-wine`. A bare
-   `wineserver`/`wineloader`/`wine64` name match is never sufficient — foreign
-   launchers run processes with those exact names.
+   `is_force_kill_target`, `update.sh`, process-manager helper) must prove
+   ownership from the process executable (`argv[0]`), not from arbitrary
+   command-line arguments. A target must use an allowlisted executable in
+   `~/.metalsharp/runtime/wine/bin/`, an explicitly allowlisted MetalSharp
+   runtime helper, or an executable under an MS-owned prefix, bottle, or game
+   root.
+   A MetalSharp path or `.exe` token appearing only in arguments is untrusted
+   and never establishes ownership. A bare `wineserver`/`wineloader`/`wine64`
+   name match is never sufficient — foreign launchers run processes with those
+   exact names.
 5. **Vulkan ICD**: `VK_ICD_FILENAMES` must resolve inside the runtime
    (`$MS_ROOT/etc/vulkan/icd.d/MoltenVK_icd.json`) or be unset — never a
    hardcoded Homebrew path, which is absent on CrossOver-only machines.


### PR DESCRIPTION
## Summary

Fixes #404 by making `/processes/force-kill` establish ownership from the process executable rather than arbitrary command-line text. This prevents unrelated tools such as `vim` or `open` from being terminated merely because an argument mentions a MetalSharp `.exe` or home path.

## Changes

- Parse `argv[0]` from `ps` output and use component-aware path checks.
- Restrict Wine matches to allowlisted binaries in MetalSharp's bundled `runtime/wine/bin` and preserve exact MetalSharp runtime helper matches.
- Keep executables launched from MetalSharp-owned prefix, bottle, and game roots eligible for cleanup.
- Add regression coverage for the reported false positives, foreign Wine arguments, path-boundary cases, and retained owned processes.
- Update the Wine isolation contract to document executable-only ownership proof.

## PR Readiness (MANDATORY)

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

## Local toolchain (run before push)

- [x] `cargo fmt --all -- --check` passes (Rust)
- [x] `cargo clippy --all-targets -- -D warnings` passes (Rust)
- [x] `cargo build --release` passes (Rust backend)
- [x] `cargo test` passes (Rust — 762 tests)
- [x] C++ compiles if changed: not applicable; no C++ files changed
- [x] `clang-format --dry-run --Werror` passes on any changed C/C++/Obj-C file: not applicable
- [x] `ctest --test-dir build-native` passes if tests changed: not applicable
- [x] TypeScript compiles if changed: not applicable; no TypeScript files changed
- [x] Biome + Prettier pass if TS/JS changed: not applicable; no TS/JS files changed
- [x] Shell scripts lint if changed: not applicable; no shell scripts changed
- [x] `tools/ci/validate-rules-toml.py` passes if `configs/mtsp-rules.toml` changed: not applicable
- [x] `python3 tools/ci/verify-dmg-workflow.py` passes if release/bundle tooling changed: not applicable
- [ ] Tested with at least one game (which one? which launch method? which drive?)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files should be added to the repo root; place them under `app/`, `tools/`, `tests/`, etc.

## Test notes

- Full Rust suite: `cargo test --quiet` — 762 passed, 0 failed.
- Rust formatting, clippy with `-D warnings`, and release build all passed.
- Real-game launch testing was not performed; this is a low-level process-matcher fix validated with focused regression tests in the isolated `/Volumes/AverySSD/MetalSharp-404-fix` checkout. The `checklist-exception` label is intentional for this non-launch change.

## Risk

The matcher is deliberately fail-closed: an unrecognized executable will be reported as a survivor rather than killed. Existing MetalSharp Wine, GOGDL, prefix, bottle, and game-root ownership paths remain covered. If a runtime process name is added later, extend the allowlist and regression tests; rollback is the single commit in this PR.
