### PR TITLE
fix(api): secure local backend requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,14 @@ The backend is a bin-only `tiny_http` server listening on
 dispatch and the trust boundary for registered running-game PIDs; do not make
 global stop endpoints accept arbitrary system PIDs.
 
+The Electron main process supplies a fresh per-session `METALSHARP_API_TOKEN`
+to the backend and attaches it to every API request. The backend rejects
+missing or invalid bearer tokens before dispatching routes; `/health` is the
+only unauthenticated endpoint and returns version/readiness information only.
+Browser origins are defense-in-depth and are limited to the fixed Vite origins
+(`http://localhost:5173` and `http://127.0.0.1:5173`); packaged Electron UI
+requests use the main-process bridge rather than direct browser CORS.
+
 The backend's important layers are:
 
 - `mtsp/engine.rs` defines public and internal pipeline nodes.
@@ -402,6 +410,10 @@ With a backend running on `127.0.0.1:9274`, these are the preferred diagnostic
 checks before and after route/runtime work. Dry-run/artifact endpoints are
 read-only; doctor and preparation endpoints may stage files, run probes, or
 write logs, so use an isolated `METALSHARP_HOME`/prefix when appropriate:
+
+Direct diagnostic requests must include `Authorization: Bearer
+$METALSHARP_API_TOKEN`; the Electron bridge adds this header automatically.
+Only `GET /health` is intentionally public for updater/readiness checks.
 
 | Endpoint | Purpose |
 |---|---|

--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -52,6 +52,9 @@ use tiny_http::{Header, Method, Response, Server};
 static RUNNING_GAMES: OnceLock<Mutex<HashMap<u32, i32>>> = OnceLock::new();
 static ISSUE_LOG_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+const API_TOKEN_ENV: &str = "METALSHARP_API_TOKEN";
+const TRUSTED_DEV_ORIGINS: [&str; 2] = ["http://localhost:5173", "http://127.0.0.1:5173"];
+
 fn running_games() -> &'static Mutex<HashMap<u32, i32>> {
     RUNNING_GAMES.get_or_init(|| Mutex::new(HashMap::new()))
 }
@@ -179,8 +182,11 @@ fn main() {
         let _ = kernel_translation::ipc_bridge::start_ipc_listener();
     }
 
-    let cors_header = Header::from_bytes(&b"Access-Control-Allow-Origin"[..], &b"*"[..]).unwrap();
     let json_header = Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..]).unwrap();
+    let api_token = configured_api_token();
+    if api_token.is_none() {
+        eprintln!("{API_TOKEN_ENV} is missing or invalid; refusing backend requests");
+    }
 
     loop {
         let mut request = match server.recv() {
@@ -194,19 +200,27 @@ fn main() {
         // process down (the app has no live-session supervisor).
         let outcome =
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| -> Option<Response<std::io::Cursor<Vec<u8>>>> {
-                // Local-API origin guard (H9): the Electron renderer talks to this
-                // backend through the preload bridge, which sends no Origin header
-                // (Node http.request). Any request carrying a browser Origin must be
-                // from a trusted local origin (dev server / file://). Everything else
-                // is a cross-origin webpage trying to reach the local API (DNS
-                // rebinding / CSRF) and gets 403 before any route logic runs.
+                let is_public_health_check = is_public_health_request(request.method(), request.url());
+                if !is_public_health_check && !is_authorized_request(&request, api_token.as_deref()) {
+                    return Some(
+                        Response::from_data(br#"{"ok":false,"error":"unauthorized"}"#.to_vec())
+                            .with_header(json_header.clone())
+                            .with_status_code(401),
+                    );
+                }
+
+                // Local-API origin guard (H9): Electron reaches the backend
+                // through the main-process bridge and sends no Origin header.
+                // If a browser client is used during development, only the
+                // fixed Vite origins are accepted. `null`, `file://`, arbitrary
+                // localhost ports, and attacker-controlled origins are rejected.
                 let origin = request
                     .headers()
                     .iter()
                     .find(|h| h.field.equiv("Origin"))
-                    .map(|h| h.value.as_str().trim())
+                    .map(|h| h.value.as_str().trim().to_string())
                     .filter(|o| !o.is_empty());
-                if let Some(origin) = origin {
+                if let Some(origin) = origin.as_deref() {
                     if !is_trusted_local_origin(origin) {
                         eprintln!("rejected cross-origin request from {origin}");
                         return Some(
@@ -215,42 +229,9 @@ fn main() {
                                 .with_status_code(403),
                         );
                     }
-                    // Trusted browser origin: echo it back (never the wildcard), so
-                    // responses are readable only by the page that owns that origin.
-                    if let Ok(echo) = Header::from_bytes(&b"Access-Control-Allow-Origin"[..], origin.as_bytes()) {
-                        let resp = match route(&mut request) {
-                            RouteResponse::Json(code, body) => Response::from_data(body)
-                                .with_header(echo)
-                                .with_header(json_header.clone())
-                                .with_status_code(code),
-                            RouteResponse::Raw(code, data, mime) => {
-                                let content_header = Header::from_bytes(&b"Content-Type"[..], mime.as_bytes())
-                                    .unwrap_or_else(|_| json_header.clone());
-                                Response::from_data(data)
-                                    .with_header(echo)
-                                    .with_header(content_header)
-                                    .with_status_code(code)
-                            },
-                        };
-                        return Some(resp);
-                    }
                 }
 
-                let route_resp = route(&mut request);
-                Some(match route_resp {
-                    RouteResponse::Json(code, body) => Response::from_data(body)
-                        .with_header(cors_header.clone())
-                        .with_header(json_header.clone())
-                        .with_status_code(code),
-                    RouteResponse::Raw(code, data, mime) => {
-                        let content_header = Header::from_bytes(&b"Content-Type"[..], mime.as_bytes())
-                            .unwrap_or_else(|_| json_header.clone());
-                        Response::from_data(data)
-                            .with_header(cors_header.clone())
-                            .with_header(content_header)
-                            .with_status_code(code)
-                    },
-                })
+                Some(response_for_route(route(&mut request), &json_header, origin.as_deref()))
             }));
         match outcome {
             Ok(Some(resp)) => {
@@ -263,10 +244,8 @@ fn main() {
                 app_log(&format!("request handler panicked: {}", msg));
                 let safe = msg.replace('"', "'").replace('\\', "/");
                 let body = format!(r#"{{"ok":false,"error":"internal handler panic: {}"}}"#, safe);
-                let resp = Response::from_data(body.into_bytes())
-                    .with_header(cors_header.clone())
-                    .with_header(json_header.clone())
-                    .with_status_code(500);
+                let resp =
+                    Response::from_data(body.into_bytes()).with_header(json_header.clone()).with_status_code(500);
                 let _ = request.respond(resp);
             },
         }
@@ -283,26 +262,93 @@ fn panic_payload_message(payload: &Box<dyn std::any::Any + Send>) -> String {
     }
 }
 
-/// True when a browser `Origin` header is allowed to call the local API:
-/// the Electron dev server (Vite) and the packaged `file://` surface. All
-/// other origins (any https/http web page, or a `localhost.attacker.com`
-/// lookalike) are rejected.
-fn is_trusted_local_origin(origin: &str) -> bool {
-    if origin == "file://" || origin == "null" {
-        return true;
+fn configured_api_token() -> Option<String> {
+    let token = std::env::var(API_TOKEN_ENV).ok()?;
+    if token.len() < 32 || !token.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return None;
     }
-    let lower = origin.to_ascii_lowercase();
-    for prefix in ["http://localhost:", "http://127.0.0.1:"] {
-        if let Some(port) = lower.strip_prefix(prefix) {
-            // Port must be 1-5 ASCII digits and a valid TCP port (<= 65535):
-            // no path, no host trick, no overflow.
-            if port.is_empty() || port.len() > 5 || !port.bytes().all(|b| b.is_ascii_digit()) {
-                return false;
-            }
-            return port.parse::<u32>().map(|p| p <= 65535).unwrap_or(false);
+    Some(token)
+}
+
+fn request_authorization(request: &tiny_http::Request) -> Option<&str> {
+    request
+        .headers()
+        .iter()
+        .find(|header| header.field.equiv("Authorization"))
+        .map(|header| header.value.as_str().trim())
+}
+
+fn constant_time_token_eq(expected: &str, provided: &str) -> bool {
+    let expected_bytes = expected.as_bytes();
+    let provided_bytes = provided.as_bytes();
+    let max_len = expected_bytes.len().max(provided_bytes.len());
+    let mut difference = expected_bytes.len() ^ provided_bytes.len();
+    for index in 0..max_len {
+        let left = expected_bytes.get(index).copied().unwrap_or(0);
+        let right = provided_bytes.get(index).copied().unwrap_or(0);
+        difference |= usize::from(left ^ right);
+    }
+    difference == 0
+}
+
+fn is_authorized_bearer(authorization: Option<&str>, expected_token: Option<&str>) -> bool {
+    let Some(expected_token) = expected_token else {
+        return false;
+    };
+    let Some(authorization) = authorization else {
+        return false;
+    };
+    let Some(provided_token) = authorization.strip_prefix("Bearer ") else {
+        return false;
+    };
+    constant_time_token_eq(expected_token, provided_token)
+}
+
+fn is_authorized_request(request: &tiny_http::Request, expected_token: Option<&str>) -> bool {
+    is_authorized_bearer(request_authorization(request), expected_token)
+}
+
+fn is_public_health_request(method: &Method, url: &str) -> bool {
+    method == &Method::Get && url.split('?').next().unwrap_or(url) == "/health"
+}
+
+fn response_with_trusted_origin(
+    response: Response<std::io::Cursor<Vec<u8>>>,
+    origin: Option<&str>,
+) -> Response<std::io::Cursor<Vec<u8>>> {
+    if let Some(origin) = origin.filter(|origin| is_trusted_local_origin(origin)) {
+        if let Ok(header) = Header::from_bytes(&b"Access-Control-Allow-Origin"[..], origin.as_bytes()) {
+            return response.with_header(header);
         }
     }
-    false
+    response
+}
+
+fn response_for_route(
+    route_response: RouteResponse,
+    json_header: &Header,
+    origin: Option<&str>,
+) -> Response<std::io::Cursor<Vec<u8>>> {
+    match route_response {
+        RouteResponse::Json(code, body) => response_with_trusted_origin(
+            Response::from_data(body).with_header(json_header.clone()).with_status_code(code),
+            origin,
+        ),
+        RouteResponse::Raw(code, data, mime) => {
+            let content_header =
+                Header::from_bytes(&b"Content-Type"[..], mime.as_bytes()).unwrap_or_else(|_| json_header.clone());
+            response_with_trusted_origin(
+                Response::from_data(data).with_header(content_header).with_status_code(code),
+                origin,
+            )
+        },
+    }
+}
+
+/// True only for the fixed Vite development origins. Packaged Electron
+/// requests use the main-process bridge and intentionally carry no Origin.
+fn is_trusted_local_origin(origin: &str) -> bool {
+    TRUSTED_DEV_ORIGINS.iter().any(|trusted| origin.eq_ignore_ascii_case(trusted))
 }
 
 fn route(req: &mut tiny_http::Request) -> RouteResponse {
@@ -311,6 +357,7 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
     let path = url.split('?').next().unwrap_or(&url);
 
     match (method, path) {
+        (Method::Get, "/health") => resp(200, json!({"ok": true, "version": env!("CARGO_PKG_VERSION")})),
         (Method::Get, "/status") => {
             app_log("Backend status checked");
             resp(
@@ -3180,25 +3227,41 @@ mod tests {
     use super::*;
 
     #[test]
-    fn local_origin_guard_accepts_only_trusted_local_origins() {
-        // Trusted: dev server, packaged surface, and no-origin (Electron
-        // bridge sends none; CLI/curl send none).
+    fn local_origin_guard_accepts_only_pinned_vite_origins() {
+        // Browser access is limited to the actual Vite development server.
         assert!(is_trusted_local_origin("http://localhost:5173"));
-        assert!(is_trusted_local_origin("http://localhost:9274"));
         assert!(is_trusted_local_origin("http://127.0.0.1:5173"));
-        assert!(is_trusted_local_origin("file://"));
-        assert!(is_trusted_local_origin("null"));
 
-        // Rejected: any real web page, and host/port tricks.
+        // Rejected: opaque/file origins, arbitrary localhost ports, and host tricks.
+        assert!(!is_trusted_local_origin("file://"));
+        assert!(!is_trusted_local_origin("null"));
+        assert!(!is_trusted_local_origin("http://localhost:9274"));
+        assert!(!is_trusted_local_origin("http://localhost:5174"));
         assert!(!is_trusted_local_origin("https://evil.example"));
         assert!(!is_trusted_local_origin("http://evil.example"));
         assert!(!is_trusted_local_origin("http://localhost.evil.example"));
         assert!(!is_trusted_local_origin("http://localhost:5173.evil.example"));
         assert!(!is_trusted_local_origin("http://localhost:5173/path"));
-        assert!(!is_trusted_local_origin("http://localhost:"));
-        assert!(!is_trusted_local_origin("http://localhost:99999"));
-        assert!(!is_trusted_local_origin("http://localhost:5173a"));
         assert!(!is_trusted_local_origin("https://localhost:5173"));
+    }
+
+    #[test]
+    fn api_requires_the_current_session_bearer_token() {
+        let token = "0123456789abcdef0123456789abcdef";
+        assert!(is_authorized_bearer(Some("Bearer 0123456789abcdef0123456789abcdef"), Some(token)));
+        assert!(!is_authorized_bearer(None, Some(token)));
+        assert!(!is_authorized_bearer(Some("Bearer wrong"), Some(token)));
+        assert!(!is_authorized_bearer(Some("Basic 0123456789abcdef0123456789abcdef"), Some(token)));
+        assert!(!is_authorized_bearer(Some("bearer 0123456789abcdef0123456789abcdef"), Some(token)));
+        assert!(!is_authorized_bearer(Some("Bearer 0123456789abcdef0123456789abcdef"), None));
+    }
+
+    #[test]
+    fn only_read_only_health_check_is_public() {
+        assert!(is_public_health_request(&Method::Get, "/health"));
+        assert!(is_public_health_request(&Method::Get, "/health?probe=1"));
+        assert!(!is_public_health_request(&Method::Get, "/status"));
+        assert!(!is_public_health_request(&Method::Post, "/health"));
     }
 
     #[test]

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -1,7 +1,6 @@
 import { execFile, execFileSync, spawn } from "child_process";
 import { app, BrowserWindow, clipboard, dialog, globalShortcut, ipcMain, shell } from "electron";
 import * as fs from "fs";
-import * as http from "http";
 import * as os from "os";
 import * as path from "path";
 import { ejectDmgVolume } from "./dmg-eject";
@@ -591,27 +590,17 @@ function registerGameStopShortcut(): void {
 
 async function checkNeedsMigration(): Promise<boolean> {
   const marker = hasPostUpdateMigrationMarker();
-  return new Promise((resolve) => {
-    const req = http.get("http://127.0.0.1:9274/update/migrate/check", (res) => {
-      const chunks: Buffer[] = [];
-      res.on("data", (c) => chunks.push(c));
-      res.on("end", () => {
-        try {
-          const data = JSON.parse(Buffer.concat(chunks).toString());
-          const needed = data.ok && data.needed === true;
-          if (!needed && !marker.needed) clearPostUpdateMigrationMarker();
-          resolve(needed);
-        } catch {
-          resolve(marker.needed);
-        }
-      });
-    });
-    req.on("error", () => resolve(marker.needed));
-    req.setTimeout(3000, () => {
-      req.destroy();
-      resolve(marker.needed);
-    });
-  });
+  try {
+    const data = (await bridge.request("GET", "/update/migrate/check", undefined, 3000)) as {
+      ok?: boolean;
+      needed?: boolean;
+    };
+    const needed = data.ok === true && data.needed === true;
+    if (!needed && !marker.needed) clearPostUpdateMigrationMarker();
+    return needed;
+  } catch {
+    return marker.needed;
+  }
 }
 
 async function createWindow(migrating = false) {
@@ -716,7 +705,7 @@ app.whenReady().then(async () => {
   if (isDevRuntime()) process.env.METALSHARP_DEV = "1";
   ensureMetalsharpDirs();
   bridge = new RustBridge({ devMode: isDevRuntime(), metalsharpHome: getMetalsharpDir() });
-  updaterBridge = new UpdaterBridge(bridge.getPort());
+  updaterBridge = new UpdaterBridge(bridge.getPort(), bridge.getApiToken());
   const backendStart = await bridge.start();
   if (!backendStart.ok) {
     console.warn(`MetalSharp backend did not start during app launch: ${backendStart.error}`);
@@ -831,6 +820,21 @@ function registerIpc() {
       return requestBackend(method, url, body, timeoutMs);
     },
   );
+  ipcMain.handle("backend:cover", async (_e, id: string) => {
+    if (
+      isUiOnlyRuntime() ||
+      isProcessManagerOnlyRuntime() ||
+      !bridge ||
+      typeof id !== "string" ||
+      id.length === 0 ||
+      id.length > 256
+    ) {
+      return null;
+    }
+    const ready = await bridge.ensureRunning();
+    if (!ready.ok) return null;
+    return bridge.requestImage(`/sharp-library/cover?id=${encodeURIComponent(id)}`);
+  });
 
   ipcMain.handle("app:is-first-launch", () => {
     if (isUiOnlyRuntime() || isDevPreviewRuntime()) return false;

--- a/app/src/main/preload.ts
+++ b/app/src/main/preload.ts
@@ -4,6 +4,7 @@ import type { ProcessManagerAction } from "./process-manager-types";
 contextBridge.exposeInMainWorld("metalsharp", {
   request: (method: string, url: string, body?: Record<string, unknown>, timeoutMs?: number) =>
     ipcRenderer.invoke("backend:request", method, url, body, timeoutMs),
+  getCover: (id: string) => ipcRenderer.invoke("backend:cover", id),
   isFirstLaunch: () => ipcRenderer.invoke("app:is-first-launch"),
   isMigrationMode: () => ipcRenderer.invoke("app:is-migration-mode"),
   restartAfterMigration: () => ipcRenderer.invoke("app:restart-after-migration"),

--- a/app/src/main/rust-bridge.ts
+++ b/app/src/main/rust-bridge.ts
@@ -1,4 +1,5 @@
-import { type ChildProcess, spawn } from "child_process";
+import { type ChildProcess, execFile, spawn } from "child_process";
+import { randomBytes } from "crypto";
 import * as fs from "fs";
 import * as http from "http";
 import * as path from "path";
@@ -34,6 +35,7 @@ export class RustBridge {
   private startPromise: Promise<{ ok: boolean; error?: string }> | null = null;
   private devMode: boolean;
   private metalsharpHome?: string;
+  private readonly apiToken: string;
 
   constructor(options: RustBridgeOptions = {}) {
     this.devMode = options.devMode === true || process.env.METALSHARP_DEV === "1";
@@ -41,10 +43,15 @@ export class RustBridge {
     const defaultPort = this.devMode ? "9276" : "9274";
     this.port = parseInt(process.env.METALSHARP_PORT || defaultPort, 10);
     this.base = `http://127.0.0.1:${this.port}`;
+    this.apiToken = randomBytes(32).toString("hex");
   }
 
   getPort(): number {
     return this.port;
+  }
+
+  getApiToken(): string {
+    return this.apiToken;
   }
 
   async start(): Promise<{ ok: boolean; error?: string }> {
@@ -133,7 +140,7 @@ export class RustBridge {
     this.proc = null;
 
     // Also find and kill any backend still listening on our port.
-    const pid = await this.getBackendPid();
+    const pid = (await this.getBackendPid()) ?? (await this.getListeningBackendPid());
     if (pid) {
       try {
         process.kill(pid, "SIGTERM");
@@ -164,9 +171,9 @@ export class RustBridge {
 
   async isAlive(): Promise<boolean> {
     return new Promise((resolve) => {
-      const req = http.get(`http://127.0.0.1:${this.port}/status`, (res) => {
+      const req = http.get(`http://127.0.0.1:${this.port}/status`, { headers: this.authHeaders() }, (res) => {
         res.resume();
-        resolve(true);
+        resolve(res.statusCode === 200);
       });
       req.on("error", () => resolve(false));
       // Dev backends can be busy with a first-run bottle scan; don't treat a
@@ -180,13 +187,18 @@ export class RustBridge {
 
   async getBackendPid(): Promise<number | null> {
     return new Promise((resolve) => {
-      const req = http.get(`http://127.0.0.1:${this.port}/status`, (res) => {
+      const req = http.get(`http://127.0.0.1:${this.port}/status`, { headers: this.authHeaders() }, (res) => {
         const chunks: Buffer[] = [];
         res.on("data", (c) => chunks.push(c));
         res.on("end", () => {
+          if (res.statusCode !== 200) {
+            resolve(null);
+            return;
+          }
           try {
             const data = JSON.parse(Buffer.concat(chunks).toString());
-            resolve(data.pid ?? null);
+            const pid = Number(data.pid);
+            resolve(Number.isInteger(pid) && pid > 0 ? pid : null);
           } catch {
             resolve(null);
           }
@@ -211,6 +223,7 @@ export class RustBridge {
         headers: {
           "Content-Type": "application/json",
           "Content-Length": Buffer.byteLength(payload),
+          ...this.authHeaders(),
         },
         timeout: timeoutMs ?? 30000,
       };
@@ -238,6 +251,64 @@ export class RustBridge {
     });
   }
 
+  async requestImage(url: string, timeoutMs = 10000): Promise<string | null> {
+    return new Promise((resolve) => {
+      const opts: http.RequestOptions = {
+        hostname: "127.0.0.1",
+        port: this.port,
+        path: url,
+        method: "GET",
+        headers: this.authHeaders(),
+        timeout: timeoutMs,
+      };
+      let settled = false;
+      const finish = (value: string | null) => {
+        if (settled) return;
+        settled = true;
+        resolve(value);
+      };
+
+      const req = http.request(opts, (res) => {
+        if (res.statusCode !== 200) {
+          res.resume();
+          finish(null);
+          return;
+        }
+
+        const contentType = res.headers["content-type"];
+        const mime = typeof contentType === "string" ? contentType.split(";", 1)[0].trim() : "";
+        if (!/^image\/[a-z0-9.+-]+$/i.test(mime)) {
+          res.resume();
+          finish(null);
+          return;
+        }
+
+        const chunks: Buffer[] = [];
+        let total = 0;
+        res.on("data", (chunk: Buffer) => {
+          total += chunk.length;
+          if (total > 8 * 1024 * 1024) {
+            req.destroy();
+            finish(null);
+            return;
+          }
+          chunks.push(chunk);
+        });
+        res.on("end", () => {
+          if (!settled) finish(`data:${mime};base64,${Buffer.concat(chunks).toString("base64")}`);
+        });
+        res.on("error", () => finish(null));
+      });
+
+      req.on("error", () => finish(null));
+      req.on("timeout", () => {
+        req.destroy();
+        finish(null);
+      });
+      req.end();
+    });
+  }
+
   private spawnBackend(binPath: string) {
     this.proc = spawn(binPath, [], {
       env: {
@@ -245,6 +316,7 @@ export class RustBridge {
         PATH: shellPath,
         METALSHARP_PORT: String(this.port),
         ...(this.metalsharpHome ? { METALSHARP_HOME: this.metalsharpHome } : {}),
+        METALSHARP_API_TOKEN: this.apiToken,
         ...(this.devMode ? { METALSHARP_DEV: "1" } : {}),
       },
       stdio: ["ignore", "pipe", "pipe"],
@@ -320,10 +392,14 @@ export class RustBridge {
 
   private async getBackendVersion(): Promise<string | null> {
     return new Promise((resolve) => {
-      const req = http.get(`http://127.0.0.1:${this.port}/status`, (res) => {
+      const req = http.get(`http://127.0.0.1:${this.port}/status`, { headers: this.authHeaders() }, (res) => {
         const chunks: Buffer[] = [];
         res.on("data", (c) => chunks.push(c));
         res.on("end", () => {
+          if (res.statusCode !== 200) {
+            resolve(null);
+            return;
+          }
           try {
             const data = JSON.parse(Buffer.concat(chunks).toString());
             resolve(data.version ?? null);
@@ -343,8 +419,7 @@ export class RustBridge {
   private async getProcessPath(pid: number): Promise<string | null> {
     if (!Number.isInteger(pid) || pid <= 0) return null;
     return new Promise((resolve) => {
-      const { exec } = require("child_process");
-      exec(`ps -o comm= -p ${Math.floor(pid)} 2>/dev/null`, (err: Error | null, stdout: string) => {
+      execFile("ps", ["-o", "comm=", "-p", String(Math.floor(pid))], (err, stdout) => {
         if (err || !stdout.trim()) {
           resolve(null);
         } else {
@@ -386,8 +461,14 @@ export class RustBridge {
           return;
         }
         let settled = false;
-        const req = http.get(`http://127.0.0.1:${this.port}/status`, (res) => {
+        const req = http.get(`http://127.0.0.1:${this.port}/status`, { headers: this.authHeaders() }, (res) => {
           if (settled) return;
+          if (res.statusCode !== 200) {
+            settled = true;
+            res.resume();
+            setTimeout(check, 200);
+            return;
+          }
           settled = true;
           res.resume();
           resolve();
@@ -406,5 +487,32 @@ export class RustBridge {
       };
       setTimeout(check, 300);
     });
+  }
+
+  private authHeaders(): Record<string, string> {
+    return { Authorization: `Bearer ${this.apiToken}` };
+  }
+
+  private async getListeningBackendPid(): Promise<number | null> {
+    const pids = await new Promise<number[]>((resolve) => {
+      execFile("lsof", ["-nP", `-tiTCP:${this.port}`, "-sTCP:LISTEN"], (err, stdout) => {
+        if (err) {
+          resolve([]);
+          return;
+        }
+        resolve(
+          stdout
+            .split(/\s+/)
+            .map((value) => Number.parseInt(value, 10))
+            .filter((pid) => Number.isInteger(pid) && pid > 0),
+        );
+      });
+    });
+
+    for (const pid of pids) {
+      const processPath = await this.getProcessPath(pid);
+      if (processPath?.endsWith("metalsharp-backend")) return pid;
+    }
+    return null;
   }
 }

--- a/app/src/main/updater-bridge.ts
+++ b/app/src/main/updater-bridge.ts
@@ -35,9 +35,11 @@ export interface UpdaterReadyResult {
 export class UpdaterBridge {
   private scriptPath: string | null = null;
   private backendPort: number;
+  private apiToken: string;
 
-  constructor(port: number = 9274) {
+  constructor(port: number = 9274, apiToken = "") {
     this.backendPort = port;
+    this.apiToken = apiToken;
   }
 
   async ensureReady(): Promise<UpdaterReadyResult> {
@@ -80,18 +82,27 @@ export class UpdaterBridge {
 
   async getBackendPid(): Promise<number | null> {
     return new Promise((resolve) => {
-      const req = http.get(`http://127.0.0.1:${this.backendPort}/status`, (res) => {
-        const chunks: Buffer[] = [];
-        res.on("data", (c) => chunks.push(c));
-        res.on("end", () => {
-          try {
-            const data = JSON.parse(Buffer.concat(chunks).toString());
-            resolve(data.pid ?? null);
-          } catch {
-            resolve(null);
-          }
-        });
-      });
+      const req = http.get(
+        `http://127.0.0.1:${this.backendPort}/status`,
+        { headers: { Authorization: `Bearer ${this.apiToken}` } },
+        (res) => {
+          const chunks: Buffer[] = [];
+          res.on("data", (c) => chunks.push(c));
+          res.on("end", () => {
+            if (res.statusCode !== 200) {
+              resolve(null);
+              return;
+            }
+            try {
+              const data = JSON.parse(Buffer.concat(chunks).toString());
+              const pid = Number(data.pid);
+              resolve(Number.isInteger(pid) && pid > 0 ? pid : null);
+            } catch {
+              resolve(null);
+            }
+          });
+        },
+      );
       req.on("error", () => resolve(null));
       req.setTimeout(1500, () => {
         req.destroy();

--- a/app/src/renderer/api-types.ts
+++ b/app/src/renderer/api-types.ts
@@ -202,6 +202,7 @@ type MetalsharpAPI = {
     body?: Record<string, unknown>,
     timeoutMs?: number,
   ) => Promise<BackendResponse>;
+  getCover: (id: string) => Promise<string | null>;
   isFirstLaunch: () => Promise<boolean>;
   isMigrationMode: () => Promise<boolean>;
   restartAfterMigration: () => Promise<{

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; font-src 'self'; img-src 'self' https://steamcdn-a.akamaihd.net https://cdn.akamai.steamstatic.com https://store.steampowered.com https://*.gog-statics.com data: http://127.0.0.1:9274; style-src 'self' 'unsafe-inline'; script-src 'self';"
+      content="default-src 'self'; font-src 'self'; img-src 'self' https://steamcdn-a.akamaihd.net https://cdn.akamai.steamstatic.com https://store.steampowered.com https://*.gog-statics.com data:; style-src 'self' 'unsafe-inline'; script-src 'self';"
     />
     <title>MetalSharp</title>
   </head>

--- a/app/src/renderer/views/SharpView.vue
+++ b/app/src/renderer/views/SharpView.vue
@@ -187,6 +187,7 @@ const headerSubtitle = computed(() =>
     : "Install and manage Windows applications outside Steam.",
 );
 const apps = ref<SharpApp[]>([]);
+const coverUrls = ref<Record<string, string>>({});
 const cardToolsOpen = ref<Record<string, boolean>>({});
 const bottles = ref<BottleManifest[]>([]);
 const runtimeProfiles = ref<RuntimeProfileDefinition[]>([]);
@@ -488,6 +489,19 @@ function sharpAppNameSort(a: SharpApp, b: SharpApp) {
   return a.name.localeCompare(b.name, undefined, { sensitivity: "base", numeric: true });
 }
 
+async function loadCovers() {
+  const loaded: Record<string, string> = {};
+  await Promise.all(
+    apps.value
+      .filter((app) => app.cover)
+      .map(async (app) => {
+        const url = await getAPI().getCover(app.id);
+        if (url) loaded[app.id] = url;
+      }),
+  );
+  coverUrls.value = loaded;
+}
+
 async function load() {
   const [result, bottleResult, profileResult, gogStatusResult, gogGamesResult] = await Promise.all([
     api<{ ok: boolean; apps: SharpApp[] }>("GET", "/sharp-library"),
@@ -498,6 +512,7 @@ async function load() {
   ]);
   if (result?.ok) {
     apps.value = [...result.apps].sort(sharpAppNameSort);
+    await loadCovers();
   }
   if (bottleResult?.ok) {
     bottles.value = bottleResult.bottles;
@@ -1566,7 +1581,7 @@ onUnmounted(stopGogMonoPoll);
             <div class="sharp-card-banner">
               <img
                 v-if="app.cover"
-                :src="`http://127.0.0.1:9274/sharp-library/cover?id=${app.id}`"
+                :src="coverUrls[app.id] ?? sharpLogoUrl"
                 :alt="app.name"
                 :style="{ objectPosition: coverPosition(app) }"
               />

--- a/app/updater/update.py
+++ b/app/updater/update.py
@@ -345,7 +345,7 @@ def wait_for_backend(timeout=45):
     while time.time() < deadline:
         try:
             req = urllib.request.Request(
-                "http://127.0.0.1:" + str(BACKEND_PORT) + "/status"
+                "http://127.0.0.1:" + str(BACKEND_PORT) + "/health"
             )
             with urllib.request.urlopen(req, timeout=3) as resp:
                 data = json.loads(resp.read())

--- a/app/updater/update.sh
+++ b/app/updater/update.sh
@@ -354,7 +354,7 @@ sleep 5
 BACKEND_VERSION=""
 deadline=$((SECONDS + 45))
 while [ $SECONDS -lt $deadline ]; do
-    RAW=$(curl -sf "http://127.0.0.1:9274/status" 2>/dev/null) || true
+    RAW=$(curl -sf "http://127.0.0.1:9274/health" 2>/dev/null) || true
     BACKEND_VERSION=$(echo "$RAW" | grep -o '"version":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
     [ -n "$BACKEND_VERSION" ] && break
     sleep 1

--- a/docs/guides/install-from-source.md
+++ b/docs/guides/install-from-source.md
@@ -71,6 +71,13 @@ GPTK/D3DMetal is not bundled in MetalSharp release assets. When you save a D3DMe
 cd app && npx electron .
 ```
 
+The Electron main process starts the Rust backend with a fresh per-session
+bearer token and attaches it to every backend request. Run the application
+through Electron rather than exposing `metalsharp-backend` directly; requests
+without that token are rejected before route handling. The backend binds only
+to loopback, and browser-origin requests are limited to the Vite development
+origins used by this checkout.
+
 ## Build a Signed App
 
 For an ad-hoc signed `.app` (no Apple Developer account needed):

--- a/docs/optimization-roadmap/local-gates.md
+++ b/docs/optimization-roadmap/local-gates.md
@@ -72,7 +72,10 @@ python3 tools/d3d12-metal-sdk/scripts/preflight-runtime-layout.py --profile meta
 ## Backend diagnostic routes (Phase 1–8)
 
 These read-only diagnostic routes are available from a running backend
-(`127.0.0.1:9274`) and are the local gates for the optimization roadmap:
+(`127.0.0.1:9274`) and are the local gates for the optimization roadmap. A
+direct request must include `Authorization: Bearer $METALSHARP_API_TOKEN`;
+the Electron bridge attaches the per-session token automatically. Only
+`GET /health` is public.
 
 | Route | Phase | What it proves |
 |-------|-------|----------------|

--- a/tools/d3d12-metal-sdk/scripts/capture-game-shader-corpus.sh
+++ b/tools/d3d12-metal-sdk/scripts/capture-game-shader-corpus.sh
@@ -8,6 +8,10 @@ LAUNCH_METHOD="dxmt_metal12"
 SECONDS_TO_RUN="20"
 RESULTS_DIR="$SDK_DIR/results"
 BACKEND_URL="${METALSHARP_BACKEND_URL:-http://127.0.0.1:9274}"
+BACKEND_AUTH_ARGS=()
+if [[ -n "${METALSHARP_API_TOKEN:-}" ]]; then
+  BACKEND_AUTH_ARGS=(-H "Authorization: Bearer ${METALSHARP_API_TOKEN}")
+fi
 GAME_DIR="/Volumes/AverySSD/SteamLibrary/steamapps/common/Subnautica2/Subnautica2/Binaries/Win64"
 CORPUS_DIR="/Volumes/AverySSD/SteamLibrary/steamapps/common/Subnautica2/.metalsharp-cache/shader-cache/m12/1962700"
 START_STEAM=0
@@ -106,24 +110,28 @@ trap cleanup EXIT
 find "$CORPUS_DIR" -type f \( -name '*.dxbc' -o -name 'pso-*.json' \) 2>/dev/null | sort > "$before_file" || true
 
 curl -fsS -X POST "$BACKEND_URL/kill" \
+  "${BACKEND_AUTH_ARGS[@]}" \
   -H 'Content-Type: application/json' \
   -d "{\"appid\":$APPID,\"pid\":0}" >/dev/null || true
 pkill -9 -f '[S]ubnautica2-Win64-Shipping.exe|[S]ubnautica2|[C]rashReportClient.exe|[c]rashpad_handler.exe' || true
 
 if [[ "$START_STEAM" == "1" ]]; then
   curl -fsS -X POST "$BACKEND_URL/steam/launch" \
+    "${BACKEND_AUTH_ARGS[@]}" \
     -H 'Content-Type: application/json' \
     -d '{}' >/dev/null
   sleep 15
 fi
 
 curl -fsS -X POST "$BACKEND_URL/steam/launch-game" \
+  "${BACKEND_AUTH_ARGS[@]}" \
   -H 'Content-Type: application/json' \
   -d "{\"appid\":$APPID,\"launchMethod\":\"$LAUNCH_METHOD\"}" > "$launch_file"
 
 sleep "$SECONDS_TO_RUN"
 
 curl -fsS -X POST "$BACKEND_URL/kill" \
+  "${BACKEND_AUTH_ARGS[@]}" \
   -H 'Content-Type: application/json' \
   -d "{\"appid\":$APPID,\"pid\":0}" >/dev/null || true
 pkill -9 -f '[S]ubnautica2-Win64-Shipping.exe|[S]ubnautica2|[C]rashReportClient.exe|[c]rashpad_handler.exe' || true

--- a/tools/migrator/main.m
+++ b/tools/migrator/main.m
@@ -93,6 +93,10 @@ static NSDictionary *fetchJSON(NSString *urlString, NSString *method) {
     NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:url];
     req.HTTPMethod = method ?: @"GET";
     req.timeoutInterval = 5.0;
+    NSString *apiToken = [[[NSProcessInfo processInfo] environment] objectForKey:@"METALSHARP_API_TOKEN"];
+    if (apiToken.length > 0) {
+        [req setValue:[NSString stringWithFormat:@"Bearer %@", apiToken] forHTTPHeaderField:@"Authorization"];
+    }
 
     dispatch_semaphore_t sem = dispatch_semaphore_create(0);
     __block NSDictionary *result = nil;


### PR DESCRIPTION
## Summary

Harden the loopback Rust API against browser CSRF and local-origin abuse by binding every sensitive request to a fresh per-Electron-session bearer token and a strict development-origin allowlist.

## Changes

- Require Authorization: Bearer <session token> before dispatching every route except the read-only /health readiness endpoint.
- Remove null, file://, arbitrary localhost ports, and wildcard ACAO behavior; only the fixed Vite origins may receive an ACAO response.
- Keep the token in Electron main/preload plumbing and route Sharp Library cover images through authenticated main-process IPC instead of unauthenticated renderer URLs.
- Update updater, migrator, and developer probe clients plus contributor documentation for the new trust boundary.
- Add Rust authorization/origin regression tests and validate the release backend with an authenticated/unauthenticated HTTP smoke test.

Fixes #398

## PR Readiness (MANDATORY)

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute /Users/... paths introduced
- [x] Config/rules TOML validated if configs/mtsp-rules.toml or DLL maps changed (not applicable; no config/rules files changed)
- [x] Version triple (CMakeLists.txt, Cargo.toml, package.json, package-lock.json) in sync if version bumped (not applicable; no version bump)
- [x] Bottle/runtime migration and launch behavior preserved (backend authentication/client plumbing only; rollback to the parent commit)
- [x] Docs / compatibility matrix updated for user-facing changes (install and local-gate documentation updated; no gameplay compatibility claim changed)
- [x] Regression test added for each bug fix

## Local toolchain

- [x] cargo fmt --all -- --check passes (Rust)
- [x] cargo clippy --all-targets -- -D warnings passes (Rust)
- [x] cargo build --release passes (Rust backend)
- [x] cargo test passes (Rust — 764 tests)
- [x] C++/Obj-C compiles: cmake -S . -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON && cmake --build build-native --parallel $(sysctl -n hw.ncpu)
- [x] tools/ci/check-clang-format.sh passes on changed Obj-C
- [x] ctest --test-dir build-native --output-on-failure -E '^(metal_device|dxbc|format_translation|phase17)$' passes (27 tests; native tests were not changed)
- [x] TypeScript compiles: cd app && npx tsc --noEmit
- [x] Biome + Prettier pass for renderer/main/shared TS and Vue sources
- [x] tools/ci/shellcheck.sh passes
- [x] python3 tools/ci/check-doc-freshness.py passes (existing warning only for docs/OPENGL-2-4-PLAN.md)
- [x] python3 tools/ci/validate-rules-toml.py not required (no rules changed)
- [x] python3 tools/ci/verify-dmg-workflow.py not required (no release/bundle workflow changed)
- [ ] Tested with at least one game (which one? which launch method? which drive?)
- [x] No hardcoded paths, secrets, or absolute /Users/... paths
- [x] No new files added to the repo root

## Test notes

- Rust: release build, clippy, format, and all 764 unit tests passed.
- Electron: npm ci, npm run build, TypeScript, Biome, and Prettier passed.
- Security smoke: a release backend in an isolated temporary home accepted public GET /health, rejected missing/wrong tokens with 401, rejected null, file://, evil, and non-Vite localhost origins with 403, and returned ACAO only for http://localhost:5173 with the current token.
- Native: CMake build, package/host ABI contracts, clang-format, and 27 runtime tests passed.
- D3D12 contract and probe-matrix validators passed. The optional host mini-probe was attempted with release assets but stopped at the pre-existing WineMetal ABI prefix gate because this isolated host had no staged Wine prefix.
- npm ci reported existing dependency-audit findings; no dependency changes or audit fixes were made.
- No live game was launched: this is an API-authentication/IPC security change, not a game or graphics-path change. The checklist-exception label records that compatibility coverage is intentionally not applicable.

## Risk

The backend now fails closed when started without a valid session token, so stale direct clients must be updated or supplied METALSHARP_API_TOKEN. Electron, updater, migrator, cover-image IPC, and the developer capture client were updated. Rollback is the parent commit of e25897bb.

<!-- checklist-exception label applied for the intentional no-live-game scope -->
