### PR TITLE
fix: render Wine Steam at Retina resolution

### DIFF
--- a/app/src-c/include/metalsharp_backend/config.h
+++ b/app/src-c/include/metalsharp_backend/config.h
@@ -7,5 +7,6 @@
 char* ms_config_get_json(const char* metalsharp_home);
 char* ms_config_set_json(const char* metalsharp_home, const unsigned char* body, size_t body_length, int* status);
 bool ms_config_msync_enabled(const char* metalsharp_home);
+bool ms_config_retina_enabled(const char* metalsharp_home);
 
 #endif

--- a/app/src-c/runtime/config.c
+++ b/app/src-c/runtime/config.c
@@ -198,6 +198,15 @@ bool ms_config_msync_enabled(const char* metalsharp_home) {
     return enabled;
 }
 
+bool ms_config_retina_enabled(const char* metalsharp_home) {
+    char* path = config_path(metalsharp_home);
+    ms_json* config = path == NULL ? NULL : read_json_file(path);
+    bool enabled = config_bool(config, "retinaMode", true);
+    free(path);
+    ms_json_free(config);
+    return enabled;
+}
+
 char* ms_config_get_json(const char* metalsharp_home) {
     char* path = config_path(metalsharp_home);
     ms_json* config = path == NULL ? NULL : read_json_file(path);
@@ -206,6 +215,7 @@ char* ms_config_get_json(const char* metalsharp_home) {
                     ? truthy(env_logs)
                     : config_bool(config, "graphicsRuntimeLogs", config_bool(config, "graphics_runtime_logs", false));
     bool msync = config_bool(config, "msync", true);
+    bool retina = config_bool(config, "retinaMode", true);
     char* controller = controller_input(config);
     ms_json_writer writer;
     char* result;
@@ -230,6 +240,8 @@ char* ms_config_get_json(const char* metalsharp_home) {
     ms_json_writer_string(&writer, controller);
     ms_json_writer_key(&writer, "msync");
     ms_json_writer_bool(&writer, msync);
+    ms_json_writer_key(&writer, "retinaMode");
+    ms_json_writer_bool(&writer, retina);
     ms_json_writer_object_end(&writer);
     result = ms_json_writer_take(&writer);
     free(controller);
@@ -261,7 +273,7 @@ static void write_member(ms_json_writer* writer, const char* key, const ms_json*
 }
 
 static bool write_config(const char* path, const ms_json* existing, bool set_logs, bool logs, bool set_controller,
-                         const char* controller, bool set_msync, bool msync) {
+                         const char* controller, bool set_msync, bool msync, bool set_retina, bool retina) {
     char* parent;
     char* slash;
     ms_json_writer writer;
@@ -270,6 +282,7 @@ static bool write_config(const char* path, const ms_json* existing, bool set_log
     bool emitted_logs_snake = false;
     bool emitted_controller = false;
     bool emitted_msync = false;
+    bool emitted_retina = false;
     parent = strdup(path);
     if (parent == NULL)
         return false;
@@ -303,6 +316,10 @@ static bool write_config(const char* path, const ms_json* existing, bool set_log
             ms_json_writer_key(&writer, key);
             ms_json_writer_bool(&writer, msync);
             emitted_msync = true;
+        } else if (set_retina && strcmp(key, "retinaMode") == 0) {
+            ms_json_writer_key(&writer, key);
+            ms_json_writer_bool(&writer, retina);
+            emitted_retina = true;
         } else {
             write_member(&writer, key, value);
         }
@@ -322,6 +339,10 @@ static bool write_config(const char* path, const ms_json* existing, bool set_log
     if (set_msync && !emitted_msync) {
         ms_json_writer_key(&writer, "msync");
         ms_json_writer_bool(&writer, msync);
+    }
+    if (set_retina && !emitted_retina) {
+        ms_json_writer_key(&writer, "retinaMode");
+        ms_json_writer_bool(&writer, retina);
     }
     ms_json_writer_object_end(&writer);
     {
@@ -347,7 +368,8 @@ char* ms_config_set_json(const char* metalsharp_home, const unsigned char* body,
     ms_json* existing = path == NULL ? NULL : read_json_file(path);
     ms_json* request = NULL;
     char error[128];
-    bool set_logs = false, logs = false, set_msync = false, msync = false, set_controller = false;
+    bool set_logs = false, logs = false, set_msync = false, msync = false, set_retina = false, retina = false,
+         set_controller = false;
     char* controller = NULL;
     char* result;
     if (status != NULL)
@@ -376,8 +398,10 @@ char* ms_config_set_json(const char* metalsharp_home, const unsigned char* body,
         set_controller = valid_controller(ms_json_object_get(request, "controllerInput"), &controller);
         value = ms_json_object_get(request, "msync");
         set_msync = value != NULL && ms_json_as_bool(value, &msync);
+        value = ms_json_object_get(request, "retinaMode");
+        set_retina = value != NULL && ms_json_as_bool(value, &retina);
     }
-    if (!write_config(path, existing, set_logs, logs, set_controller, controller, set_msync, msync))
+    if (!write_config(path, existing, set_logs, logs, set_controller, controller, set_msync, msync, set_retina, retina))
         goto fail;
     result = ms_config_get_json(metalsharp_home);
     if (status != NULL)

--- a/app/src-c/runtime/steam_actions.c
+++ b/app/src-c/runtime/steam_actions.c
@@ -46,7 +46,7 @@ static char* join(const char* a, const char* b) {
 }
 
 static void ensure_steam_launch_ready(const char* home, const char* steam_dir);
-static void seed_steam_d3d12_guard(const char* home, const char* prefix);
+static void seed_steam_registry(const char* home);
 static bool contains_ci(const char* haystack, const char* needle);
 static bool wine_steam_cleanup_target(const char* command, const char* prefix);
 static bool copy_file_path(const char* source, const char* destination);
@@ -375,10 +375,11 @@ static void set_route_paths(const char* home, const char* pipeline) {
         snprintf(unixpath, sizeof(unixpath),
                  "%s/runtime/wine/lib/dxmt/x86_64-unix:%s/runtime/wine/lib/wine/x86_64-unix", home, home);
     } else if (!strcmp(pipeline, "m9")) {
-        snprintf(dllpath, sizeof(dllpath),
-                 "%s/runtime/wine/lib/dxmt/x86_64-windows:%s/runtime/wine/lib/wine/x86_64-windows:%s/runtime/wine/lib/wine/"
-                 "i386-windows:%s/runtime/wine/lib/metalsharp/x86_64-windows",
-                 home, home, home, home);
+        snprintf(
+            dllpath, sizeof(dllpath),
+            "%s/runtime/wine/lib/dxmt/x86_64-windows:%s/runtime/wine/lib/wine/x86_64-windows:%s/runtime/wine/lib/wine/"
+            "i386-windows:%s/runtime/wine/lib/metalsharp/x86_64-windows",
+            home, home, home, home);
         snprintf(unixpath, sizeof(unixpath),
                  "%s/runtime/wine/lib/dxmt/x86_64-unix:%s/runtime/wine/lib/wine/x86_64-unix", home, home);
     } else if (!strcmp(pipeline, "m11_32")) {
@@ -2462,7 +2463,7 @@ static char* spawn_wine(const char* home, const char* first, const char* second,
     }
     redirect_wine_steam_desktop(home);
     ensure_steam_launch_ready(home, steam_dir);
-    seed_steam_d3d12_guard(home, steam_dir);
+    seed_steam_registry(home);
     child = fork();
     if (child < 0) {
         char* s = strdup(strerror(errno));
@@ -2615,7 +2616,7 @@ char* ms_steam_launch_json(const char* home, int* status) {
         return pid_result(pid, "pid", 0, false);
     }
     ensure_steam_launch_ready(home, steam_dir);
-    seed_steam_d3d12_guard(home, steam_dir);
+    seed_steam_registry(home);
     errtext = spawn_wine(home, steam, "-no-cef-sandbox", "-cef-single-process", "-noverifyfiles", "-no-dwrite", &pid);
     if (!errtext)
         for (int i = 0; i < 12 && !ms_steam_process_running(home); i++)
@@ -3206,14 +3207,14 @@ char* ms_steam_ensure_launch_ready_json(const char* home, int* status) {
     return ms_json_writer_take(&writer);
 }
 
-static void seed_steam_d3d12_guard(const char* home, const char* steam_dir) {
+static void seed_steam_registry(const char* home) {
     char* prefix = join(home, "prefix-steam");
     char* drive_c = prefix ? join(prefix, "drive_c") : NULL;
-    char* reg_file = drive_c ? join(drive_c, "metalsharp-steam-d3d12-guard.reg") : NULL;
+    char* reg_file = drive_c ? join(drive_c, "metalsharp-steam.reg") : NULL;
+    bool retina = ms_config_retina_enabled(home);
     FILE* f;
     pid_t pid;
     char* error_text;
-    (void)steam_dir;
     if (!prefix || !drive_c || !reg_file || !ensure_directory(drive_c))
         goto done;
     f = fopen(reg_file, "wb");
@@ -3232,8 +3233,12 @@ static void seed_steam_d3d12_guard(const char* home, const char* steam_dir) {
     fputs("\"d3d12\"=\"builtin\"\r\n\"d3d12core\"=\"builtin\"\r\n\"d3d12SDKLayers\"=\"builtin\"\r\n\"dxcore\"="
           "\"builtin\"\r\n",
           f);
+    fputs("\r\n[HKEY_CURRENT_USER\\Software\\Wine\\Mac Driver]\r\n", f);
+    fprintf(f, "\"RetinaMode\"=\"%c\"\r\n", retina ? 'Y' : 'N');
+    fputs("\r\n[HKEY_CURRENT_USER\\Control Panel\\Desktop]\r\n", f);
+    fprintf(f, "\"LogPixels\"=dword:%08x\r\n", retina ? 192 : 96);
     fclose(f);
-    error_text = spawn_wine_install(home, "reg", "import", "C:\\metalsharp-steam-d3d12-guard.reg", &pid);
+    error_text = spawn_wine_install(home, "reg", "import", "C:\\metalsharp-steam.reg", &pid);
     if (!error_text) {
         (void)wait_child_success(pid);
     } else {

--- a/app/src-c/tests/runtime_routes_test.c
+++ b/app/src-c/tests/runtime_routes_test.c
@@ -33,6 +33,17 @@ int main(int argc, char** argv) {
     fixture(home, "configs/config.json", "{\"msync\":true}");
     set_wine_msync(home);
     assert(!strcmp(getenv("WINEMSYNC"), "1"));
+    seed_steam_registry(home);
+    char* steam_reg_path = join(home, "prefix-steam/drive_c/metalsharp-steam.reg");
+    char* steam_reg = read_bounded_file(steam_reg_path);
+    assert(steam_reg && strstr(steam_reg, "\"RetinaMode\"=\"Y\"") && strstr(steam_reg, "\"LogPixels\"=dword:000000c0"));
+    free(steam_reg);
+    fixture(home, "configs/config.json", "{\"retinaMode\":false}");
+    seed_steam_registry(home);
+    steam_reg = read_bounded_file(steam_reg_path);
+    assert(steam_reg && strstr(steam_reg, "\"RetinaMode\"=\"N\"") && strstr(steam_reg, "\"LogPixels\"=dword:00000060"));
+    free(steam_reg);
+    free(steam_reg_path);
     set_route_paths(home, "vkd3d");
     assert(strstr(getenv("VK_DRIVER_FILES"), "lib/moltenvk-vkmt/MoltenVK_icd.json"));
     assert(!strcmp(pipeline_backend("m12"), "dxmt"));

--- a/app/src-c/tests/smoke.sh
+++ b/app/src-c/tests/smoke.sh
@@ -44,10 +44,11 @@ v = json.load(sys.stdin)
 assert v["ok"] is True
 assert v["controllerInput"] == "off"
 assert v["msync"] is True
+assert v["retinaMode"] is True
 '
 
 curl --silent --fail --request POST --header 'Content-Type: application/json' \
-    --data '{"graphicsRuntimeLogs":true,"controllerInput":"X","msync":false}' \
+    --data '{"graphicsRuntimeLogs":true,"controllerInput":"X","msync":false,"retinaMode":false}' \
     "http://127.0.0.1:$port/config" >/dev/null
 config_after=$(curl --silent --fail "http://127.0.0.1:$port/config")
 printf '%s' "$config_after" | python3 -c '
@@ -57,6 +58,7 @@ assert v["graphicsRuntimeLogs"] is True
 assert v["graphics_runtime_logs"] is True
 assert v["controllerInput"] == "x"
 assert v["msync"] is False
+assert v["retinaMode"] is False
 '
 
 progress=$(curl --silent --fail "http://127.0.0.1:$port/update/progress")

--- a/app/src/renderer/api-types.ts
+++ b/app/src/renderer/api-types.ts
@@ -35,6 +35,7 @@ interface AppConfig {
   graphics_runtime_logs?: boolean;
   controllerInput?: "off" | "x" | "d";
   msync?: boolean;
+  retinaMode?: boolean;
 }
 
 interface UpdateStatus {

--- a/app/src/renderer/views/SettingsView.vue
+++ b/app/src/renderer/views/SettingsView.vue
@@ -42,6 +42,8 @@ const shaderCache = ref<CacheSummary | null>(null);
 const pipelineCache = ref<CacheSummary | null>(null);
 const apiKeyInput = ref("");
 const graphicsRuntimeLogs = ref(false);
+const retinaMode = ref(true);
+const retinaModeBusy = ref(false);
 
 onMounted(async () => {
   apiKeyInput.value = steamApiKey.value ?? "";
@@ -54,6 +56,7 @@ async function refreshConfig() {
   if (result?.ok) {
     config.value = result;
     graphicsRuntimeLogs.value = Boolean(result.graphicsRuntimeLogs ?? result.graphics_runtime_logs);
+    retinaMode.value = result.retinaMode !== false;
   }
 }
 
@@ -311,6 +314,23 @@ async function toggleGraphicsRuntimeLogs(enabled: boolean) {
   }
 }
 
+async function toggleRetinaMode(enabled: boolean) {
+  if (retinaModeBusy.value || enabled === retinaMode.value) return;
+  const previous = retinaMode.value;
+  retinaModeBusy.value = true;
+  retinaMode.value = enabled;
+  const result = await api<AppConfig>("POST", "/config", { retinaMode: enabled });
+  if (result?.ok) {
+    config.value = result;
+    retinaMode.value = result.retinaMode !== false;
+    toast.show(`Retina rendering ${enabled ? "enabled" : "disabled"} — restart Wine Steam to apply`, "success");
+  } else {
+    retinaMode.value = previous;
+    toast.show("Failed to update Retina rendering", "error");
+  }
+  retinaModeBusy.value = false;
+}
+
 function uninstallMetalsharp() {
   getAPI().uninstallApp();
 }
@@ -383,6 +403,25 @@ function uninstallMetalsharp() {
             {{ macSteamRunning ? "Stop Steam Mac" : "Start Steam Mac" }}
           </button>
           <button v-else class="btn btn-primary btn-sm" @click="installMacSteam">Install macOS Steam</button>
+        </div>
+      </div>
+      <div class="settings-row">
+        <div>
+          <div class="settings-label">High Resolution (Retina)</div>
+          <div class="settings-desc">
+            Sharp Wine windows at native display resolution; restart Wine Steam to apply
+          </div>
+        </div>
+        <div class="settings-value">
+          <label class="settings-toggle toggle-label" aria-label="High Resolution Retina">
+            <input
+              type="checkbox"
+              :checked="retinaMode"
+              :disabled="retinaModeBusy"
+              @change="toggleRetinaMode(($event.target as HTMLInputElement).checked)"
+            />
+            <span class="toggle-switch"></span>
+          </label>
         </div>
       </div>
     </div>

--- a/app/src/shared/types.ts
+++ b/app/src/shared/types.ts
@@ -41,6 +41,7 @@ export interface AppConfig {
   launchMode: "native" | "wine";
   wineAvailable: boolean;
   nativeAvailable: boolean;
+  retinaMode?: boolean;
 }
 
 export interface RustResponse<T = unknown> {

--- a/docs/runtime/wine-architecture.md
+++ b/docs/runtime/wine-architecture.md
@@ -1,5 +1,5 @@
 # Wine Architecture
-**Updated:** 2026-09-08
+**Updated:** 2026-09-11
 
 
 MetalSharp ships a self-contained Wine runtime at:
@@ -158,6 +158,10 @@ points at `~/.metalsharp/prefix-steam/` so Runtime Doctor and repair actions aff
 Wine Steam remains the live background client that stays connected for Steam games. Env-dependent Steam game launches
 run the game executable directly through the selected MTSP pipeline with this prefix, route env, cache paths, and
 `SteamAppId`/`SteamGameId`; client-only Steam handoff remains internal for diagnostics/bootstrap cases.
+
+High Resolution (Retina) is enabled by default for this shared prefix. Before each managed launch, MetalSharp applies
+Wine's `RetinaMode` setting and sets Windows DPI to 192; disabling the setting restores 96 DPI. Restart Wine Steam after
+changing it. Because games share the prefix, disabling Retina mode can reduce render resolution and GPU load.
 
 ## Important Environment
 


### PR DESCRIPTION
## Summary

Enable native Retina rendering for Wine Steam instead of letting macOS upscale a 96-DPI backing surface, which makes the Steam client pixelated and blurry.

## Changes

- Add a default-on `retinaMode` setting and Settings toggle.
- Apply Wine `RetinaMode=Y` with `LogPixels=192` before managed launches; disabling the option restores `RetinaMode=N` and 96 DPI.
- Reuse the existing launch-time registry import so both fresh and existing prefixes converge without rebuilding or deleting the shared prefix.
- Document the shared-prefix performance tradeoff and required Wine Steam restart.
- Add config API and generated-registry regression coverage.

## PR Readiness (MANDATORY)

- [x] Compatibility verified with at least one real game (game + launch method noted below)
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths introduced
- [x] Config/rules TOML validated if `configs/mtsp-rules.toml` or DLL maps changed
- [x] Version metadata (`CMakeLists.txt`, `app/src-c/Makefile`, `package.json`, `package-lock.json`) in sync if version bumped
- [x] Bottle/runtime migration and launch behavior preserved (rollback plan noted if changed)
- [x] Docs / compatibility matrix updated for user-facing changes
- [x] Regression test added for each bug fix

## Local toolchain (run before push)

- [ ] C backend builds and tests: `make -C app/src-c test`
- [x] C++ compiles if changed: not changed
- [x] `clang-format --dry-run --Werror` passes on changed C files
- [x] `ctest --test-dir build-native` passes if tests changed: native C++ tests not changed
- [x] TypeScript compiles if changed: `cd app && npx tsc --noEmit`
- [x] Biome + Prettier pass if TS/JS changed
- [ ] Shell scripts lint if changed: ShellCheck unavailable locally; CI will run it
- [x] Rules TOML validation: not changed
- [x] DMG workflow validation: release/bundle tooling not changed
- [x] Tested with Satisfactory (App 526870), M11, managed Steam prefix/C: drive
- [x] No hardcoded paths, secrets, or absolute `/Users/...` paths
- [x] No new files added to the repository root

## Test notes

- `runtime-routes-test` passes, including both Retina-enabled and disabled registry output.
- Config smoke coverage verifies the default and persisted opt-out.
- `tsc --noEmit`, Biome, Prettier, and the Vite production build pass. Biome reports five pre-existing CSS specificity warnings.
- Full `make -C app/src-c test` passes through the new tests and all suites up to SharpEmu; the host then rejects SharpEmu's `sandbox-exec` probe with `sandbox_apply: Operation not permitted`.
- Satisfactory launched through M11 and remained running with the shared prefix after Retina mode was enabled, then was stopped through the backend.

## Risk

Retina mode doubles the Wine backing resolution and can increase GPU load for games because they share `prefix-steam`. Users can disable High Resolution in Settings; the next Wine Steam restart restores `RetinaMode=N` and 96 DPI without deleting or rebuilding the prefix.
