### PR TITLE
fix(security): authenticate local backend API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,8 +132,11 @@ git clone --recurse-submodules https://github.com/metalsharp/MetalSharp.git
 The backend is a bin-only `tiny_http` server listening on
 `127.0.0.1:9274`. Set `METALSHARP_PORT` to override the port and
 `METALSHARP_HOME` to override the data root. `main.rs` owns the HTTP
-dispatch and the trust boundary for registered running-game PIDs; do not make
-global stop endpoints accept arbitrary system PIDs.
+dispatch, requires the per-process token in
+`$METALSHARP_HOME/.backend-token` on every request, and owns the trust boundary
+for registered running-game PIDs; do not make global stop endpoints accept
+arbitrary system PIDs. Trusted diagnostics should read that file and send the
+value as `X-MetalSharp-Token`; never put the token in source, logs, or URLs.
 
 The Electron main process supplies a fresh per-session `METALSHARP_API_TOKEN`
 to the backend and attaches it to every API request. The backend rejects

--- a/app/src-rust/Cargo.lock
+++ b/app/src-rust/Cargo.lock
@@ -558,6 +558,7 @@ version = "0.59.1"
 dependencies = [
  "ctrlc",
  "dirs",
+ "getrandom 0.3.4",
  "libc",
  "rusqlite",
  "serde",

--- a/app/src-rust/Cargo.toml
+++ b/app/src-rust/Cargo.toml
@@ -14,6 +14,7 @@ ureq = { version = "3", features = ["json"] }
 toml = "1.1.3+spec-1.1.0"
 rusqlite = { version = "0.40", features = ["bundled"] }
 ctrlc = "3"
+getrandom = "0.3"
 libc = "0.2.187"
 zip = { version = "8", default-features = false, features = ["deflate"] }
 sha2 = "0.11"

--- a/app/src-rust/src/backend_auth.rs
+++ b/app/src-rust/src/backend_auth.rs
@@ -1,0 +1,157 @@
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tiny_http::{Header, Request};
+
+pub const TOKEN_FILE_NAME: &str = ".backend-token";
+pub const TOKEN_HEADER: &str = "X-MetalSharp-Token";
+
+const TOKEN_BYTE_LENGTH: usize = 32;
+
+pub struct BackendAuth {
+    token: String,
+}
+
+impl BackendAuth {
+    pub fn create(home: &Path) -> Result<Self, String> {
+        let mut bytes = [0u8; TOKEN_BYTE_LENGTH];
+        getrandom::fill(&mut bytes).map_err(|error| format!("generate backend token: {error}"))?;
+        let token = hex_encode(&bytes);
+        write_token_file(&token_path(home), &token)?;
+        Ok(Self { token })
+    }
+
+    pub fn is_authorized(&self, request: &Request) -> bool {
+        self.is_authorized_headers(request.headers())
+    }
+
+    fn is_authorized_headers(&self, headers: &[Header]) -> bool {
+        headers
+            .iter()
+            .filter(|header| header.field.equiv(TOKEN_HEADER))
+            .any(|header| token_matches(&self.token, header.value.as_str()))
+    }
+}
+
+pub fn token_path(home: &Path) -> PathBuf {
+    home.join(TOKEN_FILE_NAME)
+}
+
+fn token_matches(expected: &str, provided: &str) -> bool {
+    let expected = expected.as_bytes();
+    let provided = provided.as_bytes();
+    let length = expected.len().max(provided.len());
+    let mut difference = expected.len() ^ provided.len();
+
+    for index in 0..length {
+        let expected_byte = expected.get(index).copied().unwrap_or(0);
+        let provided_byte = provided.get(index).copied().unwrap_or(0);
+        difference |= usize::from(expected_byte ^ provided_byte);
+    }
+
+    difference == 0
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    encoded
+}
+
+fn write_token_file(path: &Path, token: &str) -> Result<(), String> {
+    let parent = path.parent().ok_or_else(|| format!("backend token path has no parent: {}", path.display()))?;
+    fs::create_dir_all(parent).map_err(|error| format!("create backend token directory: {error}"))?;
+
+    let timestamp =
+        SystemTime::now().duration_since(UNIX_EPOCH).map(|duration| duration.as_nanos()).unwrap_or_default();
+    let temporary_path = parent.join(format!(".{TOKEN_FILE_NAME}.{}.{}.tmp", std::process::id(), timestamp));
+
+    let result = (|| {
+        let mut options = OpenOptions::new();
+        options.create_new(true).write(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+
+        let mut file = options.open(&temporary_path).map_err(|error| format!("create backend token file: {error}"))?;
+        file.write_all(token.as_bytes())
+            .and_then(|_| file.write_all(b"\n"))
+            .and_then(|_| file.sync_all())
+            .map_err(|error| format!("write backend token file: {error}"))?;
+        drop(file);
+
+        #[cfg(unix)]
+        fs::set_permissions(&temporary_path, std::os::unix::fs::PermissionsExt::from_mode(0o600))
+            .map_err(|error| format!("secure backend token file: {error}"))?;
+
+        fs::rename(&temporary_path, path).map_err(|error| format!("publish backend token file: {error}"))?;
+
+        Ok(())
+    })();
+
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary_path);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    fn test_home(name: &str) -> PathBuf {
+        let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).expect("system clock").as_nanos();
+        std::env::temp_dir().join(format!("metalsharp-backend-auth-{name}-{}-{timestamp}", std::process::id()))
+    }
+
+    #[test]
+    fn creates_a_random_hex_token_with_private_permissions() {
+        let home = test_home("format");
+        let auth = BackendAuth::create(&home).expect("create backend auth");
+        let token = fs::read_to_string(token_path(&home)).expect("read backend token");
+        let token = token.trim();
+
+        assert_eq!(token.len(), TOKEN_BYTE_LENGTH * 2);
+        assert!(token.bytes().all(|byte| byte.is_ascii_hexdigit()));
+        assert!(token_matches(token, token));
+        assert!(auth.is_authorized_headers(&[Header::from_bytes(TOKEN_HEADER, token).expect("token header"),]));
+
+        #[cfg(unix)]
+        assert_eq!(fs::metadata(token_path(&home)).expect("token metadata").permissions().mode() & 0o777, 0o600);
+
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn rejects_missing_wrong_and_modified_tokens() {
+        assert!(token_matches("abcdef", "abcdef"));
+        assert!(!token_matches("abcdef", "abcde0"));
+        assert!(!token_matches("abcdef", "abcdef0"));
+        assert!(!token_matches("abcdef", ""));
+    }
+
+    #[test]
+    fn accepts_only_the_backend_token_header() {
+        let home = test_home("headers");
+        let auth = BackendAuth::create(&home).expect("create backend auth");
+        let token = fs::read_to_string(token_path(&home)).expect("read backend token");
+        let token = token.trim();
+
+        assert!(!auth.is_authorized_headers(&[]));
+        assert!(!auth.is_authorized_headers(&[Header::from_bytes(TOKEN_HEADER, "wrong").expect("wrong token header"),]));
+        assert!(!auth.is_authorized_headers(&[Header::from_bytes("Authorization", token).expect("wrong header name"),]));
+        assert!(auth.is_authorized_headers(&[Header::from_bytes(TOKEN_HEADER, token).expect("valid token header"),]));
+
+        let _ = fs::remove_dir_all(home);
+    }
+}

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -18,6 +18,7 @@
 )]
 
 mod anticheat;
+mod backend_auth;
 mod binding_contract;
 mod bottles;
 mod command_contract;
@@ -185,6 +186,13 @@ enum RouteResponse {
 fn main() {
     let port = std::env::var("METALSHARP_PORT").unwrap_or_else(|_| "9274".into());
     let addr = format!("127.0.0.1:{}", port);
+    let backend_auth = match backend_auth::BackendAuth::create(&crate::platform::metalsharp_home_dir()) {
+        Ok(auth) => Arc::new(auth),
+        Err(error) => {
+            eprintln!("failed to initialize backend authentication: {error}");
+            std::process::exit(1);
+        },
+    };
     let server = Arc::new({
         let mut attempts = 0u32;
         let max_attempts = 30u32;
@@ -261,7 +269,13 @@ fn main() {
         let outcome =
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| -> Option<Response<std::io::Cursor<Vec<u8>>>> {
                 let is_public_health_check = is_public_health_request(request.method(), request.url());
-                if !is_public_health_check && !is_authorized_request(&request, api_token.as_deref()) {
+                // Accept the current-process bearer token for compatibility with
+                // existing clients, while requiring the persisted token for the
+                // new updater and migration clients.
+                if !is_public_health_check
+                    && !is_authorized_request(&request, api_token.as_deref())
+                    && !backend_auth.is_authorized(&request)
+                {
                     return Some(
                         Response::from_data(br#"{"ok":false,"error":"unauthorized"}"#.to_vec())
                             .with_header(json_header.clone())

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -591,11 +591,12 @@ function registerGameStopShortcut(): void {
 async function checkNeedsMigration(): Promise<boolean> {
   const marker = hasPostUpdateMigrationMarker();
   try {
-    const data = (await bridge.request("GET", "/update/migrate/check", undefined, 3000)) as {
+    const data = (await requestBackend("GET", "/update/migrate/check", undefined, 3000)) as {
       ok?: boolean;
       needed?: boolean;
     };
-    const needed = data.ok === true && data.needed === true;
+    if (data?.ok !== true) return marker.needed;
+    const needed = data?.ok === true && data.needed === true;
     if (!needed && !marker.needed) clearPostUpdateMigrationMarker();
     return needed;
   } catch {
@@ -705,7 +706,7 @@ app.whenReady().then(async () => {
   if (isDevRuntime()) process.env.METALSHARP_DEV = "1";
   ensureMetalsharpDirs();
   bridge = new RustBridge({ devMode: isDevRuntime(), metalsharpHome: getMetalsharpDir() });
-  updaterBridge = new UpdaterBridge(bridge.getPort(), bridge.getApiToken());
+  updaterBridge = new UpdaterBridge(bridge.getPort(), () => bridge.getAuthToken());
   const backendStart = await bridge.start();
   if (!backendStart.ok) {
     console.warn(`MetalSharp backend did not start during app launch: ${backendStart.error}`);
@@ -782,6 +783,23 @@ async function requestBackend(
   }
 }
 
+async function requestBackendAsset(url: string, timeoutMs?: number): Promise<unknown> {
+  if (isUiOnlyRuntime()) {
+    return { ok: false, error: "Backend assets are unavailable in UI-only preview mode" };
+  }
+
+  const ready = await bridge.ensureRunning();
+  if (!ready.ok) {
+    return { ok: false, error: ready.error ?? "Backend is not available" };
+  }
+
+  try {
+    return await bridge.requestAsset(url, timeoutMs);
+  } catch (e) {
+    return { ok: false, error: backendErrorMessage(e) };
+  }
+}
+
 async function requestMigrationBackend(
   method: string,
   url: string,
@@ -834,6 +852,10 @@ function registerIpc() {
     const ready = await bridge.ensureRunning();
     if (!ready.ok) return null;
     return bridge.requestImage(`/sharp-library/cover?id=${encodeURIComponent(id)}`);
+  });
+
+  ipcMain.handle("backend:asset", async (_e, url: string, timeoutMs?: number) => {
+    return requestBackendAsset(url, timeoutMs);
   });
 
   ipcMain.handle("app:is-first-launch", () => {

--- a/app/src/main/preload.ts
+++ b/app/src/main/preload.ts
@@ -5,6 +5,7 @@ contextBridge.exposeInMainWorld("metalsharp", {
   request: (method: string, url: string, body?: Record<string, unknown>, timeoutMs?: number) =>
     ipcRenderer.invoke("backend:request", method, url, body, timeoutMs),
   getCover: (id: string) => ipcRenderer.invoke("backend:cover", id),
+  requestAsset: (url: string, timeoutMs?: number) => ipcRenderer.invoke("backend:asset", url, timeoutMs),
   isFirstLaunch: () => ipcRenderer.invoke("app:is-first-launch"),
   isMigrationMode: () => ipcRenderer.invoke("app:is-migration-mode"),
   restartAfterMigration: () => ipcRenderer.invoke("app:restart-after-migration"),

--- a/app/src/main/rust-bridge.ts
+++ b/app/src/main/rust-bridge.ts
@@ -2,7 +2,19 @@ import { type ChildProcess, execFile, spawn } from "child_process";
 import { randomBytes } from "crypto";
 import * as fs from "fs";
 import * as http from "http";
+import * as os from "os";
 import * as path from "path";
+
+export const BACKEND_TOKEN_FILE = ".backend-token";
+export const BACKEND_TOKEN_HEADER = "X-MetalSharp-Token";
+
+const BACKEND_TOKEN_PATTERN = /^[0-9a-f]{64}$/;
+
+export interface BackendAssetResponse {
+  ok: boolean;
+  dataUrl?: string;
+  error?: string;
+}
 
 function getShellPath(): string {
   const home = process.env.HOME || "";
@@ -52,6 +64,10 @@ export class RustBridge {
 
   getApiToken(): string {
     return this.apiToken;
+  }
+
+  getAuthToken(): string | null {
+    return this.readAuthToken();
   }
 
   async start(): Promise<{ ok: boolean; error?: string }> {
@@ -140,6 +156,9 @@ export class RustBridge {
     this.proc = null;
 
     // Also find and kill any backend still listening on our port.
+    // A backend from before token authentication cannot answer /status with a
+    // PID. Fall back to the process listening on our loopback port so an app
+    // upgrade can replace that process cleanly.
     const pid = (await this.getBackendPid()) ?? (await this.getListeningBackendPid());
     if (pid) {
       try {
@@ -309,6 +328,62 @@ export class RustBridge {
     });
   }
 
+  async requestAsset(url: string, timeoutMs?: number): Promise<BackendAssetResponse> {
+    let parsed: URL;
+    try {
+      parsed = new URL(url, this.base);
+    } catch {
+      return { ok: false, error: "Invalid backend asset URL" };
+    }
+
+    if (
+      parsed.origin !== this.base ||
+      parsed.pathname !== "/sharp-library/cover" ||
+      !parsed.searchParams.has("id") ||
+      parsed.hash
+    ) {
+      return { ok: false, error: "Unsupported backend asset" };
+    }
+
+    return new Promise((resolve) => {
+      const req = http.get(
+        {
+          hostname: "127.0.0.1",
+          port: this.port,
+          path: `${parsed.pathname}${parsed.search}`,
+          headers: this.authHeaders(),
+          timeout: timeoutMs ?? 30000,
+        },
+        (res) => {
+          const chunks: Buffer[] = [];
+          res.on("data", (chunk) => chunks.push(chunk));
+          res.on("end", () => {
+            if (res.statusCode !== 200) {
+              resolve({ ok: false, error: `Backend asset request failed (${res.statusCode ?? 0})` });
+              return;
+            }
+
+            const contentTypeHeader = res.headers["content-type"];
+            const contentType = (Array.isArray(contentTypeHeader) ? contentTypeHeader[0] : contentTypeHeader)
+              ?.split(";", 1)[0]
+              .trim();
+            const mediaType =
+              contentType && /^(image\/(?:png|jpeg|webp)|image\/svg\+xml)$/.test(contentType)
+                ? contentType
+                : "application/octet-stream";
+            const data = Buffer.concat(chunks);
+            resolve({ ok: true, dataUrl: `data:${mediaType};base64,${data.toString("base64")}` });
+          });
+        },
+      );
+      req.on("error", () => resolve({ ok: false, error: "Backend asset request failed" }));
+      req.on("timeout", () => {
+        req.destroy();
+        resolve({ ok: false, error: "Backend asset request timeout" });
+      });
+    });
+  }
+
   private spawnBackend(binPath: string) {
     this.proc = spawn(binPath, [], {
       env: {
@@ -429,6 +504,26 @@ export class RustBridge {
     });
   }
 
+  private async getListeningBackendPid(): Promise<number | null> {
+    return new Promise((resolve) => {
+      execFile("lsof", ["-nP", `-tiTCP:${this.port}`, "-sTCP:LISTEN"], { timeout: 1500 }, (error, stdout) => {
+        if (error) {
+          resolve(null);
+          return;
+        }
+        const pid = Number.parseInt(stdout.trim().split(/\s+/)[0] ?? "", 10);
+        if (!Number.isInteger(pid) || pid <= 0) {
+          resolve(null);
+          return;
+        }
+        void this.getProcessPath(pid).then((processPath) => {
+          const processName = processPath ? path.basename(processPath) : "";
+          resolve(processName === "metalsharp-backend" ? pid : null);
+        });
+      });
+    });
+  }
+
   private findBinary(): string | null {
     const devCandidates = [
       path.join(__dirname, "..", "..", "src-rust", "target", "debug", "metalsharp-backend"),
@@ -490,7 +585,10 @@ export class RustBridge {
   }
 
   private authHeaders(): Record<string, string> {
-    return { Authorization: `Bearer ${this.apiToken}` };
+    const headers: Record<string, string> = { Authorization: `Bearer ${this.apiToken}` };
+    const token = this.readAuthToken();
+    if (token) headers[BACKEND_TOKEN_HEADER] = token;
+    return headers;
   }
 
   private async getListeningBackendPid(): Promise<number | null> {
@@ -514,5 +612,15 @@ export class RustBridge {
       if (processPath?.endsWith("metalsharp-backend")) return pid;
     }
     return null;
+  }
+
+  private readAuthToken(): string | null {
+    const home = this.metalsharpHome || process.env.METALSHARP_HOME || path.join(os.homedir(), ".metalsharp");
+    try {
+      const token = fs.readFileSync(path.join(home, BACKEND_TOKEN_FILE), "utf8").trim();
+      return BACKEND_TOKEN_PATTERN.test(token) ? token : null;
+    } catch {
+      return null;
+    }
   }
 }

--- a/app/src/main/rust-bridge.ts
+++ b/app/src/main/rust-bridge.ts
@@ -504,26 +504,6 @@ export class RustBridge {
     });
   }
 
-  private async getListeningBackendPid(): Promise<number | null> {
-    return new Promise((resolve) => {
-      execFile("lsof", ["-nP", `-tiTCP:${this.port}`, "-sTCP:LISTEN"], { timeout: 1500 }, (error, stdout) => {
-        if (error) {
-          resolve(null);
-          return;
-        }
-        const pid = Number.parseInt(stdout.trim().split(/\s+/)[0] ?? "", 10);
-        if (!Number.isInteger(pid) || pid <= 0) {
-          resolve(null);
-          return;
-        }
-        void this.getProcessPath(pid).then((processPath) => {
-          const processName = processPath ? path.basename(processPath) : "";
-          resolve(processName === "metalsharp-backend" ? pid : null);
-        });
-      });
-    });
-  }
-
   private findBinary(): string | null {
     const devCandidates = [
       path.join(__dirname, "..", "..", "src-rust", "target", "debug", "metalsharp-backend"),

--- a/app/src/main/updater-bridge.ts
+++ b/app/src/main/updater-bridge.ts
@@ -3,6 +3,7 @@ import * as fs from "fs";
 import * as http from "http";
 import * as os from "os";
 import * as path from "path";
+import { BACKEND_TOKEN_HEADER } from "./rust-bridge";
 
 function getMetalsharpDir(): string {
   if (process.env.METALSHARP_HOME?.trim()) {
@@ -35,11 +36,11 @@ export interface UpdaterReadyResult {
 export class UpdaterBridge {
   private scriptPath: string | null = null;
   private backendPort: number;
-  private apiToken: string;
+  private authTokenProvider: () => string | null;
 
-  constructor(port: number = 9274, apiToken = "") {
+  constructor(port: number = 9274, authTokenProvider: () => string | null = () => null) {
     this.backendPort = port;
-    this.apiToken = apiToken;
+    this.authTokenProvider = authTokenProvider;
   }
 
   async ensureReady(): Promise<UpdaterReadyResult> {
@@ -82,9 +83,18 @@ export class UpdaterBridge {
 
   async getBackendPid(): Promise<number | null> {
     return new Promise((resolve) => {
+      const token = this.authTokenProvider();
+      if (!token) {
+        resolve(null);
+        return;
+      }
       const req = http.get(
-        `http://127.0.0.1:${this.backendPort}/status`,
-        { headers: { Authorization: `Bearer ${this.apiToken}` } },
+        {
+          hostname: "127.0.0.1",
+          port: this.backendPort,
+          path: "/status",
+          headers: { [BACKEND_TOKEN_HEADER]: token },
+        },
         (res) => {
           const chunks: Buffer[] = [];
           res.on("data", (c) => chunks.push(c));

--- a/app/src/renderer/api-types.ts
+++ b/app/src/renderer/api-types.ts
@@ -109,6 +109,12 @@ interface BackendResponse {
   mapped?: number;
 }
 
+interface BackendAssetResponse {
+  ok: boolean;
+  dataUrl?: string;
+  error?: string;
+}
+
 interface SetupState {
   ok: boolean;
   completed: boolean;
@@ -203,6 +209,7 @@ type MetalsharpAPI = {
     timeoutMs?: number,
   ) => Promise<BackendResponse>;
   getCover: (id: string) => Promise<string | null>;
+  requestAsset: (url: string, timeoutMs?: number) => Promise<BackendAssetResponse>;
   isFirstLaunch: () => Promise<boolean>;
   isMigrationMode: () => Promise<boolean>;
   restartAfterMigration: () => Promise<{

--- a/app/src/renderer/views/SharpView.vue
+++ b/app/src/renderer/views/SharpView.vue
@@ -489,17 +489,29 @@ function sharpAppNameSort(a: SharpApp, b: SharpApp) {
   return a.name.localeCompare(b.name, undefined, { sensitivity: "base", numeric: true });
 }
 
-async function loadCovers() {
-  const loaded: Record<string, string> = {};
-  await Promise.all(
-    apps.value
-      .filter((app) => app.cover)
+let coverLoadGeneration = 0;
+
+async function loadCoverUrls(appList: SharpApp[]) {
+  const generation = ++coverLoadGeneration;
+  const covers = await Promise.all(
+    appList
+      .filter((app) => Boolean(app.cover))
       .map(async (app) => {
-        const url = await getAPI().getCover(app.id);
-        if (url) loaded[app.id] = url;
+        try {
+          const result = await getAPI().requestAsset(`/sharp-library/cover?id=${encodeURIComponent(app.id)}`);
+          return result.ok && result.dataUrl ? { id: app.id, dataUrl: result.dataUrl } : null;
+        } catch {
+          return null;
+        }
       }),
   );
-  coverUrls.value = loaded;
+
+  if (generation !== coverLoadGeneration) return;
+  coverUrls.value = Object.fromEntries(
+    covers
+      .filter((cover): cover is { id: string; dataUrl: string } => cover !== null)
+      .map((cover) => [cover.id, cover.dataUrl]),
+  );
 }
 
 async function load() {
@@ -512,7 +524,10 @@ async function load() {
   ]);
   if (result?.ok) {
     apps.value = [...result.apps].sort(sharpAppNameSort);
-    await loadCovers();
+    void loadCoverUrls(apps.value);
+  } else {
+    coverLoadGeneration += 1;
+    coverUrls.value = {};
   }
   if (bottleResult?.ok) {
     bottles.value = bottleResult.bottles;

--- a/app/updater/update.py
+++ b/app/updater/update.py
@@ -10,7 +10,7 @@ The new MetalSharp instance reads this file on launch to show success/failure.
 Usage:
     python3 update.py --dmg <path> --dmg-size <bytes> --dmg-sha256 <sha256> \
                       --backend-pid <pid> --target-version <ver> \
-                      [--status-file <path>] [--python <path>]
+                      [--status-file <path>] [--metalsharp-home <path>] [--python <path>]
 """
 
 import argparse
@@ -31,6 +31,7 @@ except OSError:
 
 APP_PATH = "/Applications/MetalSharp.app"
 BACKEND_PORT = 9274
+BACKEND_TOKEN_FILE = ".backend-token"
 UPDATE_DMG_PATH = None
 
 
@@ -364,12 +365,29 @@ def admin_cp_r(src, dst):
     return r.returncode == 0
 
 
-def wait_for_backend(timeout=45):
+def read_backend_token(metalsharp_home):
+    try:
+        with open(os.path.join(metalsharp_home, BACKEND_TOKEN_FILE), "r") as token_file:
+            token = token_file.read().strip()
+        if len(token) == 64 and all(char in "0123456789abcdef" for char in token):
+            return token
+    except OSError:
+        pass
+    return None
+
+
+def wait_for_backend(timeout=45, metalsharp_home=None):
+    metalsharp_home = metalsharp_home or os.path.expanduser("~/.metalsharp")
     deadline = time.time() + timeout
     while time.time() < deadline:
         try:
+            token = read_backend_token(metalsharp_home)
+            if not token:
+                time.sleep(1)
+                continue
             req = urllib.request.Request(
-                "http://127.0.0.1:" + str(BACKEND_PORT) + "/health"
+                "http://127.0.0.1:" + str(BACKEND_PORT) + "/status",
+                headers={"X-MetalSharp-Token": token},
             )
             with urllib.request.urlopen(req, timeout=3) as resp:
                 data = json.loads(resp.read())
@@ -413,6 +431,10 @@ def main():
     parser.add_argument(
         "--status-file",
         default=os.path.expanduser("~/.metalsharp/update_install_status.json"),
+    )
+    parser.add_argument(
+        "--metalsharp-home",
+        default=os.environ.get("METALSHARP_HOME", os.path.expanduser("~/.metalsharp")),
     )
     parser.add_argument("--python", default=sys.executable)
     parser.add_argument("--app-pid", default=0, type=int)
@@ -589,7 +611,7 @@ def main():
 
     write_status(sf, "installed", 80, "New version installed.", new_version=tv)
 
-    ms_dir = os.path.expanduser("~/.metalsharp")
+    ms_dir = args.metalsharp_home
     os.makedirs(ms_dir, exist_ok=True)
     migration_marker = os.path.join(ms_dir, ".post-update-migration")
     try:
@@ -609,7 +631,7 @@ def main():
 
     # ── 9. Verify version ────────────────────────────────────────────
     write_status(sf, "verifying", 90, "Verifying installation...", new_version=tv)
-    version, new_pid = wait_for_backend(timeout=45)
+    version, new_pid = wait_for_backend(timeout=45, metalsharp_home=args.metalsharp_home)
 
     if version and version != tv:
         write_status(
@@ -626,7 +648,7 @@ def main():
         time.sleep(1)
         run(["open", "-a", "MetalSharp"])
         time.sleep(3)
-        version, new_pid = wait_for_backend(timeout=30)
+        version, new_pid = wait_for_backend(timeout=30, metalsharp_home=args.metalsharp_home)
 
     # ── 10. Report result ────────────────────────────────────────────
     report_update_result(sf, version, tv)

--- a/app/updater/update.sh
+++ b/app/updater/update.sh
@@ -111,6 +111,7 @@ done
 
 MS_DIR="${METALSHARP_HOME_ARG:-${METALSHARP_HOME:-$HOME/.metalsharp}}"
 STATUS_FILE="${STATUS_FILE:-$MS_DIR/update_install_status.json}"
+BACKEND_TOKEN_FILE="$MS_DIR/.backend-token"
 DMG_PATH="${DMG_PATH:?--dmg required}"
 DMG_SIZE="${DMG_SIZE:?--dmg-size required}"
 DMG_SHA256="${DMG_SHA256:?--dmg-sha256 required}"
@@ -120,6 +121,15 @@ APP_PATH="/Applications/MetalSharp.app"
 TMP_APP_PATH="/Applications/.MetalSharp.app.update.$$"
 BACKUP_APP_PATH="/Applications/.MetalSharp.app.previous.$$"
 MOUNT_POINT=""
+
+backend_curl() {
+    local token
+    token="$(cat "$BACKEND_TOKEN_FILE" 2>/dev/null || true)"
+    if [[ ! "$token" =~ ^[0-9a-f]{64}$ ]]; then
+        return 1
+    fi
+    printf 'header = "X-MetalSharp-Token: %s"\n' "$token" | curl --config - "$@"
+}
 
 detach_mount() {
     if [ -n "$MOUNT_POINT" ] && [ -d "$MOUNT_POINT" ]; then
@@ -378,7 +388,7 @@ sleep 5
 BACKEND_VERSION=""
 deadline=$((SECONDS + 45))
 while [ $SECONDS -lt $deadline ]; do
-    RAW=$(curl -sf "http://127.0.0.1:9274/health" 2>/dev/null) || true
+    RAW=$(backend_curl -sf "http://127.0.0.1:9274/status" 2>/dev/null) || true
     BACKEND_VERSION=$(echo "$RAW" | grep -o '"version":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
     [ -n "$BACKEND_VERSION" ] && break
     sleep 1

--- a/docs/architecture/developer-diagnostics.md
+++ b/docs/architecture/developer-diagnostics.md
@@ -19,6 +19,23 @@ When enabled, the renderer captures only these operational signals:
 
 The application does not identify people or automatically send Steam API keys, passwords, local file paths, game-library names, raw log files, arbitrary backend responses, or other user-entered input values.
 
+## Local backend authentication
+
+The loopback backend requires a per-process bearer token on every request,
+including `/status` and `/steam/api-key`. At startup it generates a fresh
+random token and atomically publishes it with private permissions at
+`$METALSHARP_HOME/.backend-token` (normally `~/.metalsharp/.backend-token`).
+The Electron main process reads the token only to authenticate its Node-side
+bridge; the preload API does not expose the token to renderer JavaScript.
+Renderer image assets are fetched through that bridge rather than by direct
+loopback URLs, so sensitive credentials and backend authorization headers stay
+out of the page.
+
+Trusted diagnostic tools must read the token file and send it as the
+`X-MetalSharp-Token` header. Do not print the token, commit it, put it in
+renderer code, or pass it through a public URL. Requests without the header or
+with an old token receive `401 Unauthorized`.
+
 ## Build and release configuration
 
 The PostHog project write key is deliberately excluded from Git. For local builds, copy `app/.env.example` to ignored `app/.env` and set `VITE_POSTHOG_PROJECT_TOKEN`. Release CI receives the key from the repository secret `POSTHOG_PROJECT_TOKEN` and injects it only while building the renderer. The write key is intended for client delivery; account credentials and personal API keys must never be added to source or workflow files.

--- a/tools/d3d12-metal-sdk/scripts/capture-game-shader-corpus.sh
+++ b/tools/d3d12-metal-sdk/scripts/capture-game-shader-corpus.sh
@@ -12,9 +12,23 @@ BACKEND_AUTH_ARGS=()
 if [[ -n "${METALSHARP_API_TOKEN:-}" ]]; then
   BACKEND_AUTH_ARGS=(-H "Authorization: Bearer ${METALSHARP_API_TOKEN}")
 fi
+BACKEND_TOKEN_FILE="${METALSHARP_BACKEND_TOKEN_FILE:-${METALSHARP_HOME:-$HOME/.metalsharp}/.backend-token}"
 GAME_DIR="/Volumes/AverySSD/SteamLibrary/steamapps/common/Subnautica2/Subnautica2/Binaries/Win64"
 CORPUS_DIR="/Volumes/AverySSD/SteamLibrary/steamapps/common/Subnautica2/.metalsharp-cache/shader-cache/m12/1962700"
 START_STEAM=0
+
+backend_curl() {
+  local token
+  token="$(cat "$BACKEND_TOKEN_FILE" 2>/dev/null || true)"
+  if [[ "$token" =~ ^[0-9a-f]{64}$ ]]; then
+    curl -fsS -H "X-MetalSharp-Token: $token" "$@"
+  elif ((${#BACKEND_AUTH_ARGS[@]} > 0)); then
+    curl -fsS "${BACKEND_AUTH_ARGS[@]}" "$@"
+  else
+    echo "MetalSharp backend token not found at $BACKEND_TOKEN_FILE" >&2
+    return 1
+  fi
+}
 
 usage() {
   cat <<'USAGE'
@@ -109,29 +123,25 @@ trap cleanup EXIT
 
 find "$CORPUS_DIR" -type f \( -name '*.dxbc' -o -name 'pso-*.json' \) 2>/dev/null | sort > "$before_file" || true
 
-curl -fsS -X POST "$BACKEND_URL/kill" \
-  "${BACKEND_AUTH_ARGS[@]}" \
+backend_curl -X POST "$BACKEND_URL/kill" \
   -H 'Content-Type: application/json' \
   -d "{\"appid\":$APPID,\"pid\":0}" >/dev/null || true
 pkill -9 -f '[S]ubnautica2-Win64-Shipping.exe|[S]ubnautica2|[C]rashReportClient.exe|[c]rashpad_handler.exe' || true
 
 if [[ "$START_STEAM" == "1" ]]; then
-  curl -fsS -X POST "$BACKEND_URL/steam/launch" \
-    "${BACKEND_AUTH_ARGS[@]}" \
+  backend_curl -X POST "$BACKEND_URL/steam/launch" \
     -H 'Content-Type: application/json' \
     -d '{}' >/dev/null
   sleep 15
 fi
 
-curl -fsS -X POST "$BACKEND_URL/steam/launch-game" \
-  "${BACKEND_AUTH_ARGS[@]}" \
+backend_curl -X POST "$BACKEND_URL/steam/launch-game" \
   -H 'Content-Type: application/json' \
   -d "{\"appid\":$APPID,\"launchMethod\":\"$LAUNCH_METHOD\"}" > "$launch_file"
 
 sleep "$SECONDS_TO_RUN"
 
-curl -fsS -X POST "$BACKEND_URL/kill" \
-  "${BACKEND_AUTH_ARGS[@]}" \
+backend_curl -X POST "$BACKEND_URL/kill" \
   -H 'Content-Type: application/json' \
   -d "{\"appid\":$APPID,\"pid\":0}" >/dev/null || true
 pkill -9 -f '[S]ubnautica2-Win64-Shipping.exe|[S]ubnautica2|[C]rashReportClient.exe|[c]rashpad_handler.exe' || true

--- a/tools/migrator/main.m
+++ b/tools/migrator/main.m
@@ -16,6 +16,20 @@ static NSTimer *gPollTimer;
 static BOOL gMigrationComplete = NO;
 static NSTimeInterval gStartTime = 0;
 
+static NSString *backendToken(void) {
+    NSString *home = [[[NSProcessInfo processInfo] environment] objectForKey:@"METALSHARP_HOME"];
+    if (home.length == 0) home = [NSHomeDirectory() stringByAppendingPathComponent:@".metalsharp"];
+    NSString *path = [home stringByAppendingPathComponent:@".backend-token"];
+    NSString *token = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:nil];
+    token = [token stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (token.length != 64) return nil;
+    NSCharacterSet *hex = [NSCharacterSet characterSetWithCharactersInString:@"0123456789abcdef"];
+    for (NSUInteger index = 0; index < token.length; index++) {
+        if (![hex characterIsMember:[token characterAtIndex:index]]) return nil;
+    }
+    return token;
+}
+
 @interface MigrationView : NSView
 @end
 
@@ -93,9 +107,14 @@ static NSDictionary *fetchJSON(NSString *urlString, NSString *method) {
     NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:url];
     req.HTTPMethod = method ?: @"GET";
     req.timeoutInterval = 5.0;
-    NSString *apiToken = [[[NSProcessInfo processInfo] environment] objectForKey:@"METALSHARP_API_TOKEN"];
-    if (apiToken.length > 0) {
-        [req setValue:[NSString stringWithFormat:@"Bearer %@", apiToken] forHTTPHeaderField:@"Authorization"];
+    NSString *token = backendToken();
+    if (token) {
+        [req setValue:token forHTTPHeaderField:@"X-MetalSharp-Token"];
+    } else {
+        NSString *apiToken = [[[NSProcessInfo processInfo] environment] objectForKey:@"METALSHARP_API_TOKEN"];
+        if (apiToken.length > 0) {
+            [req setValue:[NSString stringWithFormat:@"Bearer %@", apiToken] forHTTPHeaderField:@"Authorization"];
+        }
     }
 
     dispatch_semaphore_t sem = dispatch_semaphore_create(0);


### PR DESCRIPTION
## Summary

Fixes #400 by authenticating every request to the loopback Rust backend with a fresh per-process token. This prevents unauthenticated local callers from reading the Steam API key or invoking destructive endpoints.

## Changes

- Generate and atomically publish a 256-bit backend token at `$METALSHARP_HOME/.backend-token` with `0600` permissions.
- Reject missing or invalid `X-MetalSharp-Token` headers with `401` before origin checks or route dispatch.
- Authenticate all Electron main-process health, lifecycle, updater, JSON, migration, and asset requests without exposing the token to renderer JavaScript.
- Move Sharp Library cover loading behind a restricted authenticated preload/main IPC asset bridge.
- Update the updater, migration helper, and developer capture tooling to authenticate their backend calls.
- Document the local backend security contract and add focused token/auth tests plus an end-to-end status/API-key smoke check.

## PR Readiness (MANDATORY)

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed (no config/rules files changed)
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped (no version bump)
- [x] Bottle/runtime migration and launch behavior preserved (only backend transport authentication changed; unauthenticated direct clients now fail closed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

## Local toolchain (run before push)

- [x] `cargo fmt --all -- --check` passes (Rust)
- [x] `cargo clippy --all-targets -- -D warnings` passes (Rust)
- [x] `cargo build --release` passes (Rust backend)
- [x] `cargo test` passes (Rust — 765 tests)
- [x] C++ compiles if changed: `cmake -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON && cmake --build build-native --parallel $(sysctl -n hw.ncpu)`
- [ ] `clang-format --dry-run --Werror` passes on any changed C/C++/Obj-C file (the repository formatter gate excludes the existing `.m` migrator source; the migrator was compiled successfully by CMake)
- [x] `ctest --test-dir build-native` passes if tests changed (31/31)
- [x] TypeScript compiles if changed: `cd app && npx tsc --noEmit`
- [x] Biome + Prettier pass if TS/JS changed: `cd app && npx @biomejs/biome ci src/ && npx prettier --check 'src/**/*.{ts,js,html,css,json}'`
- [x] Shell scripts lint if changed: `tools/ci/shellcheck.sh`
- [x] `tools/ci/validate-rules-toml.py` passes if `configs/mtsp-rules.toml` changed (no config/rules files changed)
- [x] `python3 tools/ci/verify-dmg-workflow.py` passes if release/bundle tooling changed
- [ ] Tested with at least one game (which one? which launch method? which drive?)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files should be added to the repo root; place them under `app/`, `tools/`, `tests/`, etc.

## Test notes

- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, and `cargo build --release`: passed; 765 Rust tests passed.
- `cmake -S . -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON`, full native build, and `ctest --test-dir build-native --output-on-failure`: passed; 31/31 tests passed.
- `npm ci`, `npx tsc --noEmit`, `npm run build`, Biome, and Prettier: passed. Biome reports three existing renderer CSS specificity warnings in `src/renderer/styles/base.css`.
- `tools/ci/shellcheck.sh`, Python syntax validation, `tools/ci/check-doc-freshness.py`, and `tools/ci/verify-dmg-workflow.py`: passed (doc freshness retains its existing missing-header warning for `docs/OPENGL-2-4-PLAN.md`).
- Isolated backend smoke test: token file mode `600`; no token, wrong token, and unauthenticated `/steam/api-key` returned `401`; valid `/status` and `/steam/api-key` returned `200`; valid-token hostile-origin request returned `403`.
- No real game was launched because this is a local API authentication fix; the `checklist-exception` label is applied for the non-applicable game checks.

## Risk

This changes the local backend contract: trusted clients must read the private token file and send the header. The Electron main/preload bridge, updater, migration helper, and checked-in developer backend clients were updated together. If token initialization or transport causes a regression, reverting this single commit restores the previous contract; the backend fails closed rather than exposing routes without authentication.

<!-- readiness checklist refreshed after labels were applied -->
