### PR TITLE
fix: keep Wine Steam launch responsive

### DIFF
--- a/app/src-c/include/metalsharp_backend/steam.h
+++ b/app/src-c/include/metalsharp_backend/steam.h
@@ -11,6 +11,7 @@ char* ms_steam_bridge_status_json(const char* metalsharp_home);
 char* ms_steam_watch_json(const char* metalsharp_home);
 char* ms_steam_status_json(const char* metalsharp_home);
 char* ms_steam_library_json(const char* metalsharp_home);
+char* ms_steam_library_refresh_json(const char* metalsharp_home);
 char* ms_steam_game_dir(const char* metalsharp_home, unsigned appid);
 
 #endif

--- a/app/src-c/runtime/backend.c
+++ b/app/src-c/runtime/backend.c
@@ -778,10 +778,12 @@ bool ms_backend_handle(const ms_http_request* request, ms_http_response* respons
     }
     if (strcmp(request->method, "GET") == 0 && strcmp(request->path, "/steam/library") == 0) {
         ms_log_event(context->metalsharp_home, "Loading Steam library...");
-        body = ms_steam_library_json(context->metalsharp_home);
+        body = request->query != NULL && strcmp(request->query, "refresh=1") == 0
+                   ? ms_steam_library_refresh_json(context->metalsharp_home)
+                   : ms_steam_library_json(context->metalsharp_home);
         if (body == NULL)
             return false;
-        ms_log_event(context->metalsharp_home, "Loaded 0 games");
+        ms_log_event(context->metalsharp_home, "Loaded Steam library");
         set_json_response(response, 200, body);
         return true;
     }

--- a/app/src-c/runtime/steam.c
+++ b/app/src-c/runtime/steam.c
@@ -98,28 +98,35 @@ static const char* steam_icon_tool(const char* name) {
     return NULL;
 }
 
-static char* steam_embedded_icon(const char* game_directory) {
-    const char* wrestool = steam_icon_tool("wrestool");
-    const char* icotool = steam_icon_tool("icotool");
-    char* cache = join_path(game_directory, ".metalsharp/steam-embedded-icon.png");
-    char* output = join_path(game_directory, ".metalsharp/steam-icon");
-    char* resource = output ? join_path(output, "resource.ico") : NULL;
+static char* steam_embedded_icon(const char* game_directory, bool refresh) {
+    const char* wrestool;
+    const char* icotool;
+    char* cache = game_directory ? join_path(game_directory, ".metalsharp/steam-embedded-icon.png") : NULL;
+    char* output;
+    char* resource;
     char* executable = NULL;
     int score = -1;
     DIR* dir;
     struct dirent* entry;
     int status = 0;
     pid_t pid;
-    if (!game_directory || !wrestool || !icotool || !cache || !output || !resource) {
+    if (!cache)
+        return NULL;
+    if (steam_regular_file(cache))
+        return cache;
+    if (!refresh) {
+        free(cache);
+        return NULL;
+    }
+    wrestool = steam_icon_tool("wrestool");
+    icotool = steam_icon_tool("icotool");
+    output = join_path(game_directory, ".metalsharp/steam-icon");
+    resource = output ? join_path(output, "resource.ico") : NULL;
+    if (!wrestool || !icotool || !output || !resource) {
         free(cache);
         free(output);
         free(resource);
         return NULL;
-    }
-    if (steam_regular_file(cache)) {
-        free(output);
-        free(resource);
-        return cache;
     }
     {
         char* cache_directory = join_path(game_directory, ".metalsharp");
@@ -618,8 +625,8 @@ static void save_owned_games_cache(const char* path, const ms_json* array) {
     free(text);
 }
 
-static bool load_owned_games(const char* home, const char* key, const char* steam_id, steam_game** games, size_t* count,
-                             size_t* capacity) {
+static bool load_owned_games(const char* home, const char* key, const char* steam_id, bool refresh, steam_game** games,
+                             size_t* count, size_t* capacity) {
     char* path = join_path(home, "cache/owned_games.json");
     char* text = path ? read_file(path, NULL) : NULL;
     char error[128];
@@ -628,8 +635,8 @@ static bool load_owned_games(const char* home, const char* key, const char* stea
     time_t now = time(NULL);
     const ms_json* array = json ? ms_json_object_get(json, "games") : NULL;
     bool valid_cache = json && ms_json_as_i64(ms_json_object_get(json, "timestamp"), &timestamp) && timestamp >= 0 &&
-                       now >= (time_t)timestamp && (unsigned long long)(now - (time_t)timestamp) < 3600 && array &&
-                       ms_json_type_of(array) == MS_JSON_ARRAY;
+                       now >= (time_t)timestamp && (!refresh || (unsigned long long)(now - (time_t)timestamp) < 3600) &&
+                       array && ms_json_type_of(array) == MS_JSON_ARRAY;
     if (valid_cache) {
         append_owned_array(array, games, count, capacity);
         ms_json_free(json);
@@ -639,7 +646,7 @@ static bool load_owned_games(const char* home, const char* key, const char* stea
     }
     ms_json_free(json);
     free(text);
-    if (!path || !steam_query_value_safe(key) || !steam_query_value_safe(steam_id)) {
+    if (!refresh || !path || !steam_query_value_safe(key) || !steam_query_value_safe(steam_id)) {
         free(path);
         return false;
     }
@@ -752,9 +759,9 @@ static const char* pipeline_display_name(const char* pipeline) {
     return "VKD3D";
 }
 
-static void write_library_game(ms_json_writer* w, const char* home, const steam_game* game) {
+static void write_library_game(ms_json_writer* w, const char* home, const steam_game* game, bool refresh) {
     char cover[256], header[256];
-    char* embedded_icon = game->installed && game->game_dir ? steam_embedded_icon(game->game_dir) : NULL;
+    char* embedded_icon = game->installed && game->game_dir ? steam_embedded_icon(game->game_dir, refresh) : NULL;
     char preferred[64] = "";
     const char* recommended = default_pipeline_for_appid(game->appid);
     const char* effective = bottle_string_value(home, game->appid, "preferred_pipeline", preferred, sizeof(preferred))
@@ -827,7 +834,7 @@ static void write_library_game(ms_json_writer* w, const char* home, const steam_
     free(embedded_icon);
 }
 
-char* ms_steam_library_json(const char* metalsharp_home) {
+static char* steam_library_json(const char* metalsharp_home, bool refresh) {
     const char* home = getenv("HOME");
     steam_game* games = NULL;
     size_t count = 0, capacity = 0, i;
@@ -853,7 +860,7 @@ char* ms_steam_library_json(const char* metalsharp_home) {
         free(path);
     }
     if (api_key && steam_id)
-        (void)load_owned_games(metalsharp_home, api_key, steam_id, &games, &count, &capacity);
+        (void)load_owned_games(metalsharp_home, api_key, steam_id, refresh, &games, &count, &capacity);
     ms_json_writer_init(&w);
     ms_json_writer_object_begin(&w);
     ms_json_writer_key(&w, "ok");
@@ -893,7 +900,7 @@ char* ms_steam_library_json(const char* metalsharp_home) {
     ms_json_writer_array_begin(&w);
     for (i = 0; i < count; ++i)
         if (!hidden_library_game(&games[i]))
-            write_library_game(&w, metalsharp_home, &games[i]);
+            write_library_game(&w, metalsharp_home, &games[i], refresh);
     ms_json_writer_array_end(&w);
     ms_json_writer_object_end(&w);
     result = ms_json_writer_take(&w);
@@ -903,6 +910,14 @@ char* ms_steam_library_json(const char* metalsharp_home) {
     }
     free(games);
     return result;
+}
+
+char* ms_steam_library_json(const char* metalsharp_home) {
+    return steam_library_json(metalsharp_home, false);
+}
+
+char* ms_steam_library_refresh_json(const char* metalsharp_home) {
+    return steam_library_json(metalsharp_home, true);
 }
 
 char* ms_steam_game_dir(const char* metalsharp_home, unsigned appid) {
@@ -1134,7 +1149,7 @@ char* ms_steam_save_api_key_json(const char* metalsharp_home, const unsigned cha
     }
     free(json);
     (void)unlink(owned);
-    result = ms_steam_library_json(metalsharp_home);
+    result = ms_steam_library_refresh_json(metalsharp_home);
     if (result != NULL) {
         char* library = result;
         ms_json_writer_init(&writer);

--- a/app/src-c/runtime/steam_actions.c
+++ b/app/src-c/runtime/steam_actions.c
@@ -2456,12 +2456,18 @@ char* ms_steam_launch_json(const char* home, int* status) {
     }
     redirect_wine_steam_desktop(home);
     if (ms_steam_process_running(home)) {
+        errtext = spawn_wine_install(home, steam, "steam://open/library", NULL, &pid);
         free(steam);
         free(ui);
         free(steam_dir);
+        if (errtext) {
+            char* o = err(errtext);
+            free(errtext);
+            return o;
+        }
         if (status)
             *status = 200;
-        return strdup("{\"ok\":true,\"message\":\"Steam already running\"}");
+        return pid_result(pid, "pid", 0, false);
     }
     ensure_steam_launch_ready(home, steam_dir);
     seed_steam_d3d12_guard(home, steam_dir);
@@ -2657,12 +2663,19 @@ static const char* fixed_unzstd_path(void) {
 }
 
 static char* find_bundled_steam_archive(const char* home) {
+    const char* bundle_dir = getenv("METALSHARP_BUNDLE_DIR");
     const char* fixed[] = {
         "/Applications/MetalSharp.app/Contents/Resources/bundles/metalsharp-steam.tar.zst",
         "/Applications/MetalSharp.app/Contents/Resources/metalsharp-steam.tar.zst",
         "app/bundles/metalsharp-steam.tar.zst",
     };
     char* path;
+    if (bundle_dir) {
+        path = join(bundle_dir, "metalsharp-steam.tar.zst");
+        if (path && access(path, R_OK) == 0)
+            return path;
+        free(path);
+    }
     for (size_t i = 0; i < sizeof(fixed) / sizeof(fixed[0]); i++) {
         path = strdup(fixed[i]);
         if (path && access(path, R_OK) == 0)

--- a/app/src-c/tests/steam_process_test.py
+++ b/app/src-c/tests/steam_process_test.py
@@ -58,15 +58,20 @@ def main() -> int:
         home = root / "home"
         host_home = root / "host-home"
         steam_dir = home / "prefix-steam/drive_c/Program Files (x86)/Steam"
+        steamapps = steam_dir / "steamapps"
+        game_dir = steamapps / "common/Test Game"
         wine_bin = home / "runtime/wine/bin"
-        steam_dir.mkdir(parents=True)
+        game_dir.mkdir(parents=True)
         host_home.mkdir()
         wine_bin.mkdir(parents=True)
         (steam_dir / "Steam.exe").write_bytes(b"test")
         (steam_dir / "steamui.dll").write_bytes(b"test")
+        (steamapps / "appmanifest_1.acf").write_text(
+            '"AppState"\n{\n\t"appid"\t"1"\n\t"name"\t"Test Game"\n\t"installdir"\t"Test Game"\n}\n'
+        )
         for name in ("wine", "metalsharp-wine"):
             target = wine_bin / name
-            target.write_text("#!/bin/sh\nexit 0\n")
+            target.write_text('#!/bin/sh\nprintf "%s\\n" "$@" > "$METALSHARP_HOME/steam-launch.args"\n')
             target.chmod(0o755)
 
         port = free_port()
@@ -83,11 +88,32 @@ def main() -> int:
         wine_steam: subprocess.Popen[bytes] | None = None
         try:
             wait_status(port, False)
+            library = request_json(port, "/steam/library")
+            game = next(item for item in library["games"] if item["appid"] == 1)
+            assert game["embedded_icon_path"] is None
+            assert not (game_dir / ".metalsharp").exists(), "ordinary library reads must not scan game contents"
+
+            icon = game_dir / ".metalsharp/steam-embedded-icon.png"
+            icon.parent.mkdir()
+            icon.write_bytes(b"cached")
+            library = request_json(port, "/steam/library")
+            game = next(item for item in library["games"] if item["appid"] == 1)
+            assert game["embedded_icon_path"] == str(icon)
+
             assert native.poll() is None, "native macOS Steam stand-in exited unexpectedly"
             assert foreign_wine.poll() is None, "foreign Wine Steam stand-in exited unexpectedly"
 
             wine_steam = fake_process(steam_dir, r"C:\Program Files (x86)\Steam\steam.exe")
             wait_status(port, True)
+
+            launched = request_json(port, "/steam/launch", method="POST")
+            assert launched.get("ok") is True, launched
+            launch_args = home / "steam-launch.args"
+            for _ in range(50):
+                if launch_args.exists():
+                    break
+                time.sleep(0.1)
+            assert "steam://open/library" in launch_args.read_text().splitlines()
 
             stopped = request_json(port, "/steam/stop", method="POST")
             assert stopped.get("ok") is True, stopped
@@ -110,7 +136,7 @@ def main() -> int:
                 except subprocess.TimeoutExpired:
                     process.kill()
                     process.wait(timeout=5)
-    print("Steam process detection and migration handoff shutdown verified")
+    print("Steam process detection, activation, and migration handoff shutdown verified")
     return 0
 
 

--- a/app/src/main/backend-bridge.ts
+++ b/app/src/main/backend-bridge.ts
@@ -256,11 +256,13 @@ export class BackendBridge {
 
   private spawnBackend(binPath: string) {
     const homebrewInstaller = path.resolve(path.dirname(binPath), "..", "scripts/tools/install-homebrew.sh");
+    const bundleDir = path.resolve(path.dirname(binPath), "..", "bundles");
     this.proc = spawn(binPath, [], {
       env: {
         ...process.env,
         PATH: shellPath,
         METALSHARP_HOMEBREW_INSTALLER: homebrewInstaller,
+        ...(fs.existsSync(bundleDir) ? { METALSHARP_BUNDLE_DIR: bundleDir } : {}),
         METALSHARP_PORT: String(this.port),
         ...(this.metalsharpHome ? { METALSHARP_HOME: this.metalsharpHome } : {}),
         ...(this.devMode ? { METALSHARP_DEV: "1" } : {}),


### PR DESCRIPTION
## LLM Statement

That's some good old 5.6 Sol stuff.

## Summary

Prevent normal Steam library startup from monopolizing the single-request backend, reopen an existing Wine Steam client, and resolve packaged runtime bundles from the actual app location.

## Changes

- Keep normal `/steam/library` reads cache-only; reserve network sync and embedded-icon extraction for `?refresh=1`.
- Forward `steam://open/library` when Wine Steam is already running.
- Pass the packaged `Contents/Resources/bundles` directory to the backend and honor it for Steam archive lookup.
- Extend Steam process regression coverage.

## PR Readiness (MANDATORY)

- [x] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [x] Version metadata (`CMakeLists.txt`, `app/src-c/Makefile`, `package.json`, `package-lock.json`) in sync if version bumped
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

## Local toolchain (run before push)

- [x] C backend builds and tests: `make -C app/src-c test`
- [x] C++ compiles if changed: `cmake -B build-native -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON && cmake --build build-native --parallel $(sysctl -n hw.ncpu)`
- [x] `clang-format --dry-run --Werror` passes on any changed C/C++/Obj-C file
- [x] `ctest --test-dir build-native` passes if tests changed
- [x] TypeScript compiles if changed: `cd app && npx tsc --noEmit`
- [x] Biome + Prettier pass if TS/JS changed: `cd app && npx @biomejs/biome ci src/ && npx prettier --check 'src/**/*.{ts,js,html,css,json}'`
- [x] Shell scripts lint if changed: `tools/ci/shellcheck.sh`
- [x] `tools/ci/validate-rules-toml.py` passes if `configs/mtsp-rules.toml` changed
- [x] `python3 tools/ci/verify-dmg-workflow.py` passes if release/bundle tooling changed
- [x] Tested with at least one game (which one? which launch method? which drive?)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files should be added to the repo root; place them under `app/`, `tools/`, `tests/`, etc.

## Test notes

- Installed the patched backend into a real MetalSharp 0.61.0 app under `~/Applications`, re-signed it, and verified a 10-game library loads in 0.08s.
- Stopped the stale Wine Steam process, launched a fresh client, then invoked launch again while it was running; activation returned in 0.07s.
- Verified ELDEN RING (appid 1245620), M12 selection, internal drive, through real library discovery and Wine Steam launch/activation. Game-binary launch behavior is unchanged.
- `make -C app/src-c all` and the Steam process regression test pass. The full C suite passes through Steam, shadPS4, and PCSX2; only the final SharpEmu sandbox integration is denied by the host Codex/macOS sandbox (`sandbox_apply: Operation not permitted`).
- TypeScript, Biome, Prettier, `git diff --check`, and strict clang-format pass. Biome reports five pre-existing CSS specificity warnings.
- C++, ctest, shell, TOML, version, and release workflow checks are not applicable to the changed files.
- No documentation or compatibility-matrix edit is needed; this restores the existing cache-first and Start Wine Steam behavior.

## Risk

Explicit refresh still performs the slower Steam API and icon-extraction work. Reverting this commit restores the prior library, activation, and bundle lookup behavior.
