### PR TITLE
fix(deps): update js-yaml security override

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -3209,9 +3209,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {

--- a/app/package.json
+++ b/app/package.json
@@ -183,7 +183,7 @@
     "form-data": "4.0.6",
     "tar": "7.5.21",
     "undici": "6.28.0",
-    "js-yaml": "4.3.1",
+    "js-yaml": "4.3.2",
     "fast-uri": "3.1.6",
     "postcss": "8.5.23",
     "@electron/get": {


### PR DESCRIPTION
## Summary
Resolves Dependabot security alert #69 / `GHSA-2883-xcg3-v3hh` (`CVE-2026-84375`).

MetalSharp pins the transitive `js-yaml` dependency through `app/package.json` overrides. The pin was `4.3.1`, which is vulnerable to uncontrolled CPU consumption via empty YAML merge sources. Update the override and lockfile to patched `4.3.2`.

## Validation
- `npm audit --package-lock-only --audit-level=high` reports 0 vulnerabilities.
- Lockfile resolves `js-yaml` to `4.3.2`.
- `git diff --check` passes.

Closes Dependabot alert #69.