### PR TITLE
ci: restore main formatting gates

### DIFF
--- a/app/src/main/dependency-actions.ts
+++ b/app/src/main/dependency-actions.ts
@@ -29,11 +29,7 @@ export function parseInstallDepsAction(value: unknown): InstallDepsAction | null
     return { kind: "brew", package: value.package as BrewDependency };
   }
 
-  if (
-    value.kind === "script" &&
-    typeof value.name === "string" &&
-    Object.prototype.hasOwnProperty.call(DEPENDENCY_SCRIPTS, value.name)
-  ) {
+  if (value.kind === "script" && typeof value.name === "string" && Object.hasOwn(DEPENDENCY_SCRIPTS, value.name)) {
     if (!hasExactKeys(value, ["kind", "name"])) return null;
     return { kind: "script", name: value.name as DependencyScript };
   }

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -3,7 +3,14 @@ import { app, BrowserWindow, clipboard, dialog, globalShortcut, ipcMain, shell }
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import { dependencyScriptFileName, parseInstallDepsAction } from "./dependency-actions";
 import { ejectDmgVolume } from "./dmg-eject";
+import {
+  type BackendMethod,
+  type BackendRequestSource,
+  isBackendRequestBody,
+  validateBackendRequest,
+} from "./ipc-security";
 import {
   createProcessManagerScope,
   isNonSteamMetalSharpWineProcess,
@@ -11,13 +18,6 @@ import {
   type ProcessRow,
   stopMetalSharpWineProcesses,
 } from "./process-manager";
-import { dependencyScriptFileName, parseInstallDepsAction } from "./dependency-actions";
-import {
-  type BackendMethod,
-  type BackendRequestSource,
-  isBackendRequestBody,
-  validateBackendRequest,
-} from "./ipc-security";
 import type { ProcessManagerAction, ProcessManagerActionResult, ProcessManagerSample } from "./process-manager-types";
 import { RustBridge } from "./rust-bridge";
 import { validateUninstallTarget } from "./uninstall-safety";

--- a/tests/test_phase24.cpp
+++ b/tests/test_phase24.cpp
@@ -12,12 +12,12 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <iterator>
 #include <limits>
 #include <string>
 #include <sys/stat.h>
-#include <unistd.h>
-#include <iterator>
 #include <thread>
+#include <unistd.h>
 #include <utility>
 #include <vector>
 

--- a/tests/test_ws2_32_events.cpp
+++ b/tests/test_ws2_32_events.cpp
@@ -30,7 +30,7 @@ using metalsharp::ShimLibrary;
 
 #ifndef FALSE
 #define FALSE 0
-#define TRUE 1
+#define TRUE  1
 #endif
 
 // --- Function-pointer types matching the shim's MSABI exports ---------------
@@ -62,12 +62,12 @@ struct WsaNetworkEvents {
 
 static int g_failures = 0;
 
-#define CHECK(cond)                                                                                                  \
-    do {                                                                                                             \
-        if (!(cond)) {                                                                                                \
-            fprintf(stderr, "FAIL: %s:%d: %s\n", __FILE__, __LINE__, #cond);                                      \
-            ++g_failures;                                                                                            \
-        }                                                                                                            \
+#define CHECK(cond)                                                                                                    \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            fprintf(stderr, "FAIL: %s:%d: %s\n", __FILE__, __LINE__, #cond);                                           \
+            ++g_failures;                                                                                              \
+        }                                                                                                              \
     } while (0)
 
 static void* makeLoopbackSockaddr(sockaddr_in* out, uint16_t port) {


### PR DESCRIPTION
## Summary

Restore the formatting contracts required by the main CI workflow after the #510 merge.

## Changes

- Use `Object.hasOwn` for the dependency-script allowlist so Biome's prototype-method rule passes without weakening the security check.
- Apply Biome's import ordering in the Electron main process.
- Apply the repository clang-format rules to the two native regression tests added by the merged PRs.

## PR Readiness (MANDATORY)

- [x] Compatibility verified with at least one real game (game + launch method noted below) — not applicable; this is lint/format-only and changes no runtime path
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed — no config/rules files changed
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped — no version bump
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed) — no bottle/runtime behavior changed
- [x] Docs / compatibility matrix updated for user-facing changes — no user-facing behavior changed
- [x] Regression test added for each bug fix — no new behavioral bug fix; existing security/native regression coverage was retained and formatted

## Local toolchain

- [x] `cd app && npm test`
- [x] `cd app && npm run test:security`
- [x] `cd app && npx tsc --noEmit`
- [x] `cd app && npx @biomejs/biome ci src/main src/shared`
- [x] `cd app && npx prettier --check src/main/dependency-actions.ts src/main/index.ts`
- [x] `tools/ci/check-clang-format.sh`
- [x] `git diff --check`
- [x] No Rust, shell, release, or runtime behavior changes; those gates are not applicable.

## Test notes

Formatting and Electron/security regression gates were run locally on the clean `main` tree at `f76e7554`.
No game launch was required because this is a formatting/lint-only correction; no runtime behavior changed.

## Risk

Minimal. The TypeScript allowlist behavior is unchanged for valid dependency names; the native changes are formatting-only. Revert commit `adef69da` if needed.
