### PR TITLE
Fix migration verification for signed runtime

### DIFF
--- a/.github/workflows/virustotal-release.yml
+++ b/.github/workflows/virustotal-release.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   scan:
-    name: Scan released DMG halves
+    name: Scan released DMG thirds
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push'

--- a/app/src-c/Makefile
+++ b/app/src-c/Makefile
@@ -82,6 +82,7 @@ $(BUILD_DIR)/c-backend/%.o: %.c
 -include $(OBJECTS:.o=.d)
 
 test: $(TARGET) $(JSON_TEST) $(MIGRATION_TEST) $(HTTP_SERVER_TEST)
+	@python3 "$(CURDIR)/tests/migration_hash_contract_test.py"
 	@ms_home="$$(mktemp -d)"; test_home="$$(mktemp -d)"; test_port=$$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()'); HOME="$$test_home" METALSHARP_PORT="$$test_port" METALSHARP_HOME="$$ms_home" METALSHARP_RPCS3_RELEASE_JSON="$(CURDIR)/tests/rpcs3_release.json" METALSHARP_RPCS3_DOWNLOAD_FILE="$(CURDIR)/tests/rpcs3_bad_archive.7z" METALSHARP_SHADPS4_RELEASE_JSON="$(CURDIR)/tests/shadps4_release.json" METALSHARP_SHADPS4_DOWNLOAD_FILE="$(CURDIR)/tests/shadps4_bad_archive.zip" METALSHARP_SHADPS4_HOST_ARCH=arm64 METALSHARP_SHADPS4_HOST_MACOS=27 METALSHARP_SHADPS4_ROSETTA=1 METALSHARP_PCSX2_RELEASE_JSON="$(CURDIR)/tests/pcsx2_release.json" METALSHARP_PCSX2_DOWNLOAD_FILE="$(CURDIR)/tests/pcsx2_bad_archive.tar.xz" METALSHARP_PCSX2_HOST_ARCH=arm64 METALSHARP_PCSX2_HOST_MACOS=27 METALSHARP_PCSX2_ROSETTA=1 METALSHARP_PCSX2_SKIP_SIGNATURE_FOR_TESTS=1 METALSHARP_SHARPEMU_HOST_ARCH=arm64 METALSHARP_SHARPEMU_HOST_MACOS=27 METALSHARP_SHARPEMU_ROSETTA=1 METALSHARP_SHARPEMU_SANDBOX=1 "$(CURDIR)/tests/smoke.sh" "$(TARGET)"; rc=$$?; rm -rf "$$test_home" "$$ms_home"; exit $$rc
 	@"$(JSON_TEST)"
 	@"$(MIGRATION_TEST)"
@@ -92,7 +93,8 @@ test: $(TARGET) $(JSON_TEST) $(MIGRATION_TEST) $(HTTP_SERVER_TEST)
 	@python3 "$(CURDIR)/tests/sharpemu_update_test.py" "$(TARGET)"
 
 asan-test:
-	@set -eu; trap 'rm -rf "$(CURDIR)/build-asan"' EXIT INT TERM; \
+	@set -eu; python3 "$(CURDIR)/tests/migration_hash_contract_test.py"; \
+	trap 'rm -rf "$(CURDIR)/build-asan"' EXIT INT TERM; \
 	$(MAKE) BUILD_DIR="$(CURDIR)/build-asan" TARGET="$(CURDIR)/build-asan/metalsharp-backend" \
 		JSON_TEST="$(CURDIR)/build-asan/json-test" \
 		CFLAGS='-std=c11 -O1 -g -D_POSIX_C_SOURCE=200809L -Wall -Wextra -Wpedantic -Werror -fno-omit-frame-pointer -fsanitize=address,undefined' all; \

--- a/app/src-c/runtime/migration.c
+++ b/app/src-c/runtime/migration.c
@@ -77,10 +77,10 @@ static const char* const migration_m12_hashes[][2] = {
     {"x86_64-windows/winemetal.dll", "f6844535ce448e6c525884c8c630298895d7cad97c64eade0f85208a804b9003"},
     {"x86_64-windows/nvapi64.dll", "2eeb618e67c0c2a8d8ff0d84bf45cf69828118c15e894881126e2b94e40d1f83"},
     {"x86_64-windows/nvngx.dll", "cc268b8d89eecef4312a010d25cf77d169c1c68c0875ac1b224d2bc118b921e3"},
-    {"x86_64-unix/winemetal.so", "fb46317af86ab157d37a5fb8f781368675047614e86786a74f72a5514b8574d9"},
-    {"x86_64-unix/libc++.1.dylib", "3f0da0b4025c6fb5e50fc23c8a1feea67c839b40df93baff3b2781089b42ad35"},
-    {"x86_64-unix/libc++abi.1.dylib", "9a95b4ce2be40951b688c394db99f79b7e0b81fa2372e5e49615319869e72e49"},
-    {"x86_64-unix/libunwind.1.dylib", "964d4e5d6242163e4e8099efd08ba75540f253257b834bf5b7a45f8c84b4ea78"}};
+    {"x86_64-unix/winemetal.so", "2a635d713446f26eb275eede947574d9c03f3165a74f7828d3f48fadd9ffd519"},
+    {"x86_64-unix/libc++.1.dylib", "9bfcf5310f95ebaeddaa55482debbb115a5cb109244dece727a314933dcbcc15"},
+    {"x86_64-unix/libc++abi.1.dylib", "b819a65788f8f4e8bc1e67a601e8e3d59c52c14a74910e61f2e7307006340fb4"},
+    {"x86_64-unix/libunwind.1.dylib", "105e72335d9e919e32028d151934b97d4b75267528023cb7f22111ac8065de0e"}};
 static const char* const migration_vkd3d_hashes[][2] = {
     {"x86_64-windows/d3d12.dll", "ac2b8674798bdbdd21ce1aa48daf1e2657813ecc878b80e2641bf0d2c3f2a43e"},
     {"x86_64-windows/d3d12core.dll", "78ab917a20dbc050ba3d0def8c0241e53c90ded0a036462955108e0ef78022a8"},

--- a/app/src-c/tests/migration_hash_contract_test.py
+++ b/app/src-c/tests/migration_hash_contract_test.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Keep migration runtime verification hashes synchronized with bundle contracts."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+MIGRATION_SOURCE = ROOT / "app/src-c/runtime/migration.c"
+
+CONTRACTS = {
+    "migration_m12_hashes": ROOT / "tools/bundles/m12-dxmt-runtime-hashes.tsv",
+    "migration_vkd3d_hashes": ROOT / "tools/bundles/vkd3d-proton-runtime-hashes.tsv",
+    "migration_dxvk_hashes": ROOT / "tools/bundles/dxvk-runtime-hashes.tsv",
+}
+
+
+def read_manifest(path: Path) -> dict[str, str]:
+    rows: dict[str, str] = {}
+    for line in path.read_text().splitlines():
+        if not line or line.startswith("#") or line == "path\tsha256":
+            continue
+        fields = line.split("\t")
+        if len(fields) != 2 or not re.fullmatch(r"[0-9a-f]{64}", fields[1]):
+            raise AssertionError(f"invalid hash contract row in {path}: {line}")
+        rows[fields[0]] = fields[1]
+    if not rows:
+        raise AssertionError(f"hash contract is empty: {path}")
+    return rows
+
+
+def read_c_table(source: str, name: str) -> dict[str, str]:
+    match = re.search(
+        rf"static const char\* const {re.escape(name)}\[\]\[2\] = \{{(.*?)\}};",
+        source,
+        re.DOTALL,
+    )
+    if not match:
+        raise AssertionError(f"missing migration hash table: {name}")
+    rows = dict(re.findall(r'\{"([^"]+)",\s*"([0-9a-f]{64})"\}', match.group(1)))
+    if not rows:
+        raise AssertionError(f"migration hash table is empty: {name}")
+    return rows
+
+
+def main() -> int:
+    source = MIGRATION_SOURCE.read_text()
+    for table, manifest_path in CONTRACTS.items():
+        expected = read_manifest(manifest_path)
+        actual = read_c_table(source, table)
+        if actual != expected:
+            missing = sorted(expected.keys() - actual.keys())
+            extra = sorted(actual.keys() - expected.keys())
+            changed = sorted(
+                path for path in expected.keys() & actual.keys() if expected[path] != actual[path]
+            )
+            print(
+                f"migration hash contract mismatch for {table}: "
+                f"missing={missing} extra={extra} changed={changed}",
+                file=sys.stderr,
+            )
+            return 1
+    print("migration hash contracts match published bundle contracts")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/test_virustotal_release.py
+++ b/tools/ci/test_virustotal_release.py
@@ -20,24 +20,25 @@ SPEC.loader.exec_module(MODULE)
 
 
 class VirusTotalReleaseTests(unittest.TestCase):
-    def test_split_dmg_creates_two_verified_halves(self) -> None:
+    def test_split_dmg_creates_three_verified_parts(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             source = root / "MetalSharp-test.dmg"
             source.write_bytes(b"abcdefghijk")
-            parts = MODULE.split_dmg(source, root / "parts", max_bytes=6)
+            parts = MODULE.split_dmg(source, root / "parts", max_bytes=4)
 
-            self.assertEqual([part["size"] for part in parts], [6, 5])
+            self.assertEqual([part["size"] for part in parts], [4, 4, 3])
             rebuilt = b"".join(Path(part["path"]).read_bytes() for part in parts)
             self.assertEqual(rebuilt, source.read_bytes())
-            self.assertEqual([part["part"] for part in parts], [1, 2])
+            self.assertEqual([part["part"] for part in parts], [1, 2, 3])
+            self.assertEqual([part["part_count"] for part in parts], [3, 3, 3])
 
-    def test_split_dmg_rejects_oversized_halves(self) -> None:
+    def test_split_dmg_rejects_oversized_thirds(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             source = Path(directory) / "too-large.dmg"
             source.write_bytes(b"a" * 13)
-            with self.assertRaisesRegex(MODULE.ScanError, "equal half exceeds"):
-                MODULE.split_dmg(source, Path(directory) / "parts", max_bytes=6)
+            with self.assertRaisesRegex(MODULE.ScanError, "equal third exceeds"):
+                MODULE.split_dmg(source, Path(directory) / "parts", max_bytes=4)
 
     def test_replace_marked_section_is_idempotent(self) -> None:
         first_section = (
@@ -89,13 +90,14 @@ class VirusTotalReleaseTests(unittest.TestCase):
                 {
                     "dmg": "MetalSharp.dmg",
                     "part": 1,
+                    "part_count": 3,
                     "size": 1024 * 1024,
                     "sha256": "a" * 64,
                     "stats": {"malicious": 0, "suspicious": 1, "undetected": 9},
                 }
             ],
         )
-        self.assertIn("one raw half", report)
+        self.assertIn("one raw third", report)
         self.assertIn("not a complete mountable DMG", report)
         self.assertIn("1/10", report)
         self.assertIn(f"https://www.virustotal.com/gui/file/{'a' * 64}", report)

--- a/tools/ci/verify-dmg-workflow.py
+++ b/tools/ci/verify-dmg-workflow.py
@@ -196,8 +196,8 @@ def check_workflows() -> None:
     scanner = read("tools/ci/virustotal-release.py")
     for required in [
         "650 * 1024 * 1024",
-        "part-1-of-2",
-        "part-2-of-2",
+        "part-{index}-of-{PART_COUNT}",
+        "PART_COUNT = 3",
         "files/upload_url",
         "/api/v3/analyses/",
         "partial-file scans",

--- a/tools/ci/virustotal-release.py
+++ b/tools/ci/virustotal-release.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Split release DMGs, scan each half with VirusTotal, and format release notes."""
+"""Split release DMGs into thirds, scan each part, and format release notes."""
 
 from __future__ import annotations
 
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 MAX_VIRUSTOTAL_BYTES = 650 * 1024 * 1024
+PART_COUNT = 3
 START_MARKER = "<!-- virustotal-results:start -->"
 END_MARKER = "<!-- virustotal-results:end -->"
 
@@ -34,42 +35,44 @@ def sha256_file(path: Path) -> str:
 
 def split_dmg(path: Path, output_dir: Path, max_bytes: int = MAX_VIRUSTOTAL_BYTES) -> list[dict[str, Any]]:
     size = path.stat().st_size
-    if size < 2:
-        raise ScanError(f"DMG is too small to split: {path}")
+    if size < PART_COUNT:
+        raise ScanError(f"DMG is too small to split into {PART_COUNT} parts: {path}")
 
-    first_size = (size + 1) // 2
-    second_size = size - first_size
-    if max(first_size, second_size) > max_bytes:
+    base_size, remainder = divmod(size, PART_COUNT)
+    expected_sizes = [base_size + (1 if index < remainder else 0) for index in range(PART_COUNT)]
+    if max(expected_sizes) > max_bytes:
         raise ScanError(
-            f"{path.name} is {size} bytes; an equal half exceeds the "
+            f"{path.name} is {size} bytes; an equal third exceeds the "
             f"VirusTotal {max_bytes}-byte upload limit"
         )
 
     output_dir.mkdir(parents=True, exist_ok=True)
     part_paths = [
-        output_dir / f"{path.name}.part-1-of-2",
-        output_dir / f"{path.name}.part-2-of-2",
+        output_dir / f"{path.name}.part-{index}-of-{PART_COUNT}"
+        for index in range(1, PART_COUNT + 1)
     ]
-    remaining = first_size
-    with path.open("rb") as source, part_paths[0].open("wb") as first:
-        while remaining:
-            chunk = source.read(min(8 * 1024 * 1024, remaining))
-            if not chunk:
-                raise ScanError(f"unexpected end of file while splitting {path}")
-            first.write(chunk)
-            remaining -= len(chunk)
-        with part_paths[1].open("wb") as second:
-            while chunk := source.read(8 * 1024 * 1024):
-                second.write(chunk)
+    with path.open("rb") as source:
+        for part, expected_size in zip(part_paths, expected_sizes, strict=True):
+            remaining = expected_size
+            with part.open("wb") as output:
+                while remaining:
+                    chunk = source.read(min(8 * 1024 * 1024, remaining))
+                    if not chunk:
+                        raise ScanError(f"unexpected end of file while splitting {path}")
+                    output.write(chunk)
+                    remaining -= len(chunk)
+        if source.read(1):
+            raise ScanError(f"split did not consume exactly {size} bytes from {path}")
 
     actual_sizes = [part.stat().st_size for part in part_paths]
-    if actual_sizes != [first_size, second_size] or sum(actual_sizes) != size:
+    if actual_sizes != expected_sizes or sum(actual_sizes) != size:
         raise ScanError(f"split size verification failed for {path}")
 
     return [
         {
             "dmg": path.name,
             "part": index,
+            "part_count": PART_COUNT,
             "path": str(part),
             "size": part.stat().st_size,
             "sha256": sha256_file(part),
@@ -186,7 +189,7 @@ def markdown_report(tag: str, results: list[dict[str, Any]]) -> str:
         "",
         (
             "The release DMG exceeds VirusTotal's 650 MiB upload limit. Each report below "
-            "covers one raw half of a DMG, not a complete mountable DMG, and must not be "
+            "covers one raw third of a DMG, not a complete mountable DMG, and must not be "
             "interpreted as a whole-installer verdict."
         ),
         "",
@@ -203,7 +206,8 @@ def markdown_report(tag: str, results: list[dict[str, Any]]) -> str:
         size_mib = int(result["size"]) / (1024 * 1024)
         report_url = f"https://www.virustotal.com/gui/file/{result['sha256']}"
         lines.append(
-            f"| `{dmg}` | {result['part']}/2 | {size_mib:.1f} MiB | "
+            f"| `{dmg}` | {result['part']}/{result.get('part_count', PART_COUNT)} | "
+            f"{size_mib:.1f} MiB | "
             f"{detected}/{total} | [Report]({report_url}) |"
         )
     lines.extend(["", f"Scanned automatically for release `{tag}`.", END_MARKER, ""])
@@ -275,7 +279,7 @@ def scan_command(args: argparse.Namespace) -> int:
     for part in parts:
         path = Path(part["path"])
         print(
-            f"Uploading {part['dmg']} part {part['part']}/2 "
+            f"Uploading {part['dmg']} part {part['part']}/{part['part_count']} "
             f"({part['size']} bytes, sha256={part['sha256']})",
             flush=True,
         )
@@ -284,7 +288,7 @@ def scan_command(args: argparse.Namespace) -> int:
         result = {**part, "analysis_id": analysis_id, "stats": stats}
         results.append(result)
         print(
-            f"Completed {part['dmg']} part {part['part']}/2: "
+            f"Completed {part['dmg']} part {part['part']}/{part['part_count']}: "
             f"malicious={stats.get('malicious', 0)} suspicious={stats.get('suspicious', 0)}",
             flush=True,
         )


### PR DESCRIPTION
## Summary

Fix 0.61.0 post-update migration verification for the newly ad-hoc-signed M12 runtime, and make the VirusTotal release scan fit the actual 1.689 GB DMG by using three equal raw parts.

## Changes

- Replace four stale pre-signing M12 Mach-O hashes embedded in `migration.c` with the signed bundle contract hashes.
- Add a regression test that requires migration's M12, DXVK, and vkd3d-proton tables to match their TSV bundle contracts.
- Run the contract test in normal and ASAN backend test targets.
- Split each released DMG into three equal VirusTotal parts; the 0.61.0 DMG produces three 563,116,108-byte uploads.
- Keep the exact release-run, tag, commit, asset digest, partial-scan disclosure, polling, and release-link controls.

## PR Readiness (MANDATORY)

- [x] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [x] Version metadata (`CMakeLists.txt`, `app/src-c/Makefile`, `package.json`, `package-lock.json`) in sync if version bumped
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

## Local toolchain (run before push)

- [x] C backend builds and tests: `make -C app/src-c test`
- [x] C++ compiles if changed: not applicable; no C++ changed
- [x] `clang-format --dry-run --Werror` passes on changed C files
- [x] `ctest --test-dir build-native` passes if tests changed: not applicable; no CMake tests changed
- [x] TypeScript compiles if changed: not applicable
- [x] Biome + Prettier pass if TS/JS changed: not applicable
- [x] Shell scripts lint if changed: not applicable
- [x] `tools/ci/validate-rules-toml.py` passes if rules changed: not applicable
- [x] `python3 tools/ci/verify-dmg-workflow.py`
- [x] Tested with at least one game: Pixel Gun 3D through Epic/Legendary on `/Volumes/AverySSD`; this hotfix does not change launch routing
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files added to the repository root

## Test notes

- `make -C app/src-c test`
- `make -C app/src-c asan-test`
- pre-commit checks
- VirusTotal scanner unit tests and workflow contract validation
- actionlint on the VirusTotal workflow
- packaged and atomically installed the fixed 0.61.0 app with the validated signed bundle set
- re-ran the real post-update migration against the existing MetalSharp home
- migration completed at step 8, schema 5, version 0.61.0
- runtime readiness passed and `.post-update-migration` was removed
- preserved user-file hashes remained byte-for-byte unchanged
- installed M12 Mach-O signatures passed strict verification

## Risk

The change affects only release scanning and migration hash verification. Rollback is to restore the previous app and tag; the pre-hotfix app backup and validated original bundle assets remain local. The release was deleted before this fix, so no broken 0.61.0 release is currently published.
