### PR TITLE
fix(api): scope process termination to MetalSharp targets

### DIFF
--- a/app/src-rust/src/main.rs
+++ b/app/src-rust/src/main.rs
@@ -50,10 +50,15 @@ use std::sync::{Arc, Mutex, OnceLock};
 use tiny_http::{Header, Method, Response, Server};
 
 static RUNNING_GAMES: OnceLock<Mutex<HashMap<u32, i32>>> = OnceLock::new();
+static RUNNING_SHARP_APPS: OnceLock<Mutex<HashMap<String, i32>>> = OnceLock::new();
 static ISSUE_LOG_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 fn running_games() -> &'static Mutex<HashMap<u32, i32>> {
     RUNNING_GAMES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn running_sharp_apps() -> &'static Mutex<HashMap<String, i32>> {
+    RUNNING_SHARP_APPS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 pub(crate) fn register_game_pid(appid: u32, pid: u32) {
@@ -68,8 +73,39 @@ fn unregister_game_pid(appid: u32) {
     }
 }
 
+fn registered_game_pid(games: &HashMap<u32, i32>, appid: u32) -> Option<i32> {
+    games.get(&appid).copied().filter(|pid| *pid > 0)
+}
+
+fn registered_game_appid_for_pid(games: &HashMap<u32, i32>, pid: i32) -> Option<u32> {
+    games.iter().find_map(|(&appid, &registered_pid)| (registered_pid == pid).then_some(appid))
+}
+
 fn get_game_pid(appid: u32) -> Option<i32> {
-    running_games().lock().ok()?.get(&appid).copied()
+    running_games().lock().ok().and_then(|games| registered_game_pid(&games, appid))
+}
+
+fn get_game_appid_for_pid(pid: i32) -> Option<u32> {
+    running_games().lock().ok().and_then(|games| registered_game_appid_for_pid(&games, pid))
+}
+
+fn register_sharp_pid(app_id: &str, pid: u32) {
+    if pid == 0 || app_id.is_empty() {
+        return;
+    }
+    if let Ok(mut map) = running_sharp_apps().lock() {
+        map.insert(app_id.to_string(), pid as i32);
+    }
+}
+
+fn unregister_sharp_pid(app_id: &str) {
+    if let Ok(mut map) = running_sharp_apps().lock() {
+        map.remove(app_id);
+    }
+}
+
+fn get_sharp_pid(app_id: &str) -> Option<i32> {
+    running_sharp_apps().lock().ok()?.get(app_id).copied().filter(|pid| *pid > 0)
 }
 
 fn prune_inactive_game_pids() {
@@ -94,6 +130,14 @@ fn stop_active_games() -> Value {
     let mut errors = Vec::new();
 
     for (appid, pid) in targets {
+        if !is_metalsharp_owned_process(pid) {
+            app_log(&format!(
+                "[STOP FAILED] appid {} | pid {} | source global-shortcut | process ownership check failed",
+                appid, pid
+            ));
+            errors.push(json!({"appid": appid, "pid": pid}));
+            continue;
+        }
         match launch::kill_game_with_pid(appid, pid) {
             Ok(_) => {
                 unregister_game_pid(appid);
@@ -116,6 +160,18 @@ fn stop_active_games() -> Value {
         "stopped": stopped,
         "errors": errors,
     })
+}
+
+fn stop_registered_sharp_app(app_id: &str) -> Result<i32, String> {
+    let pid = get_sharp_pid(app_id).ok_or_else(|| "Sharp app is not registered as running".to_string())?;
+    if !is_metalsharp_owned_process(pid) {
+        unregister_sharp_pid(app_id);
+        return Err("registered Sharp app process is no longer a MetalSharp-owned target".to_string());
+    }
+
+    launch::kill_process_tree(pid).map_err(|error| error.to_string())?;
+    unregister_sharp_pid(app_id);
+    Ok(pid)
 }
 
 enum RouteResponse {
@@ -150,7 +206,11 @@ fn main() {
         if let Ok(map) = running_games().lock() {
             for (&appid, &pid) in map.iter() {
                 app_log(&format!("Killing game appid={} pid={}", appid, pid));
-                let _ = launch::kill_process_tree(pid);
+                if is_metalsharp_owned_process(pid) {
+                    let _ = launch::kill_process_tree(pid);
+                } else {
+                    app_log(&format!("Skipping unowned game pid={} during shutdown", pid));
+                }
             }
         }
         std::process::exit(0);
@@ -776,7 +836,14 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
                         },
                     };
                     match launch_result {
-                        Ok(v) => resp(200, v),
+                        Ok(v) => {
+                            if let Some(pid) =
+                                v.get("pid").and_then(|value| value.as_u64()).and_then(|pid| u32::try_from(pid).ok())
+                            {
+                                register_game_pid(id, pid);
+                            }
+                            resp(200, v)
+                        },
                         Err(e) => resp(500, json!({"ok": false, "error": e.to_string()})),
                     }
                 },
@@ -842,21 +909,24 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
                     ));
 
                     match launch_result {
-                        Ok((pid, game_type, log_path)) => resp(
-                            200,
-                            json!({
-                                "ok": true,
-                                "pid": pid,
-                                "appid": id,
-                                "gameType": game_type,
-                                "bottle_id": bottle.id,
-                                "bottle_prefix": bottle.prefix_path,
-                                "launch_log": log_path.to_string_lossy().to_string(),
-                                "pipeline": pipeline,
-                                "graphics_backend": node.graphics_backend,
-                                "offline_mode": true,
-                            }),
-                        ),
+                        Ok((pid, game_type, log_path)) => {
+                            register_game_pid(id, pid);
+                            resp(
+                                200,
+                                json!({
+                                    "ok": true,
+                                    "pid": pid,
+                                    "appid": id,
+                                    "gameType": game_type,
+                                    "bottle_id": bottle.id,
+                                    "bottle_prefix": bottle.prefix_path,
+                                    "launch_log": log_path.to_string_lossy().to_string(),
+                                    "pipeline": pipeline,
+                                    "graphics_backend": node.graphics_backend,
+                                    "offline_mode": true,
+                                }),
+                            )
+                        },
                         Err(e) => resp(500, json!({"ok": false, "error": e.to_string()})),
                     }
                 },
@@ -2175,6 +2245,9 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
             app_log(&format!("[SHARP-LIB] launch: {} engine: {}", id, engine));
             let result = sharp_library::handle_launch(&body);
             if result.get("ok").and_then(|v| v.as_bool()).unwrap_or(false) {
+                if let Some(pid) = result.get("pid").and_then(|v| v.as_u64()).and_then(|pid| u32::try_from(pid).ok()) {
+                    register_sharp_pid(id, pid);
+                }
                 app_log(&format!(
                     "[SHARP-LIB] launched pid {}",
                     result.get("pid").and_then(|v| v.as_u64()).unwrap_or(0)
@@ -2184,6 +2257,23 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
                 app_issue_log("sharp-launch", id, error, &[format!("engine={}", engine), format!("request_id={}", id)]);
             }
             resp(200, result)
+        },
+        (Method::Post, "/sharp-library/stop") => {
+            let body = read_body(req);
+            let id = body.get("id").and_then(|v| v.as_str()).unwrap_or("").trim();
+            if id.is_empty() {
+                return resp(400, json!({"ok": false, "error": "id required"}));
+            }
+            match stop_registered_sharp_app(id) {
+                Ok(pid) => {
+                    app_log(&format!("[SHARP-LIB] stopped {} pid {}", id, pid));
+                    resp(200, json!({"ok": true, "pid": pid}))
+                },
+                Err(error) => {
+                    app_issue_log("sharp-stop", id, &error, &[]);
+                    resp(409, json!({"ok": false, "error": error}))
+                },
+            }
         },
         (Method::Post, "/sharp-library/doctor") => {
             let body = read_body(req);
@@ -2367,48 +2457,93 @@ fn route(req: &mut tiny_http::Request) -> RouteResponse {
         (Method::Post, "/games/stop-active") => resp(200, stop_active_games()),
         (Method::Post, "/kill") => {
             let body = read_body(req);
-            let pid_param = body.get("pid").and_then(|v| v.as_u64()).unwrap_or(0) as i32;
-            let appid = body.get("appid").and_then(|v| v.as_u64()).map(|v| v as u32);
+            let appid = match body.get("appid") {
+                None => None,
+                Some(value) => match value
+                    .as_u64()
+                    .and_then(|value| u32::try_from(value).ok())
+                    .filter(|value| *value > 0)
+                {
+                    Some(appid) => Some(appid),
+                    None => {
+                        return resp(400, json!({"ok": false, "error": "appid must be a positive numeric Steam appid"}))
+                    },
+                },
+            };
 
-            let target_pid = if let Some(aid) = appid {
-                let registered = get_game_pid(aid);
-                let pid = registered.unwrap_or(pid_param);
-                app_log(&format!("[STOP] appid {} | registered pid {:?} | param pid {}", aid, registered, pid_param));
+            if let Some(aid) = appid {
+                // The appid is only an identifier. The PID must come from the
+                // backend's registration made at launch; never fall back to a
+                // caller-supplied PID when the app is not registered.
+                prune_inactive_game_pids();
+                let Some(target_pid) = get_game_pid(aid) else {
+                    app_log(&format!("[STOP REJECTED] appid {} is not registered", aid));
+                    return resp(409, json!({"ok": false, "error": "game is not registered as running"}));
+                };
 
-                match launch::kill_game_with_pid(aid, pid) {
+                if !is_metalsharp_owned_process(target_pid) {
+                    app_log(&format!(
+                        "[STOP REJECTED] appid {} pid {} is not a MetalSharp-owned process",
+                        aid, target_pid
+                    ));
+                    return resp(
+                        403,
+                        json!({"ok": false, "error": "registered process is not a MetalSharp-owned target"}),
+                    );
+                }
+
+                match launch::kill_game_with_pid(aid, target_pid) {
                     Ok(_) => {
                         unregister_game_pid(aid);
-                        app_log(&format!("[STOPPED] appid {} | pid {}", aid, pid));
-                        return resp(200, json!({"ok": true, "pid": pid}));
+                        app_log(&format!("[STOPPED] appid {} | pid {}", aid, target_pid));
+                        resp(200, json!({"ok": true, "pid": target_pid}))
                     },
-                    Err(e) => {
-                        app_log(&format!("[STOP FAILED] appid {} | error: {}", aid, e));
-                        app_issue_log(
-                            "stop",
-                            &aid.to_string(),
-                            &e.to_string(),
-                            &[format!("registered_pid={:?}", registered), format!("requested_pid={}", pid_param)],
-                        );
-                        return resp(500, json!({"ok": false, "error": e.to_string()}));
+                    Err(error) => {
+                        app_log(&format!("[STOP FAILED] appid {} | error: {}", aid, error));
+                        app_issue_log("stop", &aid.to_string(), &error.to_string(), &[]);
+                        resp(500, json!({"ok": false, "error": error.to_string()}))
                     },
                 }
             } else {
-                pid_param
-            };
+                let Some(target_pid) =
+                    body.get("pid").and_then(|value| value.as_u64()).and_then(|value| i32::try_from(value).ok())
+                else {
+                    return resp(400, json!({"ok": false, "error": "pid required"}));
+                };
+                if target_pid <= 0 {
+                    return resp(400, json!({"ok": false, "error": "pid required"}));
+                }
 
-            if target_pid <= 0 {
-                return resp(400, json!({"ok": false, "error": "pid required"}));
-            }
+                // PID-only calls are retained only for registered game roots.
+                // In particular, a browser cannot turn an arbitrary PID into a
+                // kill target by posting to this legacy endpoint.
+                prune_inactive_game_pids();
+                let Some(aid) = get_game_appid_for_pid(target_pid) else {
+                    app_log(&format!("[STOP REJECTED] pid {} is not a registered game", target_pid));
+                    return resp(403, json!({"ok": false, "error": "pid is not a registered MetalSharp game"}));
+                };
+                if !is_metalsharp_owned_process(target_pid) {
+                    app_log(&format!(
+                        "[STOP REJECTED] appid {} pid {} is not a MetalSharp-owned process",
+                        aid, target_pid
+                    ));
+                    return resp(
+                        403,
+                        json!({"ok": false, "error": "registered process is not a MetalSharp-owned target"}),
+                    );
+                }
 
-            match launch::kill_process_tree(target_pid) {
-                Ok(_) => {
-                    app_log(&format!("[STOPPED] pid {}", target_pid));
-                    resp(200, json!({"ok": true, "pid": target_pid}))
-                },
-                Err(e) => {
-                    app_issue_log("stop", &target_pid.to_string(), &e.to_string(), &[]);
-                    resp(500, json!({"ok": false, "error": e.to_string()}))
-                },
+                match launch::kill_process_tree(target_pid) {
+                    Ok(_) => {
+                        unregister_game_pid(aid);
+                        app_log(&format!("[STOPPED] appid {} | pid {}", aid, target_pid));
+                        resp(200, json!({"ok": true, "pid": target_pid}))
+                    },
+                    Err(error) => {
+                        app_issue_log("stop", &target_pid.to_string(), &error.to_string(), &[]);
+                        resp(500, json!({"ok": false, "error": error.to_string()}))
+                    },
+                }
             }
         },
         (Method::Post, "/steam/uninstall-game") => {
@@ -2573,12 +2708,43 @@ fn process_lines() -> Vec<String> {
         .unwrap_or_default()
 }
 
+fn process_command_from_lines(lines: &[String], pid: i32) -> Option<String> {
+    if pid <= 0 {
+        return None;
+    }
+    lines
+        .iter()
+        .filter_map(|line| parse_process_line_owned(line))
+        .find_map(|(candidate_pid, command)| (candidate_pid == pid as u32).then_some(command))
+}
+
+fn process_command_for_pid(pid: i32) -> Option<String> {
+    process_command_from_lines(&process_lines(), pid)
+}
+
 fn parse_process_line_owned(line: &str) -> Option<(u32, String)> {
     let line = line.trim_start();
     let mut parts = line.splitn(2, char::is_whitespace);
     let pid = parts.next()?.parse::<u32>().ok()?;
     let command = parts.next().unwrap_or("").trim_start().to_string();
     Some((pid, command))
+}
+
+fn is_metalsharp_game_command(command: &str, home: &std::path::Path) -> bool {
+    if is_force_kill_target(command, home) {
+        return true;
+    }
+
+    // D3DMetal's optional GPTK lane uses Apple's Wine binary rather than the
+    // MetalSharp Wine wrapper. It is still safe here because this matcher is
+    // only used after the PID has been registered for a Steam appid.
+    let lower = command.to_ascii_lowercase();
+    lower.contains("game porting toolkit.app") && lower.contains(".exe")
+}
+
+fn is_metalsharp_owned_process(pid: i32) -> bool {
+    let home = crate::platform::metalsharp_home_dir();
+    process_command_for_pid(pid).map(|command| is_metalsharp_game_command(&command, &home)).unwrap_or(false)
 }
 
 fn is_force_kill_target(command: &str, home: &std::path::Path) -> bool {
@@ -3206,6 +3372,47 @@ mod tests {
         let targets = active_game_targets(&HashMap::from([(620, 4242), (4000, 0), (1260320, -1)]));
 
         assert_eq!(targets, vec![(620, 4242)]);
+    }
+
+    #[test]
+    fn kill_authorization_never_falls_back_to_requested_pid() {
+        let games = HashMap::from([(620, 4242), (4000, 0)]);
+
+        assert_eq!(registered_game_pid(&games, 620), Some(4242));
+        assert_eq!(registered_game_pid(&games, 4000), None);
+        assert_eq!(registered_game_pid(&games, 730), None);
+        assert_eq!(registered_game_appid_for_pid(&games, 4242), Some(620));
+        assert_eq!(registered_game_appid_for_pid(&games, 9999), None);
+    }
+
+    #[test]
+    fn process_command_lookup_is_limited_to_requested_pid() {
+        let lines = vec![
+            "  4242 /Users/test/.metalsharp/runtime/wine/bin/metalsharp-wine game.exe".to_string(),
+            "  9999 /Applications/Steam.app/Contents/MacOS/steam_osx".to_string(),
+        ];
+
+        assert_eq!(
+            process_command_from_lines(&lines, 4242),
+            Some("/Users/test/.metalsharp/runtime/wine/bin/metalsharp-wine game.exe".to_string())
+        );
+        assert_eq!(process_command_from_lines(&lines, 1234), None);
+    }
+
+    #[test]
+    fn game_process_ownership_allows_metalsharp_and_registered_gptk_commands_only() {
+        let home = std::path::Path::new("/Users/test/.metalsharp");
+
+        assert!(is_metalsharp_game_command("/Users/test/.metalsharp/runtime/wine/bin/metalsharp-wine game.exe", home));
+        assert!(is_metalsharp_game_command(
+            "/Applications/Game Porting Toolkit.app/Contents/Resources/wine/bin/wine64 game.exe",
+            home
+        ));
+        assert!(!is_metalsharp_game_command(
+            "/Applications/CrossOver.app/Contents/SharedSupport/CrossOver/bin/wine64 game.exe",
+            home
+        ));
+        assert!(!is_metalsharp_game_command("/Applications/Steam.app/Contents/MacOS/steam_osx", home));
     }
 
     #[test]

--- a/app/src/renderer/views/SharpView.vue
+++ b/app/src/renderer/views/SharpView.vue
@@ -1231,9 +1231,17 @@ async function launchApp(id: string, engine: string) {
 async function stopSharpApp(app: SharpApp) {
   const pid = runningSharpPids.value[app.id];
   if (!pid) return;
-  await api("POST", "/kill", { pid });
-  delete runningSharpPids.value[app.id];
-  toast.show(`Closed ${app.name}`);
+  const bottle = app.bottle_id ? bottles.value.find((item) => item.id === app.bottle_id) : undefined;
+  const isD3DMetalLaunch = app.engine === "d3dmetal" && bottle?.steam_app_id;
+  const result = isD3DMetalLaunch
+    ? await api<{ ok: boolean; error?: string }>("POST", "/kill", { appid: bottle.steam_app_id })
+    : await api<{ ok: boolean; error?: string }>("POST", "/sharp-library/stop", { id: app.id });
+  if (result?.ok) {
+    delete runningSharpPids.value[app.id];
+    toast.show(`Closed ${app.name}`);
+  } else {
+    toast.show(result?.error ?? `Failed to close ${app.name}`, "error");
+  }
 }
 
 async function updateEngine(id: string, engine: string) {

--- a/docs/architecture/launch-architecture.md
+++ b/docs/architecture/launch-architecture.md
@@ -157,7 +157,11 @@ When a title uses the Steam launch model and Goldberg is disabled, the launcher 
 ## Process Lifecycle
 
 - Running games are tracked by the backend.
-- Stop/kill actions terminate the registered process and child processes.
+- Stop/kill actions terminate only backend-registered process roots and their
+  child processes. Game stops resolve the PID from the registered `appid` (or
+  the legacy PID-only route accepts only a registered game root); caller-
+  supplied PIDs are never used as a fallback. Sharp Library apps use an
+  app-id-scoped stop route with command-line ownership validation.
 - Steam process management lives in `steam.rs`.
 - Launching a Steam game keeps Wine Steam alive for Steam connectivity. Env-dependent routes apply route-specific
   environment to the spawned game process rather than trying to make an already-running Steam client inherit it.


### PR DESCRIPTION
## Summary

Fixes #399. Scope `/kill` so a caller cannot terminate arbitrary system PIDs.

## Changes

- Resolve game stop PIDs only from the backend's registered `appid` map; remove the caller-supplied PID fallback.
- Reject PID-only `/kill` requests unless the PID is a registered game root and its process command line is MetalSharp-owned.
- Add command-line ownership validation for MetalSharp Wine/GPTK process roots and apply it to active-game and shutdown cleanup.
- Add an app-scoped Sharp Library stop route with backend PID registration, preserving the Sharp Library stop UI without exposing a raw-PID kill path.
- Register all Steam launch paths needed by the scoped stop flow and document the process-lifecycle contract.
- Add unit coverage for registration-only authorization, PID lookup, and foreign-runtime rejection.

## PR Readiness (MANDATORY)

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

The `checklist-exception` label is applied because this is a local API security-boundary fix; it does not change a game's rendering or launch compatibility behavior, so a real-game run is not an applicable validation of the fix.

## Local toolchain

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo build --release` passes
- [x] `cargo test` passes (**765 passed, 0 failed**)
- [ ] C++ compiles if changed (not applicable; no C++ files changed)
- [ ] `clang-format --dry-run --Werror` passes on changed C/C++/Obj-C files (not applicable)
- [ ] `ctest --test-dir build-native` passes if tests changed (not applicable)
- [x] TypeScript compiles: `cd app && npx tsc --noEmit`
- [x] Biome + Prettier pass: `cd app && npx @biomejs/biome ci src/ && npx prettier --check 'src/**/*.{ts,js,html,css,json}'`
- [ ] Shell scripts lint if changed (not applicable)
- [ ] Rules TOML validation if changed (not applicable)
- [ ] DMG workflow validation if release/bundle tooling changed (not applicable)
- [ ] Tested with at least one game (not applicable to this security-boundary fix)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files added to the repo root

## Test notes

- Rust validation ran from `/Volumes/AverySSD/MetalSharp-399-clean/app/src-rust`.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo build --release`, and `cargo test` all passed.
- The Rust suite ran **765 tests** with no failures.
- `npx tsc --noEmit`, Biome, and the repository Prettier check passed. Biome reported only the repository's existing CSS specificity warnings.
- Endpoint smoke test posted both an arbitrary PID-only request and an unregistered `appid` plus PID; both were rejected and the victim process remained alive.
- No real game was launched because the change is isolated to local process-stop authorization and does not alter game launch/rendering behavior.

## Risk

The stop API is intentionally stricter: only registered MetalSharp game roots or backend-registered Sharp Library app IDs can be stopped. Existing launch paths now register their returned roots before the UI can stop them. Rollback is `git revert 5bdc88bb9a16179366b33addb089101d80a1bb11`.
