### PR TITLE
fix(updater): publish polled progress atomically

### DIFF
--- a/app/src-c/runtime/updater.c
+++ b/app/src-c/runtime/updater.c
@@ -353,8 +353,10 @@ static bool write_progress(const char* home, const char* status, unsigned percen
     char* path = progress_path(home);
     ms_json_writer writer;
     char* json;
-    FILE* file;
-    bool ok;
+    char* temporary;
+    FILE* file = NULL;
+    int fd;
+    bool ok = false;
     if (path == NULL)
         return false;
     ms_json_writer_init(&writer);
@@ -376,10 +378,30 @@ static bool write_progress(const char* home, const char* status, unsigned percen
         free(path);
         return false;
     }
-    file = fopen(path, "wb");
-    ok = file != NULL && fputs(json, file) >= 0 && fclose(file) == 0;
-    if (file != NULL && !ok)
-        fclose(file);
+    /* Readers poll this file while the download worker updates it. Writing
+     * directly to the destination exposes the truncate-before-write window
+     * and can return an empty, invalid JSON response. Publish a complete file
+     * with an atomic same-directory rename instead. */
+    temporary = malloc(strlen(path) + sizeof(".tmp.XXXXXX"));
+    if (temporary != NULL) {
+        snprintf(temporary, strlen(path) + sizeof(".tmp.XXXXXX"), "%s.tmp.XXXXXX", path);
+        fd = mkstemp(temporary);
+        if (fd >= 0) {
+            file = fdopen(fd, "wb");
+            if (file != NULL) {
+                bool complete = fputs(json, file) >= 0 && fflush(file) == 0 && fsync(fd) == 0;
+                complete = fclose(file) == 0 && complete;
+                file = NULL;
+                if (complete)
+                    ok = rename(temporary, path) == 0;
+            } else {
+                close(fd);
+            }
+            if (!ok)
+                unlink(temporary);
+        }
+        free(temporary);
+    }
     free(json);
     free(path);
     return ok;


### PR DESCRIPTION
## Summary
Fix the C CI failure in `updater_test.py`. The download worker rewrote `update_progress.json` directly with `fopen(..., "wb")`, creating a truncate-before-write window. The renderer/test poller could read an empty response and fail JSON decoding.

Write and flush a complete temporary file in the same directory, sync it, then atomically rename it over the progress path. Failed writes remove the temporary file and leave the last valid progress document visible.

## Evidence
- Main CI run 34295271569 failed with `JSONDecodeError` while polling `/update/progress` during the throttled download test.
- Full `make -C app/src-c test` passes.
- The complete baseline/FEX updater test, including throttled progress polling, passed five additional consecutive runs.
- C formatting and `git diff --check` pass.

## Readiness
- [x] No hardcoded user paths, secrets, config/rules, version, payload, migration, or launch behavior changes.
- [x] Existing updater progress regression test exercises the race path.
- [ ] New real-game validation (not applicable to atomic updater status persistence).

Checklist exception requested for a focused CI race fix. No release retag or app installation is included.

## Risk / rollback
The rename is same-directory and therefore atomic. The worker still owns the existing updater lock, so this does not introduce competing progress writers. Revert this commit to restore direct writes, including the observed empty-read race.