### PR TITLE
fix(steam): force Overwatch D3D11 when using M11

### DIFF
--- a/app/src-c/runtime/steam_actions.c
+++ b/app/src-c/runtime/steam_actions.c
@@ -594,6 +594,8 @@ static void build_launch_args(unsigned id, const char* pipeline, char** argv, si
         append_launch_arg(argv, count, max, "-d3d10");
     else if (id == 17300 && !strcmp(pipeline, "m10"))
         append_launch_arg(argv, count, max, "-dx10");
+    else if (id == 2357570 && !strcmp(pipeline, "m11"))
+        append_launch_arg(argv, count, max, "-d3d11");
 
     if (id == 1196590 || id == 1623730 || id == 1928870 || id == 2358720 || id == 2456740) {
         if (!strcmp(pipeline, "m12")) {

--- a/app/src-c/tests/runtime_routes_test.c
+++ b/app/src-c/tests/runtime_routes_test.c
@@ -27,6 +27,15 @@ int main(int argc, char** argv) {
     free(cs2_exe);
     free(cs2_dir);
 
+    char* overwatch_args[4] = {NULL};
+    size_t overwatch_argc = 0;
+    build_launch_args(2357570, "m11", overwatch_args, &overwatch_argc, 4);
+    assert(overwatch_argc == 1);
+    assert(!strcmp(overwatch_args[0], "-d3d11"));
+    overwatch_argc = 0;
+    build_launch_args(2357570, "d3dmetal", overwatch_args, &overwatch_argc, 4);
+    assert(overwatch_argc == 0);
+
     fixture(home, "configs/config.json", "{\"msync\":false}");
     set_wine_msync(home);
     assert(!strcmp(getenv("WINEMSYNC"), "0"));


### PR DESCRIPTION
## Summary
Overwatch (Steam AppID 2357570) launches through D3DMetal but fails to start through M11. M11 supplies the D3D11 DXMT lane, while Overwatch can otherwise select its D3D12 renderer.

- Add `-d3d11` specifically when AppID 2357570 is launched with M11.
- Leave D3DMetal launch arguments unchanged so that route retains its existing behavior.
- Add regression coverage for both pipeline argument sets.

## Validation
- Full `make -C app/src-c test` passes.
- `git diff --check` passes.
- No game was launched and no Steam/prefix state was modified.

## Readiness
- [x] Based on latest `main` (`f1df865`).
- [x] Pipeline-scoped fix with regression coverage.
- [x] D3DMetal behavior remains unchanged.
- [ ] Real Overwatch M11 validation (requires explicit launch permission and is intentionally not performed here).

Checklist exception requested for this focused launch-routing fix.