### PR TITLE
fix(release): reduce bundle extraction and animate update progress

### DIFF
--- a/app/src-c/runtime/updater.c
+++ b/app/src-c/runtime/updater.c
@@ -536,6 +536,9 @@ char* ms_update_start_json(const char* metalsharp_home, const unsigned char* bod
         ms_json* json = info == NULL ? NULL : ms_json_parse(info, strlen(info), error, sizeof(error));
         char* url = json == NULL ? NULL : release_field_json(json, fex ? "fex_download_url" : "download_url");
         char* latest = json == NULL ? NULL : release_field_json(json, "latest_version");
+        long long download_size = 0;
+        if (json)
+            (void)ms_json_as_i64(ms_json_object_get(json, fex ? "fex_download_size" : "download_size"), &download_size);
         free(info);
         ms_json_free(json);
         if (url == NULL || latest == NULL || url[0] == '\0') {
@@ -559,9 +562,34 @@ char* ms_update_start_json(const char* metalsharp_home, const unsigned char* bod
                     }
                     if (curl_pid > 0) {
                         int curl_status = 0;
-                        if (waitpid(curl_pid, &curl_status, 0) == curl_pid && WIFEXITED(curl_status) &&
-                            WEXITSTATUS(curl_status) == 0)
-                            downloaded = true;
+                        for (;;) {
+                            pid_t waited = waitpid(curl_pid, &curl_status, WNOHANG);
+                            if (waited == curl_pid) {
+                                downloaded = WIFEXITED(curl_status) && WEXITSTATUS(curl_status) == 0;
+                                break;
+                            }
+                            if (waited < 0) {
+                                if (errno == EINTR)
+                                    continue;
+                                break;
+                            }
+                            struct stat st;
+                            if (stat(tmp, &st) == 0 && st.st_size >= 0) {
+                                /* Reserve 80-100 for installation. Never report completion
+                                 * before curl succeeds and the temporary file is renamed. */
+                                double fraction = download_size > 0 ? (double)st.st_size / download_size : 0;
+                                unsigned percent = 10 + (unsigned)(69 * (fraction > 1 ? 1 : fraction));
+                                char message[128];
+                                if (download_size > 0)
+                                    snprintf(message, sizeof(message), "Downloading DMG: %.1f / %.1f MiB",
+                                             (double)st.st_size / 1048576, (double)download_size / 1048576);
+                                else
+                                    snprintf(message, sizeof(message), "Downloading DMG: %.1f MiB",
+                                             (double)st.st_size / 1048576);
+                                (void)write_progress(metalsharp_home, "downloading", percent, message, NULL);
+                            }
+                            sleep(1);
+                        }
                     }
                 }
                 if (downloaded && rename(tmp, dest) == 0) {

--- a/app/src-c/tests/updater_test.py
+++ b/app/src-c/tests/updater_test.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import json
+import http.server
+import threading
 import os
 import signal
 import socket
@@ -132,9 +134,62 @@ def write_release(root: Path) -> tuple[Path, bytes, bytes]:
     return release, regular_bytes, fex_bytes
 
 
+def test_download_progress(root: Path) -> None:
+    payload = b"x" * (1024 * 1024)
+
+    class SlowDownload(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            for offset in range(0, len(payload), 65536):
+                self.wfile.write(payload[offset:offset + 65536])
+                self.wfile.flush()
+                time.sleep(0.25)
+
+        def log_message(self, *_: object) -> None:
+            pass
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), SlowDownload)
+    worker = threading.Thread(target=server.serve_forever, daemon=True)
+    worker.start()
+    try:
+        release, _, _ = write_release(root)
+        data = json.loads(release.read_text())
+        for asset in data["assets"]:
+            asset["browser_download_url"] = f"http://127.0.0.1:{server.server_port}/download.dmg"
+            asset["size"] = len(payload)
+        release.write_text(json.dumps(data))
+        with Backend(root, release, 27) as backend:
+            assert request(backend.port, "POST", "/update/start", {"variant": "regular"})["ok"]
+            observed = set()
+            deadline = time.time() + 20
+            while time.time() < deadline:
+                progress = request(backend.port, "GET", "/update/progress")
+                if progress["status"] == "downloading":
+                    observed.add(progress["percent"])
+                    assert progress["percent"] < 80
+                if progress["status"] == "downloaded":
+                    break
+                assert progress["status"] != "error", progress
+                time.sleep(0.1)
+            else:
+                raise AssertionError("slow download did not complete")
+            assert len([p for p in observed if 10 < p < 80]) >= 2, observed
+            result = request(backend.port, "GET", "/update/dmg-path")
+            assert Path(result["path"]).read_bytes() == payload
+    finally:
+        server.shutdown()
+        server.server_close()
+        worker.join()
+
+
 def main() -> None:
     with tempfile.TemporaryDirectory(prefix="metalsharp-updater-") as temporary:
         root = Path(temporary)
+        slow_root = root / "slow"
+        slow_root.mkdir()
+        test_download_progress(slow_root)
         release, regular_bytes, fex_bytes = write_release(root)
         supported_root = root / "supported"
         supported_root.mkdir()

--- a/tools/bundles/tests/hash-manifest-test.sh
+++ b/tools/bundles/tests/hash-manifest-test.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+# Load only the helper, not the verifier's command-line entry point.
+eval "$(sed -n '/^verify_hash_manifest() {/,/^}/p' "$ROOT/tools/bundles/verify-bundles.sh")"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/input/assets"
+printf 'payload\n' > "$tmp/input/assets/test.dll"
+tar -cf "$tmp/test.tar" -C "$tmp/input" assets
+zstd -q "$tmp/test.tar" -o "$tmp/test.tar.zst"
+hash="$(shasum -a 256 "$tmp/input/assets/test.dll" | awk '{print $1}')"
+printf 'path\tsha256\ntest.dll\t%s\n' "$hash" > "$tmp/hashes.tsv"
+verify_hash_manifest "$tmp/test.tar.zst" TEST assets "$tmp/hashes.tsv"
+printf 'path\tsha256\ntest.dll\tbad\n' > "$tmp/hashes.tsv"
+if verify_hash_manifest "$tmp/test.tar.zst" TEST assets "$tmp/hashes.tsv" 2>"$tmp/error"; then
+  echo 'corrupt hash accepted' >&2; exit 1
+fi
+grep -q 'HASH MISMATCH' "$tmp/error"
+printf 'path\tsha256\nmissing.dll\t%s\n' "$hash" > "$tmp/hashes.tsv"
+if verify_hash_manifest "$tmp/test.tar.zst" TEST assets "$tmp/hashes.tsv" 2>"$tmp/error"; then
+  echo 'missing member accepted' >&2; exit 1
+fi
+grep -q 'INVALID: unable to extract' "$tmp/error"
+grep -qi 'missing.dll' "$tmp/error"
+printf 'hash manifest regression tests passed\n'

--- a/tools/bundles/verify-bundles.sh
+++ b/tools/bundles/verify-bundles.sh
@@ -231,8 +231,19 @@ verify_hash_manifest() {
   local failed=0
   local hash_tmp
   hash_tmp="$(mktemp -d "${TMPDIR:-/tmp}/metalsharp-bundle-hash.XXXXXX")"
-  if ! tar --use-compress-program=unzstd -xf "$archive" -C "$hash_tmp" >/dev/null 2>&1; then
+  # Materialize only the files whose hashes are checked. The assets archive
+  # contains large unrelated runtimes, especially costly after DMG packaging.
+  local members="$hash_tmp/members.txt"
+  awk -F '\t' -v prefix="$prefix" 'NF >= 2 && $1 != "path" && $1 !~ /^#/ { print prefix "/" $1 }' "$manifest" > "$members"
+  if [ ! -s "$members" ]; then
+    echo "$label INVALID: empty hash manifest $manifest" >&2
+    rm -rf "$hash_tmp"
+    return 1
+  fi
+  if ! tar --use-compress-program=unzstd -xf "$archive" -C "$hash_tmp" -T "$members" >"$hash_tmp/extract.log" 2>&1; then
     echo "$label INVALID: unable to extract $archive for hash verification" >&2
+    cat "$hash_tmp/extract.log" >&2
+    df -h "$hash_tmp" >&2 || true
     rm -rf "$hash_tmp"
     return 1
   fi


### PR DESCRIPTION
## Summary
- Extract only hash-manifest members during verification instead of unpacking large unrelated runtimes.
- Retain tar error output and report disk space on failure. The previous failed release discarded the extraction error, so its precise cause remains unconfirmed; this change reduces temporary storage pressure and makes future failures actionable.
- Report DMG download byte progress each second, mapped to the existing 10–79% download range. Previously the backend blocked on curl and left the progress bar at 10%. Completion remains gated on curl success and final rename.

## Validation
- Full C suite passes, including a throttled HTTP download test requiring multiple intermediate percentages and exact downloaded bytes.
- Published assets, graphics, and runtime archives pass the revised verifier.
- Hash verifier regression checks pass for correct, wrong-hash, and missing-member cases; extraction errors retain the missing member name.
- ShellCheck, bash syntax, C formatting, and diff checks pass.

## Risk / rollback
No hashes, payloads, version, or release tags changed. Unknown download sizes display transferred bytes without an invented percentage. Revert these changes to restore prior behavior. No interactive game test applies; documented checklist exception for release tooling and updater progress tests.