### PR TITLE
fix(runtime): reconcile Steam graphics routes and D3DMetal launches

### DIFF
--- a/app/src-c/Makefile
+++ b/app/src-c/Makefile
@@ -81,7 +81,11 @@ $(BUILD_DIR)/c-backend/%.o: %.c
 
 -include $(OBJECTS:.o=.d)
 
-test: $(TARGET) $(JSON_TEST) $(MIGRATION_TEST) $(HTTP_SERVER_TEST)
+$(BUILD_DIR)/runtime-routes-test: tests/runtime_routes_test.c runtime/steam_actions.c $(OBJECTS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o "$@" tests/runtime_routes_test.c $(filter-out $(BUILD_DIR)/c-backend/runtime/main.o $(BUILD_DIR)/c-backend/runtime/steam_actions.o,$(OBJECTS))
+
+test: $(TARGET) $(JSON_TEST) $(MIGRATION_TEST) $(HTTP_SERVER_TEST) $(BUILD_DIR)/runtime-routes-test
+	@home="$$(mktemp -d)"; "$(BUILD_DIR)/runtime-routes-test" "$$home"; rc=$$?; rm -rf "$$home"; exit $$rc
 	@python3 "$(CURDIR)/tests/migration_hash_contract_test.py"
 	@ms_home="$$(mktemp -d)"; test_home="$$(mktemp -d)"; test_port=$$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()'); HOME="$$test_home" METALSHARP_PORT="$$test_port" METALSHARP_HOME="$$ms_home" METALSHARP_RPCS3_RELEASE_JSON="$(CURDIR)/tests/rpcs3_release.json" METALSHARP_RPCS3_DOWNLOAD_FILE="$(CURDIR)/tests/rpcs3_bad_archive.7z" METALSHARP_SHADPS4_RELEASE_JSON="$(CURDIR)/tests/shadps4_release.json" METALSHARP_SHADPS4_DOWNLOAD_FILE="$(CURDIR)/tests/shadps4_bad_archive.zip" METALSHARP_SHADPS4_HOST_ARCH=arm64 METALSHARP_SHADPS4_HOST_MACOS=27 METALSHARP_SHADPS4_ROSETTA=1 METALSHARP_PCSX2_RELEASE_JSON="$(CURDIR)/tests/pcsx2_release.json" METALSHARP_PCSX2_DOWNLOAD_FILE="$(CURDIR)/tests/pcsx2_bad_archive.tar.xz" METALSHARP_PCSX2_HOST_ARCH=arm64 METALSHARP_PCSX2_HOST_MACOS=27 METALSHARP_PCSX2_ROSETTA=1 METALSHARP_PCSX2_SKIP_SIGNATURE_FOR_TESTS=1 METALSHARP_SHARPEMU_HOST_ARCH=arm64 METALSHARP_SHARPEMU_HOST_MACOS=27 METALSHARP_SHARPEMU_ROSETTA=1 METALSHARP_SHARPEMU_SANDBOX=1 "$(CURDIR)/tests/smoke.sh" "$(TARGET)"; rc=$$?; rm -rf "$$test_home" "$$ms_home"; exit $$rc
 	@"$(JSON_TEST)"

--- a/app/src-c/include/metalsharp_backend/config.h
+++ b/app/src-c/include/metalsharp_backend/config.h
@@ -6,5 +6,6 @@
 
 char* ms_config_get_json(const char* metalsharp_home);
 char* ms_config_set_json(const char* metalsharp_home, const unsigned char* body, size_t body_length, int* status);
+bool ms_config_msync_enabled(const char* metalsharp_home);
 
 #endif

--- a/app/src-c/include/metalsharp_backend/steam_actions.h
+++ b/app/src-c/include/metalsharp_backend/steam_actions.h
@@ -15,6 +15,11 @@ char* ms_steam_launch_game_json(const char*, const char*, size_t, int*);
 char* ms_steam_launch_auto_json(const char*, const char*, size_t, int*);
 char* ms_steam_launch_external_json(const char*, const char*, size_t, int*);
 char* ms_steam_launch_d3dmetal_json(const char*, unsigned, const char*, const char*, int*);
+/* App-aware executable selection for D3DMetal bottles (for example Unreal
+ * launchers versus their actual Win64 shipping executable). */
+char* ms_steam_d3dmetal_game_executable(const char*, unsigned);
+/* Remove only byte-matched MetalSharp route DLLs before staging a new route. */
+void ms_steam_cleanup_route_dlls(const char*, const char*, const char*, const char*);
 char* ms_steam_prepare_bottle_route_json(const char*, const char*);
 /* Canonical MTSP recipe/prepare/doctor inspection.  mode: 0 prepare, 1 recipe, 2 doctor. */
 char* ms_steam_mtsp_inspect_json(const char*, const unsigned char*, size_t, int*, int);

--- a/app/src-c/runtime/config.c
+++ b/app/src-c/runtime/config.c
@@ -189,6 +189,15 @@ static bool config_bool(const ms_json* config, const char* key, bool fallback) {
     return json_boolish(ms_json_object_get(config, key), &value) ? value : fallback;
 }
 
+bool ms_config_msync_enabled(const char* metalsharp_home) {
+    char* path = config_path(metalsharp_home);
+    ms_json* config = path == NULL ? NULL : read_json_file(path);
+    bool enabled = config_bool(config, "msync", true);
+    free(path);
+    ms_json_free(config);
+    return enabled;
+}
+
 char* ms_config_get_json(const char* metalsharp_home) {
     char* path = config_path(metalsharp_home);
     ms_json* config = path == NULL ? NULL : read_json_file(path);

--- a/app/src-c/runtime/d3dmetal.c
+++ b/app/src-c/runtime/d3dmetal.c
@@ -26,6 +26,7 @@
 #define GPTK3_INNER_DMG_NAME "Evaluation environment for Windows games 3.0.dmg"
 #define GPTK3_MSC_PKG_NAME   "Metal Shader Converter 3.0.pkg"
 #define GPTK3_MIN_DMG_SIZE   (80ULL * 1024ULL * 1024ULL)
+#define D3DMETAL_RUNTIME     "runtime/d3dmetal-gptk4-beta2"
 
 static const char* gptk_route_dlls[] = {"d3d10.dll", "d3d11.dll",   "d3d12.dll",
                                         "dxgi.dll",  "nvapi64.dll", "nvngx-on-metalfx.dll"};
@@ -108,40 +109,6 @@ static char* path_join(const char* a, const char* b) {
     return p;
 }
 
-static char* find_game_exe(const char* root, unsigned depth) {
-    DIR* dir;
-    struct dirent* entry;
-    if (!root || depth > 8 || !(dir = opendir(root)))
-        return NULL;
-    while ((entry = readdir(dir)) != NULL) {
-        char* path;
-        struct stat info;
-        size_t length;
-        if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
-            continue;
-        path = path_join(root, entry->d_name);
-        if (!path || stat(path, &info) != 0) {
-            free(path);
-            continue;
-        }
-        length = strlen(entry->d_name);
-        if (S_ISREG(info.st_mode) && length > 4 && !strcasecmp(entry->d_name + length - 4, ".exe")) {
-            closedir(dir);
-            return path;
-        }
-        if (S_ISDIR(info.st_mode)) {
-            char* found = find_game_exe(path, depth + 1);
-            free(path);
-            if (found) {
-                closedir(dir);
-                return found;
-            }
-        } else
-            free(path);
-    }
-    closedir(dir);
-    return NULL;
-}
 static bool mkdirs(const char* path) {
     char* p = strdup(path);
     size_t i;
@@ -661,7 +628,7 @@ static bool gptk_vcpp_ready(const char* home) {
     return ok;
 }
 
-static bool install_homebrew_gptk(void) {
+static __attribute__((unused)) bool install_homebrew_gptk(void) {
     const char* brew = access("/opt/homebrew/bin/brew", X_OK) == 0 ? "/opt/homebrew/bin/brew" : "/usr/local/bin/brew";
     char* tap[] = {NULL, (char*)"tap", (char*)"gcenx/wine", NULL};
     char* trust[] = {NULL, (char*)"trust", (char*)"--cask", (char*)"gcenx/wine/game-porting-toolkit", NULL};
@@ -675,12 +642,12 @@ static bool install_homebrew_gptk(void) {
            run_process(brew, install, NULL, NULL) && homebrew_gptk_ready();
 }
 
-static bool install_rosetta(void) {
+static __attribute__((unused)) bool install_rosetta(void) {
     char* const argv[] = {(char*)"softwareupdate", (char*)"--install-rosetta", (char*)"--agree-to-license", NULL};
     return run_process("/usr/sbin/softwareupdate", argv, NULL, NULL) && rosetta_ready();
 }
 
-static bool seed_gptk_prefix(const char* home) {
+static __attribute__((unused)) bool seed_gptk_prefix(const char* home) {
     char* prefix = gptk_prefix(home);
     char* system32 = prefix ? path_join(prefix, "drive_c/windows/system32") : NULL;
     char* syswow64 = prefix ? path_join(prefix, "drive_c/windows/syswow64") : NULL;
@@ -1003,8 +970,18 @@ static dstate* state_for(const char* home, const char* id) {
     if (s)
         return s;
     s = load_state(home, id);
-    if (s)
+    if (s) {
+        /* Executable-discovery rules can be corrected after a bottle was saved.
+         * Refresh persisted Steam bottles rather than retaining a stale
+         * recursive fallback (such as an anti-cheat service executable). */
+        char* detected = s->appid ? ms_steam_d3dmetal_game_executable(home, s->appid) : NULL;
+        if (detected && strcmp(s->game_exe, detected)) {
+            snprintf(s->game_exe, sizeof(s->game_exe), "%s", detected);
+            (void)save_state(home, s);
+        }
+        free(detected);
         return s;
+    }
     {
         char* bottles = path_join(home, "bottles");
         char* directory = bottles ? path_join(bottles, id) : NULL;
@@ -1035,7 +1012,7 @@ static dstate* state_for(const char* home, const char* id) {
                     }
                 }
                 {
-                    char* detected = find_game_exe(s->game_dir, 0);
+                    char* detected = ms_steam_d3dmetal_game_executable(home, s->appid);
                     snprintf(s->game_exe, sizeof(s->game_exe), "%s", detected ? detected : "");
                     free(detected);
                 }
@@ -1070,7 +1047,7 @@ static dstate* state_from_steam_app(const char* home, unsigned long long appid, 
     snprintf(s->name, sizeof(s->name), "Game %llu", appid);
     snprintf(s->game_dir, sizeof(s->game_dir), "%s", game_dir);
     {
-        char* detected = find_game_exe(game_dir, 0);
+        char* detected = ms_steam_d3dmetal_game_executable(home, s->appid);
         snprintf(s->game_exe, sizeof(s->game_exe), "%s", detected ? detected : "");
         free(detected);
     }
@@ -1103,12 +1080,27 @@ done:
     return ok;
 }
 
-static bool stage_d3dmetal_game_local(const dstate* s) {
+static bool stage_d3dmetal_game_local(const char* home, dstate* s) {
     char* dir;
     char* slash;
     bool ok = false;
+    /* A bottle can be saved before Steam finishes library discovery. Resolve
+     * the path at the staging boundary so save/reopen never loses its route. */
+    if (s && !s->game_exe[0] && s->appid) {
+        char* detected_dir = ms_steam_game_dir(home, s->appid);
+        if (detected_dir) {
+            char* detected_exe = ms_steam_d3dmetal_game_executable(home, s->appid);
+            snprintf(s->game_dir, sizeof(s->game_dir), "%s", detected_dir);
+            snprintf(s->game_exe, sizeof(s->game_exe), "%s", detected_exe ? detected_exe : "");
+            free(detected_exe);
+            free(detected_dir);
+        }
+    }
     if (!s || !s->game_exe[0] || !(dir = strdup(s->game_exe)))
         return false;
+    /* Match normal Steam route changes: remove only exact MetalSharp artifacts
+     * from the previous pipeline before deploying this route. */
+    ms_steam_cleanup_route_dlls(home, "d3dmetal", s->game_dir, s->game_exe);
     slash = strrchr(dir, '/');
     if (!slash)
         goto done;
@@ -1117,7 +1109,7 @@ static bool stage_d3dmetal_game_local(const dstate* s) {
     for (size_t i = 0; ok && i < sizeof(gptk_route_dlls) / sizeof(gptk_route_dlls[0]); i++) {
         char source[PATH_MAX];
         char* target;
-        snprintf(source, sizeof(source), "%s/%s", GPTK_PE, gptk_route_dlls[i]);
+        snprintf(source, sizeof(source), "%s/%s/wine/x86_64-windows/%s", home, D3DMETAL_RUNTIME, gptk_route_dlls[i]);
         target = path_join(dir, gptk_route_dlls[i]);
         ok = file_ready(source) && target && copy_file_checked(source, target);
         free(target);
@@ -1134,41 +1126,40 @@ static bool gptk3_installed(const char* home) {
     return ready;
 }
 
+static bool d3dmetal_runtime_ready(const char* home) {
+    char* framework = path_join(home, D3DMETAL_RUNTIME "/external/D3DMetal.framework");
+    bool ok = framework_ready(framework);
+    for (size_t i = 0; ok && i < sizeof(gptk_route_dlls) / sizeof(gptk_route_dlls[0]); i++) {
+        char relative[PATH_MAX];
+        char* payload;
+        snprintf(relative, sizeof(relative), D3DMETAL_RUNTIME "/wine/x86_64-windows/%s", gptk_route_dlls[i]);
+        payload = path_join(home, relative);
+        ok = file_ready(payload);
+        free(payload);
+    }
+    free(framework);
+    return ok;
+}
+
 static void refresh_d3dmetal_state(const char* home, dstate* s) {
-    bool gptk = homebrew_gptk_ready();
-    bool prefix = gptk && rosetta_ready() && gptk_prefix_route_ready(home);
-    snprintf(s->step[0], 20, "%s", gptk ? "installed" : "missing");
-    snprintf(s->step[1], 20, "%s", rosetta_ready() ? "installed" : "missing");
-    snprintf(s->step[2], 20, "%s", gptk ? "updated" : "missing");
-    snprintf(s->step[3], 20, "%s", prefix && gptk_vcpp_ready(home) ? "installed" : "missing");
-    snprintf(s->step[4], 20, "%s",
-             prefix && gptk_vcpp_ready(home) && d3dmetal_game_local_ready(s) ? "seeded" : "missing");
-    snprintf(s->step[5], 20, "%s", gptk3_installed(home) ? "installed" : "missing");
-    s->ready = !strcmp(s->step[0], "installed") && !strcmp(s->step[1], "installed") && !strcmp(s->step[2], "updated") &&
-               !strcmp(s->step[3], "installed") && !strcmp(s->step[4], "seeded");
+    bool runtime = d3dmetal_runtime_ready(home);
+    snprintf(s->step[0], 20, "%s", runtime ? "installed" : "missing");
+    snprintf(s->step[1], 20, "%s", runtime && d3dmetal_game_local_ready(s) ? "seeded" : "missing");
+    s->ready = runtime && !strcmp(s->step[1], "seeded");
 }
 
 static void actions_json(ms_json_writer* w, const dstate* s) {
-    const char* ids[] = {"install_homebrew_gptk", "install_rosetta", "repair_gptk_payload",
-                         "install_x64_redist",    "seed_prefix",     "play_d3dmetal"};
-    const char* labels[] = {"Repair Homebrew GPTK", "Repair Rosetta", "Repair GPTK Payload",
-                            "Repair Redist",        "Seed Prefix",    "Play D3DMetal"};
-    const char* steps[] = {"gptk_homebrew", "rosetta", "gptk_payload", "x64_redist", "seed", "play_ready"};
+    const char* ids[] = {"repair_gptk_payload", "seed_prefix", "play_d3dmetal"};
+    const char* labels[] = {"Verify bundled D3DMetal payload", "Stage D3DMetal DLLs", "Play D3DMetal"};
+    const char* steps[] = {"bundled_payload", "game_local_dlls", "play_ready"};
     ms_json_writer_array_begin(w);
-    for (size_t i = 0; i < 6; i++) {
-        const char* sv = i == 0   ? s->step[0]
-                         : i == 1 ? s->step[1]
-                         : i == 2 ? s->step[2]
-                         : i == 3 ? s->step[3]
-                         : i == 4 ? s->step[4]
-                                  : (s->ready ? "installed" : "missing");
+    for (size_t i = 0; i < 3; i++) {
+        const char* sv = i < 2 ? s->step[i] : (s->ready ? "installed" : "missing");
         ms_json_writer_object_begin(w);
         step(w, "id", ids[i]);
         step(w, "label", labels[i]);
         ms_json_writer_key(w, "enabled");
-        ms_json_writer_bool(w, i == 5 ? s->ready
-                                      : strcmp(sv, "installed") != 0 && strcmp(sv, "updated") != 0 &&
-                                            strcmp(sv, "seeded") != 0);
+        ms_json_writer_bool(w, i == 2 ? s->ready : strcmp(sv, "installed") != 0 && strcmp(sv, "seeded") != 0);
         step(w, "state", sv);
         step(w, "detail", steps[i]);
         ms_json_writer_object_end(w);
@@ -1267,27 +1258,8 @@ done:
 }
 
 char* ms_d3dmetal_json(const char* home, const char* action, const unsigned char* body, size_t len, int* status) {
-    if (!strcmp(action, "repair-gptk3")) {
-        char* downloaded = gptk3_download_path();
-        if (!downloaded) {
-            pid_t pid = fork();
-            int wait_status = 0;
-            if (pid == 0) {
-                execl("/usr/bin/open", "open", "https://developer.apple.com/download/all/?q=game%20porting%20toolkit",
-                      (char*)NULL);
-                _exit(127);
-            }
-            if (pid >= 0)
-                while (waitpid(pid, &wait_status, 0) < 0 && errno == EINTR) {
-                }
-            if (pid >= 0 && WIFEXITED(wait_status) && WEXITSTATUS(wait_status) == 0)
-                return strdup(
-                    "{\"ok\":true,\"download_opened\":true,\"download_required\":true,\"download_url\":\"https://"
-                    "developer.apple.com/download/all/?q=game%20porting%20toolkit\"}");
-            return bad("Could not launch /usr/bin/open");
-        }
-        free(downloaded);
-    }
+    if (!strcmp(action, "repair-gptk3"))
+        return bad("GPTK 3 overlay staging is retired; MetalSharp uses its bundled GPTK 4 D3DMetal payload");
     ms_json* j = parse(body, len);
     char id[129] = {0}, *s, *game;
     unsigned long long appid = 0;
@@ -1314,10 +1286,14 @@ char* ms_d3dmetal_json(const char* home, const char* action, const unsigned char
             free(game);
             game = ms_steam_game_dir(home, (unsigned)appid);
         }
-        if (!game || !game[0]) {
-            free(game);
+        /* Library discovery can lag behind a bottle edit. Save the requested
+         * pipeline now and leave staging pending; status/play will resolve the
+         * Steam install path when it becomes available. */
+        if (!game)
+            game = strdup("");
+        if (!game) {
             ms_json_free(j);
-            return bad("D3DMetal save requires a detected game install path");
+            return bad("out of memory while saving D3DMetal bottle");
         }
         s = text(j, "name", NULL);
         if (!ensure_d3dmetal_bottle_manifest(home, id, appid, s, game)) {
@@ -1339,11 +1315,18 @@ char* ms_d3dmetal_json(const char* home, const char* action, const unsigned char
         snprintf(st->name, sizeof(st->name), "%s", s && s[0] ? s : "D3DMetal Game");
         free(s);
         snprintf(st->game_dir, sizeof(st->game_dir), "%s", game);
-        {
-            char* detected = find_game_exe(game, 0);
+        if (game[0]) {
+            char* detected = ms_steam_d3dmetal_game_executable(home, st->appid);
             snprintf(st->game_exe, sizeof(st->game_exe), "%s", detected ? detected : "");
             free(detected);
+        } else {
+            st->game_exe[0] = '\0';
         }
+        /* Saving a resolved bottle performs the same route staging as play.
+         * This makes the saved override immediately durable instead of leaving
+         * a surprise "Stage D3DMetal DLLs" action after reopening it. */
+        if (d3dmetal_runtime_ready(home) && st->game_exe[0])
+            (void)stage_d3dmetal_game_local(home, st);
         refresh_d3dmetal_state(home, st);
         st->updated = now_ms();
         save_state(home, st);
@@ -1382,40 +1365,19 @@ char* ms_d3dmetal_json(const char* home, const char* action, const unsigned char
         ms_json_free(j);
         goto respond_state;
     }
-    if (!strcmp(action, "install-homebrew-gptk")) {
-        if (!install_homebrew_gptk()) {
+    if (!strcmp(action, "install-homebrew-gptk") || !strcmp(action, "repair-gptk-payload")) {
+        if (!d3dmetal_runtime_ready(home)) {
             ms_json_free(j);
-            return bad("Homebrew GPTK installation or payload verification failed");
+            return bad("The bundled D3DMetal payload is incomplete; repair the MetalSharp runtime installation");
         }
         snprintf(st->step[0], 20, "installed");
-    } else if (!strcmp(action, "install-rosetta")) {
-        if (!rosetta_ready() && !install_rosetta()) {
+    } else if (!strcmp(action, "install-rosetta") || !strcmp(action, "install-x64-redist") ||
+               !strcmp(action, "seed-prefix")) {
+        if (!d3dmetal_runtime_ready(home) || !stage_d3dmetal_game_local(home, st)) {
             ms_json_free(j);
-            return bad("Rosetta installation failed");
+            return bad("Could not stage the bundled D3DMetal DLLs beside the game executable");
         }
-        snprintf(st->step[1], 20, "installed");
-    } else if (!strcmp(action, "repair-gptk-payload")) {
-        if (strcmp(st->step[0], "installed")) {
-            free(j);
-            return bad("Homebrew GPTK must be installed before repairing the payload");
-        }
-        if (!homebrew_gptk_ready()) {
-            ms_json_free(j);
-            return bad("Homebrew GPTK payload is incomplete");
-        }
-        snprintf(st->step[2], 20, "updated");
-    } else if (!strcmp(action, "install-x64-redist")) {
-        if (!seed_gptk_prefix(home) || !gptk_vcpp_ready(home)) {
-            ms_json_free(j);
-            return bad("VC++ runtime seeding into the GPTK prefix failed");
-        }
-        snprintf(st->step[3], 20, "installed");
-    } else if (!strcmp(action, "seed-prefix")) {
-        if (!gptk_vcpp_ready(home) || !seed_gptk_prefix(home) || !stage_d3dmetal_game_local(st)) {
-            ms_json_free(j);
-            return bad("GPTK prefix seeding failed");
-        }
-        snprintf(st->step[4], 20, "seeded");
+        snprintf(st->step[1], 20, "seeded");
     } else if (!strcmp(action, "repair-gptk3")) {
         char* repair_error = repair_gptk3_overlay(home);
         if (repair_error) {
@@ -1427,6 +1389,13 @@ char* ms_d3dmetal_json(const char* home, const char* action, const unsigned char
         snprintf(st->step[5], 20, "installed");
         snprintf(st->step[2], 20, "updated");
     } else if (!strcmp(action, "play")) {
+        /* Refresh game-local payloads on every launch, so runtime updates take
+         * effect without leaving a stale GPTK/Homebrew dependency behind. */
+        if (!d3dmetal_runtime_ready(home) || !stage_d3dmetal_game_local(home, st)) {
+            ms_json_free(j);
+            return bad("Could not update the D3DMetal DLLs beside the game executable");
+        }
+        refresh_d3dmetal_state(home, st);
         if (!st->ready) {
             free(j);
             return bad("D3DMetal bottle is not ready to play");

--- a/app/src-c/runtime/diagnostics.c
+++ b/app/src-c/runtime/diagnostics.c
@@ -1,4 +1,5 @@
 #include "metalsharp_backend/diagnostics.h"
+#include "metalsharp_backend/config.h"
 #include "metalsharp_backend/json.h"
 #include "metalsharp_backend/json_writer.h"
 #include <CommonCrypto/CommonDigest.h>
@@ -1946,8 +1947,7 @@ static char* pipeline_diagnostic(const char* kind, const char* query, int* statu
         struct stat st;
         char* hash;
         const char* source = !strcmp(pipeline, "vkd3d") && i >= 2 ? "dxvk/x86_64-windows" : deploy_subpath;
-        snprintf(path, sizeof(path), "%s/%s/%s", !strcmp(pipeline, "vkd3d") ? lane_root : root, source,
-                 deploy_pe[i]);
+        snprintf(path, sizeof(path), "%s/%s/%s", !strcmp(pipeline, "vkd3d") ? lane_root : root, source, deploy_pe[i]);
         bool present = stat(path, &st) == 0 && S_ISREG(st.st_mode) && st.st_size > 0;
         bool optional =
             strcmp(pipeline, "m12") && (!strncmp(deploy_pe[i], "nvapi", 5) || !strncmp(deploy_pe[i], "nvngx", 5));
@@ -1988,16 +1988,15 @@ static char* pipeline_diagnostic(const char* kind, const char* query, int* statu
         if (!user_home || !*user_home)
             user_home = home;
         if (!strcmp(pipeline, "m12")) {
-            snprintf(unix_path, sizeof(unix_path), "%s/lib/dxmt_m12/x86_64-unix:%s/lib/wine/x86_64-unix", root,
-                     root);
+            snprintf(unix_path, sizeof(unix_path), "%s/lib/dxmt_m12/x86_64-unix:%s/lib/wine/x86_64-unix", root, root);
             snprintf(fallback_unix_path, sizeof(fallback_unix_path), "%s", unix_path);
             snprintf(windows_path, sizeof(windows_path), "%s/lib/dxmt_m12/x86_64-windows", root);
         } else if (!strcmp(pipeline, "vkd3d")) {
             snprintf(unix_path, sizeof(unix_path), "%s/lib/wine/x86_64-unix", root);
             snprintf(fallback_unix_path, sizeof(fallback_unix_path), "%s", unix_path);
             snprintf(windows_path, sizeof(windows_path),
-                     "%s/vkd3d-proton/x86_64-windows:%s/dxvk/x86_64-windows:%s/lib/wine/x86_64-windows",
-                     lane_root, lane_root, root);
+                     "%s/vkd3d-proton/x86_64-windows:%s/dxvk/x86_64-windows:%s/lib/wine/x86_64-windows", lane_root,
+                     lane_root, root);
         } else {
             snprintf(unix_path, sizeof(unix_path), "%s/lib/wine/x86_64-unix", root);
             snprintf(fallback_unix_path, sizeof(fallback_unix_path), "%s", unix_path);
@@ -2036,7 +2035,7 @@ static char* pipeline_diagnostic(const char* kind, const char* query, int* statu
             ENV_PAIR("VK_DRIVER_FILES", value);
         }
         ENV_PAIR("MS_GRAPHICS_BACKEND", !strcmp(pipeline, "m12") ? "dxmt" : "vulkan");
-        ENV_PAIR("WINEMSYNC", "1");
+        ENV_PAIR("WINEMSYNC", ms_config_msync_enabled(home) ? "1" : "0");
         ENV_PAIR("METALSHARP_SHADER_CACHE_PATH", shader_path);
         ENV_PAIR("METALSHARP_PIPELINE_CACHE_PATH", pipeline_path);
         ENV_PAIR("METALSHARP_CACHE_SUMMARY", summary);
@@ -2062,8 +2061,8 @@ static char* pipeline_diagnostic(const char* kind, const char* query, int* statu
             ENV_PAIR("DXMT_ASYNC_PIPELINE_COMPILE", "1");
             ENV_PAIR("DXMT_D3D12_UE_SM6_COMPAT", "1");
             ENV_PAIR("DXMT_D3D12_PSO_WORKERS", "6");
-            ENV_PAIR("DXMT_CONFIG",
-                     "d3d11.metalSpatialUpscaleFactor=1.43;d3d11.preferredMaxFrameRate=60;dxmt.shaderMetalVersion=310");
+            ENV_PAIR("DXMT_CONFIG", "d3d11.metalSpatialUpscaleFactor=1.43;d3d11.preferredMaxFrameRate=60;d3d11."
+                                    "maxFeatureLevel=12_1;dxmt.shaderMetalVersion=310");
         }
 #undef ENV_PAIR
     }
@@ -2089,8 +2088,7 @@ static char* pipeline_diagnostic(const char* kind, const char* query, int* statu
         bool optional =
             strcmp(pipeline, "m12") && (!strncmp(deploy_pe[i], "nvapi", 5) || !strncmp(deploy_pe[i], "nvngx", 5));
         const char* source = !strcmp(pipeline, "vkd3d") && i >= 2 ? "dxvk/x86_64-windows" : deploy_subpath;
-        snprintf(path, sizeof(path), "%s/%s/%s", !strcmp(pipeline, "vkd3d") ? lane_root : root, source,
-                 deploy_pe[i]);
+        snprintf(path, sizeof(path), "%s/%s/%s", !strcmp(pipeline, "vkd3d") ? lane_root : root, source, deploy_pe[i]);
         if (!optional && (stat(path, &st) != 0 || !S_ISREG(st.st_mode) || st.st_size == 0)) {
             ms_json_writer_object_begin(&w);
             ms_json_writer_key(&w, "filename");

--- a/app/src-c/runtime/setup.c
+++ b/app/src-c/runtime/setup.c
@@ -21,12 +21,12 @@
 #include <time.h>
 #include <unistd.h>
 
-#define MS_DXMT_VERSION                MS_BACKEND_VERSION "-m12-isolated-surface-v1"
+#define MS_DXMT_VERSION                MS_BACKEND_VERSION "-dxmt-v0.80-baseline-v1"
 #define MS_DXMT_MANIFEST               "metalsharp-dxmt-runtime.json"
 #define MS_MOLTENVK_LIBRARY_SHA256     "8249d81ebf2d46f82b16ca166c2e5cca5d76d91d0a412cd6d3db1aaa6e8430bf"
 #define MS_MOLTENVK_LANE_ICD_SHA256    "578ff08cd0d8734619357541771a5abc9c3470ca300030219a971a9e9dbbe466"
 #define MS_MOLTENVK_RUNTIME_ICD_SHA256 "0dcbf7707cc0a347d0ba2941e835e5e92709919370a1bb0fc252e8dc4d95d322"
-#define MS_DXMT_SCHEMA                 "metalsharp.dxmt-runtime.v1"
+#define MS_DXMT_SCHEMA                 "metalsharp.dxmt-runtime.v2"
 
 static const char* const dxmt_pe[] = {
     "d3d10core.dll", "d3d11.dll", "d3d12.dll", "dxgi.dll", "dxgi_dxmt.dll", "winemetal.dll", "nvapi64.dll", "nvngx.dll",
@@ -46,6 +46,52 @@ static char* join_path(const char* left, const char* right) {
 static bool file_nonempty(const char* path) {
     struct stat st;
     return path != NULL && stat(path, &st) == 0 && S_ISREG(st.st_mode) && st.st_size > 0;
+}
+
+/* Native DXMT bridges are unpacked from a tarball. Re-sign after extraction so
+ * Gatekeeper sees a valid local ad-hoc signature even if archive metadata was
+ * normalized by a release or updater tool. */
+static bool adhoc_sign_native_bridge(const char* path) {
+    pid_t child;
+    int status;
+    pid_t waited;
+    if (!file_nonempty(path))
+        return false;
+    child = fork();
+    if (child < 0)
+        return false;
+    if (child == 0) {
+        execl("/usr/bin/codesign", "codesign", "--force", "--sign", "-", path, (char*)NULL);
+        _exit(127);
+    }
+    do {
+        waited = waitpid(child, &status, 0);
+    } while (waited < 0 && errno == EINTR);
+    if (waited < 0 || !WIFEXITED(status) || WEXITSTATUS(status) != 0)
+        return false;
+    child = fork();
+    if (child < 0)
+        return false;
+    if (child == 0) {
+        execl("/usr/bin/codesign", "codesign", "--verify", "--strict", path, (char*)NULL);
+        _exit(127);
+    }
+    do {
+        waited = waitpid(child, &status, 0);
+    } while (waited < 0 && errno == EINTR);
+    return waited > 0 && WIFEXITED(status) && WEXITSTATUS(status) == 0;
+}
+
+static bool sign_dxmt_native_bridges(const char* runtime_dir) {
+    char *x64 = join_path(runtime_dir, "x86_64-unix/winemetal.so"),
+         *x86 = join_path(runtime_dir, "i386-unix/winemetal.so");
+    bool ok = x64 && adhoc_sign_native_bridge(x64);
+    /* M12 has no i386 bridge; standard DXMT does. */
+    if (x86 && access(x86, F_OK) == 0)
+        ok = adhoc_sign_native_bridge(x86) && ok;
+    free(x64);
+    free(x86);
+    return ok;
 }
 
 static char* setup_read_text(const char* path) {
@@ -322,7 +368,7 @@ static bool download_bundle_archive(const char* home, const char* name) {
     pid = fork();
     if (pid == 0) {
         char url[512];
-        snprintf(url, sizeof(url), "https://github.com/aaf2tbz/metalsharp/releases/download/bundles/%s", name);
+        snprintf(url, sizeof(url), "https://github.com/metalsharp/MetalSharp/releases/download/bundles/%s", name);
         execl("/usr/bin/curl", "curl", "--fail", "--location", "--silent", "--show-error", "--retry", "2",
               "--connect-timeout", "30", "--max-time", "600", "-o", temporary, url, (char*)NULL);
         _exit(127);
@@ -1792,6 +1838,7 @@ static void run_install_all_worker(const char* home) {
                               copy_directory_contents(src_m12, dst_m12) &&
                               (!has_dxvk || (dst_dxvk && copy_directory_contents(src_dxvk, dst_dxvk))) &&
                               (!has_vkd3d || (dst_vkd3d && copy_directory_contents(src_vkd3d, dst_vkd3d))) &&
+                              sign_dxmt_native_bridges(dst_dxmt) && sign_dxmt_native_bridges(dst_m12) &&
                               write_dxmt_manifest(dst_dxmt) && write_dxmt_manifest(dst_m12);
                 free(src_dxmt);
                 free(src_m12);
@@ -2133,7 +2180,7 @@ char* ms_setup_install_vcpp_json(const char* home, bool x86, int* status) {
         char library_env[PATH_MAX * 2];
         char* args[] = {wine, "start", "/wait", "/unix", installer, "/install", NULL};
         setenv("WINEPREFIX", prefix, 1);
-        setenv("WINEARCH", "win64", 1);
+        setenv("WINEARCH", "wow64", 1);
         setenv("WINEDEBUG", "-all", 1);
         snprintf(library_env, sizeof(library_env), "%s/runtime/wine/lib:%s/runtime/wine/lib/wine/x86_64-unix", home,
                  home);

--- a/app/src-c/runtime/steam.c
+++ b/app/src-c/runtime/steam.c
@@ -1183,14 +1183,19 @@ char* ms_steam_status_json(const char* metalsharp_home) {
     const char* home = getenv("HOME");
     char* wine_prefix = join_path(metalsharp_home, "prefix-steam/drive_c/Program Files (x86)/Steam");
     char* wine_exe = wine_prefix == NULL ? NULL : join_path(wine_prefix, "Steam.exe");
+    char* steam_x64 = wine_prefix == NULL ? NULL : join_path(wine_prefix, "steamclient64.dll");
+    char* steam_manifest64 =
+        wine_prefix == NULL ? NULL : join_path(wine_prefix, "package/steam_client_win64.installed");
     char* wine = join_path(metalsharp_home, "runtime/wine/bin/wine");
     char* wine_wrapper = join_path(metalsharp_home, "runtime/wine/bin/metalsharp-wine");
     char* install_lock = join_path(metalsharp_home, ".steam-installing");
     char* mac_app = home == NULL ? NULL : join_path(home, "Applications/Steam.app");
     char* mac_bundle =
         home == NULL ? NULL : join_path(home, "Library/Application Support/Steam/Steam.AppBundle/Steam/Steam.app");
-    bool windows_installed = wine_exe != NULL && access(wine_exe, F_OK) == 0;
     bool installing = install_lock != NULL && access(install_lock, F_OK) == 0;
+    bool windows_installed = wine_exe != NULL && steam_x64 != NULL && steam_manifest64 != NULL &&
+                             access(wine_exe, F_OK) == 0 && access(steam_x64, F_OK) == 0 &&
+                             access(steam_manifest64, F_OK) == 0 && !installing;
     bool mac_installed = access("/Applications/Steam.app", F_OK) == 0 ||
                          (mac_app != NULL && access(mac_app, F_OK) == 0) ||
                          (mac_bundle != NULL && access(mac_bundle, F_OK) == 0);
@@ -1250,6 +1255,8 @@ char* ms_steam_status_json(const char* metalsharp_home) {
     result = ms_json_writer_take(&writer);
     free(wine_prefix);
     free(wine_exe);
+    free(steam_x64);
+    free(steam_manifest64);
     free(wine);
     free(wine_wrapper);
     free(install_lock);

--- a/app/src-c/runtime/steam_actions.c
+++ b/app/src-c/runtime/steam_actions.c
@@ -4,6 +4,7 @@
 #endif
 #endif
 #include "metalsharp_backend/steam_actions.h"
+#include "metalsharp_backend/config.h"
 #include "metalsharp_backend/json.h"
 #include "metalsharp_backend/json_writer.h"
 #include "metalsharp_backend/mtsp.h"
@@ -233,6 +234,10 @@ static bool pipeline_is_dxmt(const char* pipeline) {
                         !strcmp(pipeline, "dxmt"));
 }
 
+static void set_wine_msync(const char* home) {
+    setenv("WINEMSYNC", ms_config_msync_enabled(home) ? "1" : "0", 1);
+}
+
 static const char* pipeline_backend(const char* pipeline) {
     if (!strcmp(pipeline, "vkd3d"))
         return "vulkan";
@@ -251,7 +256,7 @@ static const char* pipeline_overrides(const char* pipeline) {
     if (!strcmp(pipeline, "vkd3d"))
         return "d3d12,d3d12core,d3d11,d3d10core,dxgi,d3d9=n,b;gameoverlayrenderer,gameoverlayrenderer64=d";
     if (!strcmp(pipeline, "m11"))
-        return "winemetal,dxgi,d3d11,d3d10core=n,b;gameoverlayrenderer,gameoverlayrenderer64=d";
+        return "winemetal,dxgi,d3d11,d3d12,d3d10core=n,b;gameoverlayrenderer,gameoverlayrenderer64=d";
     if (!strcmp(pipeline, "m11_32"))
         return "d3d11,dxgi,winemetal=n,b;gameoverlayrenderer,gameoverlayrenderer64=d";
     if (!strcmp(pipeline, "m10"))
@@ -302,20 +307,37 @@ static void ensure_dxmt_shader_metal_version(const char* home) {
         return;
     }
     existing = read_bounded_file(path);
-    if (existing && strstr(existing, "dxmt.shaderMetalVersion") != NULL) {
-        free(existing);
-        free(etc);
-        free(path);
-        return;
-    }
     file = fopen(path, "wb");
     if (file) {
-        if (existing && existing[0]) {
-            fputs(existing, file);
-            if (existing[strlen(existing) - 1] != '\n')
-                fputc('\n', file);
+        bool wrote_feature_level = false, wrote_shader_version = false;
+        char* cursor = existing;
+        while (cursor && *cursor) {
+            char* line = cursor;
+            char* newline = strchr(cursor, '\n');
+            char* key = line;
+            if (newline) {
+                *newline = '\0';
+                cursor = newline + 1;
+            } else
+                cursor = NULL;
+            while (*key == ' ' || *key == '\t')
+                key++;
+            if (!strncmp(key, "d3d11.maxFeatureLevel", 21) && (key[21] == ' ' || key[21] == '\t' || key[21] == '=')) {
+                if (!wrote_feature_level)
+                    fputs("d3d11.maxFeatureLevel = 12_1\n", file);
+                wrote_feature_level = true;
+            } else if (!strncmp(key, "dxmt.shaderMetalVersion", 23) &&
+                       (key[23] == ' ' || key[23] == '\t' || key[23] == '=')) {
+                if (!wrote_shader_version)
+                    fputs("dxmt.shaderMetalVersion = 310\n", file);
+                wrote_shader_version = true;
+            } else
+                fprintf(file, "%s\n", line);
         }
-        fputs("dxmt.shaderMetalVersion = 310\n", file);
+        if (!wrote_feature_level)
+            fputs("d3d11.maxFeatureLevel = 12_1\n", file);
+        if (!wrote_shader_version)
+            fputs("dxmt.shaderMetalVersion = 310\n", file);
         fclose(file);
     }
     free(existing);
@@ -376,7 +398,16 @@ static void set_route_paths(const char* home, const char* pipeline) {
             dllpath, sizeof(dllpath),
             "%s/vkd3d/vkd3d-proton/x86_64-windows:%s/vkd3d/dxvk/x86_64-windows:%s/runtime/wine/lib/wine/x86_64-windows",
             home, home, home);
-        snprintf(unixpath, sizeof(unixpath), "%s/runtime/wine/lib/wine/x86_64-unix", home);
+        /* Keep VKD3D on its dedicated current MoltenVK lane.  Do not use the
+         * Wine-bundled fallback driver or any DXMT/M12 sidecars here. */
+        snprintf(unixpath, sizeof(unixpath), "%s/runtime/wine/lib/moltenvk-vkmt:%s/runtime/wine/lib/wine/x86_64-unix",
+                 home, home);
+    } else if (!strcmp(pipeline, "d3dmetal")) {
+        snprintf(dllpath, sizeof(dllpath),
+                 "%s/runtime/d3dmetal-gptk4-beta2/wine/x86_64-windows:%s/runtime/wine/lib/wine/x86_64-windows", home,
+                 home);
+        snprintf(unixpath, sizeof(unixpath),
+                 "%s/runtime/d3dmetal-gptk4-beta2/external:%s/runtime/wine/lib/wine/x86_64-unix", home, home);
     } else if (!strcmp(pipeline, "m32") || !strcmp(pipeline, "wine_bare")) {
         snprintf(unixpath, sizeof(unixpath), "%s/runtime/wine/lib/wine/x86_64-unix", home);
     }
@@ -400,15 +431,46 @@ static void set_route_paths(const char* home, const char* pipeline) {
     } else {
         unsetenv("DXMT_CONFIG_FILE");
     }
-    if (pipeline_is_dxmt(pipeline))
-        setenv("DXMT_WINEMETAL_UNIXLIB", "winemetal.so", 1);
-    else
+    if (pipeline_is_dxmt(pipeline)) {
+        char winemetal[PATH_MAX];
+        char runtime_dir[PATH_MAX];
+        const char* route = !strcmp(pipeline, "m12")                                       ? "dxmt_m12/x86_64-unix"
+                            : (!strcmp(pipeline, "m10_32") || !strcmp(pipeline, "m11_32")) ? "dxmt/i386-unix"
+                                                                                           : "dxmt/x86_64-unix";
+        /* __wine_load_unix_lib() takes an NT path, not a host POSIX path. */
+        snprintf(winemetal, sizeof(winemetal), "\\??\\Z:%s/runtime/wine/lib/%s/winemetal.so", home, route);
+        for (char* p = winemetal + 5; *p; ++p)
+            if (*p == '/')
+                *p = '\\';
+        snprintf(runtime_dir, sizeof(runtime_dir), "%s/runtime/wine/lib/%s", home,
+                 !strcmp(pipeline, "m12") ? "dxmt_m12" : "dxmt");
+        setenv("DXMT_WINEMETAL_UNIXLIB", winemetal, 1);
+        setenv("DXMT_RUNTIME_DIR", runtime_dir, 1);
+        setenv("GRAPHICS_BACKEND", "dxmt", 1);
+    } else {
         unsetenv("DXMT_WINEMETAL_UNIXLIB");
+        unsetenv("DXMT_RUNTIME_DIR");
+        setenv("GRAPHICS_BACKEND", backend, 1);
+    }
     setenv("MS_GRAPHICS_BACKEND", backend, 1);
-    setenv("WINEMSYNC", "1", 1);
+    set_wine_msync(home);
+    if (!strcmp(pipeline, "d3dmetal")) {
+        char framework[PATH_MAX];
+        char runtime[PATH_MAX];
+        snprintf(framework, sizeof(framework), "%s/runtime/d3dmetal-gptk4-beta2/external/D3DMetal.framework/D3DMetal",
+                 home);
+        snprintf(runtime, sizeof(runtime), "%s/runtime/d3dmetal-gptk4-beta2", home);
+        setenv("D3DMETAL_FRAMEWORK_PATH", framework, 1);
+        /* Wine's D3DMetal loader resolves PE and Unix companions from this
+         * root; WINEDLLPATH alone only stages the PE side. */
+        setenv("D3DMETAL_RUNTIME_DIR", runtime, 1);
+    } else {
+        unsetenv("D3DMETAL_FRAMEWORK_PATH");
+        unsetenv("D3DMETAL_RUNTIME_DIR");
+    }
     if (!strcmp(pipeline, "vkd3d")) {
         char icd[PATH_MAX];
-        snprintf(icd, sizeof(icd), "%s/runtime/wine/etc/vulkan/icd.d/MoltenVK_icd.json", home);
+        snprintf(icd, sizeof(icd), "%s/runtime/wine/lib/moltenvk-vkmt/MoltenVK_icd.json", home);
         setenv("VK_ICD_FILENAMES", icd, 1);
         setenv("VK_DRIVER_FILES", icd, 1);
     } else {
@@ -455,11 +517,13 @@ static void set_route_default_env(const char* pipeline) {
             setenv("DXMT_D3D12_UE_SM6_COMPAT", "1", 1);
             setenv("DXMT_D3D12_PSO_WORKERS", "6", 1);
             setenv("DXMT_CONFIG",
-                   "d3d11.metalSpatialUpscaleFactor=1.43;d3d11.preferredMaxFrameRate=60;dxmt.shaderMetalVersion=310",
+                   "d3d11.metalSpatialUpscaleFactor=1.43;d3d11.preferredMaxFrameRate=60;d3d11.maxFeatureLevel=12_1;"
+                   "dxmt.shaderMetalVersion=310",
                    1);
         } else {
             setenv("DXMT_CONFIG",
-                   "d3d11.metalSpatialUpscaleFactor=1.43;d3d11.preferredMaxFrameRate=60;dxmt.shaderMetalVersion=310",
+                   "d3d11.metalSpatialUpscaleFactor=1.43;d3d11.preferredMaxFrameRate=60;d3d11.maxFeatureLevel=12_1;"
+                   "dxmt.shaderMetalVersion=310",
                    1);
         }
     } else {
@@ -476,6 +540,8 @@ static void set_route_default_env(const char* pipeline) {
         setenv("MVK_PRESENT_MODE", "1", 1);
         setenv("MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS", "1", 1);
         setenv("MVK_CONFIG_RESUME_LOST_DEVICE", "1", 1);
+        setenv("MVK_CONFIG_USE_METAL_PRIVATE_API", "1", 1);
+        setenv("MVK_CONFIG_FORCE_RETAINED_COMMAND_BUFFERS", "1", 1);
     }
 }
 
@@ -1140,7 +1206,7 @@ static bool stage_route_asset(const char* home, const char* source_subpath, cons
     char* source = NULL;
     char* target = NULL;
     bool ok = false;
-    if (!strncmp(source_subpath, "vkd3d/", 6))
+    if (!strncmp(source_subpath, "vkd3d/", 6) || !strncmp(source_subpath, "runtime/", 8))
         source_root = strdup(home);
     else
         source_root = join(home, "runtime/wine");
@@ -1186,39 +1252,30 @@ static bool files_match(const char* left, const char* right) {
 
 static void remove_stale_route_dlls(const char* home, const char* pipeline, const char* game_dir,
                                     const char* executable) {
-    static const char* const names[] = {"d3d12.dll",
-                                        "d3d12core.dll",
-                                        "d3d11.dll",
-                                        "d3d10.dll",
-                                        "d3d10_1.dll",
-                                        "d3d10core.dll",
-                                        "d3d9.dll",
-                                        "dxgi.dll",
-                                        "dxgi_dxmt.dll",
-                                        "nvapi64.dll",
-                                        "nvngx.dll",
-                                        "winemetal.dll",
-                                        "metalsharp_ntdll_hook.dll"};
-    const char* source_subpaths[] = {"runtime/wine/lib/dxmt/x86_64-windows",
-                                     "runtime/wine/lib/dxmt/i386-windows",
-                                     "runtime/wine/lib/dxmt_m12/x86_64-windows",
-                                     "runtime/wine/lib/metalsharp/x86_64-windows",
-                                     "runtime/wine/lib/metalsharp/i386-windows",
-                                     "runtime/wine/lib/wine/x86_64-windows",
-                                     "runtime/wine/lib/wine/i386-windows",
-                                     "vkd3d/vkd3d-proton/x86_64-windows",
-                                     "vkd3d/dxvk/x86_64-windows"};
+    static const char* const names[] = {"d3d12.dll",     "d3d12core.dll",
+                                        "d3d11.dll",     "d3d10.dll",
+                                        "d3d10_1.dll",   "d3d10core.dll",
+                                        "d3d9.dll",      "dxgi.dll",
+                                        "dxgi_dxmt.dll", "nvapi64.dll",
+                                        "nvngx.dll",     "nvngx-on-metalfx.dll",
+                                        "winemetal.dll", "metalsharp_ntdll_hook.dll"};
+    const char* source_subpaths[] = {
+        "runtime/wine/lib/dxmt/x86_64-windows",     "runtime/wine/lib/dxmt/i386-windows",
+        "runtime/wine/lib/dxmt_m12/x86_64-windows", "runtime/wine/lib/metalsharp/x86_64-windows",
+        "runtime/wine/lib/metalsharp/i386-windows", "runtime/wine/lib/wine/x86_64-windows",
+        "runtime/wine/lib/wine/i386-windows",       "runtime/d3dmetal-gptk4-beta2/wine/x86_64-windows",
+        "vkd3d/vkd3d-proton/x86_64-windows",        "vkd3d/dxvk/x86_64-windows"};
     char* exe_dir = executable ? strdup(executable) : NULL;
     char* slash = exe_dir ? strrchr(exe_dir, '/') : NULL;
+    (void)pipeline;
     const char* dirs[2] = {game_dir, NULL};
     if (slash) {
         *slash = '\0';
         dirs[1] = exe_dir;
     }
-    if (!pipeline_is_dxmt(pipeline) && strcmp(pipeline, "vkd3d") != 0) {
-        free(exe_dir);
-        return;
-    }
+    /* Run for every pipeline transition. A route DLL is removed only after a
+     * byte-for-byte comparison against a bundled known artifact, so a game's
+     * own DLL (or a user-modified one) is never removed. */
     for (size_t d = 0; d < 2; d++) {
         if (!dirs[d] || (d == 1 && dirs[0] && !strcmp(dirs[0], dirs[1])))
             continue;
@@ -1245,6 +1302,10 @@ static void remove_stale_route_dlls(const char* home, const char* pipeline, cons
     free(exe_dir);
 }
 
+void ms_steam_cleanup_route_dlls(const char* home, const char* pipeline, const char* game_dir, const char* executable) {
+    remove_stale_route_dlls(home, pipeline, game_dir, executable);
+}
+
 static bool stage_route_dlls(const char* home, unsigned id, const char* pipeline, const char* executable) {
     char* exe_dir = NULL;
     char* game_dir = NULL;
@@ -1255,8 +1316,7 @@ static bool stage_route_dlls(const char* home, unsigned id, const char* pipeline
     size_t file_count = 0;
     bool is32 = executable_is_32bit(executable);
 
-    if (!strcmp(pipeline, "m13") || !strcmp(pipeline, "d3dmetal") || !strcmp(pipeline, "m32") ||
-        !strcmp(pipeline, "wine_bare"))
+    if (!strcmp(pipeline, "m13") || !strcmp(pipeline, "m32") || !strcmp(pipeline, "wine_bare"))
         return true;
     exe_dir = strdup(executable);
     cursor = exe_dir ? strrchr(exe_dir, '/') : NULL;
@@ -1265,7 +1325,17 @@ static bool stage_route_dlls(const char* home, unsigned id, const char* pipeline
     *cursor = '\0';
     game_dir = ms_steam_game_dir(home, id);
 
-    if (!strcmp(pipeline, "m12")) {
+    if (!strcmp(pipeline, "d3dmetal")) {
+        if (is32)
+            return false;
+        source = "runtime/d3dmetal-gptk4-beta2/wine/x86_64-windows";
+        files[file_count++] = "d3d10.dll";
+        files[file_count++] = "d3d11.dll";
+        files[file_count++] = "d3d12.dll";
+        files[file_count++] = "dxgi.dll";
+        files[file_count++] = "nvapi64.dll";
+        files[file_count++] = "nvngx-on-metalfx.dll";
+    } else if (!strcmp(pipeline, "m12")) {
         source = "lib/dxmt_m12/x86_64-windows";
         files[file_count++] = "d3d12.dll";
         files[file_count++] = "d3d11.dll";
@@ -1287,7 +1357,6 @@ static bool stage_route_dlls(const char* home, unsigned id, const char* pipeline
         source = !strcmp(pipeline, "m11_32") ? "lib/dxmt/i386-windows" : "lib/dxmt/x86_64-windows";
         files[file_count++] = "d3d11.dll";
         files[file_count++] = "dxgi.dll";
-        files[file_count++] = "dxgi_dxmt.dll";
         files[file_count++] = "d3d10core.dll";
         files[file_count++] = "winemetal.dll";
         if (!strcmp(pipeline, "m11")) {
@@ -1305,7 +1374,6 @@ static bool stage_route_dlls(const char* home, unsigned id, const char* pipeline
         source = !strcmp(pipeline, "m10_32") ? "lib/dxmt/i386-windows" : "lib/dxmt/x86_64-windows";
         files[file_count++] = "d3d11.dll";
         files[file_count++] = "dxgi.dll";
-        files[file_count++] = "dxgi_dxmt.dll";
         files[file_count++] = "d3d10core.dll";
         files[file_count++] = "winemetal.dll";
     } else if (!strcmp(pipeline, "m9")) {
@@ -2077,6 +2145,8 @@ static char* preferred_steam_game_executable(const char* game_dir, unsigned id, 
         return ruled;
     if (id == 1097150)
         preferred[count++] = "FallGuys_client_game.exe";
+    else if (id == 4704690)
+        preferred[count++] = "Chameleon/Binaries/Win64/PenguinHotel-Win64-Shipping.exe";
     else if (id == 1145360 && pipeline && !strcmp(pipeline, "m11_32"))
         preferred[count++] = "x86/Hades.exe";
     else if (id == 1145360)
@@ -2094,7 +2164,9 @@ static char* preferred_steam_game_executable(const char* game_dir, unsigned id, 
     else if (id == 1888160)
         preferred[count++] = "armoredcore6.exe";
     else if (id == 1962700)
-        preferred[count++] = "Subnautica2.exe";
+        preferred[count++] = "Subnautica2/Binaries/Win64/Subnautica2-Win64-Shipping.exe";
+    else if (id == 3240220)
+        preferred[count++] = "GTA5_Enhanced.exe";
     else if (id == 2767030)
         preferred[count++] = "MarvelGame/Marvel/Binaries/Win64/Marvel-Win64-Shipping.exe";
     else if (id == 220)
@@ -2124,6 +2196,10 @@ static char* preferred_steam_game_executable(const char* game_dir, unsigned id, 
 
 static void set_pipeline_runtime_env(const char*, const char*);
 
+char* ms_steam_d3dmetal_game_executable(const char* home, unsigned id) {
+    return find_steam_game_executable(home, id, "d3dmetal");
+}
+
 static char* spawn_offline_game(const char* home, const char* executable, unsigned id, const char* pipeline,
                                 pid_t* pid) {
     char* wine = join(home, "runtime/wine/bin/metalsharp-wine");
@@ -2151,8 +2227,14 @@ static char* spawn_offline_game(const char* home, const char* executable, unsign
         setenv("SteamGameId", app_id, 1);
         setenv("METALSHARP_PIPELINE", pipeline, 1);
         set_pipeline_runtime_env(home, pipeline);
-        snprintf(library_env, sizeof(library_env), "%s/runtime/wine/lib:%s/runtime/wine/lib/wine/x86_64-unix", home,
-                 home);
+        if (!strcmp(pipeline, "d3dmetal"))
+            snprintf(
+                library_env, sizeof(library_env),
+                "%s/runtime/d3dmetal-gptk4-beta2/external:%s/runtime/wine/lib:%s/runtime/wine/lib/wine/x86_64-unix",
+                home, home, home);
+        else
+            snprintf(library_env, sizeof(library_env), "%s/runtime/wine/lib:%s/runtime/wine/lib/wine/x86_64-unix", home,
+                     home);
 #ifdef __APPLE__
         setenv("DYLD_FALLBACK_LIBRARY_PATH", library_env, 1);
 #else
@@ -2191,16 +2273,38 @@ static void set_pipeline_runtime_env(const char* home, const char* pipeline) {
         setenv("VK_DRIVER_FILES", vulkan_icd, 1);
         backend = "vkd3d-proton";
     } else if (!strcmp(pipeline, "d3dmetal")) {
+        snprintf(winedllpath, sizeof(winedllpath),
+                 "%s/runtime/d3dmetal-gptk4-beta2/wine/x86_64-windows:%s/runtime/wine/lib/wine/x86_64-windows", home,
+                 home);
+        setenv("WINEDLLPATH", winedllpath, 1);
+        snprintf(winemetal, sizeof(winemetal), "%s/runtime/d3dmetal-gptk4-beta2/external/D3DMetal.framework/D3DMetal",
+                 home);
+        setenv("D3DMETAL_FRAMEWORK_PATH", winemetal, 1);
+        snprintf(winemetal, sizeof(winemetal), "%s/runtime/d3dmetal-gptk4-beta2", home);
+        setenv("D3DMETAL_RUNTIME_DIR", winemetal, 1);
+        setenv("WINEDLLOVERRIDES", "d3d10,d3d11,d3d12,dxgi,nvapi64,nvngx-on-metalfx=n,b", 1);
         backend = "d3dmetal";
     }
     if (strncmp(pipeline, "m", 1) == 0 || !strcmp(pipeline, "dxmt")) {
+        char runtime_dir[PATH_MAX];
+        const char* route =
+            (!strcmp(pipeline, "m10_32") || !strcmp(pipeline, "m11_32")) ? "dxmt/i386-unix" : "dxmt/x86_64-unix";
         snprintf(dxmt_config, sizeof(dxmt_config), "%s/runtime/wine/etc/dxmt.conf", home);
-        snprintf(winemetal, sizeof(winemetal), "%s/runtime/wine/lib/dxmt/x86_64-unix/winemetal.so", home);
+        snprintf(winemetal, sizeof(winemetal), "\\??\\Z:%s/runtime/wine/lib/%s/winemetal.so", home, route);
+        for (char* p = winemetal + 5; *p; ++p)
+            if (*p == '/')
+                *p = '\\';
+        snprintf(runtime_dir, sizeof(runtime_dir), "%s/runtime/wine/lib/dxmt", home);
         setenv("DXMT_CONFIG_FILE", dxmt_config, 1);
         setenv("DXMT_WINEMETAL_UNIXLIB", winemetal, 1);
+        setenv("DXMT_RUNTIME_DIR", runtime_dir, 1);
+        setenv("GRAPHICS_BACKEND", "dxmt", 1);
+    } else {
+        unsetenv("DXMT_RUNTIME_DIR");
+        setenv("GRAPHICS_BACKEND", backend, 1);
     }
     setenv("MS_GRAPHICS_BACKEND", backend, 1);
-    setenv("WINEMSYNC", "1", 1);
+    set_wine_msync(home);
 }
 
 static bool process_cwd_within(pid_t pid, const char* root) {
@@ -2301,6 +2405,39 @@ static void signal_wine_steam_processes(const char* home, int signal_number) {
             (void)kill((pid_t)raw_pid, signal_number);
     }
     pclose(pipe);
+}
+
+/* SteamSetup may start Steam as soon as its payload is committed.  The setup
+ * flow must remain in control until prerequisite installers have run, so tear
+ * down every process owned by the Steam prefix, including a wineserver whose
+ * command line no longer mentions Steam. */
+static void terminate_wine_steam_session(const char* home) {
+    char* wineserver = join(home, "runtime/wine/bin/wineserver");
+    char* prefix = join(home, "prefix-steam");
+    pid_t child = -1;
+
+    signal_wine_steam_processes(home, SIGTERM);
+    if (wineserver && prefix && access(wineserver, X_OK) == 0 && (child = fork()) == 0) {
+        setenv("WINEPREFIX", prefix, 1);
+        execl(wineserver, wineserver, "-k", (char*)NULL);
+        _exit(127);
+    }
+    if (child > 0) {
+        int status;
+        for (unsigned i = 0; i < 20; i++) {
+            pid_t waited = waitpid(child, &status, WNOHANG);
+            if (waited == child || (waited < 0 && errno != EINTR))
+                break;
+            usleep(100000);
+        }
+        if (waitpid(child, &status, WNOHANG) == 0) {
+            (void)kill(child, SIGKILL);
+            (void)waitpid(child, &status, 0);
+        }
+    }
+    free(wineserver);
+    free(prefix);
+    signal_wine_steam_processes(home, SIGKILL);
 }
 
 static char* spawn_wine(const char* home, const char* first, const char* second, const char* third, const char* fourth,
@@ -2465,7 +2602,7 @@ char* ms_steam_launch_json(const char* home, int* status) {
     }
     ensure_steam_launch_ready(home, steam_dir);
     seed_steam_d3d12_guard(home, steam_dir);
-    errtext = spawn_wine(home, steam, "-no-cef-sandbox", "-noverifyfiles", "-no-dwrite", NULL, &pid);
+    errtext = spawn_wine(home, steam, "-no-cef-sandbox", "-cef-single-process", "-noverifyfiles", "-no-dwrite", &pid);
     free(steam);
     free(ui);
     free(steam_dir);
@@ -2481,9 +2618,7 @@ char* ms_steam_launch_json(const char* home, int* status) {
 char* ms_steam_stop_json(const char* home, int* status) {
     if (status)
         *status = 200;
-    signal_wine_steam_processes(home, SIGTERM);
-    sleep(1);
-    signal_wine_steam_processes(home, SIGKILL);
+    terminate_wine_steam_session(home);
     usleep(500000);
     {
         ms_json_writer w;
@@ -2648,6 +2783,18 @@ static bool steam_install_lock_active(const char* path) {
     return active;
 }
 
+static bool steam_install_complete(const char* steam_dir) {
+    char* steam_exe = steam_dir ? join(steam_dir, "Steam.exe") : NULL;
+    char* steam_x64 = steam_dir ? join(steam_dir, "steamclient64.dll") : NULL;
+    char* win64_manifest = steam_dir ? join(steam_dir, "package/steam_client_win64.installed") : NULL;
+    bool complete = steam_exe && steam_x64 && win64_manifest && access(steam_exe, F_OK) == 0 &&
+                    access(steam_x64, F_OK) == 0 && access(win64_manifest, F_OK) == 0;
+    free(steam_exe);
+    free(steam_x64);
+    free(win64_manifest);
+    return complete;
+}
+
 static const char* fixed_unzstd_path(void) {
     if (access("/opt/homebrew/bin/unzstd", X_OK) == 0)
         return "/opt/homebrew/bin/unzstd";
@@ -2784,7 +2931,7 @@ static char* download_steam_bundle_archive(const char* home) {
         goto fail;
     if (pid == 0) {
         execl("/usr/bin/curl", "curl", "--fail", "--location", "--silent", "--show-error", "--retry", "3", "-o",
-              temporary, "https://github.com/aaf2tbz/metalsharp/releases/download/bundles/metalsharp-steam.tar.zst",
+              temporary, "https://github.com/metalsharp/MetalSharp/releases/download/bundles/metalsharp-steam.tar.zst",
               (char*)NULL);
         _exit(127);
     }
@@ -3003,7 +3150,6 @@ static void steam_install_worker(const char* home, const char* lock_path, const 
     char* steam_dir = prefix ? join(prefix, "drive_c/Program Files (x86)/Steam") : NULL;
     char* steam_exe = steam_dir ? join(steam_dir, "Steam.exe") : NULL;
     char* steam_ui = steam_dir ? join(steam_dir, "steamui.dll") : NULL;
-    bool install_crashed = false;
     if (owner) {
         fprintf(owner, "%ld\\n", (long)getpid());
         fclose(owner);
@@ -3023,7 +3169,9 @@ static void steam_install_worker(const char* home, const char* lock_path, const 
         goto done;
     if (access(installer, F_OK) != 0)
         goto done;
-    wine_error = spawn_wine_install(home, "wineboot", "--init", NULL, &pid);
+    /* A first Wine invocation initializes a fresh prefix automatically. Running
+     * wineboot --init here also explicitly starts a second service manager. */
+    wine_error = spawn_wine_install(home, "cmd", "/c", "exit 0", &pid);
     if (wine_error) {
         free(wine_error);
         goto done;
@@ -3041,23 +3189,20 @@ static void steam_install_worker(const char* home, const char* lock_path, const 
         free(wine_error);
         goto done;
     }
-    for (int i = 0; i < 70; i++) {
+    /* SteamSetup creates Steam.exe before it finishes downloading and committing
+     * the real x64 client. Do not release the install lock or report success
+     * until steamclient64.dll and steam_client_win64.installed exist. */
+    for (int i = 0; i < 300; i++) {
         pid_t waited = waitpid(pid, &wait_status, WNOHANG);
-        if (waited == pid) {
-            install_crashed = !WIFEXITED(wait_status) || WEXITSTATUS(wait_status) != 0;
+        if (waited < 0 && errno != EINTR && errno != ECHILD)
             break;
-        }
-        if (waited < 0 && errno != EINTR)
-            break;
-        if (steam_exe && steam_ui && access(steam_exe, F_OK) == 0 && access(steam_ui, F_OK) == 0)
+        if (steam_install_complete(steam_dir))
             break;
         sleep(1);
     }
-    if (install_crashed) {
-        sleep(3);
-        if (!steam_exe || !steam_ui || access(steam_exe, F_OK) != 0 || access(steam_ui, F_OK) != 0)
-            goto done;
-    }
+    if (!steam_install_complete(steam_dir))
+        goto done;
+    terminate_wine_steam_session(home);
 done:
     free(prefix);
     free(windows_dir);
@@ -3530,7 +3675,8 @@ static char* spawn_direct_game(const char* home, const char* executable, unsigne
             setenv("DXMT_ASYNC_PIPELINE_COMPILE", "0", 1);
             setenv("DXMT_METALFX_SPATIAL_SWAPCHAIN", "0", 1);
             setenv("DXMT_METALFX_SPATIAL", "0", 1);
-            setenv("DXMT_CONFIG", "d3d11.preferredMaxFrameRate=60;dxmt.shaderMetalVersion=310", 1);
+            setenv("DXMT_CONFIG",
+                   "d3d11.preferredMaxFrameRate=60;d3d11.maxFeatureLevel=12_1;dxmt.shaderMetalVersion=310", 1);
             setenv("METALSHARP_M9_SYNC_LOADING", "1", 1);
         }
         if (id == 1962700 && !strcmp(pipeline, "m12")) {
@@ -3544,7 +3690,8 @@ static char* spawn_direct_game(const char* home, const char* executable, unsigne
             setenv("DXMT_METALFX_SPATIAL_SWAPCHAIN", "0", 1);
             setenv("DXMT_METALFX_SPATIAL", "0", 1);
             setenv("DXMT_METALFX_TEMPORAL", "0", 1);
-            setenv("DXMT_CONFIG", "d3d11.preferredMaxFrameRate=60;dxmt.shaderMetalVersion=310", 1);
+            setenv("DXMT_CONFIG",
+                   "d3d11.preferredMaxFrameRate=60;d3d11.maxFeatureLevel=12_1;dxmt.shaderMetalVersion=310", 1);
         }
         snprintf(library_env, sizeof(library_env), "%s/runtime/wine/lib:%s/runtime/wine/lib/wine/x86_64-unix", home,
                  home);
@@ -3638,9 +3785,9 @@ static char* spawn_gptk_game(const char* home, const char* executable, unsigned 
         size_t argc = 0;
         snprintf(app_id, sizeof(app_id), "%u", id);
         setenv("WINEPREFIX", prefix, 1);
-        setenv("WINEARCH", "win64", 1);
+        setenv("WINEARCH", "wow64", 1);
         setenv("WINEDEBUG", "-all", 1);
-        setenv(!strcmp(pipeline, "d3dmetal") ? "WINEESYNC" : "WINEMSYNC", "1", 1);
+        set_wine_msync(home);
         setenv("WINEDLOVERRIDES",
                "d3d10,d3d11,d3d12,dxgi,nvapi64,nvngx-on-metalfx=n,b;gameoverlayrenderer,gameoverlayrenderer64=d", 1);
         if (!strcmp(pipeline, "d3dmetal"))
@@ -3669,13 +3816,22 @@ char* ms_steam_launch_d3dmetal_json(const char* home, unsigned id, const char* b
                                     int* status) {
     pid_t pid;
     char* error_text;
+    char* game_dir;
     ms_json_writer writer;
     if (!executable || !executable[0]) {
         if (status)
             *status = 400;
         return err("D3DMetal game executable not found");
     }
-    error_text = spawn_gptk_game(home, executable, id, "d3dmetal", &pid);
+    /* Use the same Steam-prefix direct launcher as every routed Steam
+     * pipeline. It preserves SteamAppId/SteamGameId/SteamOverlayGameId and
+     * route setup, rather than marking this game as offline. */
+    /* D3DMetal uses its own bottle play endpoint, so reconcile controller
+     * shims here as well as in the generic Steam launch path. */
+    game_dir = ms_steam_game_dir(home, id);
+    deploy_controller_input_shims(home, game_dir);
+    free(game_dir);
+    error_text = spawn_direct_game(home, executable, id, "d3dmetal", &pid);
     if (error_text) {
         char* result = err(error_text);
         free(error_text);
@@ -3698,7 +3854,7 @@ char* ms_steam_launch_d3dmetal_json(const char* home, unsigned id, const char* b
     ms_json_writer_array_begin(&writer);
     ms_json_writer_array_end(&writer);
     ms_json_writer_key(&writer, "launch_mode");
-    ms_json_writer_string(&writer, "d3dmetal_direct_game_exe");
+    ms_json_writer_string(&writer, "d3dmetal_steam_prefix_direct");
     ms_json_writer_object_end(&writer);
     if (status)
         *status = 200;
@@ -3840,7 +3996,7 @@ static char* ms_steam_launch_game_json_internal(const char* home, const char* bo
     if (!strcmp(pipeline, "m13"))
         e = spawn_gptk_game(home, executable, id, pipeline, &pid);
     else if (!strcmp(pipeline, "d3dmetal"))
-        e = spawn_gptk_game(home, executable, id, pipeline, &pid);
+        e = spawn_direct_game(home, executable, id, pipeline, &pid);
     else
         e = spawn_direct_game(home, executable, id, pipeline, &pid);
     free(executable);
@@ -3922,7 +4078,7 @@ char* ms_steam_launch_external_json(const char* home, const char* body, size_t l
             *status = 500;
         return err("required graphics runtime DLLs are missing");
     }
-    if (!strcmp(pipeline, "m13") || !strcmp(pipeline, "d3dmetal"))
+    if (!strcmp(pipeline, "m13"))
         error_text = spawn_gptk_game(home, executable, id, pipeline, &pid);
     else
         error_text = spawn_direct_game(home, executable, id, pipeline, &pid);

--- a/app/src-c/tests/runtime_routes_test.c
+++ b/app/src-c/tests/runtime_routes_test.c
@@ -1,0 +1,53 @@
+/* Exercise routing helpers without launching Wine or touching a real prefix. */
+#include "../runtime/steam_actions.c"
+#include <assert.h>
+
+static void fixture(const char* home, const char* relative, const char* bytes) {
+    char* path = join(home, relative);
+    char* parent = strdup(path);
+    *strrchr(parent, '/') = '\0';
+    assert(ensure_directory(parent));
+    FILE* f = fopen(path, "wb");
+    assert(f);
+    assert(fputs(bytes, f) >= 0);
+    assert(fclose(f) == 0);
+    free(parent);
+    free(path);
+}
+
+int main(int argc, char** argv) {
+    assert(argc == 2);
+    const char* home = argv[1];
+    fixture(home, "configs/config.json", "{\"msync\":false}");
+    set_wine_msync(home);
+    assert(!strcmp(getenv("WINEMSYNC"), "0"));
+    fixture(home, "configs/config.json", "{\"msync\":true}");
+    set_wine_msync(home);
+    assert(!strcmp(getenv("WINEMSYNC"), "1"));
+    set_route_paths(home, "vkd3d");
+    assert(strstr(getenv("VK_DRIVER_FILES"), "lib/moltenvk-vkmt/MoltenVK_icd.json"));
+    assert(!strcmp(pipeline_backend("m12"), "dxmt"));
+    set_route_paths(home, "d3dmetal");
+    assert(getenv("D3DMETAL_RUNTIME_DIR"));
+    assert(strstr(getenv("D3DMETAL_FRAMEWORK_PATH"), "D3DMetal.framework/D3DMetal"));
+    assert(!getenv("VK_DRIVER_FILES"));
+    fixture(home, "runtime/d3dmetal-gptk4-beta2/wine/x86_64-windows/nvngx-on-metalfx.dll", "known");
+    fixture(home, "game/nvngx-on-metalfx.dll", "known");
+    fixture(home, "game/d3d11.dll", "user DLL");
+    char* game = join(home, "game");
+    char* exe = join(game, "game.exe");
+    char* stale = join(game, "nvngx-on-metalfx.dll");
+    char* custom = join(game, "d3d11.dll");
+    remove_stale_route_dlls(home, "vkd3d", game, exe);
+    assert(access(stale, F_OK) != 0);
+    assert(access(custom, F_OK) == 0);
+    fixture(home, "game/nvngx-on-metalfx.dll", "user modification");
+    remove_stale_route_dlls(home, "vkd3d", game, exe);
+    assert(access(stale, F_OK) == 0);
+    free(game);
+    free(exe);
+    free(stale);
+    free(custom);
+    puts("runtime routing regressions passed");
+    return 0;
+}

--- a/app/src/renderer/components/GameCard.vue
+++ b/app/src/renderer/components/GameCard.vue
@@ -418,13 +418,9 @@ function runtimeReportFromD3DMetalState(state: D3DMetalGptkState, actions: D3DMe
     prefix_path: "Homebrew GPTK",
     game_install_path: state.game_dir,
     runtime_assets: [],
-    components: [
-      { id: "gptk", state: d3dmetalComponentState(state.gptk_payload) },
-      { id: "rosetta", state: d3dmetalComponentState(state.rosetta) },
-      { id: "vcrun2019_x64", state: d3dmetalComponentState(state.x64_redist) },
-      { id: "vcrun2019_x86", state: d3dmetalComponentState(state.x64_redist) },
-      { id: "gptk_prefix", state: d3dmetalComponentState(state.seed) },
-    ],
+    // D3DMetal is a self-contained bundled route; do not expose legacy
+    // GPTK/Rosetta/VC++/prefix implementation details as bottle components.
+    components: [],
     actions: requiredActions,
   };
 }
@@ -438,12 +434,7 @@ const pendingD3DMetalActions = computed(() =>
 const d3dmetalStatusItems = computed(() => {
   const state = d3dmetalState.value;
   if (!state) return [];
-  return [
-    { label: "GPTK", ready: d3dmetalStateReady(state.gptk_payload) },
-    { label: "Rosetta", ready: d3dmetalStateReady(state.rosetta) },
-    { label: "VC++", ready: d3dmetalStateReady(state.x64_redist) },
-    { label: "Prefix", ready: d3dmetalStateReady(state.seed) },
-  ];
+  return [{ label: "D3DMetal", ready: state.play_ready }];
 });
 
 const unresolvedRuntimeComponents = computed(() =>
@@ -880,16 +871,10 @@ async function saveBottleEdit() {
   }
   bottleSaving.value = true;
   if (bottlePreferredMode.value === "d3dmetal") {
-    const gameDir = runtimeReport.value?.game_install_path;
-    if (!gameDir) {
-      toast.show("D3DMetal save requires a detected game install path", "error");
-      bottleSaving.value = false;
-      return;
-    }
-    // The first save downloads the GPTK fork via Homebrew, which can
-    // take several minutes. Surface a bottom-right toast so the bottle
-    // doesn't look stale while the request is in flight.
-    toast.show("Saving D3DMetal bottle — downloading GPTK runtime on first save…", "success");
+    const gameDir = runtimeReport.value?.game_install_path ?? "";
+    // Steam library discovery can lag a bottle edit. The backend saves the
+    // route and resolves/stages the game path on save or launch.
+    toast.show("Saving D3DMetal bottle…", "success");
     const d3dmetalResult = await api<D3DMetalGptkResponse>(
       "POST",
       "/d3dmetal/bottles/save",
@@ -1194,12 +1179,6 @@ function formatBytes(bytes: number): string {
                   </span>
                 </div>
                 <div v-if="d3dmetalState.last_error" class="doctor-notes blocked">{{ d3dmetalState.last_error }}</div>
-                <div v-if="!gptk3Installed" class="runtime-action-row compact-repair-row">
-                  <span>Add GPTK 3.0 overlay (optional){{ gptk3DmgFound ? "" : " — download DMG to ~/Downloads" }}</span>
-                  <button class="btn btn-secondary btn-sm" :disabled="gptk3Installed || d3dmetalActiveActionId !== null" @click="repairGptk3">
-                    {{ d3dmetalActiveActionId === "gptk3" ? "Working..." : "Repair" }}
-                  </button>
-                </div>
                 <div
                   v-for="action in pendingD3DMetalActions"
                   :key="action.id"

--- a/app/src/renderer/components/SetupWizard.vue
+++ b/app/src/renderer/components/SetupWizard.vue
@@ -131,8 +131,8 @@ async function startInstall() {
 }
 
 async function checkSteam() {
-  const s = await api<{ installed: boolean; running: boolean }>("GET", "/steam/status");
-  if (s?.installed || s?.running) {
+  const s = await api<{ installed: boolean; running: boolean; installing?: boolean }>("GET", "/steam/status");
+  if (s?.installed && !s?.installing) {
     steamInstalled.value = true;
   }
   installingSteam.value = true;
@@ -147,8 +147,8 @@ async function installSteam() {
     return;
   }
   const poll = setInterval(async () => {
-    const s = await api<{ installed: boolean; running: boolean }>("GET", "/steam/status");
-    if (s?.installed || s?.running) {
+    const s = await api<{ installed: boolean; running: boolean; installing?: boolean }>("GET", "/steam/status");
+    if (s?.installed && !s?.installing) {
       clearInterval(poll);
       steamInstalled.value = true;
       steamInstalling.value = false;
@@ -185,8 +185,8 @@ async function finish() {
     }
   }
 
-  await api("POST", "/steam/stop");
-
+  // Do not stop Wine Steam here. Steam may still be completing its first
+  // x64 client update, and killing the prefix at this point leaves it partial.
   emit("done");
 }
 

--- a/app/src/renderer/views/SharpView.vue
+++ b/app/src/renderer/views/SharpView.vue
@@ -910,7 +910,9 @@ const visibleRuntimeProfiles = computed(() => {
         {
           id: "d3dmetal",
           name: "D3DMetal (GPTK)",
-          components: ["gptk", "rosetta", "gptk_prefix", "vcrun2019_x64", "vcrun2019_x86"],
+          // D3DMetal is fully bundled; legacy implementation prerequisites
+          // are not bottle components presented to the user.
+          components: [],
         },
       ];
   return profiles
@@ -2713,15 +2715,14 @@ async function loadD3DMetalStatus(bottle: BottleManifest) {
 }
 
 async function saveD3DMetalBottle(bottle: BottleManifest) {
-  if (!bottle.steam_app_id || !bottle.game_install_path) {
-    toast.show("D3DMetal save requires a Steam app id and game install path", "error");
+  if (!bottle.steam_app_id) {
+    toast.show("D3DMetal save requires a Steam app id", "error");
     return;
   }
   bottleLoading.value[bottle.id] = true;
-  // The first save downloads the GPTK fork via Homebrew, which can
-  // take several minutes. Surface a bottom-right toast so the bottle
-  // doesn't look stale while the request is in flight.
-  toast.show("Saving D3DMetal bottle — downloading GPTK runtime on first save…", "success");
+  // Steam library discovery can lag a bottle edit; the backend resolves and
+  // stages the game path again at the save/launch boundary.
+  toast.show("Saving D3DMetal bottle…", "success");
   const result = await api<D3DMetalGptkResponse>(
     "POST",
     "/d3dmetal/bottles/save",
@@ -2729,7 +2730,7 @@ async function saveD3DMetalBottle(bottle: BottleManifest) {
       appid: bottle.steam_app_id,
       bottleId: bottle.id,
       name: bottle.name,
-      gameDir: bottle.game_install_path,
+      gameDir: bottle.game_install_path ?? "",
     },
     10 * 60 * 1000,
   );

--- a/docs/runtime/backend-route-updates.md
+++ b/docs/runtime/backend-route-updates.md
@@ -1,0 +1,43 @@
+# Backend route updates
+
+D3DMetal uses the bundled GPTK 4 payload and the Steam-prefix direct launcher,
+retaining Steam application identifiers. The framework environment variable names
+the framework executable, and the runtime root is supplied separately. Saving a
+bottle before library discovery is allowed; staging resolves the game later.
+Saved executable selection is refreshed when loading persisted Steam state.
+Subnautica 2 targets its Shipping executable; GTA V Enhanced targets its game
+binary rather than the BattlEye service.
+
+Route transitions compare DLL bytes with known runtime artifacts before cleanup,
+including D3DMetal's `nvngx-on-metalfx.dll`. Modified or game-provided graphics
+DLLs are not removed by cleanup. D3DMetal play also invokes the existing controller
+shim reconciliation. The controller helper's existing ownership behavior is
+unchanged by this PR.
+
+VKD3D selects the isolated MoltenVK lane and enables private API and retained
+command buffers. M12 remains DXMT; no contributor hashes are adopted.
+MSYNC is read from configuration for launches and diagnostics. Wine caches server
+synchronization settings, so a running shared prefix does not hot-switch MSYNC.
+
+The setup UI waits for Steam's x64 installation markers and does not stop Steam
+when finishing the wizard. D3DMetal displays a single readiness indicator rather
+than obsolete GPTK 3 repair controls.
+
+## Validation and deployment
+
+Run `make -C app/src-c test` and `cd app && npm run build`. The routing regression
+harness uses a temporary fixture home and never launches Wine. It checks MSYNC,
+D3DMetal environment paths, VKD3D/M12 separation, and byte-matched cleanup.
+
+Manual checks on an external SSD included Nine Sols and Elden Ring through the
+Steam-prefix D3DMetal direct route, and Control route staging/cleanup. Executable
+selection was checked for GTA V Enhanced and Subnautica 2.
+
+This source-only PR does not include runtime archives, Wine binaries, local prefix
+state, or version bumps. DXMT manifest v2 identifies the v0.80 baseline: deployment
+must pair setup with that graphics payload, not relabel an older archive. Native
+DXMT bridges are ad-hoc signed and verified after extraction.
+
+Rollback: revert this PR and deploy the matching previous graphics payload and
+manifest metadata. Re-prepare affected bottles for the selected route; do not
+wipe the shared Steam prefix or user game data.


### PR DESCRIPTION
## Summary

Consolidate the current C backend runtime-routing fixes and matching renderer changes. Keep M12 on DXMT and VKD3D on its own lane. No contributor hashes, runtime archives, generated binaries, or unrelated working-tree edits are included.

## Changes

- Launch bundled GPTK 4 D3DMetal through the Steam-prefix direct path with correct runtime/framework variables and Steam IDs.
- Refresh saved executable selection; prefer Subnautica 2's Shipping executable and GTA V Enhanced's game binary.
- Allow save before discovery; stage on save/play and remove only byte-matched known graphics artifacts, including `nvngx-on-metalfx.dll`.
- Reconcile controller shims on the separate D3DMetal play path.
- Persist MSYNC selection into launch environment and diagnostics; use WoW64 prefix configuration.
- Select the isolated MoltenVK ICD/library lane for VKD3D and enable private API/retained command buffers, without repurposing M12.
- Update DXMT baseline metadata and sign/verify extracted native bridges; handle waitpid failures safely.
- Wait for Steam x64 installation completion, preserve Steam at wizard completion, and simplify D3DMetal readiness UI.
- Add isolated routing regression coverage and runtime documentation.

## PR Readiness (MANDATORY)

- [x] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [x] Version metadata (`CMakeLists.txt`, `app/src-c/Makefile`, `package.json`, `package-lock.json`) in sync if version bumped
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [ ] Regression test added for each bug fix

## Local toolchain (run before push)

- [x] C backend builds and tests: `make -C app/src-c test`
- [x] C++ compiles if changed: not changed
- [x] `clang-format --dry-run --Werror` passes on changed C/header files
- [x] `ctest --test-dir build-native` passes if tests changed: native engine/tests not changed
- [x] TypeScript compiles: `cd app && npx tsc --noEmit`
- [x] Electron production build: `cd app && npm run build`
- [x] Shell scripts lint if changed: no shell changes
- [x] Rules validation if changed: no TOML changes
- [x] DMG workflow validation if changed: no workflow/bundle-tool changes
- [x] Tested with at least one game (below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files added to the repo root

## Test notes

Full C suite passes, including JSON, migration/hash contracts, HTTP disconnect, updater, Steam process, shadPS4, PCSX2, and SharpEmu tests. New fixture-only regression tests cover MSYNC off/on, D3DMetal environment paths, VKD3D ICD selection, M12 backend separation, known MetalFX DLL removal and modified DLL preservation. They never launch Wine or touch the user's prefix.

Manual validation during development: Nine Sols and Elden Ring using the Steam-prefix D3DMetal direct route on an external SSD; Control graphics staging/hash checks and stale MetalFX cleanup; GTA V Enhanced and Subnautica 2 executable selection. Steam was preserved during backend updates.

Remaining readiness work is **coverage for each individual fix**, particularly executable discovery/persisted D3DMetal state, controller reconciliation, first-install Steam completion, and extraction/signing failure paths. This is opened as a draft rather than claiming that unchecked gate is satisfied. Fresh packaging/deployment of this exact PR worktree has not been performed; prior installed development builds passed deep signature verification.

## Risk

Source-only change: shipping setup must use the matching DXMT v0.80 graphics payload. Manifest v2 must not be paired with the old archive. No app version bump or migration hash changes are included. MSYNC is not a hot switch for a running wineserver. Existing controller ownership semantics are unchanged.

Rollback: revert the PR, deploy the matching prior graphics payload/manifest metadata, and re-prepare affected routes. Preserve the shared Steam prefix and user game data.
