### PR TITLE
Switch MetalSharp installation and migration to VKMT Wine

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,20 +149,13 @@ jobs:
       - name: Download bundles for DMG
         run: |
           METALSHARP_REPAIR_BUNDLES=0 METALSHARP_REPAIR_M12=0 tools/dmg/create-bundles.sh
-          tools/dmg/stage-release-bundles.sh app/bundles dist/staged-bundles
           for required in \
-            metalsharp-electron.tar.zst \
-            metalsharp-graphics-dll.tar.zst \
-            metalsharp-runtime.tar.zst \
-            metalsharp-assets.tar.zst \
-            metalsharp-scripts-tools.tar.zst \
             metalsharp-steam.tar.zst \
-            metalsharp-d3d12-developer-sdk.tar.zst
+            goldberg.tar.zst
           do
             test -s "app/bundles/$required"
           done
           ls -lh app/bundles/
-          find dist/staged-bundles -type d | sort | sed -n '1,120p'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/app/package.json
+++ b/app/package.json
@@ -139,36 +139,16 @@
         ]
       },
       {
-        "from": "bundles/metalsharp-electron.tar.zst",
-        "to": "bundles/metalsharp-electron.tar.zst"
-      },
-      {
-        "from": "bundles/metalsharp-graphics-dll.tar.zst",
-        "to": "bundles/metalsharp-graphics-dll.tar.zst"
-      },
-      {
-        "from": "bundles/metalsharp-runtime.tar.zst",
-        "to": "bundles/metalsharp-runtime.tar.zst"
-      },
-      {
-        "from": "bundles/metalsharp-assets.tar.zst",
-        "to": "bundles/metalsharp-assets.tar.zst"
-      },
-      {
-        "from": "bundles/fnalibs.tar.zst",
-        "to": "bundles/fnalibs.tar.zst"
-      },
-      {
-        "from": "bundles/metalsharp-scripts-tools.tar.zst",
-        "to": "bundles/metalsharp-scripts-tools.tar.zst"
+        "from": "../tools/migrator/migrate-to-vkmt-runtime.sh",
+        "to": "scripts/tools/migrator/migrate-to-vkmt-runtime.sh"
       },
       {
         "from": "bundles/metalsharp-steam.tar.zst",
         "to": "bundles/metalsharp-steam.tar.zst"
       },
       {
-        "from": "bundles/metalsharp-d3d12-developer-sdk.tar.zst",
-        "to": "bundles/metalsharp-d3d12-developer-sdk.tar.zst"
+        "from": "bundles/goldberg.tar.zst",
+        "to": "bundles/goldberg.tar.zst"
       }
     ],
     "directories": {

--- a/app/src-rust/src/bottles.rs
+++ b/app/src-rust/src/bottles.rs
@@ -51,6 +51,15 @@ fn vcpp_download(url: &str, dest: &Path) -> Result<(), String> {
         let _ = fs::remove_file(&tmp);
         return Err(format!("downloaded file too small or missing: {}", dest.display()));
     }
+    let file_type = Command::new("/usr/bin/file")
+        .args(["-b", tmp.to_string_lossy().as_ref()])
+        .output()
+        .map_err(|e| format!("file type check failed: {}", e))?;
+    let file_type = String::from_utf8_lossy(&file_type.stdout).to_ascii_lowercase();
+    if !file_type.contains("pe32") && !file_type.contains("ms-dos") {
+        let _ = fs::remove_file(&tmp);
+        return Err(format!("downloaded VC++ installer is not a Windows executable: {}", file_type.trim()));
+    }
     let _ = fs::rename(&tmp, dest);
     Ok(())
 }
@@ -170,15 +179,18 @@ fn run_interactive_vcpp_installer(prefix: &Path, installer: &Path, arch: &str) -
         return Err("MetalSharp Wine not found".into());
     }
     let prefix_str = prefix.to_string_lossy().to_string();
-    eprintln!("vcredist: launching interactive VC++ 2015-2022 {} installer into {} ...", arch, prefix.display());
+    eprintln!("vcredist: launching VC++ 2015-2022 {} installer into {} ...", arch, prefix.display());
     let mut cmd = Command::new(&wine);
-    cmd.arg("start")
-        .arg("/wait")
-        .arg("/unix")
-        .arg(installer)
+    // Invoke the PE directly through the VKMT Wine launcher. `wine start
+    // /wait /unix` returns status 1 on this WoW64/FEX runtime even when it
+    // successfully opens the redistributable, and setting WINEARCH=win64 on
+    // an existing prefix can make both x86 and x64 installers exit before
+    // doing any work. The direct invocation plus wineserver drain gives us a
+    // reliable completion boundary, and the DLL checks below remain the
+    // authoritative success test.
+    cmd.arg(installer)
         .args(vcpp_setup_install_args())
         .env("WINEPREFIX", &prefix_str)
-        .env("WINEARCH", "win64")
         .env("WINEDEBUG", "-all")
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
@@ -188,7 +200,13 @@ fn run_interactive_vcpp_installer(prefix: &Path, installer: &Path, arch: &str) -
     }
     crate::platform::set_runtime_library_env(&mut cmd, &ms_root);
     let status = cmd.status().map_err(|e| format!("wine {} failed: {}", arch, e))?;
-    if vcpp_installer_status_ok(status.code()) {
+    let _ = Command::new(ms_root.join("bin").join("wineserver")).env("WINEPREFIX", &prefix_str).arg("-w").status();
+    let verified = match arch {
+        "x64" => vcpp_prefix_has_x64(prefix),
+        "x86" => vcpp_prefix_has_x86(prefix),
+        _ => false,
+    };
+    if vcpp_installer_status_ok(status.code()) || verified {
         Ok(())
     } else {
         Err(format!("VC++ {} installer exited with status {:?}", arch, status.code()))

--- a/app/src-rust/src/installer.rs
+++ b/app/src-rust/src/installer.rs
@@ -383,21 +383,58 @@ fn run_vkmt_install(script: &Path) {
         },
     };
     let ms_dir = crate::platform::metalsharp_home_dir_for(&home);
-    let total = 4;
-    write_progress(0, total, "VKMT Wine", "installing", "Downloading and verifying VKMT Wine...", None);
+    let total = 100;
+    write_progress(0, total, "MetalSharp Wine", "installing", "Preparing MetalSharp Wine installation...", None);
 
-    if let Err(error) = ensure_zstd() {
-        write_progress(1, total, "VKMT Wine", "error", &error, Some(&error));
+    write_progress(2, total, "Xcode Command Line Tools", "installing", "Checking Xcode Command Line Tools...", None);
+    if let Err(error) = install_xcode_cli() {
+        write_progress(
+            2,
+            total,
+            "Xcode Command Line Tools",
+            "error",
+            &format!("Xcode Command Line Tools check failed: {}", error),
+            Some(&error),
+        );
+        return;
+    }
+    write_progress(
+        5,
+        total,
+        "Xcode Command Line Tools",
+        "done",
+        "Xcode Command Line Tools are installed and functional.",
+        None,
+    );
+
+    if !check_command("brew") {
+        let error = "Homebrew is required to install zstd; return to the Homebrew step and install it first";
+        write_progress(5, total, "Homebrew", "error", error, Some(error));
         return;
     }
 
+    write_progress(7, total, "zstd", "installing", "Checking for zstd...", None);
+
+    if let Err(error) = ensure_zstd() {
+        write_progress(7, total, "zstd", "error", &error, Some(&error));
+        return;
+    }
+    write_progress(10, total, "zstd", "done", "zstd is installed and ready.", None);
+
     let _ = fs::create_dir_all(ms_dir.join("logs"));
     let log_path = ms_dir.join("logs/vkmt-install.log");
+    let progress_path = ms_dir.join("install_progress.json");
     let log = fs::OpenOptions::new().create(true).write(true).truncate(true).open(&log_path).ok();
     let log_stderr = log.as_ref().and_then(|file| file.try_clone().ok());
 
     let mut command = Command::new("/bin/bash");
-    command.arg(script).arg("--apply").env("METALSHARP_HOME", &ms_dir).env("METALSHARP_VKMT_PRIMARY", "1");
+    command
+        .arg(script)
+        .arg("--apply")
+        .env("METALSHARP_HOME", &ms_dir)
+        .env("METALSHARP_VKMT_PRIMARY", "1")
+        .env("METALSHARP_INSTALL_PROGRESS_FILE", &progress_path);
+    write_progress(12, total, "MetalSharp Wine", "downloading", "Downloading and verifying MetalSharp Wine...", None);
     if let Some(file) = log {
         command.stdout(Stdio::from(file));
     } else {
@@ -411,16 +448,27 @@ fn run_vkmt_install(script: &Path) {
     let status = command.status();
 
     match status {
-        Ok(result) if result.success() => {
-            write_progress(total, total, "Complete", "complete", "VKMT Wine and fresh Steam prefix installed.", None);
+        Ok(result) if result.success() && crate::migrate::vkmt_runtime_current_for_ms_dir(&ms_dir) => {
+            write_progress(
+                total,
+                total,
+                "Complete",
+                "complete",
+                "MetalSharp Wine and the VKMT Steam prefix are ready.",
+                None,
+            );
         },
         Ok(result) => {
-            let error = format!("VKMT migration script exited with status {}", result);
-            write_progress(1, total, "VKMT Wine", "error", &error, Some(&error));
+            let error = if result.success() {
+                "MetalSharp Wine installer finished, but the runtime or Steam prefix is incomplete".to_string()
+            } else {
+                format!("MetalSharp Wine installer exited with status {}", result)
+            };
+            write_progress(95, total, "MetalSharp Wine", "error", &error, Some(&error));
         },
         Err(error) => {
             let message = format!("failed to run VKMT migration script: {}", error);
-            write_progress(1, total, "VKMT Wine", "error", &message, Some(&message));
+            write_progress(12, total, "MetalSharp Wine", "error", &message, Some(&message));
         },
     }
 }
@@ -659,11 +707,23 @@ fn install_xcode_cli() -> Result<bool, String> {
 }
 
 fn xcode_cli_functional() -> bool {
-    let clang = match find_system_command("clang") {
-        Some(p) => p,
-        None => return false,
+    let developer_dir = match Command::new("/usr/bin/xcode-select").arg("-p").output() {
+        Ok(output) if output.status.success() => String::from_utf8_lossy(&output.stdout).trim().to_string(),
+        _ => return false,
     };
-    Command::new(&clang)
+    if developer_dir.is_empty() || !Path::new(&developer_dir).is_dir() {
+        return false;
+    }
+
+    let clang = match Command::new("/usr/bin/xcrun").args(["--sdk", "macosx", "--find", "clang"]).output() {
+        Ok(output) if output.status.success() => String::from_utf8_lossy(&output.stdout).trim().to_string(),
+        _ => return false,
+    };
+    if clang.is_empty() || !Path::new(&clang).is_file() {
+        return false;
+    }
+
+    Command::new(clang)
         .args(["-x", "c", "-c", "-o", "/dev/null", "-"])
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::null())
@@ -2481,7 +2541,7 @@ fn make_executable(path: &PathBuf) {
 }
 
 pub fn ensure_zstd() -> Result<bool, String> {
-    if check_command("unzstd") {
+    if check_command("zstd") && check_command("unzstd") {
         return Ok(false);
     }
     brew_install("zstd")

--- a/app/src-rust/src/installer.rs
+++ b/app/src-rust/src/installer.rs
@@ -1,7 +1,7 @@
 use serde_json::{json, Value};
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
@@ -337,12 +337,92 @@ pub fn start_install_all() -> Result<Value, Box<dyn std::error::Error>> {
         return Ok(json!({"ok": false, "error": "installation already in progress"}));
     }
 
-    std::thread::spawn(|| {
-        run_install_all();
+    let vkmt_script = vkmt_migration_script_path();
+    std::thread::spawn(move || {
+        if let Some(script) = vkmt_script {
+            run_vkmt_install(&script);
+        } else {
+            run_install_all();
+        }
         INSTALLING.store(false, Ordering::SeqCst);
     });
 
     Ok(json!({"ok": true}))
+}
+
+fn vkmt_migration_script_path() -> Option<PathBuf> {
+    if let Ok(explicit) = std::env::var("METALSHARP_VKMT_MIGRATION_SCRIPT") {
+        let path = PathBuf::from(explicit);
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+
+    if let Some(resources) = crate::platform::app_resources_dir() {
+        let path = resources.join("scripts/tools/migrator/migrate-to-vkmt-runtime.sh");
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+
+    [
+        PathBuf::from("tools/migrator/migrate-to-vkmt-runtime.sh"),
+        PathBuf::from("../tools/migrator/migrate-to-vkmt-runtime.sh"),
+        PathBuf::from("../../tools/migrator/migrate-to-vkmt-runtime.sh"),
+    ]
+    .into_iter()
+    .find(|path| path.is_file())
+}
+
+fn run_vkmt_install(script: &Path) {
+    let home = match dirs::home_dir() {
+        Some(home) => home,
+        None => {
+            write_progress(0, 0, "VKMT Wine", "error", "no home directory", Some("no_home"));
+            return;
+        },
+    };
+    let ms_dir = crate::platform::metalsharp_home_dir_for(&home);
+    let total = 4;
+    write_progress(0, total, "VKMT Wine", "installing", "Downloading and verifying VKMT Wine...", None);
+
+    if let Err(error) = ensure_zstd() {
+        write_progress(1, total, "VKMT Wine", "error", &error, Some(&error));
+        return;
+    }
+
+    let _ = fs::create_dir_all(ms_dir.join("logs"));
+    let log_path = ms_dir.join("logs/vkmt-install.log");
+    let log = fs::OpenOptions::new().create(true).write(true).truncate(true).open(&log_path).ok();
+    let log_stderr = log.as_ref().and_then(|file| file.try_clone().ok());
+
+    let mut command = Command::new("/bin/bash");
+    command.arg(script).arg("--apply").env("METALSHARP_HOME", &ms_dir).env("METALSHARP_VKMT_PRIMARY", "1");
+    if let Some(file) = log {
+        command.stdout(Stdio::from(file));
+    } else {
+        command.stdout(Stdio::null());
+    }
+    if let Some(file) = log_stderr {
+        command.stderr(Stdio::from(file));
+    } else {
+        command.stderr(Stdio::null());
+    }
+    let status = command.status();
+
+    match status {
+        Ok(result) if result.success() => {
+            write_progress(total, total, "Complete", "complete", "VKMT Wine and fresh Steam prefix installed.", None);
+        },
+        Ok(result) => {
+            let error = format!("VKMT migration script exited with status {}", result);
+            write_progress(1, total, "VKMT Wine", "error", &error, Some(&error));
+        },
+        Err(error) => {
+            let message = format!("failed to run VKMT migration script: {}", error);
+            write_progress(1, total, "VKMT Wine", "error", &message, Some(&message));
+        },
+    }
 }
 
 fn run_install_all() {

--- a/app/src-rust/src/migrate.rs
+++ b/app/src-rust/src/migrate.rs
@@ -2,11 +2,11 @@ use serde_json::json;
 use std::cmp::Ordering as CmpOrdering;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 const MIGRATE_VERSION: &str = env!("CARGO_PKG_VERSION");
-const MIGRATE_SCHEMA_VERSION: u64 = 5;
+const MIGRATE_SCHEMA_VERSION: u64 = 6;
 const GOG_PREFIX_BOTTLE_ID: &str = "gog-prefix";
 const MIGRATION_PAYLOAD_DENY_NAMES: &[&str] = &[
     "steamapps",
@@ -339,6 +339,10 @@ fn parse_version_parts(value: &str) -> Vec<u32> {
 }
 
 fn runtime_core_ready(ms_dir: &Path) -> bool {
+    if vkmt_runtime_current_for_ms_dir(ms_dir) {
+        return true;
+    }
+
     let runtime_wine = ms_dir.join("runtime").join("wine");
     let runtime_host = ms_dir.join("runtime").join("host");
     let wine = crate::platform::runtime_wine_binary(&runtime_wine);
@@ -427,6 +431,16 @@ fn run_migration() {
     if let Some(error) = post_update_target_error(post_update_marker.as_ref()) {
         write_migrate_progress("error", 0, MIGRATION_TOTAL_STEPS, &error, Some("post_update_target_version_mismatch"));
         log_to_file(&format!("Migration blocked before runtime work: {}", error));
+        return;
+    }
+
+    // New DMG builds carry only the Steam and Goldberg bootstrap archives.
+    // Their migration path downloads and verifies VKMT-Wine itself, creates a
+    // fresh VKMT prefix, and restores only Steam/state data. Keep the legacy
+    // Rust bundle migration below as a compatibility fallback for older app
+    // resources and developer trees.
+    if let Some(script) = vkmt_migration_script_path() {
+        run_vkmt_migration_script(&script, &ms_dir);
         return;
     }
 
@@ -562,6 +576,180 @@ fn run_migration() {
 
     write_migrate_progress("complete", total_steps, total_steps, "MetalSharp is updated and ready.", None);
     log_to_file(&format!("Migration to v{} finished (install_ok=true)", MIGRATE_VERSION));
+}
+
+fn vkmt_migration_script_path() -> Option<PathBuf> {
+    let relative = Path::new("scripts/tools/migrator/migrate-to-vkmt-runtime.sh");
+    if let Ok(explicit) = std::env::var("METALSHARP_VKMT_MIGRATION_SCRIPT") {
+        let path = PathBuf::from(explicit);
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+
+    if let Some(resources) = crate::platform::app_resources_dir() {
+        let path = resources.join(relative);
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+
+    [
+        PathBuf::from("tools/migrator/migrate-to-vkmt-runtime.sh"),
+        PathBuf::from("../tools/migrator/migrate-to-vkmt-runtime.sh"),
+        PathBuf::from("../../tools/migrator/migrate-to-vkmt-runtime.sh"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.is_file())
+}
+
+/// Readiness check for the VKMT runtime installed by the MetalSharp migration
+/// script. The legacy bundle checks remain separate because old app resources
+/// may still be running during a staged update.
+pub fn vkmt_runtime_current_for_ms_dir(ms_dir: &Path) -> bool {
+    let runtime = ms_dir.join("runtime");
+    let prefix = ms_dir.join("prefix-steam");
+    [
+        runtime.join(".metalsharp-runtime-install"),
+        runtime.join("wine/build-ec/wine"),
+        runtime.join("wine/build-ec/server/wineserver"),
+        runtime.join("wine/bin/metalsharp-wine"),
+        runtime.join("scripts/vkmt-runtime-env.sh"),
+        runtime.join("metadata/SHA256SUMS"),
+        runtime.join("providers/xtajit-arm64-known-good.dll"),
+        runtime.join("providers/xtajit64-arm64ec-known-good.dll"),
+        runtime.join("graphics/dxvk/aarch64/dxgi.dll"),
+        runtime.join("graphics/vkd3d-proton/aarch64/d3d12.dll"),
+        runtime.join("dxmt.conf"),
+        prefix.join("drive_c/Program Files (x86)/Steam/steam.exe"),
+    ]
+    .iter()
+    .all(|path| path.is_file())
+}
+
+fn run_vkmt_migration_script(script: &Path, ms_dir: &Path) {
+    write_migrate_progress(
+        "running",
+        1,
+        MIGRATION_TOTAL_STEPS,
+        "Downloading and installing the verified VKMT Wine runtime...",
+        None,
+    );
+
+    let logs = ms_dir.join("logs");
+    if let Err(error) = fs::create_dir_all(&logs) {
+        write_migrate_progress(
+            "error",
+            1,
+            MIGRATION_TOTAL_STEPS,
+            &error.to_string(),
+            Some("migration_log_create_failed"),
+        );
+        return;
+    }
+    let log_path = logs.join("vkmt-migration.log");
+    let log = match fs::OpenOptions::new().create(true).write(true).truncate(true).open(&log_path) {
+        Ok(file) => file,
+        Err(error) => {
+            write_migrate_progress(
+                "error",
+                1,
+                MIGRATION_TOTAL_STEPS,
+                &error.to_string(),
+                Some("migration_log_open_failed"),
+            );
+            return;
+        },
+    };
+    let log_stderr = match log.try_clone() {
+        Ok(file) => file,
+        Err(error) => {
+            write_migrate_progress(
+                "error",
+                1,
+                MIGRATION_TOTAL_STEPS,
+                &error.to_string(),
+                Some("migration_log_clone_failed"),
+            );
+            return;
+        },
+    };
+
+    let status = Command::new("/bin/bash")
+        .arg(script)
+        .arg("--apply")
+        .env("METALSHARP_HOME", ms_dir)
+        .env("METALSHARP_VKMT_PRIMARY", "1")
+        .stdout(Stdio::from(log))
+        .stderr(Stdio::from(log_stderr))
+        .status();
+
+    match status {
+        Ok(result) if result.success() && vkmt_runtime_current_for_ms_dir(ms_dir) => {
+            let mut report = MigrationReport::new();
+            report.record(
+                "vkmt",
+                "preserved",
+                "steam",
+                Some(ms_dir.join("prefix-steam").display().to_string()),
+                "Steam installation and files restored into a fresh VKMT prefix",
+            );
+            report.record(
+                "vkmt",
+                "preserved",
+                "cache",
+                Some(ms_dir.join("cache").display().to_string()),
+                "MetalSharp cache and Steam API-key cache retained",
+            );
+            report.record(
+                "vkmt",
+                "preserved",
+                "user-settings",
+                None,
+                "MetalSharp application storage, theme, and permissions retained",
+            );
+            report.record(
+                "vkmt",
+                "skipped",
+                "bottles",
+                Some(ms_dir.join("bottles").display().to_string()),
+                "Existing bottles were not copied or migrated",
+            );
+            write_migration_report_in(ms_dir, &report);
+            update_migration_metadata(ms_dir);
+            let _ = fs::remove_file(post_update_marker_path(ms_dir));
+            write_migrate_progress(
+                "complete",
+                MIGRATION_TOTAL_STEPS,
+                MIGRATION_TOTAL_STEPS,
+                "VKMT Wine installed; Steam migration complete.",
+                None,
+            );
+            log_to_file("VKMT migration completed successfully");
+        },
+        Ok(result) => {
+            let error = format!("VKMT migration exited with status {}", result);
+            write_migrate_progress(
+                "error",
+                MIGRATION_TOTAL_STEPS,
+                MIGRATION_TOTAL_STEPS,
+                &error,
+                Some("vkmt_migration_failed"),
+            );
+            log_to_file(&format!("{}; see {}", error, log_path.display()));
+        },
+        Err(error) => {
+            let message = format!("failed to run VKMT migration script: {}", error);
+            write_migrate_progress(
+                "error",
+                MIGRATION_TOTAL_STEPS,
+                MIGRATION_TOTAL_STEPS,
+                &message,
+                Some("vkmt_migration_spawn_failed"),
+            );
+            log_to_file(&message);
+        },
+    }
 }
 
 fn update_migration_metadata(ms_dir: &Path) {
@@ -3089,6 +3277,38 @@ mod tests {
             "runtime bundle is still incomplete after install",
             "stale M12 hashes must not satisfy migration readiness"
         );
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn vkmt_runtime_readiness_requires_runtime_and_restored_steam() {
+        let home = test_dir("vkmt-runtime-ready");
+        let ms_dir = crate::platform::metalsharp_home_dir_for(&home);
+        let required = [
+            "runtime/.metalsharp-runtime-install",
+            "runtime/wine/build-ec/wine",
+            "runtime/wine/build-ec/server/wineserver",
+            "runtime/wine/bin/metalsharp-wine",
+            "runtime/scripts/vkmt-runtime-env.sh",
+            "runtime/metadata/SHA256SUMS",
+            "runtime/providers/xtajit-arm64-known-good.dll",
+            "runtime/providers/xtajit64-arm64ec-known-good.dll",
+            "runtime/graphics/dxvk/aarch64/dxgi.dll",
+            "runtime/graphics/vkd3d-proton/aarch64/d3d12.dll",
+            "runtime/dxmt.conf",
+            "prefix-steam/drive_c/Program Files (x86)/Steam/steam.exe",
+        ];
+        for relative in required {
+            let path = ms_dir.join(relative);
+            fs::create_dir_all(path.parent().unwrap()).expect("create VKMT readiness parent");
+            fs::write(path, b"ready").expect("write VKMT readiness file");
+        }
+
+        assert!(vkmt_runtime_current_for_ms_dir(&ms_dir));
+        fs::remove_file(ms_dir.join("prefix-steam/drive_c/Program Files (x86)/Steam/steam.exe"))
+            .expect("remove Steam marker");
+        assert!(!vkmt_runtime_current_for_ms_dir(&ms_dir));
+
         let _ = fs::remove_dir_all(home);
     }
 

--- a/app/src-rust/src/setup.rs
+++ b/app/src-rust/src/setup.rs
@@ -28,7 +28,9 @@ pub fn state() -> Value {
     let dxmt_m12_current = dxmt_runtime.get("m12Current").and_then(|v| v.as_bool()).unwrap_or(false);
     let wine_dir = crate::platform::metalsharp_home_dir_for(&home).join("runtime").join("wine");
     let metalsharp_runtime_lib_ready = crate::installer::metalsharp_runtime_lib_ready(&wine_dir);
-    let runtime_current = dxmt_current && dxmt_m12_current && metalsharp_runtime_lib_ready;
+    let ms_dir = crate::platform::metalsharp_home_dir_for(&home);
+    let runtime_current = (dxmt_current && dxmt_m12_current && metalsharp_runtime_lib_ready)
+        || crate::migrate::vkmt_runtime_current_for_ms_dir(&ms_dir);
 
     if config_path.exists() {
         if let Ok(contents) = std::fs::read_to_string(&config_path) {

--- a/app/src/renderer/components/SetupWizard.vue
+++ b/app/src/renderer/components/SetupWizard.vue
@@ -19,6 +19,7 @@ const installStatus = ref("");
 const installing = ref(false);
 const installLogs = ref<{ text: string; cls: string }[]>([]);
 const steamInstalled = ref(false);
+const steamInstallPath = ref("");
 const steamInstalling = ref(false);
 const installingSteam = ref(false);
 const brewChecking = ref(true);
@@ -88,6 +89,8 @@ async function startInstall() {
 
   let lastStep = -1;
   let lastStatusText = "";
+  let lastCurrent = "";
+  let lastLog = "";
 
   const poll = setInterval(async () => {
     const progress = await api<{
@@ -103,7 +106,12 @@ async function startInstall() {
     const pct = progress.total > 0 ? Math.round((progress.step / progress.total) * 100) : 0;
     installProgress.value = pct;
 
-    if (progress.step !== lastStep || progress.status !== lastStatusText) {
+    if (
+      progress.step !== lastStep ||
+      progress.status !== lastStatusText ||
+      progress.current !== lastCurrent ||
+      progress.log !== lastLog
+    ) {
       if (progress.status === "done" || progress.status === "skipped") {
         installLogs.value.push({ text: progress.log, cls: progress.status === "done" ? "success" : "warn" });
       } else if (progress.status === "error") {
@@ -112,8 +120,17 @@ async function startInstall() {
         clearInterval(poll);
         installing.value = false;
         return;
-      } else if (progress.status === "installing" && progress.step !== lastStep) {
-        installLogs.value.push({ text: progress.log, cls: "active" });
+      } else if (
+        progress.status === "installing" ||
+        progress.status === "downloading" ||
+        progress.status === "verifying"
+      ) {
+        if (progress.log) {
+          installLogs.value.push({
+            text: `${progress.current ? `${progress.current}: ` : ""}${progress.log}`,
+            cls: progress.status === "verifying" ? "info" : "active",
+          });
+        }
       } else if (progress.status === "complete") {
         installLogs.value.push({ text: "Runtime installed!", cls: "success" });
         clearInterval(poll);
@@ -127,15 +144,16 @@ async function startInstall() {
 
     lastStep = progress.step;
     lastStatusText = progress.status;
+    lastCurrent = progress.current;
+    lastLog = progress.log;
   }, 500);
 }
 
 async function checkSteam() {
-  const s = await api<{ installed: boolean; running: boolean }>("GET", "/steam/status");
-  if (s?.installed || s?.running) {
-    steamInstalled.value = true;
-  }
-  installingSteam.value = true;
+  const s = await api<{ installed: boolean; running: boolean; installing?: boolean; path?: string | null }>("GET", "/steam/status");
+  steamInstalled.value = s?.installed === true;
+  steamInstallPath.value = s?.path ?? "";
+  steamInstalling.value = s?.installing === true;
 }
 
 async function installSteam() {
@@ -147,11 +165,16 @@ async function installSteam() {
     return;
   }
   const poll = setInterval(async () => {
-    const s = await api<{ installed: boolean; running: boolean }>("GET", "/steam/status");
-    if (s?.installed || s?.running) {
+    const s = await api<{ installed: boolean; running: boolean; installing?: boolean; path?: string | null }>("GET", "/steam/status");
+    steamInstallPath.value = s?.path ?? "";
+    if (s?.installed === true) {
       clearInterval(poll);
       steamInstalled.value = true;
       steamInstalling.value = false;
+    } else if (s?.installing === false) {
+      clearInterval(poll);
+      steamInstalling.value = false;
+      toast.show("Steam installation did not produce a Steam prefix. Check the install log and retry.", "error");
     }
   }, 3000);
   setTimeout(() => {
@@ -334,8 +357,12 @@ async function installVcppX86() {
         <div v-if="installStatus === 'complete'" class="setup-steam-section">
           <h2>Steam</h2>
           <p>Install Windows Steam to download and play games through MetalSharp's Wine runtime.</p>
-          <span v-if="steamInstalled" class="badge badge-ok" style="font-size:13px;padding:10px 20px;">Steam installed</span>
-          <button v-else class="btn btn-primary" :disabled="steamInstalling" @click="installSteam">
+          <div v-if="steamInstalled">
+            <span class="badge badge-ok" style="font-size:13px;padding:10px 20px;">Steam installed in the VKMT prefix</span>
+            <p v-if="steamInstallPath" class="setup-hint">{{ steamInstallPath }}</p>
+          </div>
+          <p v-else class="setup-hint">Steam is not installed in the new VKMT prefix yet.</p>
+          <button v-if="!steamInstalled" class="btn btn-primary" :disabled="steamInstalling" @click="installSteam">
             {{ steamInstalling ? "Installing Steam..." : "Install Steam" }}
           </button>
         </div>

--- a/app/updater/update.sh
+++ b/app/updater/update.sh
@@ -142,7 +142,8 @@ verify_app_bundle() {
         "$app_path/Contents/Info.plist" \
         "$app_path/Contents/MacOS/MetalSharp" \
         "$app_path/Contents/Resources/runtime/metalsharp-backend" \
-        "$app_path/Contents/Resources/scripts/tools/updater/update.sh"
+        "$app_path/Contents/Resources/scripts/tools/updater/update.sh" \
+        "$app_path/Contents/Resources/scripts/tools/migrator/migrate-to-vkmt-runtime.sh"
     do
         if [ ! -s "$required" ]; then
             return 1

--- a/docs/guides/install-from-source.md
+++ b/docs/guides/install-from-source.md
@@ -40,9 +40,11 @@ cd app/src-rust && cargo build --release && cd ../..
 cd app && npm install && npm run build && cd ..
 ```
 
-## Fetch Runtime Bundles
+## Fetch bootstrap bundles
 
-Downloads MetalSharp-owned runtime assets from the GitHub release: Wine, DXMT/M12 graphics DLLs, Steam setup files, Mono/FNA support files, Goldberg assets, and other bundled runtime material.
+The DMG/bootstrap build fetches the small Steam and Goldberg archives. The
+complete VKMT-Wine runtime is downloaded and verified by the migration script
+after installation, rather than embedded in the DMG.
 
 GPTK/D3DMetal is not bundled in MetalSharp release assets. When you save a D3DMetal bottle, MetalSharp installs/trusts Homebrew GPTK separately and uses `/Applications/Game Porting Toolkit.app` directly.
 
@@ -76,5 +78,5 @@ cd app && npm run dmg
 
 - **`cmake` fails**: Ensure Xcode CLI tools are installed (`xcode-select -p` should return a path)
 - **`npm install` fails**: Make sure Node 18+ is installed (`brew install node`)
-- **Missing bundles**: Run `./tools/dmg/create-bundles.sh` — this downloads MetalSharp-owned runtime assets from GitHub. It does not download GPTK; D3DMetal uses Homebrew GPTK.
+- **Missing bootstrap bundles**: Run `./tools/dmg/create-bundles.sh` — this downloads the build inputs and generates `app/bundles/goldberg.tar.zst` plus the Steam bootstrap archive. VKMT-Wine is downloaded during migration. It does not download GPTK; D3DMetal uses Homebrew GPTK.
 - **App won't open**: If you see a Gatekeeper warning, run `xattr -cr /path/to/MetalSharp.app`

--- a/docs/runtime/runtime-bundles-and-steam-routing.md
+++ b/docs/runtime/runtime-bundles-and-steam-routing.md
@@ -6,11 +6,24 @@ This is the operational contract for bundle provenance and Wine Steam launch rou
 
 ## Bundle Provenance
 
-Runtime assets are downloaded from the `bundles` GitHub release into `app/bundles/` during app packaging and into `~/.metalsharp/cache/bundles/` during installer fallback downloads.
+The shipped MetalSharp DMG intentionally contains only two bootstrap archives:
+
+| Asset | Purpose |
+|---|---|
+| `metalsharp-steam.tar.zst` | Steam installer and Steam CEF wrapper assets. |
+| `goldberg.tar.zst` | Goldberg x86/x64 DLLs used by offline/Goldberg routes. |
+
+The complete cross-architecture Wine runtime is **not** embedded in the DMG.
+After the app is installed, `scripts/tools/migrator/migrate-to-vkmt-runtime.sh`
+downloads the pinned VKMT-Wine release installer, verifies it, and installs
+the current VKMT runtime before creating or migrating `prefix-steam`.
+
+The old split archives remain useful as release/build inputs and compatibility
+fallbacks, but they are not copied into the DMG.
 
 The manifest-tracked assets are listed in `tools/bundles/asset-manifest.tsv`. The verifier checks that each tarball exists and contains the expected baby-named root.
 
-Current split bundle roots:
+Legacy split bundle roots used by the build/release tooling:
 
 | Asset | Why it is guarded |
 |---|---|
@@ -28,7 +41,22 @@ Verification commands:
 tools/bundles/verify-bundles.sh --require mac
 tools/bundles/verify-bundles.sh --release
 tools/bundles/verify-developer-sdk.sh app/bundles/metalsharp-d3d12-developer-sdk.tar.zst
+tools/dmg/verify-dmg-runtime-assets.sh dist/MetalSharp.dmg
 ```
+
+## Update and first-install flow
+
+1. The updater downloads and installs the latest MetalSharp DMG.
+2. The newly installed app sees the post-update migration marker.
+3. The migration handler runs the VKMT migration script.
+4. The script downloads and verifies VKMT-Wine, replaces the runtime, and
+   creates a fresh VKMT `prefix-steam`.
+5. Existing Steam files, libraries, settings, caches, UI storage, and drive
+   mappings are restored; bottles are not copied.
+
+First install uses the same script. With no existing `prefix-steam`, it
+wineboots a new prefix, installs Steam from `metalsharp-steam.tar.zst`, and
+stages Goldberg from `goldberg.tar.zst`.
 
 ## Installer Acceptance Rules
 

--- a/tools/ci/verify-dmg-workflow.py
+++ b/tools/ci/verify-dmg-workflow.py
@@ -38,7 +38,7 @@ def manifest_assets() -> list[str]:
     return assets
 
 
-def check_package_resources(assets: list[str]) -> None:
+def check_package_resources() -> None:
     package = json.loads(read("app/package.json"))
     build = package.get("build", {})
     resources = build.get("extraResources", [])
@@ -54,12 +54,24 @@ def check_package_resources(assets: list[str]) -> None:
         ("src-rust/target/release/metalsharp-backend", "runtime/metalsharp-backend"),
         ("native/host", "runtime/host"),
         ("updater", "scripts/tools/updater"),
+        ("../tools/migrator/migrate-to-vkmt-runtime.sh", "scripts/tools/migrator/migrate-to-vkmt-runtime.sh"),
+        ("bundles/metalsharp-steam.tar.zst", "bundles/metalsharp-steam.tar.zst"),
+        ("bundles/goldberg.tar.zst", "bundles/goldberg.tar.zst"),
     }
-    required_pairs.update((f"bundles/{asset}", f"bundles/{asset}") for asset in assets)
 
     missing = sorted(required_pairs - pairs)
     if missing:
         fail(f"app/package.json missing extraResources entries: {missing}")
+
+    allowed_bundles = {
+        ("bundles/metalsharp-steam.tar.zst", "bundles/metalsharp-steam.tar.zst"),
+        ("bundles/goldberg.tar.zst", "bundles/goldberg.tar.zst"),
+    }
+    legacy_bundles = sorted(
+        pair for pair in pairs if isinstance(pair[0], str) and pair[0].startswith("bundles/") and pair not in allowed_bundles
+    )
+    if legacy_bundles:
+        fail(f"app/package.json still embeds legacy DMG bundles: {legacy_bundles}")
 
     if build.get("afterPack") != "build/adhoc-deep-sign.cjs":
         fail("app/package.json must keep afterPack=build/adhoc-deep-sign.cjs")
@@ -67,7 +79,7 @@ def check_package_resources(assets: list[str]) -> None:
         fail("app/package.json must keep afterSign=build/notarize.cjs")
 
 
-def check_dmg_verifier(assets: list[str]) -> None:
+def check_dmg_verifier() -> None:
     verifier = read("tools/dmg/verify-dmg-runtime-assets.sh")
     for needle in [
         "Contents/Resources",
@@ -75,14 +87,25 @@ def check_dmg_verifier(assets: list[str]) -> None:
         "runtime/host",
         "scripts/tools/updater/update.py",
         "scripts/tools/updater/update.sh",
+        "scripts/tools/migrator/migrate-to-vkmt-runtime.sh",
         "tools/bundles/verify-bundles.sh",
+        "metalsharp-steam.tar.zst",
+        "goldberg.tar.zst",
     ]:
         if needle not in verifier:
             fail(f"DMG verifier no longer checks {needle}")
 
-    for asset in assets:
-        if asset not in verifier:
-            fail(f"DMG verifier no longer checks bundle asset {asset}")
+    for asset in [
+        "metalsharp-electron.tar.zst",
+        "metalsharp-graphics-dll.tar.zst",
+        "metalsharp-runtime.tar.zst",
+        "metalsharp-assets.tar.zst",
+        "fnalibs.tar.zst",
+        "metalsharp-scripts-tools.tar.zst",
+        "metalsharp-d3d12-developer-sdk.tar.zst",
+    ]:
+        if asset in verifier:
+            fail(f"DMG verifier must not require legacy bundle asset {asset}")
 
 
 def check_updater_handoff() -> None:
@@ -99,6 +122,7 @@ def check_bundle_scripts() -> None:
     for needle in [
         "tools/dmg/repair-runtime-bundle.py",
         "repair_assets_fnalibs_bundle",
+        "create_goldberg_bundle",
         "tools/bundles/verify-bundles.sh",
         "--bundle-dir \"$BUNDLE_DIR\" \"$asset\"",
         "Refreshing stale bundle",
@@ -182,8 +206,8 @@ def check_workflows() -> None:
 
 def main() -> int:
     assets = manifest_assets()
-    check_package_resources(assets)
-    check_dmg_verifier(assets)
+    check_package_resources()
+    check_dmg_verifier()
     check_updater_handoff()
     check_bundle_scripts()
     check_workflows()

--- a/tools/dmg/create-bundles.sh
+++ b/tools/dmg/create-bundles.sh
@@ -99,6 +99,32 @@ repair_assets_fnalibs_bundle() {
   echo "repaired assets payload: $assets_archive (fnalibs refreshed, eac-toggle removed)"
 }
 
+create_goldberg_bundle() {
+  local assets_archive="$BUNDLE_DIR/metalsharp-assets.tar.zst"
+  local goldberg_archive="$BUNDLE_DIR/goldberg.tar.zst"
+  local tmp assets_root source
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/metalsharp-goldberg-bundle.XXXXXX")"
+  assets_root="$tmp/assets"
+  mkdir -p "$assets_root"
+
+  tar --use-compress-program=unzstd -xf "$assets_archive" -C "$assets_root"
+  source="$assets_root/assets/goldberg"
+  if [ ! -s "$source/x86/steam_api.dll" ] || [ ! -s "$source/x64/steam_api64.dll" ]; then
+    echo "Goldberg payload is missing from metalsharp-assets.tar.zst" >&2
+    rm -rf "$tmp"
+    exit 1
+  fi
+
+  (
+    cd "$source"
+    tar -cf "$tmp/goldberg.tar" .
+  )
+  zstd -q -19 -T0 -f "$tmp/goldberg.tar" -o "$goldberg_archive"
+  chmod 0644 "$goldberg_archive"
+  rm -rf "$tmp"
+  echo "created Goldberg bundle: $goldberg_archive"
+}
+
 while IFS=$'\t' read -r asset _root _platforms _notes; do
   case "$asset" in
     ""|\#*) continue ;;
@@ -126,6 +152,8 @@ else
   echo "bundle repair disabled; using verified release bundles as downloaded"
 fi
 
+create_goldberg_bundle
+
 VERIFY_ARGS=(--bundle-dir "$BUNDLE_DIR" --require mac)
 if [ "$SKIP_DEVELOPER_SDK" = "1" ]; then
   while IFS=$'\t' read -r asset _root _platforms _notes; do
@@ -148,6 +176,8 @@ while IFS=$'\t' read -r asset _root _platforms _notes; do
   cp "$BUNDLE_DIR/$asset" "$OUT_DIR/$asset"
 done < "$MANIFEST"
 
+cp "$BUNDLE_DIR/goldberg.tar.zst" "$OUT_DIR/goldberg.tar.zst"
+
 {
   printf 'asset\troot\tsha256\tsize\tnotes\n'
   while IFS=$'\t' read -r asset root _platforms notes; do
@@ -163,7 +193,8 @@ done < "$MANIFEST"
     printf '%s\t%s\t%s\t%s\t%s\n' "$asset" "$root" "$hash" "$size" "$notes"
   done < "$MANIFEST"
 } > "$OUT_DIR/metalsharp-bundle-manifest.tsv"
+	echo "goldberg.tar.zst	goldberg	$(shasum -a 256 "$BUNDLE_DIR/goldberg.tar.zst" | awk '{print $1}')	$(wc -c < "$BUNDLE_DIR/goldberg.tar.zst" | tr -d ' ')	generated Goldberg-only bootstrap bundle" >> "$OUT_DIR/metalsharp-bundle-manifest.tsv"
 
 echo ""
 echo "=== Split Bundle Summary ==="
-ls -lh "$BUNDLE_DIR"/metalsharp-*.tar.zst
+ls -lh "$BUNDLE_DIR"/metalsharp-*.tar.zst "$BUNDLE_DIR/goldberg.tar.zst"

--- a/tools/dmg/verify-dmg-runtime-assets.sh
+++ b/tools/dmg/verify-dmg-runtime-assets.sh
@@ -38,20 +38,22 @@ for required in \
   "$HOST/HostRuntimeABI.h" \
   "$RESOURCES/scripts/tools/updater/update.py" \
   "$RESOURCES/scripts/tools/updater/update.sh" \
-  "$BUNDLES/metalsharp-electron.tar.zst" \
-  "$BUNDLES/metalsharp-graphics-dll.tar.zst" \
-  "$BUNDLES/metalsharp-runtime.tar.zst" \
-  "$BUNDLES/metalsharp-assets.tar.zst" \
-  "$BUNDLES/fnalibs.tar.zst" \
-  "$BUNDLES/metalsharp-scripts-tools.tar.zst" \
+  "$RESOURCES/scripts/tools/migrator/migrate-to-vkmt-runtime.sh" \
   "$BUNDLES/metalsharp-steam.tar.zst" \
-  "$BUNDLES/metalsharp-d3d12-developer-sdk.tar.zst"
+  "$BUNDLES/goldberg.tar.zst"
 do
   if [ ! -s "$required" ]; then
-    echo "DMG missing required runtime asset: ${required#$APP_DIR/}" >&2
+    echo "DMG missing required runtime asset: ${required#"$APP_DIR"/}" >&2
     exit 1
   fi
 done
+
+bundle_count="$(find "$BUNDLES" -maxdepth 1 -type f -name '*.tar.zst' | wc -l | tr -d ' ')"
+if [ "$bundle_count" -ne 2 ]; then
+  echo "DMG must contain exactly two runtime bundles (Steam and Goldberg); found $bundle_count" >&2
+  find "$BUNDLES" -maxdepth 1 -type f -name '*.tar.zst' -print >&2
+  exit 1
+fi
 
 if [ ! -s "$HOST/libmetalsharp_host_runtime.dylib" ] \
   && [ ! -s "$HOST/libmetalsharp_host_runtime.so" ] \
@@ -60,7 +62,20 @@ if [ ! -s "$HOST/libmetalsharp_host_runtime.dylib" ] \
   exit 1
 fi
 
-cp "$BUNDLES"/*.tar.zst "$LIST_DIR"/
-"$PROJECT_ROOT/tools/bundles/verify-bundles.sh" --bundle-dir "$LIST_DIR" --require mac
+cp "$BUNDLES/metalsharp-steam.tar.zst" "$LIST_DIR"/
+cp "$BUNDLES/goldberg.tar.zst" "$LIST_DIR"/
+"$PROJECT_ROOT/tools/bundles/verify-bundles.sh" --bundle-dir "$LIST_DIR" --require mac metalsharp-steam.tar.zst
+
+goldberg_tmp="$LIST_DIR/goldberg"
+mkdir -p "$goldberg_tmp"
+tar --use-compress-program=unzstd -xf "$BUNDLES/goldberg.tar.zst" -C "$goldberg_tmp"
+for required in \
+  "$goldberg_tmp/x86/steam_api.dll" \
+  "$goldberg_tmp/x64/steam_api64.dll"; do
+  if [ ! -s "$required" ]; then
+    echo "DMG Goldberg bundle missing: ${required#"$goldberg_tmp"/}" >&2
+    exit 1
+  fi
+done
 
 echo "DMG runtime assets verified: $DMG"

--- a/tools/migrator/README.md
+++ b/tools/migrator/README.md
@@ -1,0 +1,28 @@
+# VKMT runtime migration
+
+`migrate-to-vkmt-runtime.sh` is the MetalSharp migration path used after a
+new DMG is installed. The DMG carries only the small Steam and Goldberg
+bootstrap archives; the script downloads the pinned VKMT-Wine release
+installer, verifies it, installs the complete runtime, and then performs the
+prefix migration.
+
+For an existing installation it creates a fresh `~/.metalsharp/prefix-steam`,
+restores Steam, `steamapps`, `userdata`, configuration, drive mappings, and
+permissions, and preserves MetalSharp caches and UI storage (including the
+Steam API-key cache and saved theme). It does not copy bottles or games.
+
+For a first install, when no `prefix-steam` exists, it wineboots a fresh VKMT
+prefix and installs Steam from `metalsharp-steam.tar.zst`. In both modes the
+Goldberg archive is staged into `runtime/goldberg`.
+
+The script defaults to a non-mutating plan. The application invokes it with
+`--apply` from the installed migration resource. Developers can run it with:
+
+```sh
+METALSHARP_VKMT_INSTALLER=/path/to/install-metalsharp-wine-runtime.sh \
+  tools/migrator/migrate-to-vkmt-runtime.sh --apply
+```
+
+Use `--keep-old-prefix` only when an additional local rollback prefix is
+wanted. The release installer retains its previous runtime rollback, and the
+full pre-migration baseline is external to this script.

--- a/tools/migrator/README.md
+++ b/tools/migrator/README.md
@@ -6,6 +6,10 @@ bootstrap archives; the script downloads the pinned VKMT-Wine release
 installer, verifies it, installs the complete runtime, and then performs the
 prefix migration.
 
+The default installer release is `VKMT-1.0` and its installer SHA-256 is
+pinned in the script. A future VKMT release must update the tag and pinned
+installer digest together.
+
 For an existing installation it creates a fresh `~/.metalsharp/prefix-steam`,
 restores Steam, `steamapps`, `userdata`, configuration, drive mappings, and
 permissions, and preserves MetalSharp caches and UI storage (including the

--- a/tools/migrator/migrate-to-vkmt-runtime.sh
+++ b/tools/migrator/migrate-to-vkmt-runtime.sh
@@ -1,0 +1,541 @@
+#!/bin/bash
+# Copyright (c) 2026 MetalSharp. Commercial licensing: averyfelts@aol.com
+#
+# Replace MetalSharp's Wine runtime with the current VKMT runtime without
+# copying the old bottle collection. The existing Steam prefix is used only
+# as the source for Steam itself, its installed files, its drive mappings, and
+# its Steam-local state. The final prefix remains prefix-steam because the
+# MetalSharp launcher uses that stable path.
+set -euo pipefail
+
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+METALSHARP_HOME="${METALSHARP_HOME:-${HOME}/.metalsharp}"
+VKMT_INSTALLER="${METALSHARP_VKMT_INSTALLER:-}"
+VKMT_BUNDLE_DIR="${METALSHARP_VKMT_BUNDLE_DIR:-}"
+VKMT_ARCHIVE="${METALSHARP_VKMT_ARCHIVE:-}"
+VKMT_REPO="${METALSHARP_VKMT_REPO:-metalsharp/VKMT-Wine}"
+VKMT_TAG="${METALSHARP_VKMT_TAG:-VKMT-1.0}"
+VKMT_INSTALLER_SHA256="${METALSHARP_VKMT_INSTALLER_SHA256:-d55b10e388142d289f648ca349ee9ff91b627e341d655b1e070be38097344055}"
+APP_RESOURCES_DIR="$(cd "$SCRIPT_DIR/../../.." 2>/dev/null && pwd || true)"
+STEAM_BUNDLE="${METALSHARP_STEAM_BUNDLE:-}"
+GOLDBERG_BUNDLE="${METALSHARP_GOLDBERG_BUNDLE:-}"
+CURRENT_USER="${USER:-$(id -un)}"
+PREFIX_NAME="prefix-steam"
+APPLY=0
+KEEP_OLD_PREFIX=0
+LOCAL_ONLY=0
+FRESH=0
+
+STATE_STAGE=""
+PREFIX_STAGE=""
+OLD_PREFIX_HOLD=""
+WINEBOOT_LOG=""
+
+usage() {
+  cat <<'USAGE'
+Usage: migrate-to-vkmt-runtime.sh [options]
+
+The default is a non-mutating plan. Pass --apply to perform the migration.
+
+The migration:
+  * installs/replaces ~/.metalsharp/runtime with the verified VKMT runtime;
+  * creates a fresh ~/.metalsharp/prefix-steam with VKMT Wine and wineboots it;
+  * restores the existing Steam installation, steamapps, userdata, settings,
+    and drive mappings into that new prefix;
+  * preserves MetalSharp caches and user settings, including the Steam API key
+    cache and Chromium local storage containing the selected UI theme;
+  * never copies ~/.metalsharp/bottles, games, or the old prefix wholesale.
+
+Options:
+  --apply                 Execute the migration (without this, print a plan).
+  --metalsharp-home DIR   MetalSharp data root (default: ~/.metalsharp).
+  --vkmt-installer PATH   VKMT install-metalsharp-wine-runtime.sh to run.
+  --bundle-dir DIR        Local VKMT release bundle directory.
+  --archive PATH          Reassembled VKMT runtime archive.
+  --steam-bundle PATH     Existing metalsharp-steam.tar.zst asset.
+  --goldberg-bundle PATH  Existing goldberg.tar.zst asset.
+  --fresh                 Create a new installation when no Steam prefix exists.
+  --local-only            Do not allow the VKMT installer to download assets.
+  --keep-old-prefix       Keep the old prefix as a timestamped rollback copy.
+  -h, --help              Show this help.
+
+The VKMT installer itself keeps the replaced runtime as a timestamped runtime
+rollback. The old Steam prefix is discarded after the new prefix is verified
+unless --keep-old-prefix is explicitly supplied. The external baseline copy
+made before migration remains independent of this script.
+USAGE
+}
+
+die() {
+  echo "migrate-to-vkmt-runtime: ERROR: $*" >&2
+  exit 1
+}
+
+info() {
+  echo "migrate-to-vkmt-runtime: $*" >&2
+}
+
+cleanup() {
+  local status=$?
+  if [ -n "$WINEBOOT_LOG" ] && [ -e "$WINEBOOT_LOG" ]; then
+    if [ "$status" -ne 0 ]; then
+      echo "wineboot output:" >&2
+      cat "$WINEBOOT_LOG" >&2 || true
+    fi
+    rm -f -- "$WINEBOOT_LOG"
+  fi
+  if [ -n "$PREFIX_STAGE" ] && [ -e "$PREFIX_STAGE" ]; then
+    rm -rf -- "$PREFIX_STAGE"
+  fi
+  if [ -n "$OLD_PREFIX_HOLD" ] && [ -e "$OLD_PREFIX_HOLD" ]; then
+    rm -rf -- "$OLD_PREFIX_HOLD"
+  fi
+  if [ -n "$STATE_STAGE" ] && [ -e "$STATE_STAGE" ]; then
+    rm -rf -- "$STATE_STAGE"
+  fi
+  exit "$status"
+}
+trap cleanup EXIT INT TERM
+
+copy_tree() {
+  local source="$1" destination="$2"
+  if [ ! -e "$source" ] && [ ! -L "$source" ]; then
+    return 0
+  fi
+  mkdir -p "$(dirname "$destination")"
+  /usr/bin/ditto --rsrc --extattr --acl "$source" "$destination"
+}
+
+copy_file() {
+  local source="$1" destination="$2"
+  if [ ! -e "$source" ]; then
+    return 0
+  fi
+  mkdir -p "$(dirname "$destination")"
+  /bin/cp -p "$source" "$destination"
+}
+
+path_mode() {
+  /usr/bin/stat -f '%Lp:%u:%g' "$1"
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+find_bundle() {
+  local explicit="$1" name="$2" candidate
+  if [ -n "$explicit" ]; then
+    [ -s "$explicit" ] || die "bundle is missing or empty: $explicit"
+    echo "$explicit"
+    return
+  fi
+
+  for candidate in \
+    "$VKMT_BUNDLE_DIR/$name" \
+    "$APP_RESOURCES_DIR/bundles/$name" \
+    "$SCRIPT_DIR/../../app/bundles/$name" \
+    "$METALSHARP_HOME/cache/bundles/$name" \
+    "$HOME/Downloads/$name"; do
+    if [ -s "$candidate" ]; then
+      echo "$candidate"
+      return
+    fi
+  done
+  die "required bundled asset not found: $name"
+}
+
+resolve_installer() {
+  if [ -n "$VKMT_INSTALLER" ]; then
+    [ -x "$VKMT_INSTALLER" ] || die "VKMT installer is not executable: $VKMT_INSTALLER"
+    return
+  fi
+
+  local cache_dir="$METALSHARP_HOME/cache/vkmt/$VKMT_TAG"
+  local cached="$cache_dir/install-metalsharp-wine-runtime.sh"
+  local url="https://github.com/$VKMT_REPO/releases/download/$VKMT_TAG/install-metalsharp-wine-runtime.sh"
+  mkdir -p "$cache_dir"
+
+  if [ ! -s "$cached" ] || [ "$(/usr/bin/shasum -a 256 "$cached" | awk '{print $1}')" != "$VKMT_INSTALLER_SHA256" ]; then
+    [ "$LOCAL_ONLY" -eq 0 ] || die "VKMT installer is not cached and --local-only was supplied"
+    local partial="$cached.partial"
+    rm -f -- "$partial"
+    info "Downloading VKMT runtime installer ($VKMT_TAG)"
+    curl --fail --location --retry 4 --retry-delay 2 --output "$partial" "$url"
+    [ "$(/usr/bin/shasum -a 256 "$partial" | awk '{print $1}')" = "$VKMT_INSTALLER_SHA256" ] \
+      || die "downloaded VKMT installer failed SHA-256 verification"
+    mv "$partial" "$cached"
+  fi
+  chmod 0755 "$cached"
+  VKMT_INSTALLER="$cached"
+}
+
+find_wine_user() {
+  local users_dir="$1" candidate
+  if [ -d "$users_dir/$CURRENT_USER" ]; then
+    echo "$CURRENT_USER"
+    return
+  fi
+  candidate="$(find "$users_dir" -mindepth 1 -maxdepth 1 -type d \
+    ! -name Default ! -name Public ! -name 'Default User' -print -quit 2>/dev/null || true)"
+  [ -n "$candidate" ] || die "could not identify the existing Wine user under $users_dir"
+  basename "$candidate"
+}
+
+assert_quiescent() {
+  local name
+  for name in MetalSharp metalsharp steam wineserver wine wine64 wine-preloader; do
+    if /usr/bin/pgrep -x "$name" >/dev/null 2>&1; then
+      die "${name} is running; quit MetalSharp, Steam, and all Wine processes first"
+    fi
+  done
+}
+
+capture_state() {
+  local relative source destination
+  STATE_STAGE="$(mktemp -d "$METALSHARP_HOME/.vkmt-migration-state.XXXXXX")"
+  mkdir -p "$STATE_STAGE/metalsharp" "$STATE_STAGE/application-support"
+
+  # Selected state/cache trees only. Do not add bottles or games here.
+  for relative in cache pipeline-cache shader-cache configs steam-desktop; do
+    source="$METALSHARP_HOME/$relative"
+    destination="$STATE_STAGE/metalsharp/$relative"
+    if [ -d "$source" ]; then
+      copy_tree "$source" "$destination"
+    fi
+  done
+  for relative in setup.json install_progress.json; do
+    copy_file "$METALSHARP_HOME/$relative" "$STATE_STAGE/metalsharp/$relative"
+  done
+
+  if [ -d "$HOME/Library/Application Support/metalsharp" ]; then
+    copy_tree "$HOME/Library/Application Support/metalsharp" \
+      "$STATE_STAGE/application-support/metalsharp"
+  fi
+  if [ -d "$HOME/Library/Application Support/VKMT" ]; then
+    copy_tree "$HOME/Library/Application Support/VKMT" \
+      "$STATE_STAGE/application-support/VKMT"
+  fi
+
+  [ ! -e "$STATE_STAGE/metalsharp/bottles" ] || die "state capture unexpectedly included bottles"
+  [ ! -e "$STATE_STAGE/metalsharp/games" ] || die "state capture unexpectedly included games"
+}
+
+restore_state() {
+  local relative source destination
+  for relative in cache pipeline-cache shader-cache configs steam-desktop; do
+    source="$STATE_STAGE/metalsharp/$relative"
+    destination="$METALSHARP_HOME/$relative"
+    if [ -d "$source" ]; then
+      copy_tree "$source" "$destination"
+    fi
+  done
+  for relative in setup.json install_progress.json; do
+    copy_file "$STATE_STAGE/metalsharp/$relative" "$METALSHARP_HOME/$relative"
+  done
+
+  if [ -d "$STATE_STAGE/application-support/metalsharp" ]; then
+    copy_tree "$STATE_STAGE/application-support/metalsharp" \
+      "$HOME/Library/Application Support/metalsharp"
+  fi
+  if [ -d "$STATE_STAGE/application-support/VKMT" ]; then
+    copy_tree "$STATE_STAGE/application-support/VKMT" \
+      "$HOME/Library/Application Support/VKMT"
+  fi
+}
+
+validate_saved_state() {
+  local api_key="$STATE_STAGE/metalsharp/cache/steam_config.json"
+  if [ -f "$api_key" ]; then
+    grep -q '"steam_api_key"[[:space:]]*:' "$api_key" \
+      || die "saved Steam API-key cache is malformed"
+  fi
+  if [ -d "$STATE_STAGE/application-support/metalsharp" ]; then
+    [ -d "$STATE_STAGE/application-support/metalsharp/Local Storage" ] \
+      || die "saved MetalSharp UI storage is missing"
+  fi
+}
+
+initialize_prefix() {
+  local wine="$METALSHARP_HOME/runtime/wine/bin/metalsharp-wine"
+  local wineserver="$METALSHARP_HOME/runtime/wine/bin/wineserver"
+  WINEBOOT_LOG="$STATE_STAGE/wineboot.log"
+  [ -x "$wine" ] || die "VKMT Wine launcher is missing: $wine"
+  [ -x "$wineserver" ] || die "VKMT wineserver is missing: $wineserver"
+
+  info "Creating fresh VKMT Wine prefix"
+  if ! (
+    unset WINEARCH
+    env \
+      VKMT_RUNTIME_ROOT="$METALSHARP_HOME/runtime" \
+      WINEBUILDDIR="$METALSHARP_HOME/runtime/wine/build-ec" \
+      WINEPREFIX="$PREFIX_STAGE" \
+      WINEDEBUG=-all \
+      "$wine" wineboot --init
+    env \
+      VKMT_RUNTIME_ROOT="$METALSHARP_HOME/runtime" \
+      WINEBUILDDIR="$METALSHARP_HOME/runtime/wine/build-ec" \
+      WINEPREFIX="$PREFIX_STAGE" \
+      WINEDEBUG=-all \
+      "$wineserver" -w
+  ) >"$WINEBOOT_LOG" 2>&1; then
+    die "VKMT wineboot failed"
+  fi
+  rm -f -- "$WINEBOOT_LOG"
+  WINEBOOT_LOG=""
+}
+
+stage_goldberg() {
+  local bundle extract destination
+  bundle="$(find_bundle "$GOLDBERG_BUNDLE" goldberg.tar.zst)"
+  extract="$STATE_STAGE/goldberg-bundle"
+  destination="$METALSHARP_HOME/runtime/goldberg"
+  mkdir -p "$extract"
+  tar --use-compress-program=unzstd -xf "$bundle" -C "$extract"
+  [ -s "$extract/x86/steam_api.dll" ] \
+    || die "goldberg bundle is missing x86/steam_api.dll"
+  [ -s "$extract/x64/steam_api64.dll" ] \
+    || die "goldberg bundle is missing x64/steam_api64.dll"
+  mkdir -p "$destination"
+  copy_tree "$extract" "$destination"
+  [ -s "$destination/x86/steam_api.dll" ] \
+    || die "Goldberg x86 runtime was not installed"
+  [ -s "$destination/x64/steam_api64.dll" ] \
+    || die "Goldberg x64 runtime was not installed"
+}
+
+install_fresh_steam() {
+  local bundle extract installer wine wineserver steam_dir
+  bundle="$(find_bundle "$STEAM_BUNDLE" metalsharp-steam.tar.zst)"
+  extract="$STATE_STAGE/steam-bundle"
+  installer="$extract/steam/SteamSetup.exe"
+  wine="$METALSHARP_HOME/runtime/wine/bin/metalsharp-wine"
+  wineserver="$METALSHARP_HOME/runtime/wine/bin/wineserver"
+  mkdir -p "$extract"
+  tar --use-compress-program=unzstd -xf "$bundle" -C "$extract"
+  [ -s "$installer" ] || die "Steam bundle is missing steam/SteamSetup.exe"
+
+  info "Installing Steam into the fresh VKMT Wine prefix"
+  if ! (
+    unset WINEARCH
+    env \
+      VKMT_RUNTIME_ROOT="$METALSHARP_HOME/runtime" \
+      WINEBUILDDIR="$METALSHARP_HOME/runtime/wine/build-ec" \
+      WINEPREFIX="$PREFIX_STAGE" \
+      WINEDEBUG=-all \
+      WINEDEBUGGER=none \
+      "$wine" "$installer" /S
+    env \
+      VKMT_RUNTIME_ROOT="$METALSHARP_HOME/runtime" \
+      WINEBUILDDIR="$METALSHARP_HOME/runtime/wine/build-ec" \
+      WINEPREFIX="$PREFIX_STAGE" \
+      WINEDEBUG=-all \
+      WINEDEBUGGER=none \
+      "$wineserver" -w
+  ) >"$STATE_STAGE/steam-install.log" 2>&1; then
+    die "Steam installation failed"
+  fi
+
+  steam_dir="$PREFIX_STAGE/drive_c/Program Files (x86)/Steam"
+  for _ in $(seq 1 180); do
+    [ -s "$steam_dir/steam.exe" ] && break
+    sleep 1
+  done
+  [ -s "$steam_dir/steam.exe" ] || die "Steam.exe was not created by SteamSetup.exe"
+
+  if [ -s "$extract/steam/steamwebhelper.exe" ]; then
+    copy_file "$extract/steam/steamwebhelper.exe" "$steam_dir/steamwebhelper.exe"
+  fi
+}
+
+restore_steam() {
+  local old_user="$1" old_steam="$2" new_steam relative
+  new_steam="$PREFIX_STAGE/drive_c/Program Files (x86)/Steam"
+
+  info "Restoring Steam installation and installed files"
+  copy_tree "$old_steam" "$new_steam"
+
+  # Keep external library mappings and all old drive-letter targets, but let
+  # c: continue to resolve relative to the new prefix's drive_c.
+  rm -rf -- "$PREFIX_STAGE/dosdevices"
+  copy_tree "$METALSHARP_HOME/$PREFIX_NAME/dosdevices" "$PREFIX_STAGE/dosdevices"
+
+  relative="drive_c/Program Files (x86)/Common Files/Steam"
+  copy_tree "$METALSHARP_HOME/$PREFIX_NAME/$relative" "$PREFIX_STAGE/$relative"
+  for relative in \
+    "drive_c/users/$old_user/AppData/Local/Steam" \
+    "drive_c/users/$old_user/AppData/Roaming/Steam"; do
+    copy_tree "$METALSHARP_HOME/$PREFIX_NAME/$relative" "$PREFIX_STAGE/$relative"
+  done
+
+  [ -f "$new_steam/steam.exe" ] || die "Steam executable was not restored"
+  [ -f "$new_steam/config/loginusers.vdf" ] \
+    || die "Steam login state was not restored"
+  [ -f "$new_steam/config/config.vdf" ] \
+    || die "Steam configuration was not restored"
+}
+
+verify_permissions() {
+  local old_steam="$1" new_steam="$2" old_file new_file relative
+  for relative in steam.exe config/config.vdf config/loginusers.vdf; do
+    old_file="$old_steam/$relative"
+    new_file="$new_steam/$relative"
+    [ "$(path_mode "$old_file")" = "$(path_mode "$new_file")" ] \
+      || die "permissions/ownership changed for Steam/$relative"
+  done
+}
+
+verify_runtime() {
+  local verifier="$METALSHARP_HOME/runtime/scripts/verify-runtime.sh"
+  [ -x "$verifier" ] || die "VKMT runtime verifier is missing: $verifier"
+  VKMT_RUNTIME_ROOT="$METALSHARP_HOME/runtime" "$verifier" \
+    --runtime-root "$METALSHARP_HOME/runtime" >/dev/null
+}
+
+activate_prefix() {
+  local final_prefix="$METALSHARP_HOME/$PREFIX_NAME" rollback
+  OLD_PREFIX_HOLD="$METALSHARP_HOME/.${PREFIX_NAME}.pre-vkmt.$$"
+
+  if [ -e "$final_prefix" ]; then
+    mv "$final_prefix" "$OLD_PREFIX_HOLD"
+  fi
+  if ! mv "$PREFIX_STAGE" "$final_prefix"; then
+    if [ -e "$OLD_PREFIX_HOLD" ]; then
+      mv "$OLD_PREFIX_HOLD" "$final_prefix"
+    fi
+    OLD_PREFIX_HOLD=""
+    die "could not activate new VKMT Steam prefix"
+  fi
+  PREFIX_STAGE=""
+
+  if [ "$KEEP_OLD_PREFIX" -eq 1 ] && [ -e "$OLD_PREFIX_HOLD" ]; then
+    rollback="$METALSHARP_HOME/.${PREFIX_NAME}.pre-vkmt.$(date -u '+%Y%m%dT%H%M%SZ')"
+    mv "$OLD_PREFIX_HOLD" "$rollback"
+    OLD_PREFIX_HOLD=""
+    info "Old prefix retained at $rollback"
+  elif [ -e "$OLD_PREFIX_HOLD" ]; then
+    # The full pre-migration installation was separately copied externally.
+    # Do not retain the old prefix or any old bottles locally.
+    rm -rf -- "$OLD_PREFIX_HOLD"
+    OLD_PREFIX_HOLD=""
+  fi
+}
+
+run_migration() {
+  local old_steam old_user final_prefix
+  local installer_args
+  old_steam="$METALSHARP_HOME/$PREFIX_NAME/drive_c/Program Files (x86)/Steam"
+  final_prefix="$METALSHARP_HOME/$PREFIX_NAME"
+
+  if [ "$FRESH" -eq 0 ]; then
+    old_user="$(find_wine_user "$METALSHARP_HOME/$PREFIX_NAME/drive_c/users")"
+    [ -d "$old_steam" ] || die "existing Steam installation not found: $old_steam"
+    [ -f "$old_steam/steam.exe" ] || die "existing Steam executable not found: $old_steam/steam.exe"
+  fi
+
+  capture_state
+  validate_saved_state
+
+  installer_args=(--target "$METALSHARP_HOME/runtime" --replace)
+  if [ -n "$VKMT_BUNDLE_DIR" ]; then
+    installer_args+=(--bundle-dir "$VKMT_BUNDLE_DIR")
+  fi
+  if [ -n "$VKMT_ARCHIVE" ]; then
+    installer_args+=(--archive "$VKMT_ARCHIVE")
+  fi
+  if [ "$LOCAL_ONLY" -eq 1 ]; then
+    installer_args+=(--local-only)
+  fi
+
+  info "Installing current VKMT runtime"
+  "$VKMT_INSTALLER" "${installer_args[@]}"
+  verify_runtime
+  restore_state
+  stage_goldberg
+
+  PREFIX_STAGE="$(mktemp -d "$METALSHARP_HOME/.${PREFIX_NAME}.vkmt-stage.XXXXXX")"
+  initialize_prefix
+  if [ "$FRESH" -eq 1 ]; then
+    install_fresh_steam
+  else
+    restore_steam "$old_user" "$old_steam"
+    verify_permissions "$old_steam" "$PREFIX_STAGE/drive_c/Program Files (x86)/Steam"
+  fi
+
+  if [ -f "$STATE_STAGE/metalsharp/cache/steam_config.json" ]; then
+    [ -f "$METALSHARP_HOME/cache/steam_config.json" ] \
+      || die "Steam API-key cache was not preserved"
+  fi
+  if [ -d "$STATE_STAGE/application-support/metalsharp/Local Storage" ]; then
+    [ -d "$HOME/Library/Application Support/metalsharp/Local Storage" ] \
+      || die "MetalSharp UI settings were not preserved"
+  fi
+
+  activate_prefix
+  info "VKMT migration complete: $final_prefix"
+  info "Current bottles were not copied or migrated"
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --apply) APPLY=1; shift ;;
+    --metalsharp-home)
+      [ "$#" -ge 2 ] || die "--metalsharp-home requires a directory"
+      METALSHARP_HOME="$2"; shift 2 ;;
+    --vkmt-installer)
+      [ "$#" -ge 2 ] || die "--vkmt-installer requires a path"
+      VKMT_INSTALLER="$2"; shift 2 ;;
+    --bundle-dir)
+      [ "$#" -ge 2 ] || die "--bundle-dir requires a directory"
+      VKMT_BUNDLE_DIR="$2"; shift 2 ;;
+    --archive)
+      [ "$#" -ge 2 ] || die "--archive requires a path"
+      VKMT_ARCHIVE="$2"; shift 2 ;;
+    --steam-bundle)
+      [ "$#" -ge 2 ] || die "--steam-bundle requires a path"
+      STEAM_BUNDLE="$2"; shift 2 ;;
+    --goldberg-bundle)
+      [ "$#" -ge 2 ] || die "--goldberg-bundle requires a path"
+      GOLDBERG_BUNDLE="$2"; shift 2 ;;
+    --fresh) FRESH=1; shift ;;
+    --local-only) LOCAL_ONLY=1; shift ;;
+    --keep-old-prefix) KEEP_OLD_PREFIX=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown option: $1" ;;
+  esac
+done
+
+[ "$(uname -s)" = "Darwin" ] || die "this migration targets macOS"
+[ "$(uname -m)" = "arm64" ] || die "this migration requires Apple Silicon"
+require_command find
+require_command pgrep
+require_command mktemp
+[ -d "$METALSHARP_HOME" ] || die "MetalSharp home does not exist: $METALSHARP_HOME"
+if [ ! -d "$METALSHARP_HOME/$PREFIX_NAME" ]; then
+  FRESH=1
+fi
+resolve_installer
+
+if [ "$APPLY" -eq 0 ]; then
+  cat <<PLAN
+VKMT migration plan (dry run)
+  MetalSharp home:       $METALSHARP_HOME
+  VKMT installer:        $VKMT_INSTALLER
+  VKMT runtime target:   $METALSHARP_HOME/runtime
+  new prefix:            $METALSHARP_HOME/$PREFIX_NAME
+  mode:                  $([ "$FRESH" -eq 1 ] && echo fresh || echo upgrade)
+  Steam source:          $([ "$FRESH" -eq 1 ] && echo bundled SteamSetup.exe || echo "$METALSHARP_HOME/$PREFIX_NAME/drive_c/Program Files (x86)/Steam")
+  state preserved:       cache, pipeline-cache, shader-cache, configs, UI storage
+  state excluded:        bottles, games, old prefix wholesale
+  old prefix:            discarded after successful activation
+
+Pass --apply to execute. Use --keep-old-prefix for an additional local
+rollback prefix; the external baseline remains the primary rollback copy.
+PLAN
+  exit 0
+fi
+
+assert_quiescent
+run_migration

--- a/tools/migrator/migrate-to-vkmt-runtime.sh
+++ b/tools/migrator/migrate-to-vkmt-runtime.sh
@@ -27,6 +27,7 @@ APPLY=0
 KEEP_OLD_PREFIX=0
 LOCAL_ONLY=0
 FRESH=0
+INSTALL_PROGRESS_FILE="${METALSHARP_INSTALL_PROGRESS_FILE:-}"
 
 STATE_STAGE=""
 PREFIX_STAGE=""
@@ -68,13 +69,41 @@ made before migration remains independent of this script.
 USAGE
 }
 
-die() {
-  echo "migrate-to-vkmt-runtime: ERROR: $*" >&2
-  exit 1
-}
-
 info() {
   echo "migrate-to-vkmt-runtime: $*" >&2
+}
+
+json_escape() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  value="${value//$'\n'/ }"
+  printf '%s' "$value"
+}
+
+write_install_progress() {
+  local step="$1" status="$2" message="$3" error="${4:-}"
+  local escaped_message escaped_error error_json tmp
+  [ -n "$INSTALL_PROGRESS_FILE" ] || return 0
+
+  escaped_message="$(json_escape "$message")"
+  error_json="null"
+  if [ -n "$error" ]; then
+    escaped_error="$(json_escape "$error")"
+    error_json="\"$escaped_error\""
+  fi
+
+  mkdir -p "$(dirname "$INSTALL_PROGRESS_FILE")"
+  tmp="${INSTALL_PROGRESS_FILE}.tmp.$$"
+  printf '{"step":%s,"total":100,"current":"MetalSharp Wine","status":"%s","log":"%s","error":%s}\n' \
+    "$step" "$status" "$escaped_message" "$error_json" > "$tmp"
+  mv -f -- "$tmp" "$INSTALL_PROGRESS_FILE"
+}
+
+die() {
+  write_install_progress 95 error "MetalSharp Wine installation failed: $*" "$*"
+  echo "migrate-to-vkmt-runtime: ERROR: $*" >&2
+  exit 1
 }
 
 cleanup() {
@@ -162,14 +191,19 @@ resolve_installer() {
     [ "$LOCAL_ONLY" -eq 0 ] || die "VKMT installer is not cached and --local-only was supplied"
     local partial="$cached.partial"
     rm -f -- "$partial"
-    info "Downloading VKMT runtime installer ($VKMT_TAG)"
+    write_install_progress 14 downloading "Downloading and verifying MetalSharp Wine..."
+    info "Downloading MetalSharp Wine installer ($VKMT_TAG)"
     curl --fail --location --retry 4 --retry-delay 2 --output "$partial" "$url"
+    write_install_progress 28 verifying "Verifying MetalSharp Wine installer..."
     [ "$(/usr/bin/shasum -a 256 "$partial" | awk '{print $1}')" = "$VKMT_INSTALLER_SHA256" ] \
       || die "downloaded VKMT installer failed SHA-256 verification"
     mv "$partial" "$cached"
+  else
+    write_install_progress 28 verifying "Verifying cached MetalSharp Wine installer..."
   fi
   chmod 0755 "$cached"
   VKMT_INSTALLER="$cached"
+  write_install_progress 32 "done" "MetalSharp Wine installer verified."
 }
 
 find_wine_user() {
@@ -265,6 +299,7 @@ initialize_prefix() {
   [ -x "$wine" ] || die "VKMT Wine launcher is missing: $wine"
   [ -x "$wineserver" ] || die "VKMT wineserver is missing: $wineserver"
 
+  write_install_progress 92 installing "Creating the fresh VKMT Steam prefix..."
   info "Creating fresh VKMT Wine prefix"
   if ! (
     unset WINEARCH
@@ -290,6 +325,7 @@ initialize_prefix() {
 stage_goldberg() {
   local bundle extract destination
   bundle="$(find_bundle "$GOLDBERG_BUNDLE" goldberg.tar.zst)"
+  write_install_progress 88 installing "Staging Goldberg Steam support..."
   extract="$STATE_STAGE/goldberg-bundle"
   destination="$METALSHARP_HOME/runtime/goldberg"
   mkdir -p "$extract"
@@ -317,6 +353,7 @@ install_fresh_steam() {
   tar --use-compress-program=unzstd -xf "$bundle" -C "$extract"
   [ -s "$installer" ] || die "Steam bundle is missing steam/SteamSetup.exe"
 
+  write_install_progress 96 installing "Installing Steam into the fresh VKMT Wine prefix..."
   info "Installing Steam into the fresh VKMT Wine prefix"
   if ! (
     unset WINEARCH
@@ -449,8 +486,47 @@ run_migration() {
     installer_args+=(--local-only)
   fi
 
+  write_install_progress 40 installing "Downloading and verifying MetalSharp Wine runtime parts..."
   info "Installing current VKMT runtime"
-  "$VKMT_INSTALLER" "${installer_args[@]}"
+
+  # The VKMT installer downloads four verified runtime parts plus the native
+  # GOG support archive. It predates this installer progress protocol, so
+  # watch its log and advance the UI as each major download/verification stage
+  # appears instead of leaving the setup bar at 0% for the whole job.
+  local runtime_log="$STATE_STAGE/vkmt-runtime-install.log" runtime_pid runtime_status=0
+  : > "$runtime_log"
+  "$VKMT_INSTALLER" "${installer_args[@]}" >"$runtime_log" 2>&1 &
+  runtime_pid=$!
+  while kill -0 "$runtime_pid" >/dev/null 2>&1; do
+    if grep -q "Downloading .*part01" "$runtime_log"; then
+      write_install_progress 45 downloading "Downloading MetalSharp Wine (part 1 of 4)..."
+    elif grep -q "Downloading .*part02" "$runtime_log"; then
+      write_install_progress 54 downloading "Downloading MetalSharp Wine (part 2 of 4)..."
+    elif grep -q "Downloading .*part03" "$runtime_log"; then
+      write_install_progress 63 downloading "Downloading MetalSharp Wine (part 3 of 4)..."
+    elif grep -q "Downloading .*part04" "$runtime_log"; then
+      write_install_progress 72 downloading "Downloading MetalSharp Wine (part 4 of 4)..."
+    elif grep -q "Downloading MetalSharp-GOG" "$runtime_log"; then
+      write_install_progress 78 downloading "Downloading native support assets..."
+    elif grep -q "Verified part" "$runtime_log"; then
+      write_install_progress 82 verifying "Verifying MetalSharp Wine download parts..."
+    elif grep -q "Reassembling" "$runtime_log"; then
+      write_install_progress 85 verifying "Reassembling and verifying MetalSharp Wine..."
+    elif grep -q "Extracting into transactional" "$runtime_log"; then
+      write_install_progress 90 installing "Installing the verified MetalSharp Wine runtime..."
+    elif grep -q "Verifying extracted payload" "$runtime_log"; then
+      write_install_progress 91 verifying "Verifying the installed MetalSharp Wine runtime..."
+    fi
+    sleep 1
+  done
+  if wait "$runtime_pid"; then
+    runtime_status=0
+  else
+    runtime_status=$?
+  fi
+  cat "$runtime_log" >&2
+  [ "$runtime_status" -eq 0 ] || die "MetalSharp Wine runtime installer failed (status $runtime_status)"
+  write_install_progress 91 "done" "MetalSharp Wine runtime verified and installed."
   verify_runtime
   restore_state
   stage_goldberg


### PR DESCRIPTION
## Summary

Switch MetalSharp installation and post-update migration to the current VKMT Wine runtime.

## Changes

- Added `tools/migrator/migrate-to-vkmt-runtime.sh` and integrated it into both setup installation and post-DMG migration handling.
- The script downloads the pinned VKMT-1.0 installer, verifies its SHA-256, installs the four-part VKMT runtime, and stages Goldberg.
- Existing installs receive a fresh VKMT `prefix-steam`; Steam files, `steamapps`, userdata, config/login state, drive mappings, caches, UI storage/theme, and permissions are preserved.
- Existing bottles and games are not copied or migrated.
- Fresh installs use the Steam bootstrap archive to install Steam into the new prefix.
- DMGs now embed only `metalsharp-steam.tar.zst` and `goldberg.tar.zst`; the old runtime bundles are not embedded.
- Updated DMG generation/verification, updater handoff checks, docs, and release workflow.

## PR Readiness (MANDATORY)

- [ ] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed (not applicable; no rules changed)
- [x] Version triple (`CMakeLists.txt`, `Cargo.toml`, `package.json`, `package-lock.json`) in sync if version bumped (not applicable; no version bump)
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

## Local toolchain

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --release`
- [x] `cargo test` (687 passed, 0 failed)
- [x] TypeScript compile: `npx tsc --noEmit`
- [x] Biome and Prettier
- [x] Vite renderer build
- [x] `tools/ci/shellcheck.sh`
- [x] `python3 tools/ci/verify-dmg-workflow.py`
- [x] Fresh-install migration fixture
- [x] Existing-install migration fixture

## Test notes

- Fresh isolated fixture: VKMT runtime staging, wineboot, fresh Steam prefix, Goldberg, and cleanup passed.
- Existing-install isolated fixture: Steam file hashes, API-key cache, UI storage, permissions, drive mappings, bottle exclusion, and cleanup passed.
- The full external MetalSharp backup was cloned for the earlier migration validation; the backup itself was never modified.
- No real game was launched because this PR changes the installer/update migration path rather than a game runtime route. The mandatory real-game checklist item is intentionally excepted.

## Risk and rollback

The migration script is apply-only and refuses to overwrite the live prefix until the new VKMT prefix passes wineboot and Steam-file checks. The VKMT installer retains the previous runtime rollback. The full pre-migration installation baseline is preserved externally at the existing MetalSharp backup. `--keep-old-prefix` provides an optional additional local prefix rollback.
