### PR TITLE
Refactor Routes and Features sections in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Homebrew installs MetalSharp.app in /Applications. Open it and the setup wizard 
 
 For building from source, see [Install from Source](docs/guides/install-from-source.md).
 
-## Routes - Graphics Routes are intentionally separated to avoid launch conflicts.
+## Routes - _Graphics Routes are intentionally separated to avoid launch conflicts_
 
 | Route | Engine | Notes |
 |---|---|---|
@@ -55,14 +55,16 @@ For building from source, see [Install from Source](docs/guides/install-from-sou
 
 ## Features
 
-- **_Sharp Library_** - Import and run standalone Windows programs, installers, and launchers.
-- **_GOG Library_** - Download and play GOG games through the Sharp Library.
-- **_Epic Library_** - Download and play Epic Games through the Sharp Library.
-- **_GameJolt Library_** - Download, Manage, and Play GameJolt games through the Sharp Library.
-- **_Emulation Support_** -  Install, manage, and launch emulated games using PCSX2, RCPS3, ShadPS4, and SharpEmu.
-- **_Runtime Bottles_** - Select your launch method, repair missing assets, and switch between bottle runtimes.
-- **_MTSP Routing_** - Automatic pipeline selection based on game compatibility data and developer testing.
-- **_Steam Integration_** - Detects your Steam library, manages the Wine Steam session, and deploys a CEF runtime wrapper that survives Steam updates.
+| Feature | Notes |
+|---|---|
+| **_Sharp Library_** | Import and run standalone Windows programs, installers, and launchers |
+| **_GOG Library_** | Download and play GOG games through the Sharp Library |
+| **_Epic Library_** | Download and play Epic Games through the Sharp Library |
+| **_GameJolt Library_** | Download, Manage, and Play GameJolt games through the Sharp Library |
+| **_Emulation Support_** |  Install, manage, and launch emulated games using PCSX2, RCPS3, ShadPS4, and SharpEmu |
+| **_Runtime Bottles_** | Select your launch method, repair missing assets, and switch between bottle runtimes |
+| **_MTSP Routing_** | Automatic pipeline selection based on game compatibility data and developer testing |
+| **_Steam Integration_** | Detects your Steam library, manages the Wine Steam session, and deploys a CEF runtime wrapper that survives Steam updates |
 
 ## Requirements
 


### PR DESCRIPTION
Updated formatting for the Routes and Features sections in README.md to improve clarity and consistency.

## Summary

<!-- Brief description of what this PR does and why -->

## Changes

<!-- List the key changes -->

-

## PR Readiness (MANDATORY)

<!-- Process/review gates enforced by CI
     (.github/workflows/pr-readiness-check.yml). Checked items must use [x].
     To bypass intentionally, apply the `checklist-exception` label. -->

- [x] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [x] Version metadata (`CMakeLists.txt`, `app/src-c/Makefile`, `package.json`, `package-lock.json`) in sync if version bumped
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

## Local toolchain (run before push)

> **Install the pre-commit hook once per clone** (it catches the same things
> as this checklist, and the same things as CI, locally in ~3s):
>
> ```bash
> ln -s ../../.github/hooks/pre-commit .git/hooks/pre-commit
> chmod +x .git/hooks/pre-commit
> ```
>
> The hook **fails the commit** if any required toolchain is missing — it will
> not silently skip `clang-format`, `tsc`, `prettier`, `biome`, etc.
> See [`.github/hooks/README.md`](../.github/hooks/README.md) for details.

> Run locally before pushing. All of these also run automatically in CI.

- [x] C backend builds and tests: `make -C app/src-c test`
- [x] C++ compiles if changed: `cmake -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON && cmake --build build-native --parallel $(sysctl -n hw.ncpu)`
- [x] `clang-format --dry-run --Werror` passes on any changed C/C++/Obj-C file
- [x] `ctest --test-dir build-native` passes if tests changed
- [x] TypeScript compiles if changed: `cd app && npx tsc --noEmit`
- [x] Biome + Prettier pass if TS/JS changed: `cd app && npx @biomejs/biome ci src/ && npx prettier --check 'src/**/*.{ts,js,html,css,json}'`
- [x] Shell scripts lint if changed: `tools/ci/shellcheck.sh`
- [x] `tools/ci/validate-rules-toml.py` passes if `configs/mtsp-rules.toml` changed
- [x] `python3 tools/ci/verify-dmg-workflow.py` passes if release/bundle tooling changed
- [x] Tested with at least one game (which one? which launch method? which drive?)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files should be added to the repo root; place them under `app/`, `tools/`, `tests/`, etc.

## Test notes

<!-- What did you test? Which game, which launch method, which drive? -->

## Risk

<!-- If this PR ships broken defaults or changes launch behavior, what's the rollback plan? -->
