### PR TITLE
fix(ui): keep library header controls outside window drag regions

### DIFF
--- a/app/src/renderer/views/LibraryView.vue
+++ b/app/src/renderer/views/LibraryView.vue
@@ -401,6 +401,7 @@ watch([library, search, filter], () => {
 <template>
   <div class="library-view">
     <div class="library-header glass-header">
+      <div class="library-drag-strip" aria-hidden="true"></div>
       <div class="library-title-row">
         <div>
           <h1>Library</h1>
@@ -494,7 +495,6 @@ watch([library, search, filter], () => {
   padding: 44px 28px 14px;
   min-width: 0;
   border-bottom: 1px solid var(--border);
-  -webkit-app-region: drag;
   position: relative;
   overflow: hidden;
 }
@@ -503,16 +503,18 @@ watch([library, search, filter], () => {
   margin: 0 -28px;
   padding: 20px 28px 32px;
 }
-.library-header::after {
-  content: "";
+/* Native drag rectangles must never overlap the control row. Do not put
+   app-region: drag on the header ancestor or a full-header decoration. */
+.library-drag-strip {
   position: absolute;
-  inset: 0;
-  background:
-    radial-gradient(ellipse 60% 80% at 20% 50%, rgba(95, 183, 232, 0.08) 0%, transparent 70%),
-    radial-gradient(ellipse 40% 60% at 80% 50%, rgba(95, 183, 232, 0.05) 0%, transparent 60%);
-  pointer-events: none;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 44px;
+  -webkit-app-region: drag;
 }
 .library-title-row {
+  -webkit-app-region: drag;
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, auto);
   align-items: flex-start;
@@ -581,6 +583,7 @@ watch([library, search, filter], () => {
   min-width: 0;
 }
 .library-control-button {
+  -webkit-app-region: no-drag;
   flex: 0 1 auto;
   min-width: 0;
   max-width: 100%;

--- a/app/tests/library-drag-region.cjs
+++ b/app/tests/library-drag-region.cjs
@@ -1,0 +1,21 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const source = fs.readFileSync(path.join(__dirname, '../src/renderer/views/LibraryView.vue'), 'utf8');
+const css = source.split('<style scoped>')[1];
+assert.ok(css, 'library styles present');
+function rule(selector) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return css.match(new RegExp(escaped + '\\s*\\{([^}]+)\\}'))?.[1] ?? '';
+}
+for (const selector of ['.library-controls', '.library-control-button']) {
+  assert.match(rule(selector), /-webkit-app-region:\s*no-drag;/, `${selector} must not intercept clicks for window dragging`);
+}
+assert.doesNotMatch(rule('.library-header'), /-webkit-app-region:/, 'no ancestor drag region may overlap controls');
+assert.ok(!css.includes('.library-header::after'), 'no full-header overlay');
+assert.match(rule('.library-drag-strip'), /height:\s*44px;/);
+assert.match(rule('.library-drag-strip'), /-webkit-app-region:\s*drag;/);
+assert.match(source, /class="library-drag-strip" aria-hidden="true"/);
+assert.match(rule('.library-title-row'), /-webkit-app-region:\s*drag;/, 'title remains draggable');
+assert.match(source, /@click="toggleSteam"/, 'Steam button handler retained');
+console.log('library drag-region regression checks passed');


### PR DESCRIPTION
## Summary
Remove the overlapping whole-header drag region and decorative overlay. Use a separate 44px top drag strip and draggable title row, leaving library controls outside native drag rectangles.

## Validation
- User tested the replacement frontend in the installed app and confirmed the final fix works.
- Frontend production build and TypeScript checks pass.
- Drag-region regression checks and git diff checks pass.
- Installed frontend only; backend, Wine runtime, and Steam prefixes unchanged.

## Rollback / scope
Revert this commit to restore the previous header layout. Current installed app.asar backup is preserved locally. No game compatibility changes or new game tests claimed; checklist exception for a focused frontend hit-region fix.