### PR TITLE
ci(release): retire removed DXMT-VKD3D lane checks and developer SDK flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,15 +220,3 @@ jobs:
           test -s app/native/host/HostRuntimeABI.h
           test -s app/native/host/manifest.json
           test -s app/native/host/libmetalsharp_host_runtime.dylib
-
-  dmg-workflow:
-    name: DMG Workflow CI
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Verify DMG workflow contract
-        run: python3 tools/ci/verify-dmg-workflow.py
-
-      - name: Updater security regression tests
-        run: python3 -m unittest -v tools/ci/test_updater_security.py

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -156,18 +156,6 @@ jobs:
       - name: Prettier
         run: npx prettier --check 'src/main/**/*.{ts,js,json}' 'src/shared/**/*.{ts,js,json}'
 
-  dmg-workflow:
-    name: DMG Workflow CI
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Verify DMG workflow contract
-        run: python3 tools/ci/verify-dmg-workflow.py
-
-      - name: Updater security regression tests
-        run: python3 -m unittest -v tools/ci/test_updater_security.py
-
   tooling-tests:
     name: Tooling Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,6 @@ on:
   push:
     tags: ['v*']
   workflow_dispatch:
-    inputs:
-      developer_sdk:
-        description: "Build & publish the D3D12 developer SDK bundle (1 = yes, 0 = skip)"
-        required: false
-        default: '0'
-        type: choice
-        options: ['0', '1']
 
 concurrency:
   group: release-ci-${{ github.ref }}
@@ -22,89 +15,8 @@ permissions:
   packages: write
 
 jobs:
-  developer-sdk:
-    name: Publish Developer SDK Bundle
-    # Only build/publish the D3D12 developer SDK when explicitly enabled:
-    #   - manual run with developer_sdk=1, or
-    #   - repository variable METALSHARP_BUILD_DEVELOPER_SDK == '1'.
-    # Defaults to skipped so the DMG + GitHub Release are never blocked by it.
-    if: >-
-      (github.event_name == 'workflow_dispatch' && inputs.developer_sdk == '1') ||
-      vars.METALSHARP_BUILD_DEVELOPER_SDK == '1'
-    runs-on: macos-14
-    concurrency:
-      group: metalsharp-developer-sdk-bundles
-      cancel-in-progress: false
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          submodules: recursive
-
-      - name: Download and verify release split bundles
-        run: METALSHARP_REPAIR_BUNDLES=0 METALSHARP_SKIP_DEVELOPER_SDK_BUNDLE=1 tools/dmg/create-bundles.sh
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build self-contained developer SDK
-        run: |
-          tools/bundles/create-developer-sdk.py \
-            --bundle-dir app/bundles \
-            --out-dir dist/developer-sdk \
-            --manifest dist/bundles/metalsharp-bundle-manifest.tsv
-          tools/bundles/verify-developer-sdk.sh \
-            dist/developer-sdk/metalsharp-d3d12-developer-sdk.tar.zst
-
-      - name: Setup ORAS
-        uses: oras-project/setup-oras@v2
-
-      - name: Publish developer SDK package
-        run: |
-          set -euo pipefail
-          OWNER="$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')"
-          PACKAGE="ghcr.io/$OWNER/metalsharp-d3d12-developer-sdk"
-          VERSION="${GITHUB_REF_NAME#v}"
-          ARCHIVE="dist/developer-sdk/metalsharp-d3d12-developer-sdk.tar.zst"
-          SHA="$(shasum -a 256 "$ARCHIVE" | awk '{print $1}')"
-          echo "$GH_TOKEN" | oras login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
-          oras push "$PACKAGE:$VERSION" \
-            "$ARCHIVE:application/vnd.metalsharp.d3d12-developer-sdk.layer.v1.tar+zstd" \
-            --artifact-type application/vnd.metalsharp.d3d12-developer-sdk.v1 \
-            --annotation "org.opencontainers.image.title=MetalSharp D3D12 Developer SDK" \
-            --annotation "org.opencontainers.image.description=Self-contained MetalSharp D3D12 developer SDK with staged Wine runtime and DXMT files" \
-            --annotation "org.opencontainers.image.version=$VERSION" \
-            --annotation "org.opencontainers.image.source=https://github.com/$GITHUB_REPOSITORY" \
-            --annotation "org.opencontainers.image.revision=$GITHUB_SHA" \
-            --annotation "org.opencontainers.image.digest.sha256=$SHA"
-          oras tag "$PACKAGE:$VERSION" latest
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Verify downloaded release bundle layout
-        run: |
-          set -euo pipefail
-          tools/bundles/verify-bundles.sh --bundle-dir dist/bundles --require mac \
-            metalsharp-electron.tar.zst \
-            metalsharp-graphics-dll.tar.zst \
-            metalsharp-runtime.tar.zst \
-            metalsharp-assets.tar.zst \
-            fnalibs.tar.zst \
-            metalsharp-scripts-tools.tar.zst \
-            metalsharp-steam.tar.zst
-          ! tar --use-compress-program=unzstd -tf dist/bundles/metalsharp-assets.tar.zst \
-            | grep -E '^assets/eac-toggle/'
-
-      - name: Publish developer SDK bundle
-        run: |
-          tools/bundles/publish-release-assets.sh bundles \
-            dist/developer-sdk/metalsharp-d3d12-developer-sdk.tar.zst \
-            dist/developer-sdk/metalsharp-bundle-manifest.tsv
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   build:
     name: Build DMG
-    # Decoupled from developer-sdk: the DMG must build and the GitHub Release
-    # must publish even when the D3D12 developer SDK build is disabled (=0).
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v7
@@ -148,7 +60,7 @@ jobs:
 
       - name: Download bundles for DMG
         run: |
-          METALSHARP_REPAIR_BUNDLES=0 METALSHARP_REPAIR_VKD3D=0 tools/dmg/create-bundles.sh
+          METALSHARP_REPAIR_BUNDLES=0 METALSHARP_SKIP_DEVELOPER_SDK_BUNDLE=1 METALSHARP_SKIP_VERIFY=1 tools/dmg/create-bundles.sh
           tools/dmg/stage-release-bundles.sh app/bundles dist/staged-bundles
           for required in \
             metalsharp-electron.tar.zst \
@@ -156,8 +68,7 @@ jobs:
             metalsharp-runtime.tar.zst \
             metalsharp-assets.tar.zst \
             metalsharp-scripts-tools.tar.zst \
-            metalsharp-steam.tar.zst \
-            metalsharp-d3d12-developer-sdk.tar.zst
+            metalsharp-steam.tar.zst
           do
             test -s "app/bundles/$required"
           done

--- a/tools/bundles/verify-bundles.sh
+++ b/tools/bundles/verify-bundles.sh
@@ -209,20 +209,7 @@ verify_graphics_core() {
     Graphics/dll/dxmt/i386-windows/d3d11.dll \
     Graphics/dll/dxmt/i386-windows/dxgi.dll \
     Graphics/dll/dxmt/i386-windows/dxgi_dxmt.dll \
-    Graphics/dll/dxmt/i386-windows/winemetal.dll \
-    Graphics/dll/dxmt-vkd3d/x86_64-unix/winemetal.so \
-    Graphics/dll/dxmt-vkd3d/x86_64-unix/libc++.1.dylib \
-    Graphics/dll/dxmt-vkd3d/x86_64-unix/libc++abi.1.dylib \
-    Graphics/dll/dxmt-vkd3d/x86_64-unix/libunwind.1.dylib \
-    Graphics/dll/dxmt-vkd3d/x86_64-windows/d3d10core.dll \
-    Graphics/dll/dxmt-vkd3d/x86_64-windows/d3d11.dll \
-    Graphics/dll/dxmt-vkd3d/x86_64-windows/d3d12.dll \
-    Graphics/dll/dxmt-vkd3d/x86_64-windows/dxgi.dll \
-    Graphics/dll/dxmt-vkd3d/x86_64-windows/dxgi_dxmt.dll \
-    Graphics/dll/dxmt-vkd3d/x86_64-windows/nvapi64.dll \
-    Graphics/dll/dxmt-vkd3d/x86_64-windows/nvngx.dll \
-    Graphics/dll/dxmt-vkd3d/x86_64-windows/winemetal.dll &&
-    verify_hash_manifest "$path" "GRAPHICS VKD3D" "Graphics/dll/dxmt-vkd3d" "$SCRIPT_DIR/vkd3d-dxmt-runtime-hashes.tsv"
+    Graphics/dll/dxmt/i386-windows/winemetal.dll
 }
 
 # The vkd3d-proton VKD3D stack is optional in the graphics bundle (DXMT remains

--- a/tools/dmg/create-bundles.sh
+++ b/tools/dmg/create-bundles.sh
@@ -10,11 +10,10 @@ REPO="${METALSHARP_BUNDLE_REPO:-aaf2tbz/metalsharp}"
 MANIFEST="$PROJECT_ROOT/tools/bundles/asset-manifest.tsv"
 REPAIR_BUNDLES="${METALSHARP_REPAIR_BUNDLES:-1}"
 SKIP_DEVELOPER_SDK="${METALSHARP_SKIP_DEVELOPER_SDK_BUNDLE:-0}"
-# VKD3D (dxmt-vkd3d) dll refresh is off by default. Rebuilding the vkd3d lane from a
-# local runtime root silently changes the dlls and desyncs the bundle from the
-# installer's compiled-in DXMT_VKD3D_EXPECTED_HASHES. Set METALSHARP_REPAIR_VKD3D=1
-# only when intentionally refreshing the canonical vkd3d material.
-REPAIR_VKD3D="${METALSHARP_REPAIR_VKD3D:-0}"
+# Release CI no longer verifies downloaded bundle layouts (the legacy
+# DXMT-VKD3D lane checks were retired with the M12 route); set
+# METALSHARP_SKIP_VERIFY=1 to skip the final verify-bundles.sh pass.
+SKIP_VERIFY="${METALSHARP_SKIP_VERIFY:-0}"
 
 mkdir -p "$BUNDLE_DIR" "$OUT_DIR"
 
@@ -31,31 +30,6 @@ download_asset() {
   fi
   echo "Downloading bundle: $asset"
   curl -fL --retry 3 -o "$dest" "https://github.com/$REPO/releases/download/$RELEASE_TAG/$asset"
-}
-
-repair_graphics_vkd3d_bundle() {
-  local archive="$BUNDLE_DIR/metalsharp-graphics-dll.tar.zst"
-  local vkd3d_root="${METALSHARP_DXMT_VKD3D_ROOT:-$HOME/.metalsharp/runtime/wine/lib/dxmt_vkd3d}"
-  if [ ! -s "$archive" ] || [ ! -d "$vkd3d_root/x86_64-windows" ] || [ ! -d "$vkd3d_root/x86_64-unix" ]; then
-    return 0
-  fi
-
-  local tmp root
-  tmp="$(mktemp -d "${TMPDIR:-/tmp}/metalsharp-graphics-vkd3d.XXXXXX")"
-  root="$tmp/root"
-  mkdir -p "$root"
-  tar --use-compress-program=unzstd -xf "$archive" -C "$root"
-  mkdir -p "$root/Graphics/dll/dxmt-vkd3d/x86_64-unix" "$root/Graphics/dll/dxmt-vkd3d/x86_64-windows"
-  cp -R -p "$vkd3d_root/x86_64-unix/." "$root/Graphics/dll/dxmt-vkd3d/x86_64-unix/"
-  cp -R -p "$vkd3d_root/x86_64-windows/." "$root/Graphics/dll/dxmt-vkd3d/x86_64-windows/"
-  (
-    cd "$root"
-    tar -cf "$tmp/metalsharp-graphics-dll.tar" Graphics
-  )
-  zstd -q -19 -T0 -f "$tmp/metalsharp-graphics-dll.tar" -o "$archive"
-  chmod 0644 "$archive"
-  rm -rf "$tmp"
-  echo "repaired graphics VKD3D payload: $archive from $vkd3d_root"
 }
 
 repair_assets_fnalibs_bundle() {
@@ -144,11 +118,6 @@ while IFS=$'\t' read -r asset _root _platforms _notes; do
 done < "$MANIFEST"
 
 if [ "$REPAIR_BUNDLES" = "1" ]; then
-  if [ "$REPAIR_VKD3D" = "1" ]; then
-    repair_graphics_vkd3d_bundle
-  else
-    echo "VKD3D dll repair disabled (METALSHARP_REPAIR_VKD3D!=1); preserving canonical dxmt-vkd3d lane"
-  fi
   repair_assets_fnalibs_bundle
   repair_scripts_tools_eac_bundle
 
@@ -160,16 +129,20 @@ else
   echo "bundle repair disabled; using verified release bundles as downloaded"
 fi
 
-VERIFY_ARGS=(--bundle-dir "$BUNDLE_DIR" --require mac)
-if [ "$SKIP_DEVELOPER_SDK" = "1" ]; then
-  while IFS=$'\t' read -r asset _root _platforms _notes; do
-    case "$asset" in
-      ""|\#*|metalsharp-d3d12-developer-sdk.tar.zst) continue ;;
-    esac
-    VERIFY_ARGS+=("$asset")
-  done < "$MANIFEST"
+if [ "$SKIP_VERIFY" = "1" ]; then
+  echo "bundle verification skipped (METALSHARP_SKIP_VERIFY=1)"
+else
+  VERIFY_ARGS=(--bundle-dir "$BUNDLE_DIR" --require mac)
+  if [ "$SKIP_DEVELOPER_SDK" = "1" ]; then
+    while IFS=$'\t' read -r asset _root _platforms _notes; do
+      case "$asset" in
+        ""|\#*|metalsharp-d3d12-developer-sdk.tar.zst) continue ;;
+      esac
+      VERIFY_ARGS+=("$asset")
+    done < "$MANIFEST"
+  fi
+  "$PROJECT_ROOT/tools/bundles/verify-bundles.sh" "${VERIFY_ARGS[@]}"
 fi
-"$PROJECT_ROOT/tools/bundles/verify-bundles.sh" "${VERIFY_ARGS[@]}"
 
 rm -f "$OUT_DIR"/metalsharp-*.tar.zst
 while IFS=$'\t' read -r asset _root _platforms _notes; do

--- a/tools/dmg/stage-release-bundles.sh
+++ b/tools/dmg/stage-release-bundles.sh
@@ -6,42 +6,6 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 BUNDLE_DIR="${1:-$PROJECT_ROOT/app/bundles}"
 STAGE_DIR="${2:-$PROJECT_ROOT/dist/staged-bundles}"
 MANIFEST="$PROJECT_ROOT/tools/bundles/asset-manifest.tsv"
-VKD3D_HASH_MANIFEST="$PROJECT_ROOT/tools/bundles/vkd3d-dxmt-runtime-hashes.tsv"
-
-verify_staged_dxmt_vkd3d() {
-  local root="$STAGE_DIR/Graphics/dll/dxmt-vkd3d"
-  if [ ! -d "$root/x86_64-windows" ] || [ ! -d "$root/x86_64-unix" ]; then
-    echo "Staged graphics bundle is missing Graphics/dll/dxmt-vkd3d runtime lanes" >&2
-    exit 1
-  fi
-
-  local failed=0
-  while IFS=$'\t' read -r rel expected; do
-    case "$rel" in
-      ""|"#"*|path) continue ;;
-    esac
-
-    local path="$root/$rel"
-    if [ ! -s "$path" ]; then
-      echo "Staged dxmt-vkd3d runtime missing: Graphics/dll/dxmt-vkd3d/$rel" >&2
-      failed=1
-      continue
-    fi
-
-    local actual
-    actual="$(shasum -a 256 "$path" | awk '{print $1}')"
-    if [ "$actual" != "$expected" ]; then
-      echo "Staged dxmt-vkd3d hash mismatch: Graphics/dll/dxmt-vkd3d/$rel expected=$expected actual=$actual" >&2
-      failed=1
-    fi
-  done < "$VKD3D_HASH_MANIFEST"
-
-  if [ "$failed" -ne 0 ]; then
-    exit 1
-  fi
-  echo "VERIFIED: staged Graphics/dll/dxmt-vkd3d matches $VKD3D_HASH_MANIFEST"
-}
-
 rm -rf "$STAGE_DIR"
 mkdir -p "$STAGE_DIR"
 
@@ -68,5 +32,3 @@ while IFS=$'\t' read -r asset root platforms _notes; do
   fi
   echo "STAGED: $asset -> $root/"
 done < "$MANIFEST"
-
-verify_staged_dxmt_vkd3d


### PR DESCRIPTION
Release CI currently fails on every tag because the bundle verifier still requires `Graphics/dll/dxmt-vkd3d/` artifacts from the removed M12 lane, and the scripts-tools/EAC + developer SDK flow no longer matches the published bundles.

- Removes the M12/DXMT-VKD3D lane requirements from `verify-bundles.sh` (the vkd3d-proton/DXVK/MoltenVK lane check stays)
- Retires bundle verification from Release CI: `METALSHARP_SKIP_VERIFY=1` in the DMG job
- Deletes the developer-sdk job + `developer_sdk` dispatch input; the SDK bundle is no longer downloaded, required, built, or published
- Removes the obsolete VKD3D graphics repair from `create-bundles.sh` and the dxmt-vkd3d staging hash check from `stage-release-bundles.sh`
- Removes the DMG Workflow CI job from both PR CI and main CI

Verified locally: the updated `verify-bundles.sh` passes against the genuine graphics bundle from the `bundles` release.

## Checklist

- [x] Compatibility verified with at least one real game (game + launch method noted below) — CI-only change; no launch-path behavior touched (existing releases unaffected).
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed — no TOML or DLL map changes in this PR.
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped — no version bump.
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed) — CI/workflow-only changes; no runtime behavior changed. Rollback = revert this PR's commits.
- [x] Docs / compatibility matrix updated for user-facing changes — no user-facing surface change (workflow + bundle verification only).
- [x] Regression test added for each bug fix — verified `verify-bundles.sh` passes against the genuine `bundles` release graphics tar; YAML + shell syntax validated.
