### PR TITLE
fix(win32): back SRW locks with mapped pthread state

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,6 +301,7 @@ add_library(metalsharp_loader STATIC
     src/win32/kernel32/Kernel32Shim.cpp
     src/win32/kernel32/NtdllShim.cpp
     src/win32/kernel32/Kernel32Extra.cpp
+    src/win32/kernel32/Win32SyncContext.cpp
     src/win32/kernel32/DRMShims.cpp
     src/win32/kernel32/VirtualFileSystem.cpp
     src/win32/kernel32/Registry.cpp

--- a/docs/research/kernel-translation/wine-kernel-compatibility-gap-analysis.md
+++ b/docs/research/kernel-translation/wine-kernel-compatibility-gap-analysis.md
@@ -1,5 +1,5 @@
 # Wine Kernel Compatibility Gap Analysis
-**Updated:** 2026-07-08
+**Updated:** 2026-08-11
 
 ## Windows NT → macOS XNU Mapping for Anti-Cheat Game Compatibility
 ### macOS 26.6 (Tahoe) / arm64 (Apple Silicon) vs Windows 10/11 (NT 10.0+)
@@ -413,8 +413,8 @@ Wine uses `fast_sync_*` (futex-like primitives) on Linux. On macOS, the mapping 
 | Mutex | os_unfair_lock / psynch_mutex |
 | Semaphore | dispatch_semaphore / semaphore_create |
 | Critical Section | pthread_mutex / os_unfair_lock |
-| SRWLock | os_unfair_lock |
-| Condition Variable | pthread_cond |
+| SRWLock | out-of-line pthread_rwlock_t keyed by guest address |
+| Condition Variable | out-of-line pthread_cond plus wait mutex keyed by guest address |
 | Timer | mk_timer_create / dispatch_after |
 
 ---

--- a/docs/runtime/darwin-sync-map.md
+++ b/docs/runtime/darwin-sync-map.md
@@ -1,5 +1,5 @@
 # MetalSharp Darwin Sync Map
-**Updated:** 2026-07-08
+**Updated:** 2026-08-11
 
 
 Status: Phase 6 foundation
@@ -24,6 +24,8 @@ It classifies each primitive by strategy, whether a kernel/system component is r
 | Semaphore | dispatch/pthread counted semaphore | yes | Current use is covered; Mach semaphore benchmarking remains useful. |
 | Mutex | `pthread_mutex_t` | yes | Current in-process ownership semantics are covered. |
 | CriticalSection | `pthread_mutex_t` | yes | Already represented by existing kernel32/ntdll shims. |
+| SRWLock | out-of-line `pthread_rwlock_t` keyed by guest address | yes | Preserves zero/static initialization and shared/exclusive modes without writing a host pthread object into the guest's pointer-sized storage. |
+| ConditionVariable | out-of-line `pthread_cond_t` plus wait mutex keyed by guest address | yes | The wait mutex closes the release/wait race; `SleepConditionVariableSRW` reacquires the mapped SRW lock before returning. |
 | WaitAny | condition-variable wakeups over tracked handles | yes | In-process only; cross-process semantics need more work. |
 | WaitAll | coordinated wait over tracked handles | no | Needs correctness tests for mixed event/semaphore/mutex waits. |
 | Futex | Darwin `ulock` candidate | no | Research candidate only; not Linux ABI compatible. |

--- a/include/metalsharp/DarwinSyncMap.h
+++ b/include/metalsharp/DarwinSyncMap.h
@@ -9,6 +9,8 @@ enum class DarwinSyncPrimitive {
     Semaphore,
     Mutex,
     CriticalSection,
+    SrwLock,
+    ConditionVariable,
     WaitAny,
     WaitAll,
     Futex,
@@ -18,6 +20,7 @@ enum class DarwinSyncPrimitive {
 enum class DarwinSyncStrategy {
     PThreadCondvar,
     PThreadMutex,
+    PThreadRWLock,
     MachSemaphoreCandidate,
     ULockCandidate,
     UnsupportedLinuxSpecific,

--- a/include/metalsharp/Win32SyncContext.h
+++ b/include/metalsharp/Win32SyncContext.h
@@ -1,0 +1,72 @@
+/// @file Win32SyncContext.h
+/// @brief Out-of-line state for zero-initialized Win32 synchronization objects.
+///
+/// SRW locks and condition variables are pointer-sized Windows objects whose
+/// static initializers are all zero. Their Darwin counterparts are larger
+/// pthread objects and cannot be placed in the guest-owned storage. This
+/// context keeps the host objects in process-lifetime maps keyed by the guest
+/// object address.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <pthread.h>
+#include <unordered_map>
+
+namespace metalsharp {
+namespace win32 {
+
+class Win32SyncContext {
+  public:
+    static Win32SyncContext& instance();
+
+    void initializeSrwLock(void* address);
+    void initializeConditionVariable(void* address);
+
+    bool acquireSrwLockExclusive(void* address);
+    bool releaseSrwLockExclusive(void* address);
+    bool tryAcquireSrwLockExclusive(void* address);
+
+    bool acquireSrwLockShared(void* address);
+    bool releaseSrwLockShared(void* address);
+    bool tryAcquireSrwLockShared(void* address);
+
+    bool sleepConditionVariableSrw(void* conditionVariable, void* srwLock, uint32_t milliseconds, uint32_t flags);
+    bool wakeConditionVariable(void* conditionVariable);
+    bool wakeAllConditionVariable(void* conditionVariable);
+
+  private:
+    struct SrwLockState {
+        pthread_rwlock_t lock{};
+        bool initialized = false;
+
+        SrwLockState();
+        ~SrwLockState();
+    };
+
+    struct ConditionVariableState {
+        pthread_cond_t condition{};
+        pthread_mutex_t waitMutex{};
+        bool conditionInitialized = false;
+        bool mutexInitialized = false;
+
+        ConditionVariableState();
+        ~ConditionVariableState();
+    };
+
+    Win32SyncContext() = default;
+
+    SrwLockState* getSrwLock(void* address);
+    ConditionVariableState* getConditionVariable(void* address);
+
+    std::mutex m_mutex;
+    std::unordered_map<uintptr_t, std::unique_ptr<SrwLockState>> m_srwLocks;
+    std::unordered_map<uintptr_t, std::unique_ptr<ConditionVariableState>> m_conditionVariables;
+};
+
+constexpr uint32_t CONDITION_VARIABLE_LOCKMODE_SHARED = 0x00000001;
+
+} // namespace win32
+} // namespace metalsharp

--- a/src/runtime/host/DarwinSyncMap.cpp
+++ b/src/runtime/host/DarwinSyncMap.cpp
@@ -37,6 +37,22 @@ constexpr DarwinSyncMapping kMappings[] = {
         "Already used by kernel32/ntdll shim coverage.",
     },
     {
+        DarwinSyncPrimitive::SrwLock,
+        DarwinSyncStrategy::PThreadRWLock,
+        "out-of-line pthread_rwlock_t keyed by guest SRWLOCK address",
+        false,
+        true,
+        "Guest SRWLOCK storage remains zero-initialized; shared and exclusive modes use the mapped host lock.",
+    },
+    {
+        DarwinSyncPrimitive::ConditionVariable,
+        DarwinSyncStrategy::PThreadCondvar,
+        "out-of-line pthread_cond_t + wait mutex keyed by guest CONDITION_VARIABLE address",
+        false,
+        true,
+        "The wait mutex closes the release/wait race before the mapped SRW lock is reacquired.",
+    },
+    {
         DarwinSyncPrimitive::WaitAny,
         DarwinSyncStrategy::PThreadCondvar,
         "poll tracked handles with condition-variable wakeups",

--- a/src/win32/kernel32/Kernel32Extra.cpp
+++ b/src/win32/kernel32/Kernel32Extra.cpp
@@ -43,6 +43,10 @@
 ///   shim_GetSystemTime/AsFileTime — Real clock via gettimeofday
 ///   shim_Sleep — usleep wrapper
 ///
+/// Synchronization
+/// ===============
+///   SRW locks and condition variables — Guest-address keyed host pthread state
+///
 /// Status: ~70% of commonly-used kernel32 exports implemented. Games that call
 /// obscure kernel32 functions will log "MISSING" in the import resolver.
 #include <cctype>
@@ -64,6 +68,7 @@
 #include <metalsharp/SyncContext.h>
 #include <metalsharp/VirtualFileSystem.h>
 #include <metalsharp/Win32Error.h>
+#include <metalsharp/Win32SyncContext.h>
 #include <metalsharp/Win32Types.h>
 #include <mutex>
 #include <pthread.h>
@@ -755,52 +760,51 @@ static void* MSABI shim_InterlockedPushEntrySList(void* ListHead, void* ListEntr
     return nullptr;
 }
 
+static void MSABI shim_InitializeSRWLock(void* SRWLock) {
+    Win32SyncContext::instance().initializeSrwLock(SRWLock);
+}
+
 static void MSABI shim_AcquireSRWLockExclusive(void* SRWLock) {
-    auto* mtx = static_cast<pthread_mutex_t*>(SRWLock);
-    pthread_mutex_lock(mtx);
+    (void)Win32SyncContext::instance().acquireSrwLockExclusive(SRWLock);
 }
 
 static void MSABI shim_ReleaseSRWLockExclusive(void* SRWLock) {
-    auto* mtx = static_cast<pthread_mutex_t*>(SRWLock);
-    pthread_mutex_unlock(mtx);
+    (void)Win32SyncContext::instance().releaseSrwLockExclusive(SRWLock);
 }
 
 static BOOL MSABI shim_TryAcquireSRWLockExclusive(void* SRWLock) {
-    (void)SRWLock;
-    return 1;
+    return Win32SyncContext::instance().tryAcquireSrwLockExclusive(SRWLock) ? 1 : 0;
+}
+
+static void MSABI shim_AcquireSRWLockShared(void* SRWLock) {
+    (void)Win32SyncContext::instance().acquireSrwLockShared(SRWLock);
+}
+
+static void MSABI shim_ReleaseSRWLockShared(void* SRWLock) {
+    (void)Win32SyncContext::instance().releaseSrwLockShared(SRWLock);
+}
+
+static BOOL MSABI shim_TryAcquireSRWLockShared(void* SRWLock) {
+    return Win32SyncContext::instance().tryAcquireSrwLockShared(SRWLock) ? 1 : 0;
+}
+
+static void MSABI shim_InitializeConditionVariable(void* ConditionVariable) {
+    Win32SyncContext::instance().initializeConditionVariable(ConditionVariable);
 }
 
 static BOOL MSABI shim_SleepConditionVariableSRW(void* ConditionVariable, void* SRWLock, DWORD dwMilliseconds,
                                                  ULONG Flags) {
-    (void)Flags;
-    auto* cond = static_cast<pthread_cond_t*>(ConditionVariable);
-    auto* mtx = static_cast<pthread_mutex_t*>(SRWLock);
-
-    if (dwMilliseconds == 0xFFFFFFFF) {
-        pthread_cond_wait(cond, mtx);
-        return 1;
-    }
-
-    struct timespec ts;
-    clock_gettime(CLOCK_REALTIME, &ts);
-    ts.tv_sec += dwMilliseconds / 1000;
-    ts.tv_nsec += (dwMilliseconds % 1000) * 1000000L;
-    if (ts.tv_nsec >= 1000000000L) {
-        ts.tv_sec++;
-        ts.tv_nsec -= 1000000000L;
-    }
-    pthread_cond_timedwait(cond, mtx, &ts);
-    return 1;
+    return Win32SyncContext::instance().sleepConditionVariableSrw(ConditionVariable, SRWLock, dwMilliseconds, Flags)
+               ? 1
+               : 0;
 }
 
 static void MSABI shim_WakeAllConditionVariable(void* ConditionVariable) {
-    auto* cond = static_cast<pthread_cond_t*>(ConditionVariable);
-    pthread_cond_broadcast(cond);
+    (void)Win32SyncContext::instance().wakeAllConditionVariable(ConditionVariable);
 }
 
 static void MSABI shim_WakeConditionVariable(void* ConditionVariable) {
-    auto* cond = static_cast<pthread_cond_t*>(ConditionVariable);
-    pthread_cond_signal(cond);
+    (void)Win32SyncContext::instance().wakeConditionVariable(ConditionVariable);
 }
 
 static void MSABI shim_InitializeCriticalSectionAndSpinCount(void* lpCriticalSection, DWORD dwSpinCount) {
@@ -2251,9 +2255,14 @@ void addMissingKernel32(ShimLibrary& lib) {
     lib.functions["SwitchToThread"] = fn((void*)shim_SwitchToThread);
     lib.functions["InitializeSListHead"] = fn((void*)shim_InitializeSListHead);
     lib.functions["InterlockedPushEntrySList"] = fn((void*)shim_InterlockedPushEntrySList);
+    lib.functions["InitializeSRWLock"] = fn((void*)shim_InitializeSRWLock);
     lib.functions["AcquireSRWLockExclusive"] = fn((void*)shim_AcquireSRWLockExclusive);
     lib.functions["ReleaseSRWLockExclusive"] = fn((void*)shim_ReleaseSRWLockExclusive);
     lib.functions["TryAcquireSRWLockExclusive"] = fn((void*)shim_TryAcquireSRWLockExclusive);
+    lib.functions["AcquireSRWLockShared"] = fn((void*)shim_AcquireSRWLockShared);
+    lib.functions["ReleaseSRWLockShared"] = fn((void*)shim_ReleaseSRWLockShared);
+    lib.functions["TryAcquireSRWLockShared"] = fn((void*)shim_TryAcquireSRWLockShared);
+    lib.functions["InitializeConditionVariable"] = fn((void*)shim_InitializeConditionVariable);
     lib.functions["SleepConditionVariableSRW"] = fn((void*)shim_SleepConditionVariableSRW);
     lib.functions["WakeAllConditionVariable"] = fn((void*)shim_WakeAllConditionVariable);
     lib.functions["WakeConditionVariable"] = fn((void*)shim_WakeConditionVariable);

--- a/src/win32/kernel32/Win32SyncContext.cpp
+++ b/src/win32/kernel32/Win32SyncContext.cpp
@@ -1,0 +1,197 @@
+/// @file Win32SyncContext.cpp
+/// @brief Out-of-line pthread state for Win32 SRW locks and condition variables.
+
+#include <metalsharp/Win32SyncContext.h>
+#include <sys/time.h>
+
+namespace metalsharp {
+namespace win32 {
+namespace {
+
+constexpr uint32_t kInfinite = 0xFFFFFFFF;
+
+void setTimeout(timespec* timeout, uint32_t milliseconds) {
+    clock_gettime(CLOCK_REALTIME, timeout);
+    timeout->tv_sec += milliseconds / 1000;
+    timeout->tv_nsec += static_cast<long>(milliseconds % 1000) * 1000000L;
+    if (timeout->tv_nsec >= 1000000000L) {
+        timeout->tv_sec++;
+        timeout->tv_nsec -= 1000000000L;
+    }
+}
+
+} // namespace
+
+Win32SyncContext::SrwLockState::SrwLockState() {
+    initialized = pthread_rwlock_init(&lock, nullptr) == 0;
+}
+
+Win32SyncContext::SrwLockState::~SrwLockState() {
+    if (initialized) {
+        pthread_rwlock_destroy(&lock);
+    }
+}
+
+Win32SyncContext::ConditionVariableState::ConditionVariableState() {
+    mutexInitialized = pthread_mutex_init(&waitMutex, nullptr) == 0;
+    if (mutexInitialized) {
+        conditionInitialized = pthread_cond_init(&condition, nullptr) == 0;
+    }
+}
+
+Win32SyncContext::ConditionVariableState::~ConditionVariableState() {
+    if (conditionInitialized) {
+        pthread_cond_destroy(&condition);
+    }
+    if (mutexInitialized) {
+        pthread_mutex_destroy(&waitMutex);
+    }
+}
+
+Win32SyncContext& Win32SyncContext::instance() {
+    // SRW locks and condition variables have no destruction APIs. Leaking the
+    // registry for the process lifetime also prevents static destruction from
+    // racing a guest thread that is still unwinding during process teardown.
+    static auto* context = new Win32SyncContext();
+    return *context;
+}
+
+Win32SyncContext::SrwLockState* Win32SyncContext::getSrwLock(void* address) {
+    if (!address) {
+        return nullptr;
+    }
+
+    const auto key = reinterpret_cast<uintptr_t>(address);
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto it = m_srwLocks.find(key);
+    if (it != m_srwLocks.end()) {
+        return it->second->initialized ? it->second.get() : nullptr;
+    }
+
+    auto state = std::make_unique<SrwLockState>();
+    if (!state->initialized) {
+        return nullptr;
+    }
+
+    auto* result = state.get();
+    m_srwLocks.emplace(key, std::move(state));
+    return result;
+}
+
+Win32SyncContext::ConditionVariableState* Win32SyncContext::getConditionVariable(void* address) {
+    if (!address) {
+        return nullptr;
+    }
+
+    const auto key = reinterpret_cast<uintptr_t>(address);
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto it = m_conditionVariables.find(key);
+    if (it != m_conditionVariables.end()) {
+        const auto* state = it->second.get();
+        return state->conditionInitialized && state->mutexInitialized ? it->second.get() : nullptr;
+    }
+
+    auto state = std::make_unique<ConditionVariableState>();
+    if (!state->conditionInitialized || !state->mutexInitialized) {
+        return nullptr;
+    }
+
+    auto* result = state.get();
+    m_conditionVariables.emplace(key, std::move(state));
+    return result;
+}
+
+void Win32SyncContext::initializeSrwLock(void* address) {
+    (void)getSrwLock(address);
+}
+
+void Win32SyncContext::initializeConditionVariable(void* address) {
+    (void)getConditionVariable(address);
+}
+
+bool Win32SyncContext::acquireSrwLockExclusive(void* address) {
+    auto* state = getSrwLock(address);
+    return state && pthread_rwlock_wrlock(&state->lock) == 0;
+}
+
+bool Win32SyncContext::releaseSrwLockExclusive(void* address) {
+    auto* state = getSrwLock(address);
+    return state && pthread_rwlock_unlock(&state->lock) == 0;
+}
+
+bool Win32SyncContext::tryAcquireSrwLockExclusive(void* address) {
+    auto* state = getSrwLock(address);
+    return state && pthread_rwlock_trywrlock(&state->lock) == 0;
+}
+
+bool Win32SyncContext::acquireSrwLockShared(void* address) {
+    auto* state = getSrwLock(address);
+    return state && pthread_rwlock_rdlock(&state->lock) == 0;
+}
+
+bool Win32SyncContext::releaseSrwLockShared(void* address) {
+    auto* state = getSrwLock(address);
+    return state && pthread_rwlock_unlock(&state->lock) == 0;
+}
+
+bool Win32SyncContext::tryAcquireSrwLockShared(void* address) {
+    auto* state = getSrwLock(address);
+    return state && pthread_rwlock_tryrdlock(&state->lock) == 0;
+}
+
+bool Win32SyncContext::sleepConditionVariableSrw(void* conditionVariable, void* srwLock, uint32_t milliseconds,
+                                                 uint32_t flags) {
+    auto* condition = getConditionVariable(conditionVariable);
+    auto* lock = getSrwLock(srwLock);
+    if (!condition || !lock || pthread_mutex_lock(&condition->waitMutex) != 0) {
+        return false;
+    }
+
+    const bool shared = (flags & CONDITION_VARIABLE_LOCKMODE_SHARED) != 0;
+    if (pthread_rwlock_unlock(&lock->lock) != 0) {
+        pthread_mutex_unlock(&condition->waitMutex);
+        return false;
+    }
+
+    int waitResult = 0;
+    if (milliseconds == kInfinite) {
+        waitResult = pthread_cond_wait(&condition->condition, &condition->waitMutex);
+    } else {
+        timespec timeout{};
+        setTimeout(&timeout, milliseconds);
+        waitResult = pthread_cond_timedwait(&condition->condition, &condition->waitMutex, &timeout);
+    }
+
+    // pthread_cond_wait/timedwait return with waitMutex held. Release that
+    // internal mutex before reacquiring the SRW lock: a waker is allowed to
+    // hold the SRW lock while calling WakeConditionVariable, and keeping the
+    // two locks held in opposite order would deadlock that valid pattern.
+    const int unlockResult = pthread_mutex_unlock(&condition->waitMutex);
+    const int reacquireResult = shared ? pthread_rwlock_rdlock(&lock->lock) : pthread_rwlock_wrlock(&lock->lock);
+    return waitResult == 0 && reacquireResult == 0 && unlockResult == 0;
+}
+
+bool Win32SyncContext::wakeConditionVariable(void* conditionVariable) {
+    auto* condition = getConditionVariable(conditionVariable);
+    if (!condition || pthread_mutex_lock(&condition->waitMutex) != 0) {
+        return false;
+    }
+
+    const int signalResult = pthread_cond_signal(&condition->condition);
+    const int unlockResult = pthread_mutex_unlock(&condition->waitMutex);
+    return signalResult == 0 && unlockResult == 0;
+}
+
+bool Win32SyncContext::wakeAllConditionVariable(void* conditionVariable) {
+    auto* condition = getConditionVariable(conditionVariable);
+    if (!condition || pthread_mutex_lock(&condition->waitMutex) != 0) {
+        return false;
+    }
+
+    const int broadcastResult = pthread_cond_broadcast(&condition->condition);
+    const int unlockResult = pthread_mutex_unlock(&condition->waitMutex);
+    return broadcastResult == 0 && unlockResult == 0;
+}
+
+} // namespace win32
+} // namespace metalsharp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -230,6 +230,12 @@ target_link_libraries(test_virtual_file_system PRIVATE metalsharp_loader metalsh
 
 add_test(NAME virtual_file_system COMMAND test_virtual_file_system)
 
+add_executable(test_win32_sync
+    test_win32_sync.cpp
+)
+target_link_libraries(test_win32_sync PRIVATE metalsharp_loader metalsharp_core)
+add_test(NAME win32_sync COMMAND test_win32_sync)
+
 add_executable(test_phase21
     test_phase21.cpp
 )

--- a/tests/test_darwin_sync_map.cpp
+++ b/tests/test_darwin_sync_map.cpp
@@ -16,6 +16,18 @@ int main() {
     assert(event->shippingReady);
     assert(!event->kernelRequired);
 
+    const auto* srwLock = darwinSyncMapping(DarwinSyncPrimitive::SrwLock);
+    assert(srwLock != nullptr);
+    assert(srwLock->strategy == DarwinSyncStrategy::PThreadRWLock);
+    assert(srwLock->shippingReady);
+    assert(!srwLock->kernelRequired);
+
+    const auto* conditionVariable = darwinSyncMapping(DarwinSyncPrimitive::ConditionVariable);
+    assert(conditionVariable != nullptr);
+    assert(conditionVariable->strategy == DarwinSyncStrategy::PThreadCondvar);
+    assert(conditionVariable->shippingReady);
+    assert(!conditionVariable->kernelRequired);
+
     const auto* waitAll = darwinSyncMapping(DarwinSyncPrimitive::WaitAll);
     assert(waitAll != nullptr);
     assert(waitAll->strategy == DarwinSyncStrategy::NeedsResearch);

--- a/tests/test_win32_sync.cpp
+++ b/tests/test_win32_sync.cpp
@@ -1,0 +1,206 @@
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <metalsharp/ExtraShims.h>
+#include <metalsharp/Win32SyncContext.h>
+#include <metalsharp/Win32Types.h>
+#include <thread>
+
+using metalsharp::ShimLibrary;
+using namespace metalsharp::win32;
+
+namespace {
+
+struct alignas(8) GuestSyncObject {
+    std::array<unsigned char, 8> bytes{};
+};
+
+using InitializeFn = void(MSABI*)(void*);
+using AcquireFn = void(MSABI*)(void*);
+using TryAcquireFn = BOOL(MSABI*)(void*);
+using SleepFn = BOOL(MSABI*)(void*, void*, DWORD, ULONG);
+using WakeFn = void(MSABI*)(void*);
+
+template <typename Function> Function getFunction(ShimLibrary& library, const char* name) {
+    auto it = library.functions.find(name);
+    if (it == library.functions.end()) {
+        return nullptr;
+    }
+    return reinterpret_cast<Function>(it->second());
+}
+
+bool isZero(const GuestSyncObject& object) {
+    for (unsigned char byte : object.bytes) {
+        if (byte != 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool test_srw_exports_and_static_initialization(ShimLibrary& library) {
+    const char* names[] = {
+        "InitializeSRWLock",          "AcquireSRWLockExclusive",     "ReleaseSRWLockExclusive",
+        "TryAcquireSRWLockExclusive", "AcquireSRWLockShared",        "ReleaseSRWLockShared",
+        "TryAcquireSRWLockShared",    "InitializeConditionVariable", "SleepConditionVariableSRW",
+        "WakeConditionVariable",      "WakeAllConditionVariable",
+    };
+    for (const char* name : names) {
+        if (!library.functions.contains(name)) {
+            return false;
+        }
+    }
+
+    auto initializeLock = getFunction<InitializeFn>(library, "InitializeSRWLock");
+    auto acquireExclusive = getFunction<AcquireFn>(library, "AcquireSRWLockExclusive");
+    auto releaseExclusive = getFunction<AcquireFn>(library, "ReleaseSRWLockExclusive");
+    auto tryExclusive = getFunction<TryAcquireFn>(library, "TryAcquireSRWLockExclusive");
+
+    GuestSyncObject lock;
+    acquireExclusive(&lock);
+    if (tryExclusive(&lock)) {
+        return false;
+    }
+    releaseExclusive(&lock);
+    if (!tryExclusive(&lock)) {
+        return false;
+    }
+    releaseExclusive(&lock);
+    if (!isZero(lock)) {
+        return false;
+    }
+
+    GuestSyncObject explicitlyInitialized;
+    initializeLock(&explicitlyInitialized);
+    return isZero(explicitlyInitialized);
+}
+
+bool test_shared_and_exclusive_modes(ShimLibrary& library) {
+    auto acquireExclusive = getFunction<AcquireFn>(library, "AcquireSRWLockExclusive");
+    auto releaseExclusive = getFunction<AcquireFn>(library, "ReleaseSRWLockExclusive");
+    auto tryExclusive = getFunction<TryAcquireFn>(library, "TryAcquireSRWLockExclusive");
+    auto acquireShared = getFunction<AcquireFn>(library, "AcquireSRWLockShared");
+    auto releaseShared = getFunction<AcquireFn>(library, "ReleaseSRWLockShared");
+    auto tryShared = getFunction<TryAcquireFn>(library, "TryAcquireSRWLockShared");
+
+    GuestSyncObject lock;
+    acquireShared(&lock);
+
+    std::atomic<BOOL> secondReader{0};
+    std::thread reader([&] {
+        secondReader.store(tryShared(&lock));
+        if (secondReader.load()) {
+            releaseShared(&lock);
+        }
+    });
+    reader.join();
+
+    const BOOL writerWhileReading = tryExclusive(&lock);
+    releaseShared(&lock);
+    const BOOL releasedReader = tryExclusive(&lock);
+    if (!secondReader.load() || writerWhileReading || !releasedReader) {
+        return false;
+    }
+    releaseExclusive(&lock);
+
+    if (!tryExclusive(&lock)) {
+        return false;
+    }
+    const BOOL readerWhileWriting = tryShared(&lock);
+    releaseExclusive(&lock);
+    return !readerWhileWriting;
+}
+
+bool test_condition_variable_wake_and_timeout(ShimLibrary& library) {
+    auto acquireExclusive = getFunction<AcquireFn>(library, "AcquireSRWLockExclusive");
+    auto releaseExclusive = getFunction<AcquireFn>(library, "ReleaseSRWLockExclusive");
+    auto tryExclusive = getFunction<TryAcquireFn>(library, "TryAcquireSRWLockExclusive");
+    auto initializeCondition = getFunction<InitializeFn>(library, "InitializeConditionVariable");
+    auto sleepCondition = getFunction<SleepFn>(library, "SleepConditionVariableSRW");
+    auto wakeCondition = getFunction<WakeFn>(library, "WakeConditionVariable");
+    auto wakeAll = getFunction<WakeFn>(library, "WakeAllConditionVariable");
+
+    GuestSyncObject lock;
+    GuestSyncObject condition;
+    initializeCondition(&condition);
+
+    std::atomic<bool> entered{false};
+    std::atomic<BOOL> woke{0};
+    std::thread waiter([&] {
+        acquireExclusive(&lock);
+        entered.store(true, std::memory_order_release);
+        woke.store(sleepCondition(&condition, &lock, 2000, 0), std::memory_order_release);
+        releaseExclusive(&lock);
+    });
+
+    while (!entered.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+
+    // Acquiring the lock proves that SleepConditionVariableSRW released it
+    // before the signal. The condition-variable wait mutex prevents the
+    // signal from being lost between those two operations.
+    while (!tryExclusive(&lock)) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    // Windows permits waking while the associated lock is held. The waiter
+    // must reacquire the lock only after this thread releases it.
+    wakeCondition(&condition);
+    releaseExclusive(&lock);
+    waiter.join();
+
+    if (!woke.load(std::memory_order_acquire)) {
+        return false;
+    }
+
+    acquireExclusive(&lock);
+    const auto start = std::chrono::steady_clock::now();
+    const BOOL timedOut = sleepCondition(&condition, &lock, 10, 0);
+    const auto elapsed =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start);
+    releaseExclusive(&lock);
+    const BOOL releasedAfterTimeout = tryExclusive(&lock);
+    if (releasedAfterTimeout) {
+        releaseExclusive(&lock);
+    }
+
+    // A condition wait must reacquire the lock even when it returns FALSE for
+    // a timeout. WakeAll is also safe when no waiter is currently present.
+    wakeAll(&condition);
+    return !timedOut && elapsed.count() < 1000 && releasedAfterTimeout && isZero(lock) && isZero(condition);
+}
+
+bool test_shared_condition_mode(ShimLibrary& library) {
+    auto acquireShared = getFunction<AcquireFn>(library, "AcquireSRWLockShared");
+    auto releaseShared = getFunction<AcquireFn>(library, "ReleaseSRWLockShared");
+    auto sleepCondition = getFunction<SleepFn>(library, "SleepConditionVariableSRW");
+
+    GuestSyncObject lock;
+    GuestSyncObject condition;
+    acquireShared(&lock);
+    const BOOL timedOut = sleepCondition(&condition, &lock, 1, CONDITION_VARIABLE_LOCKMODE_SHARED);
+    releaseShared(&lock);
+    return !timedOut && isZero(lock) && isZero(condition);
+}
+
+} // namespace
+
+int main() {
+    ShimLibrary library;
+    addMissingKernel32(library);
+
+    const bool exportsAndStaticInitialization = test_srw_exports_and_static_initialization(library);
+    const bool sharedAndExclusiveModes = test_shared_and_exclusive_modes(library);
+    const bool conditionWakeAndTimeout = test_condition_variable_wake_and_timeout(library);
+    const bool sharedConditionMode = test_shared_condition_mode(library);
+
+    std::printf("SRW/condition-variable tests: %s\n", exportsAndStaticInitialization ? "PASS" : "FAIL");
+    std::printf("shared/exclusive mode tests: %s\n", sharedAndExclusiveModes ? "PASS" : "FAIL");
+    std::printf("condition wake/timeout tests: %s\n", conditionWakeAndTimeout ? "PASS" : "FAIL");
+    std::printf("shared condition mode tests: %s\n", sharedConditionMode ? "PASS" : "FAIL");
+
+    return exportsAndStaticInitialization && sharedAndExclusiveModes && conditionWakeAndTimeout && sharedConditionMode
+               ? 0
+               : 1;
+}


### PR DESCRIPTION
## Summary

Fixes #424 by replacing the raw casts of zero-initialized Win32 SRW locks and condition variables with address-keyed, lazily initialized host synchronization state.

## Changes

- Added a process-local `Win32SyncContext` that maps guest SRW lock addresses to initialized `pthread_rwlock_t` objects and condition-variable addresses to initialized `pthread_cond_t` objects plus a wait mutex.
- Preserved zero/static initialization by keeping host pthread state out of the guest's pointer-sized storage.
- Implemented shared and exclusive SRW lock acquire/release/try paths, `InitializeSRWLock`, and `InitializeConditionVariable`.
- Made `SleepConditionVariableSRW` release and reacquire the mapped lock safely for both exclusive and shared modes, report timeouts correctly, and avoid lost wakes.
- Added focused native regression tests for lazy initialization, static storage preservation, shared/exclusive semantics, condition wake/timeout behavior, and the complete export surface.
- Updated the Darwin synchronization map and kernel-translation documentation.

## PR Readiness (MANDATORY)

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed (no config/rules files changed)
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped (no version bump)
- [x] Bottle/runtime migration and launch behavior preserved (native synchronization shim only; rollback plan noted below)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

## Local toolchain (run before push)

- [x] `cargo fmt --all -- --check` passes (not applicable; no Rust files changed)
- [x] `cargo clippy --all-targets -- -D warnings` passes (not applicable; no Rust files changed)
- [x] `cargo build --release` passes (not applicable; no Rust files changed)
- [x] `cargo test` passes (not applicable; no Rust files changed)
- [x] C++ compiles if changed: `cmake -S . -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON && cmake --build build-native --parallel $(sysctl -n hw.ncpu)`
- [x] `clang-format --dry-run --Werror` passes on all changed C/C++ files
- [x] `ctest --test-dir build-native` passes if tests changed (32/32)
- [x] TypeScript compiles if changed (not applicable; no TypeScript files changed)
- [x] Biome + Prettier pass if TS/JS changed (not applicable; no TS/JS files changed)
- [x] Shell scripts lint if changed: `tools/ci/shellcheck.sh` (passed; no shell files changed)
- [x] `tools/ci/validate-rules-toml.py` passes if `configs/mtsp-rules.toml` changed (passed; no rules files changed)
- [x] `python3 tools/ci/verify-dmg-workflow.py` passes if release/bundle tooling changed (passed; no release files changed)
- [ ] Tested with at least one game (which one? which launch method? which drive?)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files should be added to the repo root; place them under `app/`, `tools/`, `tests/`, etc.

## Test notes

- Full native Release configure/build passed.
- Full CTest suite passed: 32/32 tests, including the new `win32_sync` regression test.
- `tools/ci/check-clang-format.sh` passed.
- `tools/ci/shellcheck.sh`, rules TOML validation, and DMG workflow validation passed.
- Documentation freshness passed with the repository's existing warning for `docs/OPENGL-2-4-PLAN.md`.
- The new test repeatedly exercises zeroed guest buffers, shared/exclusive lock behavior, lock-held condition-variable wakeups, timeout reacquisition, and shared-mode waits.
- No real game was launched: this is a native synchronization-layer fix with no game-specific route change. The `checklist-exception` label is applied for the non-applicable game checks.

## Risk

This changes the host implementation of kernel32 synchronization exports while preserving the guest ABI and zero-initialized storage contract. The registry is process-local and intentionally retained for the process lifetime because Win32 SRW locks and condition variables have no destruction APIs; it does not provide cross-process synchronization. If a regression appears, revert commit `8fe148ec` to restore the previous shim behavior.

