### PR TITLE
fix(migration): accept current DXMT runtime manifests

### DIFF
--- a/app/src-c/runtime/migration.c
+++ b/app/src-c/runtime/migration.c
@@ -200,7 +200,7 @@ static bool migration_manifest_current(const char* path) {
     char* text = read_text(path);
     char expected[128];
     bool current;
-    snprintf(expected, sizeof(expected), "\"version\":\"%s-m12-isolated-surface-v1\"", MIGRATION_VERSION);
+    snprintf(expected, sizeof(expected), "\"version\":\"%s-dxmt-v0.80-baseline-v1\"", MIGRATION_VERSION);
     current = text && strstr(text, expected) != NULL;
     free(text);
     return current;

--- a/app/src-c/tests/migration_test.c
+++ b/app/src-c/tests/migration_test.c
@@ -50,6 +50,19 @@ int main(void) {
     assert(stop_managed_wine_processes(home));
     assert(steam_stop_calls == 1);
 
+    /* Setup emits the v0.80 baseline for both DXMT lanes. Migration must
+     * accept that manifest, not require the retired M12 version suffix. */
+    snprintf(path, sizeof(path), "%s/dxmt-manifest.json", home);
+    write_file(path, "{\"schema\":\"metalsharp.dxmt-runtime.v2\",\"version\":\"" MIGRATION_VERSION
+                     "-dxmt-v0.80-baseline-v1\",\"source\":\"bundled:metalsharp-graphics-dll.tar.zst\"}");
+    assert(migration_manifest_current(path));
+    write_file(path, "{\"version\":\"" MIGRATION_VERSION "-m12-isolated-surface-v1\"}");
+    assert(!migration_manifest_current(path));
+    write_file(path, "{\"version\":\"0.0.0-dxmt-v0.80-baseline-v1\"}");
+    assert(!migration_manifest_current(path));
+    unlink(path);
+    assert(!migration_manifest_current(path));
+
     snprintf(path, sizeof(path), "%s/setup.json", home);
     write_file(path, "{\"completed\":true,\"deviceName\":\"test\"}");
     snprintf(path, sizeof(path), "%s/cache/downloads", home);


### PR DESCRIPTION
## Summary
Fix the post-extraction runtime readiness check: setup writes the DXMT v0.80 manifest but migration still required the retired M12 version suffix. This rejected a complete runtime as runtime_bundle_incomplete.

## Validation
Full C test suite passes. Regression tests accept the current manifest and reject the retired suffix, wrong version, and absent file. Installed graphics hash sets were also checked and matched. No validation checks are disabled; the expected version is corrected.

No payload, app-version, or prefix changes. Revert this commit to restore the old predicate (and its failure on current manifests). Checklist exception: targeted validator fix with regression coverage, no new game launch claimed.