### PR TITLE
Stop managed Wine during update handoff

### DIFF
--- a/app/src-c/Makefile
+++ b/app/src-c/Makefile
@@ -88,6 +88,7 @@ test: $(TARGET) $(JSON_TEST) $(MIGRATION_TEST) $(HTTP_SERVER_TEST)
 	@"$(MIGRATION_TEST)"
 	@"$(HTTP_SERVER_TEST)"
 	@python3 "$(CURDIR)/tests/updater_test.py" "$(TARGET)"
+	@python3 "$(CURDIR)/tests/steam_process_test.py" "$(TARGET)"
 	@python3 "$(CURDIR)/tests/shadps4_update_test.py" "$(TARGET)"
 	@python3 "$(CURDIR)/tests/pcsx2_update_test.py" "$(TARGET)"
 	@python3 "$(CURDIR)/tests/sharpemu_update_test.py" "$(TARGET)"
@@ -116,6 +117,8 @@ asan-test:
 			"$(CURDIR)/tests/smoke.sh" "$(CURDIR)/build-asan/metalsharp-backend"; then \
 			ASAN_OPTIONS=detect_leaks=0:halt_on_error=1 python3 "$(CURDIR)/tests/updater_test.py" \
 				"$(CURDIR)/build-asan/metalsharp-backend" && \
+			ASAN_OPTIONS=detect_leaks=0:halt_on_error=1 python3 "$(CURDIR)/tests/steam_process_test.py" \
+				"$(CURDIR)/build-asan/metalsharp-backend" && \
 			ASAN_OPTIONS=detect_leaks=0:halt_on_error=1 python3 "$(CURDIR)/tests/pcsx2_update_test.py" \
 				"$(CURDIR)/build-asan/metalsharp-backend" && \
 			ASAN_OPTIONS=detect_leaks=0:halt_on_error=1 python3 "$(CURDIR)/tests/sharpemu_update_test.py" \
@@ -129,7 +132,7 @@ $(JSON_TEST): runtime/json.c runtime/json_writer.c tests/json_test.c include/met
 	@mkdir -p "$(@D)"
 	$(CC) $(CPPFLAGS) $(CFLAGS) -o "$@" runtime/json.c runtime/json_writer.c tests/json_test.c
 
-$(MIGRATION_TEST): runtime/json.c runtime/json_writer.c runtime/migration.c tests/migration_test.c include/metalsharp_backend/migration.h include/metalsharp_backend/json.h include/metalsharp_backend/json_writer.h
+$(MIGRATION_TEST): runtime/json.c runtime/json_writer.c runtime/migration.c tests/migration_test.c include/metalsharp_backend/migration.h include/metalsharp_backend/steam_actions.h include/metalsharp_backend/json.h include/metalsharp_backend/json_writer.h
 	@mkdir -p "$(@D)"
 	$(CC) $(CPPFLAGS) $(CFLAGS) -o "$@" runtime/json.c runtime/json_writer.c tests/migration_test.c -lpthread
 

--- a/app/src-c/include/metalsharp_backend/steam_actions.h
+++ b/app/src-c/include/metalsharp_backend/steam_actions.h
@@ -1,6 +1,8 @@
 #ifndef METALSHARP_BACKEND_STEAM_ACTIONS_H
 #define METALSHARP_BACKEND_STEAM_ACTIONS_H
+#include <stdbool.h>
 #include <stddef.h>
+bool ms_steam_process_running(const char*);
 char* ms_steam_launch_json(const char*, int*);
 char* ms_steam_stop_json(const char*, int*);
 char* ms_steam_mac_launch_json(const char*, int*);

--- a/app/src-c/runtime/migration.c
+++ b/app/src-c/runtime/migration.c
@@ -2,6 +2,7 @@
 #include "metalsharp_backend/json.h"
 #include "metalsharp_backend/json_writer.h"
 #include "metalsharp_backend/setup.h"
+#include "metalsharp_backend/steam_actions.h"
 #include <CommonCrypto/CommonDigest.h>
 #include <dirent.h>
 #include <errno.h>
@@ -1221,51 +1222,12 @@ static void update_existing_wine_prefixes(const char* home) {
     free(gog);
 }
 
-static bool contains_case_insensitive(const char* value, const char* needle) {
-    size_t length = strlen(needle);
-    if (!length)
-        return true;
-    for (const char* p = value; p && *p; p++)
-        if (!strncasecmp(p, needle, length))
-            return true;
-    return false;
-}
-
-static bool steam_update_process_alive(const char* prefix) {
-    FILE* processes = popen("ps axo pid=,command=", "r");
-    char line[PATH_MAX * 2];
-    bool alive = false;
-    if (!processes)
-        return false;
-    while (fgets(line, sizeof(line), processes)) {
-        if (strstr(line, prefix) &&
-            (contains_case_insensitive(line, "steam.exe") || contains_case_insensitive(line, "steamupdate.exe"))) {
-            alive = true;
-            break;
-        }
-    }
-    pclose(processes);
-    return alive;
-}
-
-static void wait_for_steam_update_windows(const char* home) {
-    char* prefix = path_join(home, "prefix-steam");
-    bool first_open = false, first_close = false, second_open = false;
-    if (!prefix)
-        return;
-    for (unsigned attempt = 0; attempt < 8; attempt++) {
-        bool alive = steam_update_process_alive(prefix);
-        if (alive && !first_open)
-            first_open = true;
-        else if (!alive && first_open && !first_close)
-            first_close = true;
-        else if (alive && first_close && !second_open)
-            second_open = true;
-        else if (!alive && second_open)
-            break;
-        sleep(2);
-    }
-    free(prefix);
+static bool stop_managed_wine_processes(const char* home) {
+    int status = 500;
+    char* result = ms_steam_stop_json(home, &status);
+    bool stopped = result != NULL && status == 200 && strstr(result, "\"running\":false") != NULL;
+    free(result);
+    return stopped;
 }
 
 static bool steam_library_has_manifest(const char* library) {
@@ -1596,7 +1558,17 @@ static void* migration_worker(void* opaque) {
         unlink(install_progress_path);
         free(install_progress_path);
     }
-    (void)write_migration_progress(job->home, "running", 1, "Ensuring extract tools (zstd) are available...", NULL);
+    (void)write_migration_progress(job->home, "running", 1,
+                                   "Stopping managed Wine processes and ensuring extract tools are available...", NULL);
+    if (!stop_managed_wine_processes(job->home)) {
+        (void)write_migration_progress(job->home, "error", 1, "Could not stop managed Wine processes",
+                                       "managed_wine_shutdown_failed");
+        unlink(job->lock_path);
+        free(job->home);
+        free(job->lock_path);
+        free(job);
+        return NULL;
+    }
     if (!ensure_migration_zstd()) {
         (void)write_migration_progress(job->home, "error", 1, "Failed to install zstd", "zstd_unavailable");
         unlink(job->lock_path);
@@ -1664,6 +1636,16 @@ static void* migration_worker(void* opaque) {
             (void)write_migration_progress(job->home, "running", 6,
                                            "Updating Wine prefixes and registering external Steam libraries...", NULL);
             update_existing_wine_prefixes(job->home);
+            if (!stop_managed_wine_processes(job->home)) {
+                (void)write_migration_progress(job->home, "error", 6,
+                                               "Could not stop Wine processes started while updating prefixes",
+                                               "managed_wine_shutdown_failed");
+                unlink(job->lock_path);
+                free(job->home);
+                free(job->lock_path);
+                free(job);
+                return NULL;
+            }
             register_external_steam_libraries(job->home);
             {
                 char* crash = path_join(job->home, "prefix-steam/drive_c/Program Files (x86)/Steam/.crash");
@@ -1671,7 +1653,6 @@ static void* migration_worker(void* opaque) {
                     unlink(crash);
                 free(crash);
             }
-            wait_for_steam_update_windows(job->home);
             if (!runtime_ready(job->home)) {
                 (void)write_migration_progress(job->home, "error", 7,
                                                "Update verification failed: runtime bundle is incomplete",

--- a/app/src-c/runtime/steam.c
+++ b/app/src-c/runtime/steam.c
@@ -3,6 +3,7 @@
 #include "metalsharp_backend/json.h"
 #include "metalsharp_backend/json_writer.h"
 #include "metalsharp_backend/mtsp.h"
+#include "metalsharp_backend/steam_actions.h"
 
 #include <ctype.h>
 #include <dirent.h>
@@ -37,9 +38,8 @@ static bool steam_regular_file(const char* path) {
 }
 
 static bool steam_exe_name_allowed(const char* name) {
-    return name && strcasecmp(name, "unitycrashhandler64.exe") != 0 &&
-           !contains_ci(name, "crashreport") && !contains_ci(name, "uninstall") && !contains_ci(name, "setup") &&
-           !contains_ci(name, "d3dconfig");
+    return name && strcasecmp(name, "unitycrashhandler64.exe") != 0 && !contains_ci(name, "crashreport") &&
+           !contains_ci(name, "uninstall") && !contains_ci(name, "setup") && !contains_ci(name, "d3dconfig");
 }
 
 static void find_steam_executable(const char* directory, unsigned depth, char** result, int* score) {
@@ -66,8 +66,8 @@ static void find_steam_executable(const char* directory, unsigned depth, char** 
             free(path);
             continue;
         }
-        if (!S_ISREG(st.st_mode) || strcasecmp(entry->d_name + strlen(entry->d_name) -
-                                                    (strlen(entry->d_name) >= 4 ? 4 : 0), ".exe") != 0 ||
+        if (!S_ISREG(st.st_mode) ||
+            strcasecmp(entry->d_name + strlen(entry->d_name) - (strlen(entry->d_name) >= 4 ? 4 : 0), ".exe") != 0 ||
             !steam_exe_name_allowed(entry->d_name)) {
             free(path);
             continue;
@@ -540,7 +540,9 @@ static char* fetch_owned_games_json(const char* key, const char* steam_id) {
     if (!steam_query_value_safe(key) || !steam_query_value_safe(steam_id))
         return NULL;
     snprintf(command, sizeof(command),
-             "curl -sL -m 15 'https://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/?key=%s&steamid=%s&include_appinfo=1&include_played_free_games=1&format=json'",
+             "curl -sL -m 15 "
+             "'https://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/"
+             "?key=%s&steamid=%s&include_appinfo=1&include_played_free_games=1&format=json'",
              key, steam_id);
     pipe = popen(command, "r");
     if (!pipe)
@@ -783,8 +785,8 @@ static void write_library_game(ms_json_writer* w, const char* home, const steam_
     ms_json_writer_key(w, "available_pipelines");
     ms_json_writer_array_begin(w);
     {
-        static const char* pipeline_ids[] = {"m12", "vkd3d", "m11", "m11_32", "m10", "m10_32", "m9", "d3dmetal",
-                                             "fna_arm64"};
+        static const char* pipeline_ids[] = {"m12",    "vkd3d", "m11",      "m11_32",   "m10",
+                                             "m10_32", "m9",    "d3dmetal", "fna_arm64"};
         for (size_t i = 0; i < sizeof(pipeline_ids) / sizeof(pipeline_ids[0]); i++) {
             ms_json_writer_object_begin(w);
             ms_json_writer_key(w, "id");
@@ -1185,21 +1187,19 @@ char* ms_steam_status_json(const char* metalsharp_home) {
     char* wine_wrapper = join_path(metalsharp_home, "runtime/wine/bin/metalsharp-wine");
     char* install_lock = join_path(metalsharp_home, ".steam-installing");
     char* mac_app = home == NULL ? NULL : join_path(home, "Applications/Steam.app");
-    char* mac_bundle = home == NULL ? NULL : join_path(home, "Library/Application Support/Steam/Steam.AppBundle/Steam/Steam.app");
+    char* mac_bundle =
+        home == NULL ? NULL : join_path(home, "Library/Application Support/Steam/Steam.AppBundle/Steam/Steam.app");
     bool windows_installed = wine_exe != NULL && access(wine_exe, F_OK) == 0;
     bool installing = install_lock != NULL && access(install_lock, F_OK) == 0;
     bool mac_installed = access("/Applications/Steam.app", F_OK) == 0 ||
                          (mac_app != NULL && access(mac_app, F_OK) == 0) ||
                          (mac_bundle != NULL && access(mac_bundle, F_OK) == 0);
-    bool running = false;
+    bool running = ms_steam_process_running(metalsharp_home);
     bool mac_running = false;
     FILE* process_pipe = popen("/bin/ps axo command=", "r");
     char process_line[2048];
     if (process_pipe != NULL) {
         while (fgets(process_line, sizeof(process_line), process_pipe) != NULL) {
-            if (strstr(process_line, metalsharp_home) != NULL && contains_ci(process_line, "steam.exe")) {
-                running = true;
-            }
             if (strstr(process_line, "/Steam.app/Contents/MacOS/steam_osx") != NULL ||
                 strstr(process_line, "Steam Helper.app/Contents/MacOS") != NULL)
                 mac_running = true;
@@ -1243,7 +1243,7 @@ char* ms_steam_status_json(const char* metalsharp_home) {
     ms_json_writer_bool(&writer, running);
     ms_json_writer_key(&writer, "metalsharp_wine_available");
     ms_json_writer_bool(&writer, (wine != NULL && access(wine, F_OK) == 0) ||
-                                      (wine_wrapper != NULL && access(wine_wrapper, F_OK) == 0));
+                                     (wine_wrapper != NULL && access(wine_wrapper, F_OK) == 0));
     ms_json_writer_key(&writer, "installing");
     ms_json_writer_bool(&writer, installing);
     ms_json_writer_object_end(&writer);

--- a/app/src-c/runtime/steam_actions.c
+++ b/app/src-c/runtime/steam_actions.c
@@ -1,3 +1,8 @@
+#ifdef __APPLE__
+#ifndef _DARWIN_C_SOURCE
+#define _DARWIN_C_SOURCE 1
+#endif
+#endif
 #include "metalsharp_backend/steam_actions.h"
 #include "metalsharp_backend/json.h"
 #include "metalsharp_backend/json_writer.h"
@@ -10,6 +15,11 @@
 #include <fcntl.h>
 #include <limits.h>
 #include <netinet/in.h>
+#include <sys/resource.h>
+#include <sys/types.h>
+#ifdef __APPLE__
+#include <libproc.h>
+#endif
 #include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -2193,17 +2203,66 @@ static void set_pipeline_runtime_env(const char* home, const char* pipeline) {
     setenv("WINEMSYNC", "1", 1);
 }
 
-static bool wine_steam_running(const char* home) {
-    char prefix[PATH_MAX];
+static bool process_cwd_within(pid_t pid, const char* root) {
+#ifdef __APPLE__
+    struct proc_vnodepathinfo info;
+    int bytes = proc_pidinfo((int)pid, PROC_PIDVNODEPATHINFO, 0, &info, (int)sizeof(info));
+    size_t length = strlen(root);
+    return bytes == (int)sizeof(info) && !strncmp(info.pvi_cdir.vip_path, root, length) &&
+           (info.pvi_cdir.vip_path[length] == '\0' || info.pvi_cdir.vip_path[length] == '/');
+#else
+    (void)pid;
+    (void)root;
+    return false;
+#endif
+}
+
+static bool process_executable_within(pid_t pid, const char* root) {
+#ifdef __APPLE__
+    char executable[PROC_PIDPATHINFO_MAXSIZE];
+    int bytes = proc_pidpath((int)pid, executable, sizeof(executable));
+    size_t length = strlen(root);
+    return bytes > 0 && !strncmp(executable, root, length) && (executable[length] == '\0' || executable[length] == '/');
+#else
+    (void)pid;
+    (void)root;
+    return false;
+#endif
+}
+
+static bool wine_process_owned(pid_t pid, const char* command, const char* prefix, const char* runtime) {
+    return strstr(command, prefix) != NULL || process_cwd_within(pid, prefix) ||
+           process_executable_within(pid, runtime);
+}
+
+static bool managed_wine_process_running(const char* home, bool steam_only) {
+    char prefix[PATH_MAX], runtime[PATH_MAX];
     FILE* pipe;
-    char line[2048];
+    char line[4096];
     bool running = false;
     snprintf(prefix, sizeof(prefix), "%s/prefix-steam", home);
-    pipe = popen("/bin/ps axo command=", "r");
+    snprintf(runtime, sizeof(runtime), "%s/runtime/wine", home);
+    pipe = popen("/bin/ps axo pid=,command=", "r");
     if (!pipe)
         return false;
     while (fgets(line, sizeof(line), pipe)) {
-        if (strstr(line, prefix) && (strstr(line, "Steam.exe") || strstr(line, "steam.exe"))) {
+        char* command = line;
+        char* end;
+        long raw_pid;
+        bool candidate;
+        while (*command == ' ' || *command == '\t')
+            command++;
+        errno = 0;
+        raw_pid = strtol(command, &end, 10);
+        if (errno != 0 || end == command || raw_pid <= 1 || raw_pid > INT_MAX)
+            continue;
+        while (*end == ' ' || *end == '\t')
+            end++;
+        candidate =
+            steam_only ? (contains_ci(end, "c:\\program files (x86)\\steam") ||
+                          contains_ci(end, "steamwebhelper.exe") || contains_ci(end, "steamwebhelper_real.exe"))
+                       : (wine_steam_cleanup_target(end, prefix) || process_executable_within((pid_t)raw_pid, runtime));
+        if (candidate && wine_process_owned((pid_t)raw_pid, end, prefix, runtime)) {
             running = true;
             break;
         }
@@ -2212,11 +2271,16 @@ static bool wine_steam_running(const char* home) {
     return running;
 }
 
+bool ms_steam_process_running(const char* home) {
+    return managed_wine_process_running(home, true);
+}
+
 static void signal_wine_steam_processes(const char* home, int signal_number) {
-    char prefix[PATH_MAX];
+    char prefix[PATH_MAX], runtime[PATH_MAX];
     FILE* pipe;
     char line[4096];
     snprintf(prefix, sizeof(prefix), "%s/prefix-steam", home);
+    snprintf(runtime, sizeof(runtime), "%s/runtime/wine", home);
     pipe = popen("/bin/ps axo pid=,command=", "r");
     if (!pipe)
         return;
@@ -2232,7 +2296,8 @@ static void signal_wine_steam_processes(const char* home, int signal_number) {
             continue;
         while (*end == ' ' || *end == '\t')
             end++;
-        if (wine_steam_cleanup_target(end, prefix))
+        if ((wine_steam_cleanup_target(end, prefix) || process_executable_within((pid_t)raw_pid, runtime)) &&
+            wine_process_owned((pid_t)raw_pid, end, prefix, runtime))
             (void)kill((pid_t)raw_pid, signal_number);
     }
     pclose(pipe);
@@ -2390,7 +2455,7 @@ char* ms_steam_launch_json(const char* home, int* status) {
         return err("Steam is not installed — use the setup wizard to install it first");
     }
     redirect_wine_steam_desktop(home);
-    if (wine_steam_running(home)) {
+    if (ms_steam_process_running(home)) {
         free(steam);
         free(ui);
         free(steam_dir);
@@ -2422,7 +2487,7 @@ char* ms_steam_stop_json(const char* home, int* status) {
     usleep(500000);
     {
         ms_json_writer w;
-        bool running = wine_steam_running(home);
+        bool running = managed_wine_process_running(home, false);
         ms_json_writer_init(&w);
         ms_json_writer_object_begin(&w);
         ms_json_writer_key(&w, "ok");
@@ -2488,7 +2553,7 @@ char* ms_steam_mac_launch_json(const char* home, int* status) {
         return err("macOS Steam is not installed");
     }
     free(app);
-    if (wine_steam_running(home)) {
+    if (ms_steam_process_running(home)) {
         if (status)
             *status = 500;
         return err("Wine Steam is running. Stop Wine Steam before launching macOS Steam.");
@@ -3644,7 +3709,7 @@ static char* launch_game_via_steam_json(const char* home, unsigned id, int* stat
     char url[64];
     char *steam_result, *error_text;
     pid_t pid;
-    if (!wine_steam_running(home)) {
+    if (!ms_steam_process_running(home)) {
         int steam_status = 500;
         steam_result = ms_steam_launch_json(home, &steam_status);
         free(steam_result);
@@ -3653,9 +3718,9 @@ static char* launch_game_via_steam_json(const char* home, unsigned id, int* stat
                 *status = steam_status;
             return err("Wine Steam could not be started for this game");
         }
-        for (int i = 0; i < 12 && !wine_steam_running(home); i++)
+        for (int i = 0; i < 12 && !ms_steam_process_running(home); i++)
             sleep(1);
-        if (!wine_steam_running(home)) {
+        if (!ms_steam_process_running(home)) {
             if (status)
                 *status = 500;
             return err("Wine Steam was started but did not become ready for game launch");
@@ -4175,7 +4240,7 @@ char* ms_steam_mac_launch_game_json(const char* home, const char* body, size_t l
         return err("appid required");
     if (status)
         *status = 500;
-    if (wine_steam_running(home))
+    if (ms_steam_process_running(home))
         return err("Wine Steam is running. Stop Wine Steam before launching through MacOS Steam.");
     if (!macos_game_installed(id))
         return err("This game is not installed in macOS Steam. Download it through macOS Steam before using the MacOS "
@@ -4244,7 +4309,7 @@ static bool wine_steam_cleanup_target(const char* command, const char* prefix) {
 }
 
 char* ms_steam_stop_targets_json(const char* home, int* status) {
-    char prefix[PATH_MAX];
+    char prefix[PATH_MAX], runtime[PATH_MAX];
     char line[4096];
     FILE* pipe;
     unsigned count = 0;
@@ -4252,6 +4317,7 @@ char* ms_steam_stop_targets_json(const char* home, int* status) {
     if (status)
         *status = 200;
     snprintf(prefix, sizeof(prefix), "%s/prefix-steam", home);
+    snprintf(runtime, sizeof(runtime), "%s/runtime/wine", home);
     ms_json_writer_init(&w);
     ms_json_writer_object_begin(&w);
     ms_json_writer_key(&w, "ok");
@@ -4278,7 +4344,8 @@ char* ms_steam_stop_targets_json(const char* home, int* status) {
                 if (newline)
                     *newline = '\0';
             }
-            target = wine_steam_cleanup_target(end, prefix);
+            target = (wine_steam_cleanup_target(end, prefix) || process_executable_within((pid_t)raw_pid, runtime)) &&
+                     wine_process_owned((pid_t)raw_pid, end, prefix, runtime);
             if (target) {
                 ms_json_writer_object_begin(&w);
                 ms_json_writer_key(&w, "pid");

--- a/app/src-c/tests/migration_test.c
+++ b/app/src-c/tests/migration_test.c
@@ -4,10 +4,20 @@
 #include <string.h>
 #include <unistd.h>
 
+static unsigned steam_stop_calls = 0;
+
 char* ms_setup_install_all_json(const char* home, int* status) {
     (void)home;
     (void)status;
     return NULL;
+}
+
+char* ms_steam_stop_json(const char* home, int* status) {
+    assert(home != NULL);
+    steam_stop_calls++;
+    if (status)
+        *status = 200;
+    return strdup("{\"ok\":true,\"running\":false}");
 }
 
 #include "../runtime/migration.c"
@@ -37,6 +47,8 @@ int main(void) {
     snprintf(home, sizeof(home), "/tmp/metalsharp-migration-test-%ld", (long)getpid());
     remove_tree_local(home);
     make_directory(home);
+    assert(stop_managed_wine_processes(home));
+    assert(steam_stop_calls == 1);
 
     snprintf(path, sizeof(path), "%s/setup.json", home);
     write_file(path, "{\"completed\":true,\"deviceName\":\"test\"}");

--- a/app/src-c/tests/steam_process_test.py
+++ b/app/src-c/tests/steam_process_test.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Regression coverage for migrated Wine Steam process detection and shutdown."""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+from pathlib import Path
+
+
+def free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def request_json(port: int, path: str, method: str = "GET") -> dict[str, object]:
+    request = urllib.request.Request(f"http://127.0.0.1:{port}{path}", method=method)
+    with urllib.request.urlopen(request, timeout=20) as response:
+        value = json.load(response)
+    assert isinstance(value, dict)
+    return value
+
+
+def wait_status(port: int, expected: bool, timeout: float = 10) -> dict[str, object]:
+    deadline = time.monotonic() + timeout
+    last: dict[str, object] = {}
+    while time.monotonic() < deadline:
+        try:
+            last = request_json(port, "/steam/status")
+            if last.get("running") is expected:
+                return last
+        except Exception:
+            pass
+        time.sleep(0.1)
+    raise AssertionError(f"Steam running never became {expected}: {last}")
+
+
+def fake_process(cwd: Path, argv0: str) -> subprocess.Popen[bytes]:
+    code = "import os,sys; os.chdir(sys.argv[1]); os.execv('/bin/sleep',[sys.argv[2],'120'])"
+    return subprocess.Popen([sys.executable, "-c", code, str(cwd), argv0])
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: steam_process_test.py BACKEND")
+    backend = Path(sys.argv[1]).resolve()
+    assert backend.is_file()
+
+    with tempfile.TemporaryDirectory(prefix="metalsharp-steam-process-") as directory:
+        root = Path(directory).resolve()
+        home = root / "home"
+        host_home = root / "host-home"
+        steam_dir = home / "prefix-steam/drive_c/Program Files (x86)/Steam"
+        wine_bin = home / "runtime/wine/bin"
+        steam_dir.mkdir(parents=True)
+        host_home.mkdir()
+        wine_bin.mkdir(parents=True)
+        (steam_dir / "Steam.exe").write_bytes(b"test")
+        (steam_dir / "steamui.dll").write_bytes(b"test")
+        for name in ("wine", "metalsharp-wine"):
+            target = wine_bin / name
+            target.write_text("#!/bin/sh\nexit 0\n")
+            target.chmod(0o755)
+
+        port = free_port()
+        env = {
+            **os.environ,
+            "HOME": str(host_home),
+            "METALSHARP_HOME": str(home),
+            "METALSHARP_PORT": str(port),
+        }
+        server = subprocess.Popen([str(backend)], env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        native = fake_process(steam_dir, "/Applications/Steam.app/Contents/MacOS/steam_osx")
+        foreign_wine = fake_process(host_home, r"C:\Program Files (x86)\Steam\steam.exe")
+        managed_service = fake_process(steam_dir, "wineserver")
+        wine_steam: subprocess.Popen[bytes] | None = None
+        try:
+            wait_status(port, False)
+            assert native.poll() is None, "native macOS Steam stand-in exited unexpectedly"
+            assert foreign_wine.poll() is None, "foreign Wine Steam stand-in exited unexpectedly"
+
+            wine_steam = fake_process(steam_dir, r"C:\Program Files (x86)\Steam\steam.exe")
+            wait_status(port, True)
+
+            stopped = request_json(port, "/steam/stop", method="POST")
+            assert stopped.get("ok") is True, stopped
+            assert stopped.get("running") is False, stopped
+            wine_steam.wait(timeout=5)
+            managed_service.wait(timeout=5)
+            assert native.poll() is None, "Wine Steam shutdown targeted native macOS Steam"
+            assert foreign_wine.poll() is None, "Wine Steam shutdown targeted another Wine prefix"
+            wait_status(port, False)
+        finally:
+            processes = (wine_steam, managed_service, foreign_wine, native, server)
+            for process in processes:
+                if process is not None and process.poll() is None:
+                    process.terminate()
+            for process in processes:
+                if process is None:
+                    continue
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=5)
+    print("Steam process detection and migration handoff shutdown verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -320,6 +320,20 @@ function deleteInstalledUpdateDmg(): string | null {
   return dmgPath;
 }
 
+function deleteStaleUpdateAppBackups(): string[] {
+  if (process.platform !== "darwin") return [];
+  const applications = "/Applications";
+  const backupPattern = /^\.MetalSharp\.app\.(?:previous|update)\.\d+$/;
+  const deleted: string[] = [];
+  for (const entry of fs.readdirSync(applications, { withFileTypes: true })) {
+    if (!backupPattern.test(entry.name) || (!entry.isDirectory() && !entry.isSymbolicLink())) continue;
+    const candidate = path.join(applications, entry.name);
+    fs.rmSync(candidate, { recursive: true, force: true });
+    deleted.push(candidate);
+  }
+  return deleted;
+}
+
 function spawnFreshInstalledAppAfterExit(appPath: string) {
   const script = `current_pid=${process.pid}\napp_path=${JSON.stringify(appPath)}\nwhile kill -0 "$current_pid" 2>/dev/null; do sleep 0.2; done\n/usr/bin/open -n "$app_path"\n`;
   const child = spawn("/bin/sh", ["-c", script], {
@@ -1084,6 +1098,24 @@ function registerIpc() {
       return { ok: false, error: "Installed MetalSharp.app was not found in /Applications." };
     }
 
+    // Prefix updates can execute Wine Run entries (including Steam's silent
+    // startup) even after the updater stopped the old runtime. Before launching
+    // the normal app, fail closed unless the migration backend has terminated
+    // every managed Wine/Steam process it can see.
+    try {
+      const rawStop = await requestMigrationBackend("POST", "/steam/stop", undefined, 15000);
+      const wrapped = rawStop as { data?: unknown };
+      const stop = (wrapped?.data ?? rawStop) as { ok?: boolean; running?: boolean; error?: string };
+      if (stop?.ok !== true || stop?.running !== false) {
+        return {
+          ok: false,
+          error: stop?.error ?? "Managed Wine processes did not stop; MetalSharp was not relaunched.",
+        };
+      }
+    } catch (error) {
+      return { ok: false, error: `Could not stop managed Wine processes: ${backendErrorMessage(error)}` };
+    }
+
     // Remove cached updater DMGs before tearing down the backend; this keeps the
     // user's disk from retaining the old installer image after a successful update.
     try {
@@ -1100,6 +1132,13 @@ function registerIpc() {
     }
     updaterBridge.clearInstallStatus();
 
+    let deletedBackupApps: string[] = [];
+    try {
+      deletedBackupApps = deleteStaleUpdateAppBackups();
+    } catch (error) {
+      console.warn("Migration handoff: failed to delete an updater backup app", error);
+    }
+
     clearPostUpdateMigrationMarker();
 
     // User-requested order: close any leftover MetalSharp app instances first,
@@ -1114,7 +1153,7 @@ function registerIpc() {
     spawnFreshInstalledAppAfterExit(appPath);
 
     setTimeout(() => app.exit(0), 50);
-    return { ok: true, deletedDmg, launched: appPath };
+    return { ok: true, deletedDmg, deletedBackupApps, launched: appPath };
   });
 
   ipcMain.handle("app:eject-dmg", async () => {

--- a/app/updater/update.sh
+++ b/app/updater/update.sh
@@ -142,6 +142,24 @@ run_privileged() {
     osascript -e "do shell script \"${command//\"/\\\"}\" with administrator privileges" 2>/dev/null
 }
 
+cleanup_update_app_backups() {
+    local candidate
+    local name
+    local quoted
+    for candidate in /Applications/.MetalSharp.app.previous.* /Applications/.MetalSharp.app.update.*; do
+        if [ ! -e "$candidate" ] && [ ! -L "$candidate" ]; then
+            continue
+        fi
+        name="$(basename "$candidate")"
+        if [[ ! "$name" =~ ^\.MetalSharp\.app\.(previous|update)\.[0-9]+$ ]]; then
+            continue
+        fi
+        rm -rf "$candidate" 2>/dev/null && continue
+        printf -v quoted '%q' "$candidate"
+        run_privileged "rm -rf $quoted" || true
+    done
+}
+
 verify_app_bundle() {
     local app_path="$1"
     for required in \
@@ -324,6 +342,7 @@ fi
 require_app_version "$APP_PATH" "Installed app"
 
 rm -rf "$BACKUP_APP_PATH" 2>/dev/null || true
+cleanup_update_app_backups
 write_status "installed" 80 "New version installed"
 
 mkdir -p "$MS_DIR"


### PR DESCRIPTION
## Summary

Prevent MetalSharp-managed Wine and Steam processes from surviving runtime migration or the final **Launch MetalSharp** handoff. This fixes the direct post-update failure where an old Wine/Steam session continued using replaced runtime files and Steam relaunched without a usable window.

## Changes

- Stop managed Wine/Steam processes before migration changes runtime files.
- Stop them again after Wine prefix updates, which can trigger Steam's silent Run entry.
- Fail closed in `app:restart-after-migration` unless `/steam/stop` confirms no managed Wine processes remain.
- Detect Wine Steam from Windows-style process command lines using macOS process cwd/executable ownership under the MetalSharp prefix/runtime.
- Exclude native macOS Steam and Wine processes belonging to other prefixes.
- Report Steam's running state through the shared prefix-aware detector.
- Remove stale updater-generated `.MetalSharp.app.previous.<pid>` and `.MetalSharp.app.update.<pid>` bundles after a successful update handoff.
- Add migration unit coverage and a backend lifecycle integration test for detection, shutdown, survivor reporting, native Steam exclusion, and foreign-prefix exclusion.

## PR Readiness (MANDATORY)

- [x] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [x] Version metadata (`CMakeLists.txt`, `app/src-c/Makefile`, `package.json`, `package-lock.json`) in sync if version bumped
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

## Local toolchain (run before push)

- [x] C backend builds and tests: `make -C app/src-c test`
- [x] C++ compiles if changed: N/A — no C++ changes
- [x] `clang-format --dry-run --Werror` passes on changed C files
- [x] `ctest --test-dir build-native` passes if tests changed: N/A — C backend/Python tests changed, no CMake tests
- [x] TypeScript compiles if changed: `cd app && npx tsc --noEmit`
- [x] Biome + Prettier pass if TS/JS changed
- [x] Shell scripts lint if changed: ShellCheck passed for `app/updater/update.sh`
- [x] `tools/ci/validate-rules-toml.py` passes if `configs/mtsp-rules.toml` changed: N/A
- [x] `python3 tools/ci/verify-dmg-workflow.py` passes if release/bundle tooling changed: N/A — release workflow and bundle selection unchanged
- [x] Tested with at least one game (which one? which launch method? which drive?)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files added to the repository root

## Test notes

- `make -C app/src-c test`
  - migration unit test
  - Steam process lifecycle integration test
  - updater, HTTP disconnect, shadPS4, PCSX2, and SharpEmu regression suites
- `cd app && npm run build`
- repository pre-commit hook
- `shellcheck app/updater/update.sh`
- `bash -n app/updater/update.sh`
- Existing 0.61.0 compatibility validation includes Pixel Gun 3D through Epic/Legendary. This process-only fix does not alter game routing; its Wine/Steam behavior is covered by deterministic backend integration fixtures using the same Windows-style process names and prefix ownership signals that caused the update defect.
- The installed application was restored to the pre-validation 0.61.0 build and left closed. No validation-only migration marker or hidden app backup remains.

No config/rules, version metadata, release workflow, or compatibility-matrix changes were required.

## Risk

The main risk is process classification: shutdown must catch MetalSharp Wine services without terminating native Steam or unrelated Wine prefixes. The integration test covers all three cases, and ownership requires either the MetalSharp prefix cwd/path or an executable inside MetalSharp's Wine runtime.

Rollback: revert commit `ea97dda1` to restore the previous migration wait and Steam process detection behavior.
