### PR TITLE
fix(steam): launch CS2 instead of VConsole2

### DIFF
--- a/app/src-c/runtime/steam_actions.c
+++ b/app/src-c/runtime/steam_actions.c
@@ -2002,8 +2002,8 @@ static char* acf_install_dir(const char* manifest_path) {
 
 static bool executable_helper_name(const char* name) {
     static const char* const ignored[] = {
-        "bootstrapper", "crash",  "easyanticheat",   "installer", "uninstall",      "setup",  "redist",
-        "vcredist",     "server", "start_protected", "d3dconfig", "steamwebhelper", "oalinst"};
+        "bootstrapper", "crash",  "easyanticheat",   "installer", "uninstall",      "setup",   "redist",
+        "vcredist",     "server", "start_protected", "d3dconfig", "steamwebhelper", "oalinst", "vconsole"};
     char lower[256];
     size_t length = strlen(name);
     if (length >= sizeof(lower))
@@ -2143,7 +2143,9 @@ static char* preferred_steam_game_executable(const char* game_dir, unsigned id, 
     char* ruled = rule_preferred_game_executable(game_dir, id);
     if (ruled)
         return ruled;
-    if (id == 1097150)
+    if (id == 730)
+        preferred[count++] = "game/bin/win64/cs2.exe";
+    else if (id == 1097150)
         preferred[count++] = "FallGuys_client_game.exe";
     else if (id == 4704690)
         preferred[count++] = "Chameleon/Binaries/Win64/PenguinHotel-Win64-Shipping.exe";

--- a/app/src-c/tests/runtime_routes_test.c
+++ b/app/src-c/tests/runtime_routes_test.c
@@ -18,6 +18,15 @@ static void fixture(const char* home, const char* relative, const char* bytes) {
 int main(int argc, char** argv) {
     assert(argc == 2);
     const char* home = argv[1];
+    fixture(home, "cs2/game/bin/win64/vconsole2.exe", "console helper");
+    fixture(home, "cs2/game/bin/win64/cs2.exe", "game executable");
+    char* cs2_dir = join(home, "cs2");
+    char* cs2_exe = preferred_steam_game_executable(cs2_dir, 730, "m11");
+    assert(cs2_exe && strstr(cs2_exe, "/game/bin/win64/cs2.exe"));
+    assert(executable_helper_name("vconsole2.exe"));
+    free(cs2_exe);
+    free(cs2_dir);
+
     fixture(home, "configs/config.json", "{\"msync\":false}");
     set_wine_msync(home);
     assert(!strcmp(getenv("WINEMSYNC"), "0"));


### PR DESCRIPTION
## Summary
Counter-Strike 2 (Steam AppID 730) contains multiple Windows executables under `game/bin/win64`. Generic recursive discovery can encounter `vconsole2.exe` before the actual game and launch the developer console instead.

- Prefer the canonical `game/bin/win64/cs2.exe` path for AppID 730 across Steam graphics pipelines.
- Classify VConsole executables as helpers so generic fallback discovery cannot select them.
- Add a routing regression fixture containing both executables and assert that CS2 is selected.

## Validation
- Full `make -C app/src-c test` passes.
- `python3 tools/ci/validate-rules-toml.py` passes (714 overrides).
- `git diff --check` passes.

## Readiness
- [x] Based on latest `main` (`82c1055`).
- [x] No game was launched and no Steam/prefix state was modified.
- [x] Regression coverage verifies executable selection without invoking Wine.
- [ ] Real CS2 launch validation (requires explicit permission and is intentionally not performed here).

Checklist exception requested for this focused executable-routing correction.