### PR TITLE
Revise DXMT and Vulkan architecture documentation

### DIFF
--- a/docs/architecture/dxmt-vulkan-architecture.md
+++ b/docs/architecture/dxmt-vulkan-architecture.md
@@ -1,38 +1,38 @@
 # DXMT and Vulkan Architecture
-**Updated:** 2026-07-08
+**Updated:** 2026-07-28
 
 
 MetalSharp has two graphics translation families:
 
 - **DXMT launch family**: M9/M10/M11/M12 to Metal
-- **DXVK + MoltenVK**: Legacy fallback assets only; no longer selected by M9
+- **DXMT 32Bit Launch Family**: M10(32)/M11(32) to Metal 
+- **DXVK + MoltenVK**: VKD3D D3D12/11/10/9 Via MoltenVk -> Metal
 
 ## Pipeline Map
 
 | Public route | Translation |
 |---|---|
+| **VKD3D** | D3D12/11/10/9 -> Moltenvk -> Metal |
 | **M12** | D3D12 -> DXMT -> Metal |
 | **M11** | D3D11 -> DXMT -> Metal |
 | **M10** | D3D10 -> DXMT -> Metal |
 | **M9** | D3D9 -> MetalSharp D3D9 -> DXMT launch family -> Metal |
-
-`dxmt` is the internal auto-router that selects M12/M11/M10/M9. M32, Wine, and macOS Steam are backend fallback/diagnostic paths, not normal graphics-route buttons.
+| **D3DMetal** | Homebrew Gptk D3D12/11 -> Metal |
 
 ## DXMT
 
-The DXMT launch family is used by M12, M11, M10, and M9.
-
-M10 is the D3D10 DXMT path. It deploys Wine's public `d3d10.dll` and `d3d10_1.dll` entrypoints for imported D3D10 APIs, then routes the core handoff through DXMT's `d3d10core.dll` and the shared D3D11/DXGI/winemetal stack.
+_The DXMT launch family is used by M12, M11, M10, and M9_
 
 DXMT-family DLLs:
 
 | DLL | Used by |
 |---|---|
-| `d3d12.dll` | M12 |
-| `d3d11.dll` | M12, M11, M10 |
+| `d3d12.dll` | M12 - Intentionally hidden from user facing routes |
+| `d3d11.dll (i386)` | M11(32) |
+| `d3d11.dll` |  M11, M10 |
 | `dxgi.dll` | M12, M11, M10 |
-| `d3d10core.dll` | M12, M11, M10 |
-| `d3d10.dll`, `d3d10_1.dll` | M10 public Wine D3D10 entrypoints |
+| `d3d10.dll(i386)`, `d3d10core(i386)` | M10(32) |
+| `d3d10.dll`, `d3d10_1.dll` `d3d10core` | M10 |
 | `winemetal.dll` | M12, M11, M10 |
 | `d3d9.dll` | M9 |
 | `winemetal.so` | Unix Metal bridge |
@@ -42,7 +42,7 @@ Basic flow:
 ```text
 Game
   -> DXMT PE DLL
-  -> winemetal.so
+  -> Winemetal.so / Winemetal.dll
   -> Metal command buffers
   -> Apple GPU
 ```
@@ -56,47 +56,23 @@ DXMT uses per-game shader caches under:
 ~/.metalsharp/shader-cache/m12/<appid>/
 ```
 
-Older `dxmt-metal` and `dxmt-metal12` cache family names may still exist on disk from previous builds, but current MTSP
-routes prefer the explicit M9/M10/M11/M12 cache namespaces.
+## VKD3D 
 
-## M9 D3D9
+_The Vulkan Launch Family used by `VKD3D`_
 
-M9 does not select DXVK/MoltenVK. The pipeline deploys the D3D9 DLL from the bundled Wine runtime and uses the same DXMT launch/cache environment family as the other Metal pipelines.
+VKD3D-Family Dlls:
 
-Basic flow:
-
-```text
-Game
-  -> d3d9.dll
-  -> Wine / MetalSharp D3D9 handoff
-  -> Metal
-```
-
-M9 cache path:
-
-```text
-~/.metalsharp/shader-cache/m9/<appid>/
-```
-
-## Current Game Notes
-
-| Game | Best/current pipeline |
+| DLL | Used By |
 |---|---|
-| Schedule 1 | M12 recommended |
-| Subnautica | M11 |
-| Subnautica: Below Zero | M12 recommended, M11 optimized |
-| Rain World | M11, M9 also works |
-| Undertale | M9 |
-| Portal 2 | M9 |
-| Nidhogg 2 | M9 |
-| Ghostrunner | M11; M12 only if needed |
-| DREDGE | Not a DXMT/FNA target yet; 32-bit Unity embedded Mono crash |
-| Goat Simulator | M9, blocked before graphics by native .NET 4.0 CLR install |
+| `d3d12.dll`,`d3d12core.dll` | VKD3D-Proton Dll's |
+| `d3d11.dll` | DXVK-MacOS Dll |
+| `d3d10core.dll` | DXVK-MacOS Dll |
+| `d3d9.dll` | DXVK-MacOS Dll |
+| `dxgi.dll` | DXVK-MacOS Dll with d3d12 support |
+| `MoltenVK.dylib`, `Moltenvk_icd.json` | Metal Renderer for VKD3D |
 
-## Notes
 
-- DXMT is the internal direct-Metal auto-router, not a visible route selector option.
-- M12 is the primary stable DXMT D3D engine method in source.
-- M10 and M11 share the `dxmt-metal` preset fallback family.
-- M9 no longer has a Vulkan/MoltenVK hop in MTSP selection.
-- 32-bit and Wine fallback cases remain backend internals unless promoted to a public route.
+
+
+
+


### PR DESCRIPTION
Updated the DXMT and Vulkan architecture documentation with new details on the launch families and DLL usage.

## Summary

<!-- Brief description of what this PR does and why -->

## Changes

<!-- List the key changes -->

-

## PR Readiness (MANDATORY)

<!-- Process/review gates enforced by CI
     (.github/workflows/pr-readiness-check.yml). Checked items must use [x].
     To bypass intentionally, apply the `checklist-exception` label. -->

- [x] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [x] Version metadata (`CMakeLists.txt`, `app/src-c/Makefile`, `package.json`, `package-lock.json`) in sync if version bumped
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

## Local toolchain (run before push)

> **Install the pre-commit hook once per clone** (it catches the same things
> as this checklist, and the same things as CI, locally in ~3s):
>
> ```bash
> ln -s ../../.github/hooks/pre-commit .git/hooks/pre-commit
> chmod +x .git/hooks/pre-commit
> ```
>
> The hook **fails the commit** if any required toolchain is missing — it will
> not silently skip `clang-format`, `tsc`, `prettier`, `biome`, etc.
> See [`.github/hooks/README.md`](../.github/hooks/README.md) for details.

> Run locally before pushing. All of these also run automatically in CI.

- [x] C backend builds and tests: `make -C app/src-c test`
- [x] C++ compiles if changed: `cmake -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON && cmake --build build-native --parallel $(sysctl -n hw.ncpu)`
- [x] `clang-format --dry-run --Werror` passes on any changed C/C++/Obj-C file
- [x] `ctest --test-dir build-native` passes if tests changed
- [x] TypeScript compiles if changed: `cd app && npx tsc --noEmit`
- [x] Biome + Prettier pass if TS/JS changed: `cd app && npx @biomejs/biome ci src/ && npx prettier --check 'src/**/*.{ts,js,html,css,json}'`
- [x] Shell scripts lint if changed: `tools/ci/shellcheck.sh`
- [x] `tools/ci/validate-rules-toml.py` passes if `configs/mtsp-rules.toml` changed
- [x] `python3 tools/ci/verify-dmg-workflow.py` passes if release/bundle tooling changed
- [x] Tested with at least one game (which one? which launch method? which drive?)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files should be added to the repo root; place them under `app/`, `tools/`, `tests/`, etc.

## Test notes

<!-- What did you test? Which game, which launch method, which drive? -->

## Risk

<!-- If this PR ships broken defaults or changes launch behavior, what's the rollback plan? -->
